### PR TITLE
feat(ui): add record pebble multi-step flow shell

### DIFF
--- a/app/record/page.tsx
+++ b/app/record/page.tsx
@@ -1,7 +1,23 @@
+"use client"
+
+import Link from "next/link"
+import { RecordStepper } from "@/components/record/RecordStepper"
+
 export default function RecordPage() {
   return (
     <section>
-      <h1 className="text-2xl font-semibold">Record</h1>
+      <nav className="mb-6">
+        <Link
+          href="/path"
+          className="text-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          &larr; Back to Path
+        </Link>
+      </nav>
+
+      <h1 className="mb-6 text-2xl font-semibold">Record a pebble</h1>
+
+      <RecordStepper />
     </section>
   )
 }

--- a/components/record/RecordStep1.tsx
+++ b/components/record/RecordStep1.tsx
@@ -1,0 +1,12 @@
+import type { RecordStepProps } from "@/components/record/RecordStepper"
+
+export function RecordStep1(_props: RecordStepProps) {
+  return (
+    <fieldset className="space-y-2">
+      <legend className="text-lg font-semibold">Time, Intensity & Emotion</legend>
+      <p className="text-sm text-muted-foreground">
+        When did this happen? How intense was it? What emotion best describes it?
+      </p>
+    </fieldset>
+  )
+}

--- a/components/record/RecordStep2.tsx
+++ b/components/record/RecordStep2.tsx
@@ -1,0 +1,12 @@
+import type { RecordStepProps } from "@/components/record/RecordStepper"
+
+export function RecordStep2(_props: RecordStepProps) {
+  return (
+    <fieldset className="space-y-2">
+      <legend className="text-lg font-semibold">Souls & Domains</legend>
+      <p className="text-sm text-muted-foreground">
+        Who was involved? Which life domains does this touch?
+      </p>
+    </fieldset>
+  )
+}

--- a/components/record/RecordStep3.tsx
+++ b/components/record/RecordStep3.tsx
@@ -1,0 +1,12 @@
+import type { RecordStepProps } from "@/components/record/RecordStepper"
+
+export function RecordStep3(_props: RecordStepProps) {
+  return (
+    <fieldset className="space-y-2">
+      <legend className="text-lg font-semibold">Cards & Review</legend>
+      <p className="text-sm text-muted-foreground">
+        Add reflective cards and review your pebble before saving.
+      </p>
+    </fieldset>
+  )
+}

--- a/components/record/RecordStepper.tsx
+++ b/components/record/RecordStepper.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { usePebbles } from "@/lib/data/usePebbles"
+import type { PebbleCard } from "@/lib/types"
+import { Button } from "@/components/ui/button"
+import { RecordStep1 } from "@/components/record/RecordStep1"
+import { RecordStep2 } from "@/components/record/RecordStep2"
+import { RecordStep3 } from "@/components/record/RecordStep3"
+
+export type RecordFormData = {
+  name: string
+  description: string
+  happened_at: string
+  intensity: 1 | 2 | 3
+  positiveness: -2 | -1 | 0 | 1 | 2
+  emotion_id: string
+  soul_ids: string[]
+  domain_ids: string[]
+  cards: PebbleCard[]
+}
+
+export type RecordStepProps = {
+  data: RecordFormData
+  onUpdate: (patch: Partial<RecordFormData>) => void
+}
+
+const STEPS = [
+  { label: "Time, Intensity & Emotion", Component: RecordStep1 },
+  { label: "Souls & Domains", Component: RecordStep2 },
+  { label: "Cards & Review", Component: RecordStep3 },
+] as const
+
+const INITIAL_DATA: RecordFormData = {
+  name: "",
+  description: "",
+  happened_at: new Date().toISOString(),
+  intensity: 2,
+  positiveness: 0,
+  emotion_id: "",
+  soul_ids: [],
+  domain_ids: [],
+  cards: [],
+}
+
+export function RecordStepper() {
+  const router = useRouter()
+  const { addPebble } = usePebbles()
+  const [currentStep, setCurrentStep] = useState(0)
+  const [formData, setFormData] = useState<RecordFormData>(INITIAL_DATA)
+  const [saving, setSaving] = useState(false)
+
+  const totalSteps = STEPS.length
+  const isFirstStep = currentStep === 0
+  const isLastStep = currentStep === totalSteps - 1
+
+  const handleUpdate = useCallback((patch: Partial<RecordFormData>) => {
+    setFormData((prev) => ({ ...prev, ...patch }))
+  }, [])
+
+  const goBack = useCallback(() => {
+    if (!isFirstStep) setCurrentStep((s) => s - 1)
+  }, [isFirstStep])
+
+  const goNext = useCallback(() => {
+    if (!isLastStep) setCurrentStep((s) => s + 1)
+  }, [isLastStep])
+
+  const handleSave = useCallback(async () => {
+    if (saving) return
+    setSaving(true)
+    try {
+      const pebble = await addPebble(formData)
+      router.push(`/pebble/${pebble.id}`)
+    } finally {
+      setSaving(false)
+    }
+  }, [addPebble, formData, router, saving])
+
+  const handleAdvance = useCallback(() => {
+    if (isLastStep) {
+      void handleSave()
+    } else {
+      goNext()
+    }
+  }, [isLastStep, handleSave, goNext])
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      // Don't capture keyboard shortcuts when an input/textarea/select is focused
+      const tag = (e.target as HTMLElement).tagName
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return
+
+      if (e.key === "Enter") {
+        e.preventDefault()
+        handleAdvance()
+      } else if (e.key === "Escape") {
+        e.preventDefault()
+        goBack()
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [handleAdvance, goBack])
+
+  const { Component: ActiveStep } = STEPS[currentStep]
+
+  return (
+    <div className="space-y-6">
+      {/* Step indicator */}
+      <div className="space-y-2">
+        <p className="text-sm text-muted-foreground" aria-live="polite">
+          Step {currentStep + 1} of {totalSteps}
+          <span className="sr-only">: {STEPS[currentStep].label}</span>
+        </p>
+        <div
+          role="progressbar"
+          aria-valuenow={currentStep + 1}
+          aria-valuemin={1}
+          aria-valuemax={totalSteps}
+          aria-label={`Step ${currentStep + 1} of ${totalSteps}`}
+          className="flex gap-1.5"
+        >
+          {STEPS.map((step, i) => (
+            <div
+              key={step.label}
+              className={`h-1.5 flex-1 rounded-full transition-colors ${
+                i <= currentStep ? "bg-primary" : "bg-muted"
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Active step */}
+      <ActiveStep data={formData} onUpdate={handleUpdate} />
+
+      {/* Navigation */}
+      <nav className="flex items-center justify-between" aria-label="Step navigation">
+        {!isFirstStep ? (
+          <Button variant="ghost" onClick={goBack}>
+            Back
+          </Button>
+        ) : (
+          <span />
+        )}
+
+        {isLastStep ? (
+          <Button onClick={() => void handleSave()} disabled={saving}>
+            {saving ? "Saving\u2026" : "Save pebble"}
+          </Button>
+        ) : (
+          <Button onClick={goNext}>Next</Button>
+        )}
+      </nav>
+    </div>
+  )
+}


### PR DESCRIPTION
Build the stepper/wizard that hosts the 3-step record flow: step 1 (time, intensity, emotion), step 2 (souls, domains), step 3 (cards, review + save). Steps are placeholders for now.

- RecordStepper manages step index, form state, and navigation
- Progress bar with aria progressbar role
- Keyboard navigation: Enter to advance, Escape to go back
- Final step calls addPebble() and redirects to detail page

Resolves #14 

<img width="1264" height="1999" alt="image" src="https://github.com/user-attachments/assets/6912789f-40e7-43bc-8cdb-8bf62f6426ed" />

