### PR TITLE
refactor(layout): extract MainContent component and hide bottom nav on record routes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { ThemeColorSync } from "@/components/layout/ThemeColorSync";
 import { DataProvider } from "@/components/layout/DataProvider";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { BottomNav } from "@/components/layout/BottomNav";
+import { MainContent } from "@/components/layout/MainContent";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -69,9 +70,7 @@ export default function RootLayout({
               <ThemeColorSync />
               <div className="flex h-full">
                 <Sidebar />
-                <main className="min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-4 py-8 pb-20 md:pb-8">
-                  <div className="mx-auto max-w-5xl">{children}</div>
-                </main>
+                <MainContent>{children}</MainContent>
               </div>
               <BottomNav />
             </ThemeProvider>

--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -7,11 +7,17 @@ import { NAV_ITEMS } from "@/lib/config/navigation"
 
 export function BottomNav() {
   const pathname = usePathname()
+  const hidden = pathname.startsWith("/record")
 
   return (
     <nav
       aria-label="Main navigation"
-      className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-background md:hidden"
+      aria-hidden={hidden}
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-50 border-t border-border bg-background md:hidden",
+        "transition-transform duration-300 ease-in-out motion-reduce:transition-none",
+        hidden && "translate-y-full",
+      )}
     >
       <ul className="flex items-center justify-around py-2">
         {NAV_ITEMS.map(({ href, label, icon: Icon, primary }) => {
@@ -28,6 +34,7 @@ export function BottomNav() {
                   primary && !isActive && "text-primary",
                 )}
                 aria-current={isActive ? "page" : undefined}
+                tabIndex={hidden ? -1 : undefined}
               >
                 <Icon className={cn("size-5", primary && "size-6")} />
                 {label}

--- a/components/layout/MainContent.tsx
+++ b/components/layout/MainContent.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { usePathname } from "next/navigation"
+import { cn } from "@/lib/utils"
+
+interface MainContentProps {
+  children: React.ReactNode
+}
+
+export function MainContent({ children }: MainContentProps) {
+  const pathname = usePathname()
+  const hideBottomNav = pathname.startsWith("/record")
+
+  return (
+    <main
+      className={cn(
+        "min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-4 py-8 md:pb-8",
+        "transition-[padding-bottom] duration-300 ease-in-out motion-reduce:transition-none",
+        hideBottomNav ? "pb-8" : "pb-20",
+      )}
+    >
+      <div className="mx-auto max-w-5xl">{children}</div>
+    </main>
+  )
+}


### PR DESCRIPTION
Resolves #40 

## Changes
- **components/layout/MainContent.tsx** (new): Extracted main content wrapper into a dedicated component that dynamically adjusts bottom padding based on route
- **components/layout/BottomNav.tsx**: Added route-aware hiding logic that slides the navigation off-screen on `/record` routes with smooth transitions and proper accessibility attributes
- **app/layout.tsx**: Replaced inline main element with the new `MainContent` component for better separation of concerns

## Notes
- The bottom navigation is hidden on `/record` routes using `translate-y-full` transform for a smooth slide-out animation
- Accessibility improvements: `aria-hidden` and `tabIndex={-1}` prevent keyboard navigation to hidden nav items
- Respects `prefers-reduced-motion` by disabling transitions for users with motion preferences
- The `MainContent` component intelligently manages padding-bottom to prevent content overlap when nav is visible
- This change maintains the existing responsive behavior (bottom nav only on mobile, sidebar on desktop)

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01NMqpPVX2DpEutBAmPuLrCF