### PR TITLE
feat(ui): add touch feedback, press states, and haptic vibration

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -466,4 +466,13 @@
   html {
     @apply font-sans;
   }
+
+  /* Fast touch response: remove double-tap-zoom delay on interactive elements */
+  button,
+  a,
+  [role="radio"],
+  [role="option"],
+  [aria-pressed] {
+    touch-action: manipulation;
+  }
 }

--- a/components/collections/CollectionCard.tsx
+++ b/components/collections/CollectionCard.tsx
@@ -13,7 +13,7 @@ export function CollectionCard({ collection }: CollectionCardProps) {
     <article>
       <Link
         href={`/collections/${collection.id}`}
-        className="block rounded-lg border border-border px-4 py-3 transition-colors hover:bg-muted/50 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+        className="block rounded-lg border border-border px-4 py-3 transition-all duration-100 hover:bg-muted/50 active:scale-[0.98] focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
       >
         <h3 className="text-sm font-medium">{collection.name}</h3>
 

--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -21,7 +21,7 @@ export function BottomNav() {
               <Link
                 href={href}
                 className={cn(
-                  "flex flex-col items-center gap-0.5 px-3 py-1 text-xs font-medium transition-colors",
+                  "flex flex-col items-center gap-0.5 px-3 py-1 text-xs font-medium transition-opacity duration-75 active:opacity-70",
                   isActive
                     ? "text-foreground"
                     : "text-muted-foreground",

--- a/components/layout/HapticsToggle.tsx
+++ b/components/layout/HapticsToggle.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { useSyncExternalStore } from "react"
+import { Vibrate, VibrateOff } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useHaptics } from "@/lib/hooks/useHaptics"
+
+function getSupported() {
+  return typeof navigator !== "undefined" && "vibrate" in navigator
+}
+
+function getServerSupported() {
+  return false
+}
+
+const noop = () => () => {}
+
+export function HapticsToggle() {
+  const { enabled, setEnabled } = useHaptics()
+  const supported = useSyncExternalStore(noop, getSupported, getServerSupported)
+
+  if (!supported) return null
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label={enabled ? "Disable haptic feedback" : "Enable haptic feedback"}
+      aria-pressed={enabled}
+      onClick={() => setEnabled(!enabled)}
+    >
+      {enabled ? (
+        <Vibrate className="size-4" />
+      ) : (
+        <VibrateOff className="size-4" />
+      )}
+    </Button>
+  )
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
 import { NAV_ITEMS } from "@/lib/config/navigation"
 import { ThemeToggle } from "@/components/layout/ThemeToggle"
+import { HapticsToggle } from "@/components/layout/HapticsToggle"
 import { ResetDataButton } from "@/components/layout/ResetDataButton"
 
 export function Sidebar() {
@@ -45,6 +46,7 @@ export function Sidebar() {
       <div className="flex items-center gap-1 border-t border-border px-4 py-3">
         <ResetDataButton />
         <ThemeToggle />
+        <HapticsToggle />
       </div>
     </aside>
   )

--- a/components/path/PebbleCard.tsx
+++ b/components/path/PebbleCard.tsx
@@ -16,7 +16,7 @@ export function PebbleCard({ pebble, emotion, soulNames }: PebbleCardProps) {
     <article>
       <Link
         href={`/pebble/${pebble.id}`}
-        className="block rounded-lg border border-border px-4 py-3 transition-colors hover:bg-muted/50 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+        className="block rounded-lg border border-border px-4 py-3 transition-all duration-100 hover:bg-muted/50 active:scale-[0.98] focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
       >
         <h3 className="text-sm font-medium">{pebble.name}</h3>
 

--- a/components/record/DomainPicker.tsx
+++ b/components/record/DomainPicker.tsx
@@ -36,7 +36,7 @@ export function DomainPicker({ value, onChange }: DomainPickerProps) {
                 aria-pressed={selected}
                 onClick={() => toggle(domain.id)}
                 className={cn(
-                  "flex w-full flex-col items-start rounded-lg px-3 py-2 text-sm transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                  "flex w-full flex-col items-start rounded-lg px-3 py-2 text-sm transition-all duration-100 active:scale-[0.97] outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
                   selected
                     ? "bg-primary/10 text-primary ring-2 ring-primary"
                     : "bg-muted/50 hover:bg-muted",

--- a/components/record/EmotionPicker.tsx
+++ b/components/record/EmotionPicker.tsx
@@ -89,7 +89,7 @@ export function EmotionPicker({ value, onChange }: EmotionPickerProps) {
                 tabIndex={i === focusableIdx ? 0 : -1}
                 onClick={() => onChange(emotion.id)}
                 className={cn(
-                  "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                  "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-all duration-100 active:scale-[0.97] outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
                   selected
                     ? "ring-2 ring-current"
                     : "bg-muted/50 hover:bg-muted"

--- a/components/record/IntensityPicker.tsx
+++ b/components/record/IntensityPicker.tsx
@@ -63,7 +63,7 @@ export function IntensityPicker({ value, onChange }: IntensityPickerProps) {
               tabIndex={selected ? 0 : -1}
               onClick={() => onChange(level.value)}
               className={cn(
-                "rounded-full transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                "rounded-full transition-all duration-100 active:scale-90 outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
                 level.size,
                 selected
                   ? "bg-primary"

--- a/components/record/PositivenessPicker.tsx
+++ b/components/record/PositivenessPicker.tsx
@@ -75,7 +75,7 @@ export function PositivenessPicker({ value, onChange }: PositivenessPickerProps)
               tabIndex={selected ? 0 : -1}
               onClick={() => onChange(v)}
               className={cn(
-                "flex size-9 items-center justify-center rounded-lg text-sm font-medium transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                "flex size-9 items-center justify-center rounded-lg text-sm font-medium transition-all duration-100 active:scale-90 outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
                 selected ? SELECTED_COLORS[v] : COLORS[v]
               )}
             >

--- a/components/record/RecordStepper.tsx
+++ b/components/record/RecordStepper.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation"
 import { CARD_TYPES } from "@/lib/config"
 import { useRecordForm } from "@/lib/hooks/useRecordForm"
 import { useStepNavigation } from "@/lib/hooks/useStepNavigation"
+import { useHaptics } from "@/lib/hooks/useHaptics"
 import { Button } from "@/components/ui/button"
 import type { RecordStepProps, StepConfig } from "@/components/record/types"
 import { StepDateTime } from "@/components/record/StepDateTime"
@@ -40,6 +41,8 @@ function makeCardFillerStep(cardTypeId: string, label: string): StepConfig {
 export function RecordStepper() {
   const router = useRouter()
 
+  const { vibrate } = useHaptics()
+
   const { formData, handleUpdate, handleSave, saving, error } = useRecordForm(
     (pebbleId) => router.push(`/pebble/${pebbleId}`),
   )
@@ -70,11 +73,13 @@ export function RecordStepper() {
   const handleAdvance = useCallback(() => {
     if (!canAdvance) return
     if (isLastStep) {
+      vibrate([10, 50, 20])
       void handleSave()
     } else {
+      vibrate(10)
       goNext()
     }
-  }, [canAdvance, isLastStep, handleSave, goNext])
+  }, [canAdvance, isLastStep, handleSave, goNext, vibrate])
 
   // Keyboard shortcuts: Enter to advance, Escape to go back
   useEffect(() => {

--- a/components/record/SoulPicker.tsx
+++ b/components/record/SoulPicker.tsx
@@ -79,7 +79,7 @@ export function SoulPicker({ value, onChange }: SoulPickerProps) {
                 type="button"
                 aria-label={`Remove ${soul.name}`}
                 onClick={() => toggle(soul.id)}
-                className="rounded-full p-0.5 text-muted-foreground hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none"
+                className="rounded-full p-0.5 text-muted-foreground transition-all duration-75 hover:text-foreground active:scale-90 focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none"
               >
                 <X className="size-3" aria-hidden="true" />
               </button>
@@ -138,7 +138,7 @@ export function SoulPicker({ value, onChange }: SoulPickerProps) {
                 onClick={() => toggle(soul.id)}
                 onPointerEnter={() => setActiveIndex(i)}
                 className={cn(
-                  "flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm",
+                  "flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm transition-colors duration-75",
                   active && "bg-muted",
                   selected && "font-medium",
                 )}

--- a/components/record/StepCardPicker.tsx
+++ b/components/record/StepCardPicker.tsx
@@ -27,7 +27,7 @@ export function StepCardPicker({ data, onUpdate }: RecordStepProps) {
           return (
             <li key={type.id}>
               <label
-                className={`flex cursor-pointer items-center gap-3 rounded-lg border px-3 py-2 text-sm transition-colors ${
+                className={`flex cursor-pointer items-center gap-3 rounded-lg border px-3 py-2 text-sm transition-all duration-100 active:scale-[0.98] ${
                   checked
                     ? "border-primary bg-primary/5"
                     : "border-border"

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:scale-[0.98] disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/lib/hooks/useHaptics.ts
+++ b/lib/hooks/useHaptics.ts
@@ -1,0 +1,38 @@
+"use client"
+
+import { useCallback, useSyncExternalStore } from "react"
+
+const STORAGE_KEY = "pbbls-haptics"
+
+function subscribe(callback: () => void) {
+  window.addEventListener("storage", callback)
+  return () => window.removeEventListener("storage", callback)
+}
+
+function getSnapshot(): boolean {
+  return localStorage.getItem(STORAGE_KEY) !== "off"
+}
+
+function getServerSnapshot(): boolean {
+  return true
+}
+
+export function useHaptics() {
+  const enabled = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+
+  const setEnabled = useCallback((value: boolean) => {
+    localStorage.setItem(STORAGE_KEY, value ? "on" : "off")
+    window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }))
+  }, [])
+
+  const vibrate = useCallback(
+    (pattern: number | number[] = 10) => {
+      if (enabled && typeof navigator !== "undefined" && navigator.vibrate) {
+        navigator.vibrate(pattern)
+      }
+    },
+    [enabled],
+  )
+
+  return { enabled, setEnabled, vibrate }
+}


### PR DESCRIPTION
Resolves #45

## Summary

- Add consistent `active:` press states across all tappable elements (buttons, cards, nav items, pickers) using CSS scale/opacity transforms with fast transitions (75–100ms)
- Create `useHaptics` hook with `navigator.vibrate()` support and localStorage preference toggle (`pbbls-haptics`)
- Wire haptic feedback to record flow step advance (subtle 10ms) and save (richer pattern)
- Add `HapticsToggle` component in sidebar (only shown when vibrate API is available)
- Add global `touch-action: manipulation` on interactive elements to eliminate double-tap-zoom delay

## Key files changed

| File | Change |
|------|--------|
| `app/globals.css` | `touch-action: manipulation` on interactive elements |
| `components/ui/button.tsx` | `active:scale-[0.98]` replacing `translate-y-px` |
| `components/path/PebbleCard.tsx` | `active:scale-[0.98]` press feedback |
| `components/collections/CollectionCard.tsx` | `active:scale-[0.98]` press feedback |
| `components/layout/BottomNav.tsx` | `active:opacity-70` press feedback |
| `components/record/EmotionPicker.tsx` | `active:scale-[0.97]` press feedback |
| `components/record/DomainPicker.tsx` | `active:scale-[0.97]` press feedback |
| `components/record/IntensityPicker.tsx` | `active:scale-90` press feedback |
| `components/record/PositivenessPicker.tsx` | `active:scale-90` press feedback |
| `components/record/StepCardPicker.tsx` | `active:scale-[0.98]` press feedback |
| `components/record/SoulPicker.tsx` | `active:scale-90` on remove buttons, `transition-colors` on options |
| `components/record/RecordStepper.tsx` | Haptic vibration on step advance and save |
| `lib/hooks/useHaptics.ts` | **New** — haptics preference hook |
| `components/layout/HapticsToggle.tsx` | **New** — toggle in sidebar |
| `components/layout/Sidebar.tsx` | Import HapticsToggle |

## Implementation notes

- Press feedback uses CSS `active:` pseudo-class (no JS touch handlers needed) — instant onset
- Scale values vary by element size: 0.98 for cards/buttons, 0.97 for picker tiles, 0.90 for small circular controls
- BottomNav uses opacity instead of scale since nav items are small icons+text
- `useHaptics` uses `useSyncExternalStore` for a lightweight, context-free approach (no provider needed)
- Haptics are ON by default (opt-out via `pbbls-haptics: "off"` in localStorage)
- Respects parallel issues #40, #41, #42 — does not touch their scope (user-select, overscroll, BottomNav hide/show)

## Test plan

- [ ] Tap each element type on mobile/emulator and verify instant visual press feedback
- [ ] Navigate through record flow — confirm haptic vibration on step advance and save
- [ ] Toggle haptics off in sidebar — confirm vibration stops
- [ ] Verify no interference with existing hover/focus states
- [ ] Verify `touch-action: manipulation` doesn't break scrolling
- [ ] TypeScript and ESLint pass cleanly (build blocked by Google Fonts network issue in CI sandbox only)

https://claude.ai/code/session_01RPJFJcD7fz7DYJEa6xLmFG