### PR TITLE
feat(ui): add glyph management pages and navigation

### DIFF
--- a/app/carve/page.tsx
+++ b/app/carve/page.tsx
@@ -1,23 +1,26 @@
 "use client"
 
+import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { CarveEditor } from "@/components/carve/CarveEditor"
 
 export default function CarvePage() {
+  const router = useRouter()
+
   return (
     <section>
       <nav className="mb-6">
         <Link
-          href="/path"
+          href="/glyphs"
           className="text-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
-          &larr; Back to Path
+          &larr; Back to Glyphs
         </Link>
       </nav>
 
-      <h1 className="mb-6 text-2xl font-semibold">Carve a mark</h1>
+      <h1 className="mb-6 text-2xl font-semibold">Carve a glyph</h1>
 
-      <CarveEditor />
+      <CarveEditor onSaved={() => router.push("/glyphs")} />
     </section>
   )
 }

--- a/app/glyphs/[id]/page.tsx
+++ b/app/glyphs/[id]/page.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { use } from "react"
+import { useRouter } from "next/navigation"
+import Link from "next/link"
+import { useMark } from "@/lib/data/useMark"
+import { useMarks } from "@/lib/data/useMarks"
+import { GlyphDetail } from "@/components/glyphs/GlyphDetail"
+import { GlyphNotFound } from "@/components/glyphs/GlyphNotFound"
+
+export default function GlyphDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = use(params)
+  const { mark, loading } = useMark(id)
+  const { removeMark } = useMarks()
+  const router = useRouter()
+
+  const handleDelete = async () => {
+    await removeMark(id)
+    router.push("/glyphs")
+  }
+
+  return (
+    <section>
+      <nav className="mb-6">
+        <Link
+          href="/glyphs"
+          className="text-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          &larr; Back to Glyphs
+        </Link>
+      </nav>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : mark ? (
+        <GlyphDetail mark={mark} onDelete={handleDelete} />
+      ) : (
+        <GlyphNotFound />
+      )}
+    </section>
+  )
+}

--- a/app/glyphs/page.tsx
+++ b/app/glyphs/page.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import Link from "next/link"
+import { useMarks } from "@/lib/data/useMarks"
+import { GlyphList } from "@/components/glyphs/GlyphList"
+import { GlyphsEmptyState } from "@/components/glyphs/GlyphsEmptyState"
+
+export default function GlyphsPage() {
+  const { marks, loading } = useMarks()
+
+  return (
+    <section>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Glyphs</h1>
+        {marks.length > 0 && (
+          <Link
+            href="/carve"
+            className="text-sm font-medium text-primary underline underline-offset-4 hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            Carve new glyph
+          </Link>
+        )}
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : marks.length === 0 ? (
+        <GlyphsEmptyState />
+      ) : (
+        <GlyphList marks={marks} />
+      )}
+    </section>
+  )
+}

--- a/components/carve/CarveEditor.tsx
+++ b/components/carve/CarveEditor.tsx
@@ -82,14 +82,14 @@ export function CarveEditor({ onSaved }: CarveEditorProps) {
   if (saved) {
     return (
       <motion.section
-        aria-label="Mark saved"
+        aria-label="Glyph saved"
         className="flex flex-col items-center gap-6 py-8"
         initial={prefersReducedMotion ? false : { scale: 0.9, opacity: 0 }}
         animate={{ scale: 1, opacity: 1 }}
         transition={{ type: "spring", stiffness: 300, damping: 25 }}
       >
         <p className="text-lg font-medium" aria-live="polite">
-          Mark saved
+          Glyph saved
         </p>
         <svg
           viewBox={shape.viewBox}
@@ -122,7 +122,7 @@ export function CarveEditor({ onSaved }: CarveEditorProps) {
           onClick={handleNewMark}
           className="text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
         >
-          Create another mark
+          Create another glyph
         </button>
       </motion.section>
     )

--- a/components/glyphs/GlyphCard.tsx
+++ b/components/glyphs/GlyphCard.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link"
+import { PEBBLE_SHAPES } from "@/lib/config"
+import type { Mark } from "@/lib/types"
+import { GlyphPreview } from "@/components/glyphs/GlyphPreview"
+
+type GlyphCardProps = {
+  mark: Mark
+}
+
+export function GlyphCard({ mark }: GlyphCardProps) {
+  const shape = PEBBLE_SHAPES.find((s) => s.id === mark.shape_id)
+  const created = new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+  }).format(new Date(mark.created_at))
+
+  return (
+    <article>
+      <Link
+        href={`/glyphs/${mark.id}`}
+        className="flex items-center gap-4 rounded-lg border border-border px-4 py-3 transition-all duration-100 hover:bg-muted/50 active:scale-[0.98] focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+      >
+        <GlyphPreview
+          mark={mark}
+          className="w-14 shrink-0 aspect-square"
+        />
+
+        <div className="min-w-0">
+          <h3 className="text-sm font-medium truncate">
+            {mark.name || "Untitled glyph"}
+          </h3>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            {shape && <span>{shape.name}</span>}
+            <span>{created}</span>
+          </div>
+        </div>
+      </Link>
+    </article>
+  )
+}

--- a/components/glyphs/GlyphDetail.tsx
+++ b/components/glyphs/GlyphDetail.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { Trash2 } from "lucide-react"
+import { PEBBLE_SHAPES } from "@/lib/config"
+import type { Mark } from "@/lib/types"
+import { GlyphPreview } from "@/components/glyphs/GlyphPreview"
+import { Button } from "@/components/ui/button"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+
+type GlyphDetailProps = {
+  mark: Mark
+  onDelete: () => void
+}
+
+export function GlyphDetail({ mark, onDelete }: GlyphDetailProps) {
+  const shape = PEBBLE_SHAPES.find((s) => s.id === mark.shape_id)
+  const created = new Intl.DateTimeFormat(undefined, {
+    dateStyle: "long",
+  }).format(new Date(mark.created_at))
+
+  return (
+    <article>
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold">
+          {mark.name || "Untitled glyph"}
+        </h1>
+
+        <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          {shape && <span>{shape.name}</span>}
+          <span aria-label={`${mark.strokes.length} strokes`}>
+            {mark.strokes.length}{" "}
+            {mark.strokes.length === 1 ? "stroke" : "strokes"}
+          </span>
+          <time dateTime={mark.created_at}>{created}</time>
+        </div>
+      </header>
+
+      <div className="flex justify-center">
+        <GlyphPreview
+          mark={mark}
+          className="w-full max-w-[240px] aspect-square"
+        />
+      </div>
+
+      <div className="mt-8 flex justify-center">
+        <AlertDialog>
+          <AlertDialogTrigger
+            render={
+              <Button variant="outline" size="sm">
+                <Trash2 className="size-4" aria-hidden="true" />
+                Delete glyph
+              </Button>
+            }
+          />
+          <AlertDialogContent size="sm">
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete this glyph?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This action cannot be undone. The glyph will be permanently
+                removed.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction variant="destructive" onClick={onDelete}>
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    </article>
+  )
+}

--- a/components/glyphs/GlyphList.tsx
+++ b/components/glyphs/GlyphList.tsx
@@ -1,0 +1,18 @@
+import type { Mark } from "@/lib/types"
+import { GlyphCard } from "@/components/glyphs/GlyphCard"
+
+type GlyphListProps = {
+  marks: Mark[]
+}
+
+export function GlyphList({ marks }: GlyphListProps) {
+  return (
+    <ul className="flex flex-col gap-2">
+      {marks.map((mark) => (
+        <li key={mark.id}>
+          <GlyphCard mark={mark} />
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/components/glyphs/GlyphNotFound.tsx
+++ b/components/glyphs/GlyphNotFound.tsx
@@ -1,0 +1,12 @@
+import { NotFoundCard } from "@/components/layout/NotFoundCard"
+
+export function GlyphNotFound() {
+  return (
+    <NotFoundCard
+      title="Glyph not found"
+      description="This glyph doesn't exist or may have been removed."
+      href="/glyphs"
+      linkText="Back to Glyphs"
+    />
+  )
+}

--- a/components/glyphs/GlyphPreview.tsx
+++ b/components/glyphs/GlyphPreview.tsx
@@ -1,0 +1,40 @@
+import { PEBBLE_SHAPES } from "@/lib/config"
+import type { Mark } from "@/lib/types"
+import { PebbleOutline } from "@/components/carve/PebbleOutline"
+import { StrokeRenderer } from "@/components/carve/StrokeRenderer"
+
+type GlyphPreviewProps = {
+  mark: Mark
+  className?: string
+}
+
+export function GlyphPreview({ mark, className }: GlyphPreviewProps) {
+  const shape = PEBBLE_SHAPES.find((s) => s.id === mark.shape_id)
+
+  if (!shape) {
+    return (
+      <svg
+        viewBox={mark.viewBox}
+        className={className}
+        aria-hidden="true"
+      >
+        <StrokeRenderer strokes={mark.strokes} />
+      </svg>
+    )
+  }
+
+  const clipId = `glyph-${mark.id}`
+
+  return (
+    <svg
+      viewBox={shape.viewBox}
+      className={className}
+      aria-hidden="true"
+    >
+      <PebbleOutline shape={shape} clipId={clipId} />
+      <g clipPath={`url(#${clipId})`}>
+        <StrokeRenderer strokes={mark.strokes} />
+      </g>
+    </svg>
+  )
+}

--- a/components/glyphs/GlyphsEmptyState.tsx
+++ b/components/glyphs/GlyphsEmptyState.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link"
+import { EmptyState } from "@/components/layout/EmptyState"
+
+export function GlyphsEmptyState() {
+  return (
+    <EmptyState
+      title="No glyphs yet"
+      description="Glyphs are symbols you carve on pebble surfaces. Create your first one."
+      action={
+        <Link
+          href="/carve"
+          className="text-sm font-medium text-primary underline underline-offset-4 hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          Carve a glyph
+        </Link>
+      }
+    />
+  )
+}

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -145,6 +145,33 @@
       "platforms": ["web", "ios", "android"]
     },
     {
+      "id": "V-glyphs-list",
+      "project_id": "pebbles",
+      "species": "view",
+      "title": "Glyphs",
+      "description": "Browse all user-created glyphs (carved marks on pebble shapes).",
+      "status": "idea",
+      "platforms": ["web", "ios", "android"]
+    },
+    {
+      "id": "V-glyph-detail",
+      "project_id": "pebbles",
+      "species": "view",
+      "title": "Glyph Detail",
+      "description": "View a single glyph with full SVG preview and metadata.",
+      "status": "idea",
+      "platforms": ["web", "ios", "android"]
+    },
+    {
+      "id": "V-glyph-carve",
+      "project_id": "pebbles",
+      "species": "view",
+      "title": "Carve Glyph",
+      "description": "Draw a new glyph on a pebble surface using the carve editor.",
+      "status": "idea",
+      "platforms": ["web", "ios", "android"]
+    },
+    {
       "id": "V-bounce-tempo",
       "project_id": "pebbles",
       "species": "view",
@@ -386,6 +413,36 @@
       }
     },
     {
+      "id": "F-manage-glyphs",
+      "project_id": "pebbles",
+      "species": "flow",
+      "title": "Manage Glyphs",
+      "description": "Browse, carve, and view glyphs (custom marks on pebble shapes).",
+      "status": "idea",
+      "platforms": ["web", "ios", "android"],
+      "metadata": {
+        "playlist": {
+          "entries": [
+            { "type": "view", "view_id": "V-glyphs-list" },
+            {
+              "type": "junction",
+              "label": "Glyph action?",
+              "cases": [
+                {
+                  "label": "View glyph",
+                  "entries": [{ "type": "view", "view_id": "V-glyph-detail" }]
+                },
+                {
+                  "label": "Carve glyph",
+                  "entries": [{ "type": "view", "view_id": "V-glyph-carve" }]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "F-weekly-wrap",
       "project_id": "pebbles",
       "species": "flow",
@@ -550,6 +607,42 @@
       "species": "data-model",
       "title": "Achievement",
       "description": "Unlockable reward earned through collecting and engagement.",
+      "status": "idea",
+      "platforms": ["web", "ios", "android"]
+    },
+    {
+      "id": "DM-mark",
+      "project_id": "pebbles",
+      "species": "data-model",
+      "title": "Mark",
+      "description": "A user-drawn glyph on a pebble shape, stored as SVG strokes.",
+      "status": "idea",
+      "platforms": ["web", "ios", "android"]
+    },
+    {
+      "id": "API-get-marks",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "GET /marks",
+      "description": "Retrieve all user marks (glyphs).",
+      "status": "idea",
+      "platforms": ["web", "ios", "android"]
+    },
+    {
+      "id": "API-create-mark",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "POST /marks",
+      "description": "Create a new mark (glyph).",
+      "status": "idea",
+      "platforms": ["web", "ios", "android"]
+    },
+    {
+      "id": "API-delete-mark",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "DELETE /marks/:id",
+      "description": "Delete a mark (glyph) by ID.",
       "status": "idea",
       "platforms": ["web", "ios", "android"]
     },
@@ -852,6 +945,18 @@
     { "id": "e-API-get-monthly-cairn-DM-pebble", "project_id": "pebbles", "source_id": "API-get-monthly-cairn", "target_id": "DM-pebble", "edge_type": "queries" },
     { "id": "e-API-register-DM-user", "project_id": "pebbles", "source_id": "API-register", "target_id": "DM-user", "edge_type": "queries" },
     { "id": "e-API-login-DM-user", "project_id": "pebbles", "source_id": "API-login", "target_id": "DM-user", "edge_type": "queries" },
-    { "id": "e-API-get-collection-rise-DM-collection", "project_id": "pebbles", "source_id": "API-get-collection-rise", "target_id": "DM-collection", "edge_type": "queries" }
+    { "id": "e-API-get-collection-rise-DM-collection", "project_id": "pebbles", "source_id": "API-get-collection-rise", "target_id": "DM-collection", "edge_type": "queries" },
+    { "id": "e-V-home-F-manage-glyphs", "project_id": "pebbles", "source_id": "V-home", "target_id": "F-manage-glyphs", "edge_type": "composes" },
+    { "id": "e-F-manage-glyphs-V-glyphs-list", "project_id": "pebbles", "source_id": "F-manage-glyphs", "target_id": "V-glyphs-list", "edge_type": "composes" },
+    { "id": "e-F-manage-glyphs-V-glyph-detail", "project_id": "pebbles", "source_id": "F-manage-glyphs", "target_id": "V-glyph-detail", "edge_type": "composes" },
+    { "id": "e-F-manage-glyphs-V-glyph-carve", "project_id": "pebbles", "source_id": "F-manage-glyphs", "target_id": "V-glyph-carve", "edge_type": "composes" },
+    { "id": "e-V-glyphs-list-API-get-marks", "project_id": "pebbles", "source_id": "V-glyphs-list", "target_id": "API-get-marks", "edge_type": "calls" },
+    { "id": "e-V-glyph-carve-API-create-mark", "project_id": "pebbles", "source_id": "V-glyph-carve", "target_id": "API-create-mark", "edge_type": "calls" },
+    { "id": "e-V-glyph-detail-API-delete-mark", "project_id": "pebbles", "source_id": "V-glyph-detail", "target_id": "API-delete-mark", "edge_type": "calls" },
+    { "id": "e-V-glyphs-list-DM-mark", "project_id": "pebbles", "source_id": "V-glyphs-list", "target_id": "DM-mark", "edge_type": "displays" },
+    { "id": "e-V-glyph-detail-DM-mark", "project_id": "pebbles", "source_id": "V-glyph-detail", "target_id": "DM-mark", "edge_type": "displays" },
+    { "id": "e-API-get-marks-DM-mark", "project_id": "pebbles", "source_id": "API-get-marks", "target_id": "DM-mark", "edge_type": "queries" },
+    { "id": "e-API-create-mark-DM-mark", "project_id": "pebbles", "source_id": "API-create-mark", "target_id": "DM-mark", "edge_type": "queries" },
+    { "id": "e-API-delete-mark-DM-mark", "project_id": "pebbles", "source_id": "API-delete-mark", "target_id": "DM-mark", "edge_type": "queries" }
   ]
 }

--- a/lib/config/navigation.ts
+++ b/lib/config/navigation.ts
@@ -1,4 +1,4 @@
-import { Route, CirclePlus, FolderOpen } from "lucide-react"
+import { Route, CirclePlus, FolderOpen, Fingerprint } from "lucide-react"
 
 export const NAV_ITEMS: ReadonlyArray<{
   href: string
@@ -9,4 +9,5 @@ export const NAV_ITEMS: ReadonlyArray<{
   { href: "/path", label: "Path", icon: Route },
   { href: "/record", label: "Record", icon: CirclePlus, primary: true },
   { href: "/collections", label: "Collections", icon: FolderOpen },
+  { href: "/glyphs", label: "Glyphs", icon: Fingerprint },
 ]


### PR DESCRIPTION
Resolves #84

## Summary

- Add `/glyphs` list page displaying all user-created glyphs with SVG previews
- Add `/glyphs/[id]` detail page with large preview, metadata, and delete with confirmation
- Add `Glyphs` entry (Fingerprint icon) to main navigation (sidebar + bottom nav)
- Update `/carve` page: back link → `/glyphs`, heading → "Carve a glyph", redirect to `/glyphs` after save
- Rename "mark" → "glyph" in user-facing text within `CarveEditor`
- Update Arkaik bundle with glyphs views, flow, data model, API endpoints, and edges

### Key files

- `components/glyphs/` — `GlyphPreview`, `GlyphCard`, `GlyphList`, `GlyphDetail`, `GlyphsEmptyState`, `GlyphNotFound`
- `app/glyphs/page.tsx` — list route
- `app/glyphs/[id]/page.tsx` — detail route
- `app/carve/page.tsx` — updated with redirect and text
- `lib/config/navigation.ts` — added Glyphs nav item

### Implementation notes

- Reuses existing `useMarks` / `useMark` hooks — no data layer changes needed
- Follows the `collections` pattern for page structure, components, and routing
- `GlyphPreview` reuses `PebbleOutline` + `StrokeRenderer` from `components/carve/`
- Delete uses `AlertDialog` confirmation dialog

## Test plan

- [ ] Navigate to `/glyphs` from sidebar and bottom nav
- [ ] Verify empty state shows "Carve a glyph" CTA linking to `/carve`
- [ ] Carve a glyph → confirm redirect to `/glyphs` with new glyph in list
- [ ] Click glyph card → verify `/glyphs/[id]` detail shows SVG preview + metadata
- [ ] Delete glyph from detail → confirm redirect to `/glyphs` and glyph is removed
- [ ] Verify back links work on detail page and carve page
- [ ] Verify keyboard navigation and focus management

https://claude.ai/code/session_017DefayLkeQLoCUQiMrabVX