### PR TITLE
feat: add PWA standalone mode detection and hide install prompts

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -493,3 +493,10 @@
     touch-action: manipulation;
   }
 }
+
+/* Hide install prompts when running as installed PWA */
+@media (display-mode: standalone) {
+  [data-install-prompt] {
+    display: none !important;
+  }
+}

--- a/lib/hooks/useStandalone.ts
+++ b/lib/hooks/useStandalone.ts
@@ -1,0 +1,34 @@
+"use client"
+
+import { useSyncExternalStore } from "react"
+
+const QUERY = "(display-mode: standalone)"
+
+function subscribe(callback: () => void) {
+  const mql = window.matchMedia(QUERY)
+  mql.addEventListener("change", callback)
+  return () => mql.removeEventListener("change", callback)
+}
+
+function getSnapshot(): boolean {
+  if (window.matchMedia(QUERY).matches) return true
+  if (
+    "standalone" in navigator &&
+    (navigator as Navigator & { standalone: boolean }).standalone
+  )
+    return true
+  return false
+}
+
+function getServerSnapshot(): boolean {
+  return false
+}
+
+export function useStandalone() {
+  const isStandalone = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  )
+  return { isStandalone }
+}


### PR DESCRIPTION
Resolves #46 

## Changes
- Added `useStandalone()` hook (`lib/hooks/useStandalone.ts`) that detects if the app is running as an installed PWA using `useSyncExternalStore`
  - Checks both the CSS media query `(display-mode: standalone)` and the `navigator.standalone` property
  - Properly handles server-side rendering by returning `false` on the server
  - Subscribes to media query changes to keep the state in sync
- Updated `app/globals.css` to hide install prompt elements when running in standalone mode using the `@media (display-mode: standalone)` query

## Notes
- The hook uses `useSyncExternalStore` to safely integrate with external state (media queries and navigator API)
- The `getServerSnapshot` returns `false` to avoid hydration mismatches since PWA detection is client-only
- Install prompts are hidden with `!important` to ensure they don't appear when the app is already installed
- The implementation supports both modern browsers (CSS media query) and older PWA implementations (navigator.standalone)

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01E247qsFr95JTsqiGoDHNcU