### PR TITLE
feat(core): add stored pebbles counter to data layer

### DIFF
--- a/lib/data/data-provider.ts
+++ b/lib/data/data-provider.ts
@@ -9,6 +9,7 @@ export type Store = {
   pebbles: Pebble[]
   souls: Soul[]
   collections: Collection[]
+  pebbles_count: number
 }
 
 // ---------------------------------------------------------------------------
@@ -36,6 +37,10 @@ export interface DataProvider {
 
   /** Overwrite store with seed data and return the new snapshot. */
   reset(): Promise<Store>
+
+  // Pebbles counter
+  getPebblesCount(): Promise<number>
+  incrementPebblesCount(): Promise<number>
 
   // Pebbles
   listPebbles(): Promise<Pebble[]>

--- a/lib/data/local-provider.ts
+++ b/lib/data/local-provider.ts
@@ -13,7 +13,7 @@ import { SEED_PEBBLES, SEED_SOULS, SEED_COLLECTIONS } from "@/lib/seed/seed-data
 
 const STORAGE_KEY = "pbbls:store"
 
-const EMPTY_STORE: Store = { pebbles: [], souls: [], collections: [] }
+const EMPTY_STORE: Store = { pebbles: [], souls: [], collections: [], pebbles_count: 0 }
 
 export class LocalProvider implements DataProvider {
   private store: Store
@@ -40,7 +40,12 @@ export class LocalProvider implements DataProvider {
         // load() side-effect-free and safe for StrictMode double-invocation.
         return this.fromSeed()
       }
-      return JSON.parse(raw) as Store
+      const parsed = JSON.parse(raw) as Store
+      // Migration: backfill pebbles_count for existing users.
+      if (parsed.pebbles_count === undefined) {
+        parsed.pebbles_count = parsed.pebbles.length
+      }
+      return parsed
     } catch {
       // Corrupt or unreadable storage — fall back to seed (no write; same as above).
       return this.fromSeed()
@@ -65,6 +70,7 @@ export class LocalProvider implements DataProvider {
       pebbles: SEED_PEBBLES.map((p) => ({ ...p, created_at: now, updated_at: now })),
       souls: SEED_SOULS.map((s) => ({ ...s, created_at: now, updated_at: now })),
       collections: SEED_COLLECTIONS.map((c) => ({ ...c, created_at: now, updated_at: now })),
+      pebbles_count: SEED_PEBBLES.length,
     }
   }
 
@@ -98,6 +104,20 @@ export class LocalProvider implements DataProvider {
   }
 
   // ---------------------------------------------------------------------------
+  // Pebbles counter
+  // ---------------------------------------------------------------------------
+
+  async getPebblesCount(): Promise<number> {
+    return this.store.pebbles_count
+  }
+
+  async incrementPebblesCount(): Promise<number> {
+    const next = this.store.pebbles_count + 1
+    this.mutate({ ...this.store, pebbles_count: next })
+    return next
+  }
+
+  // ---------------------------------------------------------------------------
   // Pebbles
   // ---------------------------------------------------------------------------
 
@@ -117,7 +137,11 @@ export class LocalProvider implements DataProvider {
       created_at: now,
       updated_at: now,
     }
-    this.mutate({ ...this.store, pebbles: [...this.store.pebbles, pebble] })
+    this.mutate({
+      ...this.store,
+      pebbles: [...this.store.pebbles, pebble],
+      pebbles_count: this.store.pebbles_count + 1,
+    })
     return pebble
   }
 

--- a/lib/data/usePebblesCount.ts
+++ b/lib/data/usePebblesCount.ts
@@ -1,0 +1,12 @@
+"use client"
+
+import { useDataProvider } from "@/lib/data/provider-context"
+
+export function usePebblesCount() {
+  const { store, loading } = useDataProvider()
+
+  return {
+    pebblesCount: store.pebbles_count,
+    loading,
+  }
+}


### PR DESCRIPTION
Resolves #58

## Summary

- Added `pebbles_count: number` to the `Store` type and `getPebblesCount()` / `incrementPebblesCount()` to the `DataProvider` interface
- Implemented in `LocalProvider` with atomic increment inside `createPebble`
- Seed data initializes `pebbles_count` to `10` (matching seed pebbles)
- Migration backfills `pebbles_count` from `pebbles.length` for existing localStorage users
- Created `usePebblesCount()` hook for UI consumption

## Key files changed

- `lib/data/data-provider.ts` — Store type + interface
- `lib/data/local-provider.ts` — implementation, seed, migration
- `lib/data/usePebblesCount.ts` — new hook

## Test plan

- [ ] Fresh load: seed store has `pebbles_count: 10`
- [ ] Create a pebble: counter increments
- [ ] Existing localStorage without `pebbles_count`: backfill from `pebbles.length`
- [ ] `usePebblesCount()` returns correct value
- [ ] Lint passes

https://claude.ai/code/session_018bMGnMHQLVNW2DwamNtfmy