### PR TITLE
feat(ui): add safe area insets for notched devices

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -55,6 +55,11 @@
    Dusty rose, soft clay, dried petals — warm pink grounded in stone
    ============================================================ */
 :root {
+  --safe-area-top: env(safe-area-inset-top, 0px);
+  --safe-area-right: env(safe-area-inset-right, 0px);
+  --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-left: env(safe-area-inset-left, 0px);
+
   --background: #F8F0F0;
   --foreground: #2E2024;
   --surface: #F0E4E4;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -68,7 +68,7 @@ export default function RootLayout({
           <ColorWorldProvider>
             <ThemeProvider>
               <ThemeColorSync />
-              <div className="flex h-full">
+              <div className="flex h-full pl-[var(--safe-area-left)] pr-[var(--safe-area-right)]">
                 <Sidebar />
                 <MainContent>{children}</MainContent>
               </div>

--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -14,7 +14,7 @@ export function BottomNav() {
       aria-label="Main navigation"
       aria-hidden={hidden}
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 border-t border-border bg-background md:hidden",
+        "fixed inset-x-0 bottom-0 z-50 border-t border-border bg-background pb-[var(--safe-area-bottom)] md:hidden",
         "transition-transform duration-300 ease-in-out motion-reduce:transition-none",
         hidden && "translate-y-full",
       )}

--- a/components/layout/MainContent.tsx
+++ b/components/layout/MainContent.tsx
@@ -14,9 +14,9 @@ export function MainContent({ children }: MainContentProps) {
   return (
     <main
       className={cn(
-        "min-w-0 flex-1 touch-pan-y overflow-x-hidden overflow-y-auto px-4 py-8 md:pb-8",
+        "min-w-0 flex-1 touch-pan-y overflow-x-hidden overflow-y-auto px-4 pt-[calc(2rem+var(--safe-area-top))] pb-8 md:pb-8",
         "transition-[padding-bottom] duration-300 ease-in-out motion-reduce:transition-none",
-        hideBottomNav ? "pb-8" : "pb-20",
+        hideBottomNav ? "pb-[calc(2rem+var(--safe-area-bottom))]" : "pb-[calc(5rem+var(--safe-area-bottom))]",
       )}
     >
       <div className="mx-auto max-w-5xl">{children}</div>


### PR DESCRIPTION
Resolves #43

## Summary

- Define `--safe-area-top/right/bottom/left` CSS custom properties in `:root` wrapping `env(safe-area-inset-*)` with `0px` fallbacks
- Add bottom safe area padding to `BottomNav` so its background extends behind the home indicator
- Update `MainContent` top/bottom padding to include safe area insets (notch + home indicator)
- Add left/right safe area padding to the layout flex wrapper for landscape-oriented notched devices

## Key files changed

| File | Change |
|------|--------|
| `app/globals.css` | Add safe area CSS custom properties to `:root` |
| `components/layout/BottomNav.tsx` | Add `pb-[var(--safe-area-bottom)]` to nav |
| `components/layout/MainContent.tsx` | Update top/bottom padding to include safe area insets |
| `app/layout.tsx` | Add left/right safe area padding to flex wrapper |

## Implementation notes

- Pure CSS solution — no JavaScript, hooks, or resize observers needed
- `env(safe-area-inset-*, 0px)` returns `0px` on non-notched devices, so `calc(2rem + 0px)` = `2rem` — no visual regression
- Works in conjunction with `viewport-fit=cover` from #38
- Padding transition on `MainContent` continues to work correctly with `calc()` values

## Test plan

- [ ] Verify no visual regression on non-notched viewports (safe area variables resolve to `0px`)
- [ ] Test with Safari responsive design mode simulating an iPhone with notch
- [ ] Confirm BottomNav background extends behind the home indicator
- [ ] Confirm content does not render behind the notch/Dynamic Island
- [ ] Verify landscape orientation respects left/right safe areas
- [ ] `npm run lint` passes

https://claude.ai/code/session_012nvpZWsuSnzeb5ajEvxjuN