### PR TITLE
feat(ui): add create, edit, and remove UI for collections

### DIFF
--- a/app/collections/[id]/page.tsx
+++ b/app/collections/[id]/page.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { use, useMemo } from "react"
+import { use, useMemo, useCallback } from "react"
 import Link from "next/link"
-import type { Pebble } from "@/lib/types"
+import type { Pebble, Collection } from "@/lib/types"
 import { useCollection } from "@/lib/data/useCollection"
+import { useCollections } from "@/lib/data/useCollections"
 import { usePebbles } from "@/lib/data/usePebbles"
 import { useSouls } from "@/lib/data/useSouls"
 import { CollectionDetailHeader } from "@/components/collections/CollectionDetailHeader"
@@ -17,6 +18,7 @@ export default function CollectionDetailPage({
 }) {
   const { id } = use(params)
   const { collection, loading: collectionLoading } = useCollection(id)
+  const { updateCollection } = useCollections()
   const { pebbles, loading: pebblesLoading } = usePebbles()
   const { souls, loading: soulsLoading } = useSouls()
 
@@ -29,6 +31,23 @@ export default function CollectionDetailPage({
       .map((pid) => pebbleMap.get(pid))
       .filter((p): p is Pebble => p != null)
   }, [collection, pebbles])
+
+  const handleEdit = useCallback(
+    async (data: { name: string; mode?: Collection["mode"] }) => {
+      await updateCollection(id, data)
+    },
+    [id, updateCollection],
+  )
+
+  const handleRemovePebble = useCallback(
+    async (pebbleId: string) => {
+      if (!collection) return
+      await updateCollection(id, {
+        pebble_ids: collection.pebble_ids.filter((pid) => pid !== pebbleId),
+      })
+    },
+    [id, collection, updateCollection],
+  )
 
   return (
     <section>
@@ -48,13 +67,18 @@ export default function CollectionDetailPage({
           <CollectionDetailHeader
             collection={collection}
             pebbleCount={resolvedPebbles.length}
+            onEdit={handleEdit}
           />
           {resolvedPebbles.length === 0 ? (
             <p className="py-10 text-center text-sm text-muted-foreground">
               No pebbles in this collection yet.
             </p>
           ) : (
-            <CollectionPebbleList pebbles={resolvedPebbles} souls={souls} />
+            <CollectionPebbleList
+              pebbles={resolvedPebbles}
+              souls={souls}
+              onRemove={handleRemovePebble}
+            />
           )}
         </>
       ) : (

--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -1,15 +1,40 @@
 "use client"
 
+import { useCallback } from "react"
+import { Plus } from "lucide-react"
 import { useCollections } from "@/lib/data/useCollections"
 import { CollectionList } from "@/components/collections/CollectionList"
 import { CollectionsEmptyState } from "@/components/collections/CollectionsEmptyState"
+import { CollectionFormDialog } from "@/components/collections/CollectionFormDialog"
+import { Button } from "@/components/ui/button"
+import type { Collection } from "@/lib/types"
 
 export default function CollectionsPage() {
-  const { collections, loading } = useCollections()
+  const { collections, loading, addCollection } = useCollections()
+
+  const handleCreate = useCallback(
+    async (data: { name: string; mode?: Collection["mode"] }) => {
+      await addCollection({ name: data.name, mode: data.mode, pebble_ids: [] })
+    },
+    [addCollection],
+  )
 
   return (
     <section>
-      <h1 className="mb-6 text-2xl font-semibold">Collections</h1>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Collections</h1>
+        <CollectionFormDialog
+          trigger={
+            <Button variant="outline" size="sm">
+              <Plus data-icon="inline-start" />
+              New
+            </Button>
+          }
+          title="New collection"
+          submitLabel="Create"
+          onSubmit={handleCreate}
+        />
+      </div>
 
       {loading ? (
         <p className="text-sm text-muted-foreground">Loading…</p>

--- a/components/collections/CollectionDetailHeader.tsx
+++ b/components/collections/CollectionDetailHeader.tsx
@@ -1,18 +1,41 @@
+import { Pencil } from "lucide-react"
 import type { Collection } from "@/lib/types"
 import { ModeBadge } from "@/components/collections/ModeBadge"
+import { CollectionFormDialog } from "@/components/collections/CollectionFormDialog"
+import { Button } from "@/components/ui/button"
 
 type CollectionDetailHeaderProps = {
   collection: Collection
   pebbleCount: number
+  onEdit: (data: { name: string; mode?: Collection["mode"] }) => void
 }
 
 export function CollectionDetailHeader({
   collection,
   pebbleCount,
+  onEdit,
 }: CollectionDetailHeaderProps) {
   return (
     <header className="mb-6">
-      <h1 className="text-2xl font-semibold">{collection.name}</h1>
+      <div className="flex items-center gap-2">
+        <h1 className="text-2xl font-semibold">{collection.name}</h1>
+        <CollectionFormDialog
+          trigger={
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Edit collection"
+            >
+              <Pencil />
+            </Button>
+          }
+          title="Edit collection"
+          submitLabel="Save"
+          initialName={collection.name}
+          initialMode={collection.mode}
+          onSubmit={onEdit}
+        />
+      </div>
 
       <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
         <ModeBadge mode={collection.mode} />

--- a/components/collections/CollectionFormDialog.tsx
+++ b/components/collections/CollectionFormDialog.tsx
@@ -1,0 +1,120 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import type { Collection } from "@/lib/types"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { MODE_META } from "@/components/collections/ModeBadge"
+
+type CollectionFormDialogProps = {
+  trigger: React.ReactElement
+  title: string
+  submitLabel: string
+  initialName?: string
+  initialMode?: Collection["mode"]
+  onSubmit: (data: { name: string; mode?: Collection["mode"] }) => void
+}
+
+const MODES = Object.entries(MODE_META) as [
+  NonNullable<Collection["mode"]>,
+  { emoji: string; label: string },
+][]
+
+export function CollectionFormDialog({
+  trigger,
+  title,
+  submitLabel,
+  initialName = "",
+  initialMode,
+  onSubmit,
+}: CollectionFormDialogProps) {
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState(initialName)
+  const [mode, setMode] = useState<Collection["mode"]>(initialMode)
+
+  const resetForm = useCallback(() => {
+    setName(initialName)
+    setMode(initialMode)
+  }, [initialName, initialMode])
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen)
+      if (nextOpen) resetForm()
+    },
+    [resetForm],
+  )
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    onSubmit({ name: trimmed, mode })
+    setOpen(false)
+  }, [name, mode, onSubmit])
+
+  const canSubmit = name.trim().length > 0
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogTrigger render={trigger} />
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+        </AlertDialogHeader>
+
+        <div className="grid gap-4">
+          <div className="grid gap-1.5">
+            <label htmlFor="collection-name" className="text-sm font-medium">
+              Name
+            </label>
+            <Input
+              id="collection-name"
+              placeholder="e.g. Morning gratitudes"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && canSubmit) handleSubmit()
+              }}
+              autoFocus
+            />
+          </div>
+
+          <fieldset className="grid gap-1.5">
+            <legend className="text-sm font-medium">Mode (optional)</legend>
+            <div className="flex gap-2">
+              {MODES.map(([key, meta]) => (
+                <Button
+                  key={key}
+                  type="button"
+                  variant={mode === key ? "secondary" : "outline"}
+                  size="sm"
+                  onClick={() => setMode(mode === key ? undefined : key)}
+                  aria-pressed={mode === key}
+                >
+                  <span aria-hidden="true">{meta.emoji}</span> {meta.label}
+                </Button>
+              ))}
+            </div>
+          </fieldset>
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction disabled={!canSubmit} onClick={handleSubmit}>
+            {submitLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/components/collections/CollectionPebbleList.tsx
+++ b/components/collections/CollectionPebbleList.tsx
@@ -1,31 +1,47 @@
 "use client"
 
+import { X } from "lucide-react"
 import type { Pebble, Soul } from "@/lib/types"
 import { useLookupMaps } from "@/lib/data/useLookupMaps"
 import { PebbleCard } from "@/components/path/PebbleCard"
+import { Button } from "@/components/ui/button"
 
 type CollectionPebbleListProps = {
   pebbles: Pebble[]
   souls: Soul[]
+  onRemove?: (pebbleId: string) => void
 }
 
 export function CollectionPebbleList({
   pebbles,
   souls,
+  onRemove,
 }: CollectionPebbleListProps) {
   const { emotionMap, soulMap } = useLookupMaps(souls)
 
   return (
     <ul className="flex flex-col gap-2">
       {pebbles.map((pebble) => (
-        <li key={pebble.id}>
-          <PebbleCard
-            pebble={pebble}
-            emotion={emotionMap.get(pebble.emotion_id)}
-            soulNames={pebble.soul_ids
-              .map((id) => soulMap.get(id)?.name)
-              .filter((name): name is string => name != null)}
-          />
+        <li key={pebble.id} className="flex items-center gap-2">
+          <div className="min-w-0 flex-1">
+            <PebbleCard
+              pebble={pebble}
+              emotion={emotionMap.get(pebble.emotion_id)}
+              soulNames={pebble.soul_ids
+                .map((id) => soulMap.get(id)?.name)
+                .filter((name): name is string => name != null)}
+            />
+          </div>
+          {onRemove && (
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              aria-label={`Remove ${pebble.name} from collection`}
+              onClick={() => onRemove(pebble.id)}
+            >
+              <X />
+            </Button>
+          )}
         </li>
       ))}
     </ul>

--- a/components/collections/ModeBadge.tsx
+++ b/components/collections/ModeBadge.tsx
@@ -1,7 +1,7 @@
 import type { Collection } from "@/lib/types"
 import { Badge } from "@/components/ui/badge"
 
-const MODE_META: Record<
+export const MODE_META: Record<
   NonNullable<Collection["mode"]>,
   { emoji: string; label: string }
 > = {


### PR DESCRIPTION
Resolves #81

## Summary

- **Create collection**: Added a "New" button on `/collections` that opens a dialog with name input and mode selector (stack/pack/track)
- **Edit collection**: Added a pencil edit button on `/collections/[id]` detail header that opens a pre-filled dialog to change name and mode
- **Remove pebbles**: Added an X button on each pebble card in the collection detail view to remove it from the collection
- **Count recomputation**: Collection count updates reactively when pebbles are removed (no additional work needed — already handled by the reactive data flow)

## Key files changed

| File | Change |
|------|--------|
| `components/collections/CollectionFormDialog.tsx` | New reusable AlertDialog form for create/edit |
| `components/collections/ModeBadge.tsx` | Exported `MODE_META` for reuse |
| `app/collections/page.tsx` | Added create button + dialog |
| `components/collections/CollectionDetailHeader.tsx` | Added edit trigger + dialog |
| `components/collections/CollectionPebbleList.tsx` | Added remove button per pebble |
| `app/collections/[id]/page.tsx` | Wired edit + remove handlers |

## Test plan

- [ ] On `/collections`, click "New", fill name + optional mode, submit → new collection appears in list
- [ ] On `/collections/[id]`, click pencil, change name/mode, save → header updates
- [ ] On `/collections/[id]`, click X on a pebble → pebble removed, count updates
- [ ] Remove all pebbles → "No pebbles in this collection yet" empty state shows
- [ ] Cancel/dismiss dialogs → no changes persisted, form resets on reopen
- [ ] Keyboard navigation works for all interactive elements

https://claude.ai/code/session_014StQuF9kYsenS3gaBBv5xv