### PR TITLE
feat(karma): add karma tracking system with event logging

### DIFF
--- a/lib/data/data-provider.ts
+++ b/lib/data/data-provider.ts
@@ -1,4 +1,4 @@
-import type { Pebble, Soul, Collection } from "@/lib/types"
+import type { Pebble, Soul, Collection, KarmaEvent } from "@/lib/types"
 
 // ---------------------------------------------------------------------------
 // Store snapshot — the in-memory representation of all persisted data.
@@ -10,6 +10,8 @@ export type Store = {
   souls: Soul[]
   collections: Collection[]
   pebbles_count: number
+  karma: number
+  karma_log: KarmaEvent[]
   bounce: number
   bounce_window: string[]
 }
@@ -43,6 +45,10 @@ export interface DataProvider {
   // Pebbles counter
   getPebblesCount(): Promise<number>
   incrementPebblesCount(): Promise<number>
+
+  // Karma
+  getKarma(): Promise<number>
+  incrementKarma(delta: number, reason: string, refId?: string): Promise<number>
 
   // Bounce
   getBounce(): Promise<number>

--- a/lib/data/local-provider.ts
+++ b/lib/data/local-provider.ts
@@ -8,7 +8,7 @@ import type {
   CreateCollectionInput,
   UpdateCollectionInput,
 } from "@/lib/data/data-provider"
-import type { Pebble, Soul, Collection } from "@/lib/types"
+import type { Pebble, Soul, Collection, KarmaEvent } from "@/lib/types"
 import { SEED_PEBBLES, SEED_SOULS, SEED_COLLECTIONS } from "@/lib/seed/seed-data"
 import { refreshBounceWindow, decayBounceWindow, todayLocal } from "@/lib/data/bounce-levels"
 
@@ -19,6 +19,8 @@ const EMPTY_STORE: Store = {
   souls: [],
   collections: [],
   pebbles_count: 0,
+  karma: 0,
+  karma_log: [],
   bounce: 0,
   bounce_window: [],
 }
@@ -52,6 +54,16 @@ export class LocalProvider implements DataProvider {
       // Migration: backfill pebbles_count for existing users.
       if (parsed.pebbles_count === undefined) {
         parsed.pebbles_count = parsed.pebbles.length
+      }
+      // Migration: backfill karma for existing users.
+      if (parsed.karma === undefined) {
+        parsed.karma = parsed.pebbles.length
+        parsed.karma_log = parsed.pebbles.map((p: Pebble) => ({
+          delta: 1,
+          reason: "pebble_created",
+          ref_id: p.id,
+          created_at: p.created_at,
+        }))
       }
       // Migration: backfill bounce fields for existing users.
       if (parsed.bounce === undefined) {
@@ -95,11 +107,20 @@ export class LocalProvider implements DataProvider {
     // Deduplicate in case offsets collapse (unlikely but safe).
     const bounceWindow = [...new Set(seedDates)].filter((d) => d <= today)
 
+    const pebbles = SEED_PEBBLES.map((p) => ({ ...p, created_at: now, updated_at: now }))
+
     return {
-      pebbles: SEED_PEBBLES.map((p) => ({ ...p, created_at: now, updated_at: now })),
+      pebbles,
       souls: SEED_SOULS.map((s) => ({ ...s, created_at: now, updated_at: now })),
       collections: SEED_COLLECTIONS.map((c) => ({ ...c, created_at: now, updated_at: now })),
       pebbles_count: SEED_PEBBLES.length,
+      karma: SEED_PEBBLES.length,
+      karma_log: pebbles.map((p) => ({
+        delta: 1,
+        reason: "pebble_created",
+        ref_id: p.id,
+        created_at: p.created_at,
+      })),
       bounce: refreshBounceWindow(bounceWindow).bounce,
       bounce_window: bounceWindow,
     }
@@ -149,6 +170,34 @@ export class LocalProvider implements DataProvider {
   }
 
   // ---------------------------------------------------------------------------
+  // Karma
+  // ---------------------------------------------------------------------------
+
+  async getKarma(): Promise<number> {
+    return this.store.karma
+  }
+
+  async incrementKarma(
+    delta: number,
+    reason: string,
+    refId?: string,
+  ): Promise<number> {
+    const event: KarmaEvent = {
+      delta,
+      reason,
+      ...(refId !== undefined && { ref_id: refId }),
+      created_at: new Date().toISOString(),
+    }
+    const next = this.store.karma + delta
+    this.mutate({
+      ...this.store,
+      karma: next,
+      karma_log: [...this.store.karma_log, event],
+    })
+    return next
+  }
+
+  // ---------------------------------------------------------------------------
   // Bounce
   // ---------------------------------------------------------------------------
 
@@ -182,10 +231,18 @@ export class LocalProvider implements DataProvider {
       created_at: now,
       updated_at: now,
     }
+    const karmaEvent: KarmaEvent = {
+      delta: 1,
+      reason: "pebble_created",
+      ref_id: pebble.id,
+      created_at: now,
+    }
     this.mutate({
       ...this.store,
       pebbles: [...this.store.pebbles, pebble],
       pebbles_count: this.store.pebbles_count + 1,
+      karma: this.store.karma + 1,
+      karma_log: [...this.store.karma_log, karmaEvent],
     })
     await this.refreshBounce()
     return pebble

--- a/lib/data/useKarma.ts
+++ b/lib/data/useKarma.ts
@@ -1,0 +1,13 @@
+"use client"
+
+import { useDataProvider } from "@/lib/data/provider-context"
+
+export function useKarma() {
+  const { store, loading } = useDataProvider()
+
+  return {
+    karma: store.karma,
+    karmaLog: store.karma_log,
+    loading,
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -43,3 +43,10 @@ export type Collection = {
   created_at: string
   updated_at: string
 }
+
+export type KarmaEvent = {
+  delta: number
+  reason: string
+  ref_id?: string
+  created_at: string
+}


### PR DESCRIPTION
Resolves #66 

## Changes

- **lib/types.ts**: Added `KarmaEvent` type to track karma changes with delta, reason, optional ref_id, and timestamp
- **lib/data/data-provider.ts**: 
  - Extended `Store` type with `karma` (number) and `karma_log` (KarmaEvent[]) fields
  - Added `getKarma()` and `incrementKarma(delta, reason, refId?)` methods to DataProvider interface
- **lib/data/local-provider.ts**:
  - Initialized karma fields in `EMPTY_STORE`
  - Added migration logic to backfill karma for existing users based on pebble count
  - Initialize karma and karma_log when creating new stores with seed data
  - Implemented `getKarma()` and `incrementKarma()` methods
  - Automatically log karma events when pebbles are created
- **lib/data/useKarma.ts**: Added new React hook to access karma and karma_log from the data provider context

## Notes

- Karma is initialized to the pebble count for both new users and during migration of existing users
- Each pebble creation automatically generates a karma event with reason "pebble_created"
- The `incrementKarma()` method accepts an optional `refId` parameter to link karma changes to specific entities
- Karma events are immutable and stored in chronological order for audit trail purposes
- The migration ensures backward compatibility with existing stored data

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01Ub22u8tWgr92fYELhUSPpZ