### PR TITLE
feat(ui): add record flow celebration screen

### DIFF
--- a/components/record/RecordCelebration.tsx
+++ b/components/record/RecordCelebration.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { useEffect } from "react"
+import Link from "next/link"
+import { motion, useReducedMotion } from "framer-motion"
+import { usePebblesCount } from "@/lib/data/usePebblesCount"
+import { useHaptics } from "@/lib/hooks/useHaptics"
+import { Button } from "@/components/ui/button"
+
+interface RecordCelebrationProps {
+  pebbleId: string
+}
+
+export function RecordCelebration({ pebbleId }: RecordCelebrationProps) {
+  const { pebblesCount } = usePebblesCount()
+  const { vibrate } = useHaptics()
+  const prefersReducedMotion = useReducedMotion()
+
+  useEffect(() => {
+    vibrate([50, 100, 50])
+  }, [vibrate])
+
+  return (
+    <section aria-label="Celebration" className="flex flex-col items-center gap-8 py-12 text-center">
+      <motion.div
+        initial={prefersReducedMotion ? false : { scale: 0.8, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        transition={{ type: "spring", stiffness: 300, damping: 20 }}
+      >
+        <h1 className="text-4xl font-bold" aria-live="polite">
+          Pebble #{pebblesCount}!
+        </h1>
+      </motion.div>
+
+      <nav className="flex flex-col gap-3" aria-label="Celebration actions">
+        <Button className="h-11 px-6" render={<Link href={`/pebble/${pebbleId}`} />}>
+          View pebble
+        </Button>
+        <Button variant="ghost" className="h-11 px-6" render={<Link href="/path" />}>
+          Back to path
+        </Button>
+      </nav>
+    </section>
+  )
+}

--- a/components/record/RecordStepper.tsx
+++ b/components/record/RecordStepper.tsx
@@ -1,7 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useMemo } from "react"
-import { useRouter } from "next/navigation"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { CARD_TYPES } from "@/lib/config"
 import { useRecordForm } from "@/lib/hooks/useRecordForm"
 import { useStepNavigation } from "@/lib/hooks/useStepNavigation"
@@ -18,6 +17,7 @@ import { StepDomains } from "@/components/record/StepDomains"
 import { StepCardPicker } from "@/components/record/StepCardPicker"
 import { StepCardFiller } from "@/components/record/StepCardFiller"
 import { StepSummary } from "@/components/record/StepSummary"
+import { RecordCelebration } from "@/components/record/RecordCelebration"
 
 const FIXED_STEPS: StepConfig[] = [
   { label: "Date and time", Component: StepDateTime, canAdvance: (d) => d.happened_at !== "" },
@@ -39,12 +39,12 @@ function makeCardFillerStep(cardTypeId: string, label: string): StepConfig {
 }
 
 export function RecordStepper() {
-  const router = useRouter()
+  const [savedPebbleId, setSavedPebbleId] = useState<string | null>(null)
 
   const { vibrate } = useHaptics()
 
   const { formData, handleUpdate, handleSave, saving, error } = useRecordForm(
-    (pebbleId) => router.push(`/pebble/${pebbleId}`),
+    (pebbleId) => setSavedPebbleId(pebbleId),
   )
 
   // Derive step list only when the set of selected card types changes,
@@ -101,6 +101,10 @@ export function RecordStepper() {
   }, [handleAdvance, goBack])
 
   const { Component: ActiveStep } = steps[currentStep]
+
+  if (savedPebbleId) {
+    return <RecordCelebration pebbleId={savedPebbleId} />
+  }
 
   return (
     <div className="touch-manipulation space-y-6">

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "esbuild-wasm": "^0.27.4",
+        "framer-motion": "^12.38.0",
         "lucide-react": "^1.7.0",
         "next": "16.2.0",
         "next-themes": "^0.4.6",
@@ -5651,6 +5652,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -7542,6 +7570,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "esbuild-wasm": "^0.27.4",
+    "framer-motion": "^12.38.0",
     "lucide-react": "^1.7.0",
     "next": "16.2.0",
     "next-themes": "^0.4.6",


### PR DESCRIPTION
After saving a pebble, a celebration screen replaces the stepper UI
showing "Pebble #{count}!" with a spring animation, haptic feedback,
and navigation links to view the pebble or return to the path.

Resolves #59

https://claude.ai/code/session_01Dwk3UHWgwGQgkAMdv7hLJ8