### PR TITLE
feat(ui): add responsive app shell with sidebar and bottom nav

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,9 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import Link from "next/link";
 import { ThemeProvider } from "@/components/layout/ThemeProvider";
-import { ThemeToggle } from "@/components/layout/ThemeToggle";
 import { DataProvider } from "@/components/layout/DataProvider";
-import { ResetDataButton } from "@/components/layout/ResetDataButton";
+import { Sidebar } from "@/components/layout/Sidebar";
+import { BottomNav } from "@/components/layout/BottomNav";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -33,39 +32,16 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
       suppressHydrationWarning
     >
-      <body className="min-h-full flex flex-col bg-background text-foreground">
+      <body className="h-full bg-background text-foreground">
         <DataProvider>
           <ThemeProvider>
-            <header className="border-b border-border">
-              <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-4">
-                <nav aria-label="Main navigation">
-                  <ul className="flex items-center gap-4 text-sm font-medium">
-                    <li>
-                      <Link href="/path" className="hover:text-primary">
-                        Path
-                      </Link>
-                    </li>
-                    <li>
-                      <Link href="/record" className="hover:text-primary">
-                        Record
-                      </Link>
-                    </li>
-                    <li>
-                      <Link href="/collections" className="hover:text-primary">
-                        Collections
-                      </Link>
-                    </li>
-                  </ul>
-                </nav>
-                <div className="flex items-center gap-1">
-                  <ResetDataButton />
-                  <ThemeToggle />
-                </div>
-              </div>
-            </header>
-            <main className="mx-auto w-full max-w-5xl flex-1 px-4 py-8">
-              {children}
-            </main>
+            <div className="flex h-full">
+              <Sidebar />
+              <main className="flex-1 overflow-y-auto px-4 py-8 pb-20 md:pb-8">
+                <div className="mx-auto max-w-5xl">{children}</div>
+              </main>
+            </div>
+            <BottomNav />
           </ThemeProvider>
         </DataProvider>
       </body>

--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { Route, CirclePlus, FolderOpen } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+const navItems: ReadonlyArray<{
+  href: string
+  label: string
+  icon: typeof Route
+  primary?: true
+}> = [
+  { href: "/path", label: "Path", icon: Route },
+  { href: "/record", label: "Record", icon: CirclePlus, primary: true },
+  { href: "/collections", label: "Collections", icon: FolderOpen },
+]
+
+export function BottomNav() {
+  const pathname = usePathname()
+
+  return (
+    <nav
+      aria-label="Main navigation"
+      className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-background md:hidden"
+    >
+      <ul className="flex items-center justify-around py-2">
+        {navItems.map(({ href, label, icon: Icon, primary }) => {
+          const isActive = pathname.startsWith(href)
+          return (
+            <li key={href}>
+              <Link
+                href={href}
+                className={cn(
+                  "flex flex-col items-center gap-0.5 px-3 py-1 text-xs font-medium transition-colors",
+                  isActive
+                    ? "text-foreground"
+                    : "text-muted-foreground",
+                  primary && !isActive && "text-primary",
+                )}
+                aria-current={isActive ? "page" : undefined}
+              >
+                <Icon className={cn("size-5", primary && "size-6")} />
+                {label}
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { Route, CirclePlus, FolderOpen } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { ThemeToggle } from "@/components/layout/ThemeToggle"
+import { ResetDataButton } from "@/components/layout/ResetDataButton"
+
+const navItems: ReadonlyArray<{
+  href: string
+  label: string
+  icon: typeof Route
+  primary?: true
+}> = [
+  { href: "/path", label: "Path", icon: Route },
+  { href: "/record", label: "Record", icon: CirclePlus, primary: true },
+  { href: "/collections", label: "Collections", icon: FolderOpen },
+]
+
+export function Sidebar() {
+  const pathname = usePathname()
+
+  return (
+    <aside className="hidden w-56 shrink-0 border-r border-border md:flex md:flex-col">
+      <div className="flex h-14 items-center px-4 text-lg font-semibold">
+        pbbls
+      </div>
+
+      <nav aria-label="Main navigation" className="flex-1 px-2 py-2">
+        <ul className="flex flex-col gap-1">
+          {navItems.map(({ href, label, icon: Icon, primary }) => {
+            const isActive = pathname.startsWith(href)
+            return (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className={cn(
+                    "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                    isActive
+                      ? "bg-muted text-foreground"
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                    primary && !isActive && "text-primary hover:text-primary",
+                  )}
+                  aria-current={isActive ? "page" : undefined}
+                >
+                  <Icon className="size-4" />
+                  {label}
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+      </nav>
+
+      <div className="flex items-center gap-1 border-t border-border px-4 py-3">
+        <ResetDataButton />
+        <ThemeToggle />
+      </div>
+    </aside>
+  )
+}


### PR DESCRIPTION
Replace header navigation with a desktop sidebar and mobile bottom navigation bar. Record link is styled as the primary CTA in both layouts. Utility buttons (theme toggle, reset data) live in the sidebar footer (desktop only for now).

Resolves #11 

## Changes
### New files
components/layout/Sidebar.tsx — Desktop sidebar with "pbbls" branding, nav links (Path, Record as primary CTA, Collections) with active state via usePathname(), plus ThemeToggle and ResetDataButton at the bottom
components/layout/BottomNav.tsx — Mobile-only fixed bottom bar with the same three nav links, Record centered and prominent with a larger icon
### Modified
app/layout.tsx — Replaced the <header> nav with a flex layout containing <Sidebar /> (desktop) and <BottomNav /> (mobile), with <main> taking remaining space and bottom padding on mobile for the fixed nav
