### PR TITLE
feat(path): add gamification stats display component

### DIFF
--- a/app/path/page.tsx
+++ b/app/path/page.tsx
@@ -5,6 +5,7 @@ import { useSouls } from "@/lib/data/useSouls"
 import { PebbleTimeline } from "@/components/path/PebbleTimeline"
 import { PathEmptyState } from "@/components/path/PathEmptyState"
 import { PebblesCounter } from "@/components/path/PebblesCounter"
+import { GamificationStats } from "@/components/path/GamificationStats"
 
 export default function PathPage() {
   const { pebbles, loading: pebblesLoading } = usePebbles()
@@ -17,6 +18,7 @@ export default function PathPage() {
       <h1 className="mb-6 text-2xl font-semibold">Path</h1>
 
       <PebblesCounter />
+      <GamificationStats />
 
       {loading ? (
         <p className="text-sm text-muted-foreground">Loading…</p>

--- a/components/path/GamificationStats.tsx
+++ b/components/path/GamificationStats.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { motion, useReducedMotion } from "framer-motion"
+import { useBounce } from "@/lib/data/useBounce"
+import { useKarma } from "@/lib/data/useKarma"
+
+function bounceLabel(level: number): string {
+  if (level === 0) return "Resting"
+  return String(level)
+}
+
+export function GamificationStats() {
+  const { bounce, loading: bounceLoading } = useBounce()
+  const { karma, loading: karmaLoading } = useKarma()
+  const prefersReducedMotion = useReducedMotion()
+
+  if (bounceLoading || karmaLoading) return null
+
+  return (
+    <motion.dl
+      className="mb-4 flex gap-4 text-xs text-muted-foreground"
+      aria-label="Gamification stats"
+      initial={prefersReducedMotion ? false : { opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.3, ease: "easeOut" }}
+    >
+      <div className="flex gap-1">
+        <dt>Bounce</dt>
+        <dd>{bounceLabel(bounce)}</dd>
+      </div>
+      <div className="flex gap-1">
+        <dt>Karma</dt>
+        <dd>{karma}</dd>
+      </div>
+    </motion.dl>
+  )
+}


### PR DESCRIPTION
Resolves #67 

## Changes
- Added new `GamificationStats` component (`components/path/GamificationStats.tsx`) that displays user bounce and karma statistics
  - Displays bounce level with "Resting" label when level is 0
  - Displays karma value
  - Includes fade-in animation with reduced motion support
  - Uses semantic HTML with `<dl>` for definition list structure
- Updated `app/path/page.tsx` to import and render the new `GamificationStats` component below the pebbles counter

## Notes
- Component uses `useBounce()` and `useKarma()` hooks to fetch gamification data
- Implements graceful loading state by returning `null` while data is being fetched
- Animation respects user's `prefers-reduced-motion` preference via `useReducedMotion()` hook
- Styled with existing design tokens (muted-foreground text color, consistent spacing)

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_018sGL3qK8vp6PW6nS8Zs1L6