### PR TITLE
Add card editor and review summary to record step 3

### DIFF
--- a/components/record/CardEditor.tsx
+++ b/components/record/CardEditor.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { Check, ChevronDown } from "lucide-react"
+import { CARD_TYPES } from "@/lib/config"
+import type { PebbleCard } from "@/lib/types"
+
+type CardEditorProps = {
+  value: PebbleCard[]
+  onChange: (cards: PebbleCard[]) => void
+}
+
+export function CardEditor({ value, onChange }: CardEditorProps) {
+  const cardMap = new Map(value.map((c) => [c.species_id, c.value]))
+
+  function handleChange(speciesId: string, text: string) {
+    const next = new Map(value.map((c) => [c.species_id, c.value]))
+    if (text.trim()) {
+      next.set(speciesId, text)
+    } else {
+      next.delete(speciesId)
+    }
+    onChange(
+      Array.from(next, ([species_id, v]) => ({ species_id, value: v })),
+    )
+  }
+
+  return (
+    <fieldset className="space-y-3">
+      <legend className="text-sm font-medium">Reflection cards</legend>
+      <p className="text-xs text-muted-foreground">
+        Optional — add thoughts to any card.
+      </p>
+
+      <div className="space-y-2">
+        {CARD_TYPES.map((type) => {
+          const filled = cardMap.has(type.id) && cardMap.get(type.id)!.trim() !== ""
+          return (
+            <details
+              key={type.id}
+              open={filled || undefined}
+              className="group rounded-lg border border-border"
+            >
+              <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-sm font-medium [&::-webkit-details-marker]:hidden">
+                <ChevronDown
+                  className="size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180"
+                  aria-hidden="true"
+                />
+                <span className="flex-1">{type.name}</span>
+                {filled && (
+                  <Check className="size-4 shrink-0 text-primary" aria-label={`${type.name} card filled`} />
+                )}
+              </summary>
+              <div className="px-3 pb-3">
+                <label htmlFor={`card-${type.id}`} className="sr-only">
+                  {type.prompt}
+                </label>
+                <textarea
+                  id={`card-${type.id}`}
+                  placeholder={type.prompt}
+                  value={cardMap.get(type.id) ?? ""}
+                  onChange={(e) => handleChange(type.id, e.target.value)}
+                  className="w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-sm outline-none field-sizing-content min-h-20 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+                />
+              </div>
+            </details>
+          )
+        })}
+      </div>
+    </fieldset>
+  )
+}

--- a/components/record/RecordStep3.tsx
+++ b/components/record/RecordStep3.tsx
@@ -1,12 +1,23 @@
-import type { RecordStepProps } from "@/components/record/RecordStepper"
+"use client"
 
-export function RecordStep3(_props: RecordStepProps) {
+import type { RecordStepProps } from "@/components/record/RecordStepper"
+import { CardEditor } from "@/components/record/CardEditor"
+import { ReviewSummary } from "@/components/record/ReviewSummary"
+
+export function RecordStep3({ data, onUpdate }: RecordStepProps) {
   return (
-    <fieldset className="space-y-2">
+    <fieldset className="space-y-6">
       <legend className="text-lg font-semibold">Cards & Review</legend>
       <p className="text-sm text-muted-foreground">
         Add reflective cards and review your pebble before saving.
       </p>
+
+      <CardEditor
+        value={data.cards}
+        onChange={(cards) => onUpdate({ cards })}
+      />
+
+      <ReviewSummary data={data} />
     </fieldset>
   )
 }

--- a/components/record/RecordStepper.tsx
+++ b/components/record/RecordStepper.tsx
@@ -60,6 +60,7 @@ export function RecordStepper() {
   const [currentStep, setCurrentStep] = useState(0)
   const [formData, setFormData] = useState<RecordFormData>(INITIAL_DATA)
   const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const totalSteps = STEPS.length
   const isFirstStep = currentStep === 0
@@ -80,9 +81,14 @@ export function RecordStepper() {
   const handleSave = useCallback(async () => {
     if (saving) return
     setSaving(true)
+    setError(null)
     try {
       const pebble = await addPebble(formData)
       router.push(`/pebble/${pebble.id}`)
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Something went wrong. Please try again."
+      setError(message)
     } finally {
       setSaving(false)
     }
@@ -149,6 +155,13 @@ export function RecordStepper() {
 
       {/* Active step */}
       <ActiveStep data={formData} onUpdate={handleUpdate} />
+
+      {/* Error message */}
+      {error && (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      )}
 
       {/* Navigation */}
       <nav className="flex items-center justify-between" aria-label="Step navigation">

--- a/components/record/ReviewSummary.tsx
+++ b/components/record/ReviewSummary.tsx
@@ -1,0 +1,138 @@
+"use client"
+
+import type { RecordFormData } from "@/components/record/RecordStepper"
+import { useSouls } from "@/lib/data/useSouls"
+import {
+  EMOTIONS,
+  DOMAINS,
+  CARD_TYPES,
+  POSITIVENESS_SIGNS,
+  POSITIVENESS_LABELS,
+} from "@/lib/config"
+import type { Soul } from "@/lib/types"
+
+type ReviewSummaryProps = {
+  data: RecordFormData
+}
+
+const dateTimeFormatter = new Intl.DateTimeFormat("en-US", {
+  weekday: "short",
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+})
+
+export function ReviewSummary({ data }: ReviewSummaryProps) {
+  const { souls } = useSouls()
+
+  const emotion = EMOTIONS.find((e) => e.id === data.emotion_id)
+  const domains = DOMAINS.filter((d) => data.domain_ids.includes(d.id))
+  const matchedSouls = data.soul_ids
+    .map((id) => souls.find((s) => s.id === id))
+    .filter((s): s is Soul => s !== undefined)
+
+  const filledCards = data.cards.filter((c) => c.value.trim() !== "")
+  const formattedDate = dateTimeFormatter.format(new Date(data.happened_at))
+
+  const intensityFilled = "●".repeat(data.intensity)
+  const intensityEmpty = "○".repeat(3 - data.intensity)
+  const positSign = POSITIVENESS_SIGNS[data.positiveness] ?? "~"
+  const positLabel = POSITIVENESS_LABELS[data.positiveness] ?? "Neutral"
+
+  return (
+    <section aria-labelledby="review-heading" className="space-y-3">
+      <h2
+        id="review-heading"
+        className="text-sm font-medium"
+      >
+        Review
+      </h2>
+
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+        {/* Date */}
+        <dt className="text-muted-foreground">When</dt>
+        <dd>
+          <time dateTime={data.happened_at}>{formattedDate}</time>
+        </dd>
+
+        {/* Emotion */}
+        {emotion && (
+          <>
+            <dt className="text-muted-foreground">Emotion</dt>
+            <dd>
+              <span
+                className="inline-block rounded-full px-2 py-0.5 text-xs font-medium"
+                style={{
+                  backgroundColor: `${emotion.color}20`,
+                  color: emotion.color,
+                }}
+              >
+                {emotion.name}
+              </span>
+            </dd>
+          </>
+        )}
+
+        {/* Intensity & Positiveness */}
+        <dt className="text-muted-foreground">Intensity</dt>
+        <dd className="flex items-center gap-3">
+          <abbr
+            title={`Intensity: ${data.intensity} of 3`}
+            className="tracking-wide no-underline"
+          >
+            {intensityFilled}
+            {intensityEmpty}
+          </abbr>
+          <abbr
+            title={`Positiveness: ${positLabel}`}
+            className="font-medium no-underline"
+          >
+            {positSign}
+          </abbr>
+        </dd>
+
+        {/* Souls */}
+        {matchedSouls.length > 0 && (
+          <>
+            <dt className="text-muted-foreground">Souls</dt>
+            <dd className="flex flex-wrap gap-1.5">
+              {matchedSouls.map((soul) => (
+                <span
+                  key={soul.id}
+                  className="rounded-full border border-border px-2 py-0.5 text-xs font-medium"
+                >
+                  {soul.name}
+                </span>
+              ))}
+            </dd>
+          </>
+        )}
+
+        {/* Domains */}
+        {domains.length > 0 && (
+          <>
+            <dt className="text-muted-foreground">Domains</dt>
+            <dd className="flex flex-wrap gap-1.5">
+              {domains.map((domain) => (
+                <span
+                  key={domain.id}
+                  className="rounded-full border border-border px-2 py-0.5 text-xs font-medium"
+                >
+                  {domain.name}
+                </span>
+              ))}
+            </dd>
+          </>
+        )}
+
+        {/* Cards */}
+        <dt className="text-muted-foreground">Cards</dt>
+        <dd>
+          {filledCards.length} of {CARD_TYPES.length} filled
+        </dd>
+      </dl>
+    </section>
+  )
+}


### PR DESCRIPTION
Resolves #17 

## Changes

- **CardEditor.tsx** (new): Interactive component for editing reflection cards with collapsible details elements. Shows filled status and allows users to add thoughts to any card type.
- **ReviewSummary.tsx** (new): Display-only component that summarizes all record data including emotion, intensity, positiveness, souls, domains, and card completion status.
- **RecordStep3.tsx**: Integrated CardEditor and ReviewSummary components into the final step of the record form.
- **RecordStepper.tsx**: Added error state management and display for save failures with user-friendly error messages.

## Notes

- CardEditor uses a Map-based approach for efficient card state management and only persists non-empty cards.
- ReviewSummary uses semantic HTML (dl/dt/dd) for accessibility and formats dates/times using Intl.DateTimeFormat.
- Error handling in RecordStepper now catches and displays save errors to the user instead of silently failing.
- Both new components are client-side only ("use client") as they manage interactive state.

https://claude.ai/code/session_01JpnrL34j15yU48pRT2W9z9