### PR TITLE
feat(bounce): implement rolling-window streak mechanic

### DIFF
--- a/lib/data/bounce-levels.ts
+++ b/lib/data/bounce-levels.ts
@@ -1,0 +1,77 @@
+// ---------------------------------------------------------------------------
+// Bounce — pure utility for the rolling-window streak mechanic.
+// No side effects, no dependencies on the provider or localStorage.
+// ---------------------------------------------------------------------------
+
+/** Number of days the rolling window covers. */
+export const BOUNCE_WINDOW_DAYS = 28
+
+/**
+ * Threshold table — sorted descending by `minDays` so the first match wins.
+ * Each entry means "if active days >= minDays, the bounce level is `level`".
+ */
+export const BOUNCE_THRESHOLDS: ReadonlyArray<{ minDays: number; level: number }> = [
+  { minDays: 25, level: 7 },
+  { minDays: 21, level: 6 },
+  { minDays: 18, level: 5 },
+  { minDays: 14, level: 4 },
+  { minDays: 10, level: 3 },
+  { minDays: 6, level: 2 },
+  { minDays: 1, level: 1 },
+]
+
+/** Map an active-day count to a bounce level (0–7). */
+export function computeBounceLevel(activeDays: number): number {
+  for (const { minDays, level } of BOUNCE_THRESHOLDS) {
+    if (activeDays >= minDays) return level
+  }
+  return 0
+}
+
+/** Return today's date as `YYYY-MM-DD` in the user's local timezone. */
+export function todayLocal(): string {
+  return new Date().toLocaleDateString("en-CA")
+}
+
+/**
+ * Remove dates older than 28 days from the window.
+ * Compares `YYYY-MM-DD` strings against a cutoff derived from today (local tz).
+ */
+export function pruneWindow(dates: string[]): string[] {
+  const cutoff = new Date()
+  cutoff.setDate(cutoff.getDate() - BOUNCE_WINDOW_DAYS)
+  const cutoffStr = cutoff.toLocaleDateString("en-CA")
+  return dates.filter((d) => d >= cutoffStr)
+}
+
+/** Append today to the window if not already present. */
+export function addTodayToWindow(window: string[]): string[] {
+  const today = todayLocal()
+  if (window.includes(today)) return window
+  return [...window, today]
+}
+
+/**
+ * Full refresh: prune → add today → compute level.
+ * Used when a pebble is created (active day earned).
+ */
+export function refreshBounceWindow(currentWindow: string[]): {
+  bounce_window: string[]
+  bounce: number
+} {
+  const pruned = pruneWindow(currentWindow)
+  const updated = addTodayToWindow(pruned)
+  return { bounce_window: updated, bounce: computeBounceLevel(updated.length) }
+}
+
+/**
+ * Decay only: prune → recompute level (no "add today").
+ * Used on app load so inactive days fall off without awarding a new active day.
+ */
+export function decayBounceWindow(currentWindow: string[]): {
+  bounce_window: string[]
+  bounce: number
+} {
+  const pruned = pruneWindow(currentWindow)
+  return { bounce_window: pruned, bounce: computeBounceLevel(pruned.length) }
+}

--- a/lib/data/data-provider.ts
+++ b/lib/data/data-provider.ts
@@ -10,6 +10,8 @@ export type Store = {
   souls: Soul[]
   collections: Collection[]
   pebbles_count: number
+  bounce: number
+  bounce_window: string[]
 }
 
 // ---------------------------------------------------------------------------
@@ -41,6 +43,10 @@ export interface DataProvider {
   // Pebbles counter
   getPebblesCount(): Promise<number>
   incrementPebblesCount(): Promise<number>
+
+  // Bounce
+  getBounce(): Promise<number>
+  refreshBounce(): Promise<number>
 
   // Pebbles
   listPebbles(): Promise<Pebble[]>

--- a/lib/data/local-provider.ts
+++ b/lib/data/local-provider.ts
@@ -10,10 +10,18 @@ import type {
 } from "@/lib/data/data-provider"
 import type { Pebble, Soul, Collection } from "@/lib/types"
 import { SEED_PEBBLES, SEED_SOULS, SEED_COLLECTIONS } from "@/lib/seed/seed-data"
+import { refreshBounceWindow, decayBounceWindow, todayLocal } from "@/lib/data/bounce-levels"
 
 const STORAGE_KEY = "pbbls:store"
 
-const EMPTY_STORE: Store = { pebbles: [], souls: [], collections: [], pebbles_count: 0 }
+const EMPTY_STORE: Store = {
+  pebbles: [],
+  souls: [],
+  collections: [],
+  pebbles_count: 0,
+  bounce: 0,
+  bounce_window: [],
+}
 
 export class LocalProvider implements DataProvider {
   private store: Store
@@ -45,6 +53,15 @@ export class LocalProvider implements DataProvider {
       if (parsed.pebbles_count === undefined) {
         parsed.pebbles_count = parsed.pebbles.length
       }
+      // Migration: backfill bounce fields for existing users.
+      if (parsed.bounce === undefined) {
+        parsed.bounce = 0
+        parsed.bounce_window = []
+      }
+      // Lazy decay: prune expired dates and recompute level on app open.
+      const decayed = decayBounceWindow(parsed.bounce_window)
+      parsed.bounce = decayed.bounce
+      parsed.bounce_window = decayed.bounce_window
       return parsed
     } catch {
       // Corrupt or unreadable storage — fall back to seed (no write; same as above).
@@ -66,11 +83,25 @@ export class LocalProvider implements DataProvider {
 
   private fromSeed(): Store {
     const now = new Date().toISOString()
+
+    // Seed bounce with ~5 recent dates so demo users see the mechanic.
+    const today = todayLocal()
+    const seedDates: string[] = []
+    for (const offset of [0, 2, 4, 7, 9]) {
+      const d = new Date()
+      d.setDate(d.getDate() - offset)
+      seedDates.push(d.toLocaleDateString("en-CA"))
+    }
+    // Deduplicate in case offsets collapse (unlikely but safe).
+    const bounceWindow = [...new Set(seedDates)].filter((d) => d <= today)
+
     return {
       pebbles: SEED_PEBBLES.map((p) => ({ ...p, created_at: now, updated_at: now })),
       souls: SEED_SOULS.map((s) => ({ ...s, created_at: now, updated_at: now })),
       collections: SEED_COLLECTIONS.map((c) => ({ ...c, created_at: now, updated_at: now })),
       pebbles_count: SEED_PEBBLES.length,
+      bounce: refreshBounceWindow(bounceWindow).bounce,
+      bounce_window: bounceWindow,
     }
   }
 
@@ -118,6 +149,20 @@ export class LocalProvider implements DataProvider {
   }
 
   // ---------------------------------------------------------------------------
+  // Bounce
+  // ---------------------------------------------------------------------------
+
+  async getBounce(): Promise<number> {
+    return this.store.bounce
+  }
+
+  async refreshBounce(): Promise<number> {
+    const { bounce, bounce_window } = refreshBounceWindow(this.store.bounce_window)
+    this.mutate({ ...this.store, bounce, bounce_window })
+    return bounce
+  }
+
+  // ---------------------------------------------------------------------------
   // Pebbles
   // ---------------------------------------------------------------------------
 
@@ -142,6 +187,7 @@ export class LocalProvider implements DataProvider {
       pebbles: [...this.store.pebbles, pebble],
       pebbles_count: this.store.pebbles_count + 1,
     })
+    await this.refreshBounce()
     return pebble
   }
 

--- a/lib/data/useBounce.ts
+++ b/lib/data/useBounce.ts
@@ -1,0 +1,13 @@
+"use client"
+
+import { useDataProvider } from "@/lib/data/provider-context"
+
+export function useBounce() {
+  const { store, loading } = useDataProvider()
+
+  return {
+    bounce: store.bounce,
+    bounceWindow: store.bounce_window,
+    loading,
+  }
+}


### PR DESCRIPTION
Resolves #65 

## Changes

- **lib/data/bounce-levels.ts** (new): Pure utility module for the bounce streak mechanic
  - `BOUNCE_WINDOW_DAYS` constant (28-day rolling window)
  - `BOUNCE_THRESHOLDS` table mapping active days to bounce levels (0–7)
  - `computeBounceLevel()`: Map active-day count to level
  - `todayLocal()`: Get today's date in `YYYY-MM-DD` format (local timezone)
  - `pruneWindow()`: Remove dates older than 28 days
  - `addTodayToWindow()`: Append today if not already present
  - `refreshBounceWindow()`: Full refresh (prune → add today → compute) for when a pebble is created
  - `decayBounceWindow()`: Decay-only (prune → compute) for app load without awarding a new active day

- **lib/data/data-provider.ts**: Extended `Store` type with `bounce` and `bounce_window` fields; added `getBounce()` and `refreshBounce()` interface methods

- **lib/data/local-provider.ts**: Integrated bounce mechanics
  - Updated `EMPTY_STORE` to include bounce fields
  - Migration logic: backfill bounce fields for existing users on load
  - Lazy decay: prune expired dates and recompute level on app open
  - Seed data: initialize demo users with ~5 recent dates to showcase the mechanic
  - `refreshBounce()` implementation: updates store and returns new bounce level
  - Auto-refresh bounce when a pebble is created

- **lib/data/useBounce.ts** (new): React hook to access bounce state from context

## Notes

- **No side effects**: All bounce logic is pure and decoupled from storage/provider details
- **Lazy decay on app load**: Inactive days naturally fall off without requiring a new pebble
- **Local timezone handling**: Uses `toLocaleDateString("en-CA")` for consistent `YYYY-MM-DD` format across timezones
- **Migration-safe**: Existing users get backfilled bounce fields on first load
- **Demo-friendly**: Seed data includes realistic bounce window dates so new users see the mechanic in action
- **Threshold table**: Sorted descending by `minDays` so first match wins; easy to adjust levels if needed

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01BhdPGqJ5UhogqRnhcYvmRt