### PR TITLE
style: disable text selection globally with exceptions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -465,5 +465,15 @@
   }
   html {
     @apply font-sans;
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-tap-highlight-color: transparent;
+  }
+  input,
+  textarea,
+  [contenteditable="true"],
+  .selectable {
+    -webkit-user-select: text;
+    user-select: text;
   }
 }


### PR DESCRIPTION
Resolves #41 

## Changes
- Modified `app/globals.css` to disable text selection (`user-select: none`) at the HTML level for the entire application
- Added exceptions for interactive elements (`input`, `textarea`, `[contenteditable="true"]`, `.selectable`) to allow text selection where needed
- Included vendor prefixes (`-webkit-user-select`) for cross-browser compatibility
- Added `-webkit-tap-highlight-color: transparent` to remove default tap highlight on mobile browsers

## Notes
This change prevents accidental text selection during normal user interactions while preserving the ability to select text in form inputs and other editable content. The `.selectable` class provides a way to opt-in to text selection for specific elements if needed in the future.

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01VXk3uh9uVnXAi5jVHXrgUL