### PR TITLE
feat(ui): add pebble detail view

### DIFF
--- a/app/pebble/[id]/page.tsx
+++ b/app/pebble/[id]/page.tsx
@@ -1,7 +1,41 @@
-export default function PebbleDetailPage() {
+"use client"
+
+import { use } from "react"
+import Link from "next/link"
+import { usePebble } from "@/lib/data/usePebble"
+import { useSouls } from "@/lib/data/useSouls"
+import { PebbleDetail } from "@/components/pebble/PebbleDetail"
+import { PebbleNotFound } from "@/components/pebble/PebbleNotFound"
+
+export default function PebbleDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = use(params)
+  const { pebble, loading: pebbleLoading } = usePebble(id)
+  const { souls, loading: soulsLoading } = useSouls()
+
+  const loading = pebbleLoading || soulsLoading
+
   return (
     <section>
-      <h1 className="text-2xl font-semibold">Pebble Detail</h1>
+      <nav className="mb-6">
+        <Link
+          href="/path"
+          className="text-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          &larr; Back to Path
+        </Link>
+      </nav>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : pebble ? (
+        <PebbleDetail pebble={pebble} souls={souls} />
+      ) : (
+        <PebbleNotFound />
+      )}
     </section>
   )
 }

--- a/components/pebble/PebbleDetail.tsx
+++ b/components/pebble/PebbleDetail.tsx
@@ -1,0 +1,164 @@
+import type { Pebble, Soul } from "@/lib/types"
+import { EMOTIONS, DOMAINS, CARD_TYPES } from "@/lib/config"
+
+type PebbleDetailProps = {
+  pebble: Pebble
+  souls: Soul[]
+}
+
+const dateTimeFormatter = new Intl.DateTimeFormat("en-US", {
+  weekday: "long",
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+})
+
+const positivenessSigns: Record<number, string> = {
+  [-2]: "−−",
+  [-1]: "−",
+  [0]: "~",
+  [1]: "+",
+  [2]: "++",
+}
+
+const positivenessLabels: Record<number, string> = {
+  [-2]: "Very negative",
+  [-1]: "Negative",
+  [0]: "Neutral",
+  [1]: "Positive",
+  [2]: "Very positive",
+}
+
+function IntensityDots({ intensity }: { intensity: 1 | 2 | 3 }) {
+  const filled = "●".repeat(intensity)
+  const empty = "○".repeat(3 - intensity)
+  return (
+    <abbr
+      title={`Intensity: ${intensity} of 3`}
+      className="text-sm tracking-wide no-underline"
+    >
+      {filled}
+      {empty}
+    </abbr>
+  )
+}
+
+function PositivenessIndicator({ value }: { value: number }) {
+  const sign = positivenessSigns[value] ?? "~"
+  const label = positivenessLabels[value] ?? "Neutral"
+  return (
+    <abbr title={`Positiveness: ${label}`} className="text-sm font-medium no-underline">
+      {sign}
+    </abbr>
+  )
+}
+
+export function PebbleDetail({ pebble, souls }: PebbleDetailProps) {
+  const emotion = EMOTIONS.find((e) => e.id === pebble.emotion_id)
+  const domains = DOMAINS.filter((d) => pebble.domain_ids.includes(d.id))
+  const matchedSouls = pebble.soul_ids
+    .map((id) => souls.find((s) => s.id === id))
+    .filter((s): s is Soul => s !== undefined)
+
+  const formattedDate = dateTimeFormatter.format(new Date(pebble.happened_at))
+
+  return (
+    <article>
+      {/* Header */}
+      <header>
+        <h1 className="text-2xl font-semibold">{pebble.name}</h1>
+
+        <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+          {emotion && (
+            <span
+              className="rounded-full px-2.5 py-0.5 text-sm font-medium"
+              style={{
+                backgroundColor: `${emotion.color}20`,
+                color: emotion.color,
+              }}
+              aria-label={`Emotion: ${emotion.name}`}
+            >
+              {emotion.name}
+            </span>
+          )}
+
+          <IntensityDots intensity={pebble.intensity} />
+          <PositivenessIndicator value={pebble.positiveness} />
+
+          <time dateTime={pebble.happened_at}>{formattedDate}</time>
+        </div>
+      </header>
+
+      {/* Description */}
+      {pebble.description && (
+        <p className="mt-4 text-sm text-foreground">{pebble.description}</p>
+      )}
+
+      {/* Souls */}
+      {matchedSouls.length > 0 && (
+        <section className="mt-6" aria-labelledby="souls-heading">
+          <h2 id="souls-heading" className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Souls
+          </h2>
+          <ul className="mt-2 flex flex-wrap gap-2" role="list">
+            {matchedSouls.map((soul) => (
+              <li
+                key={soul.id}
+                className="rounded-full border border-border px-2.5 py-0.5 text-xs font-medium"
+              >
+                {soul.name}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* Domains */}
+      {domains.length > 0 && (
+        <section className="mt-6" aria-labelledby="domains-heading">
+          <h2 id="domains-heading" className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Domains
+          </h2>
+          <ul className="mt-2 flex flex-wrap gap-2" role="list">
+            {domains.map((domain) => (
+              <li
+                key={domain.id}
+                className="rounded-full border border-border px-2.5 py-0.5 text-xs font-medium"
+                aria-label={`${domain.name}: ${domain.label}`}
+              >
+                {domain.name}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* Cards */}
+      {pebble.cards.length > 0 && (
+        <section className="mt-6" aria-labelledby="cards-heading">
+          <h2 id="cards-heading" className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Cards
+          </h2>
+          <ol className="mt-3 space-y-4" role="list">
+            {pebble.cards.map((card, index) => {
+              const cardType = CARD_TYPES.find((c) => c.id === card.species_id)
+              return (
+                <li
+                  key={`${card.species_id}-${index}`}
+                  className="rounded-lg border border-border px-4 py-3"
+                >
+                  <h3 className="text-xs font-medium text-muted-foreground">
+                    {cardType?.prompt ?? card.species_id}
+                  </h3>
+                  <p className="mt-1 text-sm whitespace-pre-wrap">{card.value}</p>
+                </li>
+              )
+            })}
+          </ol>
+        </section>
+      )}
+    </article>
+  )
+}

--- a/components/pebble/PebbleNotFound.tsx
+++ b/components/pebble/PebbleNotFound.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link"
+
+export function PebbleNotFound() {
+  return (
+    <section className="flex flex-col items-center justify-center gap-4 py-20 text-center">
+      <h1 className="text-2xl font-semibold">Pebble not found</h1>
+      <p className="text-sm text-muted-foreground">
+        This pebble doesn&apos;t exist or may have been removed.
+      </p>
+      <Link
+        href="/path"
+        className="text-sm font-medium text-primary underline underline-offset-4 hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      >
+        Back to Path
+      </Link>
+    </section>
+  )
+}


### PR DESCRIPTION
Resolves #13

## Summary
- Implement pebble detail page at `/pebble/[id]` with all fields: emotion badge, intensity dots, positiveness indicator, date/time, description, souls, domains, and reflection cards
- Add not-found state for invalid pebble IDs with back navigation
- Follow existing accessibility patterns (semantic HTML, `aria-label`, `abbr` for indicators)

## Key files
- `app/pebble/[id]/page.tsx` — page component using `usePebble(id)` and `useSouls()`
- `components/pebble/PebbleDetail.tsx` — main detail view component
- `components/pebble/PebbleNotFound.tsx` — not-found state

## Test plan
- [x] Navigate from Path timeline to a pebble — all fields render correctly
- [x] Emotion, souls, and domains resolve to display names/colors
- [x] Cards display with prompt labels and user text
- [x] Navigate to `/pebble/nonexistent-id` — shows not-found state
- [x] Back link returns to Path
- [x] Light and dark themes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)