### PR TITLE
feat(core): introduce glyph step in record flow

### DIFF
--- a/components/carve/CarveToolbar.tsx
+++ b/components/carve/CarveToolbar.tsx
@@ -11,6 +11,7 @@ type CarveToolbarProps = {
   onWidthChange: (width: number) => void
   onSave: () => void
   saving: boolean
+  showSave?: boolean
 }
 
 const WIDTH_OPTIONS = [
@@ -27,6 +28,7 @@ export function CarveToolbar({
   onWidthChange,
   onSave,
   saving,
+  showSave = true,
 }: CarveToolbarProps) {
   return (
     <nav
@@ -81,17 +83,21 @@ export function CarveToolbar({
         ))}
       </div>
 
-      <div className="flex-1" />
+      {showSave && (
+        <>
+          <div className="flex-1" />
 
-      <Button
-        onClick={onSave}
-        disabled={strokeCount === 0 || saving}
-        aria-label="Save mark"
-        className="h-11 px-4 md:h-8 md:px-2.5"
-      >
-        <Check className="mr-1.5 h-4 w-4" />
-        {saving ? "Saving\u2026" : "Save mark"}
-      </Button>
+          <Button
+            onClick={onSave}
+            disabled={strokeCount === 0 || saving}
+            aria-label="Save mark"
+            className="h-11 px-4 md:h-8 md:px-2.5"
+          >
+            <Check className="mr-1.5 h-4 w-4" />
+            {saving ? "Saving\u2026" : "Save mark"}
+          </Button>
+        </>
+      )}
     </nav>
   )
 }

--- a/components/record/MarkSelector.tsx
+++ b/components/record/MarkSelector.tsx
@@ -1,0 +1,107 @@
+"use client"
+
+import { useCallback, useRef } from "react"
+import { cn } from "@/lib/utils"
+import type { Mark } from "@/lib/types"
+import { GlyphPreview } from "@/components/glyphs/GlyphPreview"
+
+type MarkSelectorProps = {
+  marks: Mark[]
+  selectedMarkId?: string
+  onSelect: (markId: string) => void
+}
+
+const COLS = 3
+
+export function MarkSelector({ marks, selectedMarkId, onSelect }: MarkSelectorProps) {
+  const groupRef = useRef<HTMLUListElement>(null)
+
+  const focusIndex = useCallback((index: number) => {
+    const buttons = groupRef.current?.querySelectorAll<HTMLButtonElement>("button")
+    buttons?.[index]?.focus()
+  }, [])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const buttons = groupRef.current?.querySelectorAll<HTMLButtonElement>("button")
+      if (!buttons || buttons.length === 0) return
+      const currentIdx = Array.from(buttons).indexOf(e.target as HTMLButtonElement)
+      if (currentIdx === -1) return
+
+      let next = currentIdx
+
+      switch (e.key) {
+        case "ArrowRight":
+          e.preventDefault()
+          next = (currentIdx + 1) % marks.length
+          break
+        case "ArrowLeft":
+          e.preventDefault()
+          next = (currentIdx - 1 + marks.length) % marks.length
+          break
+        case "ArrowDown":
+          e.preventDefault()
+          next = (currentIdx + COLS) % marks.length
+          break
+        case "ArrowUp":
+          e.preventDefault()
+          next = (currentIdx - COLS + marks.length) % marks.length
+          break
+        default:
+          return
+      }
+
+      focusIndex(next)
+    },
+    [focusIndex, marks.length],
+  )
+
+  if (marks.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No glyphs yet. Draw one above!
+      </p>
+    )
+  }
+
+  const selectedIndex = marks.findIndex((m) => m.id === selectedMarkId)
+
+  return (
+    <ul
+      ref={groupRef}
+      role="radiogroup"
+      aria-label="Select an existing glyph"
+      className="grid grid-cols-3 gap-3"
+      onKeyDown={handleKeyDown}
+    >
+      {marks.map((mark, i) => {
+        const isSelected = mark.id === selectedMarkId
+        return (
+          <li key={mark.id}>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              aria-label={mark.name || "Untitled glyph"}
+              tabIndex={isSelected ? 0 : (selectedIndex === -1 && i === 0 ? 0 : -1)}
+              onClick={() => onSelect(mark.id)}
+              className={cn(
+                "flex w-full items-center justify-center rounded-lg p-3",
+                "transition-all duration-100 active:scale-[0.95]",
+                "outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                isSelected
+                  ? "bg-primary/10 ring-2 ring-primary"
+                  : "bg-muted/50 hover:bg-muted",
+              )}
+            >
+              <GlyphPreview
+                mark={mark}
+                className="h-16 w-16"
+              />
+            </button>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/components/record/RecordStepper.tsx
+++ b/components/record/RecordStepper.tsx
@@ -14,6 +14,7 @@ import { StepIntensity } from "@/components/record/StepIntensity"
 import { StepEmotion } from "@/components/record/StepEmotion"
 import { StepSouls } from "@/components/record/StepSouls"
 import { StepDomains } from "@/components/record/StepDomains"
+import { StepGlyph } from "@/components/record/StepGlyph"
 import { StepCardPicker } from "@/components/record/StepCardPicker"
 import { StepCardFiller } from "@/components/record/StepCardFiller"
 import { StepSummary } from "@/components/record/StepSummary"
@@ -27,6 +28,7 @@ const FIXED_STEPS: StepConfig[] = [
   { label: "Emotion", Component: StepEmotion, canAdvance: (d) => d.emotion_id !== "" },
   { label: "Souls", Component: StepSouls, canAdvance: () => true },
   { label: "Domains", Component: StepDomains, canAdvance: () => true },
+  { label: "Glyph", Component: StepGlyph, canAdvance: () => true },
   { label: "Cards", Component: StepCardPicker, canAdvance: () => true },
 ]
 

--- a/components/record/ReviewSummary.tsx
+++ b/components/record/ReviewSummary.tsx
@@ -2,9 +2,11 @@
 
 import type { RecordFormData } from "@/components/record/types"
 import { useSouls } from "@/lib/data/useSouls"
+import { useMarks } from "@/lib/data/useMarks"
 import { EMOTIONS, DOMAINS, CARD_TYPES } from "@/lib/config"
 import { IntensityDots, PositivenessIndicator } from "@/components/pebble/PebbleIndicators"
 import { Badge } from "@/components/ui/badge"
+import { GlyphPreview } from "@/components/glyphs/GlyphPreview"
 import { shortDateTimeFormatter } from "@/lib/utils/formatters"
 import type { Soul } from "@/lib/types"
 
@@ -14,8 +16,10 @@ type ReviewSummaryProps = {
 
 export function ReviewSummary({ data }: ReviewSummaryProps) {
   const { souls } = useSouls()
+  const { marks } = useMarks()
 
   const emotion = EMOTIONS.find((e) => e.id === data.emotion_id)
+  const selectedMark = data.mark_id ? marks.find((m) => m.id === data.mark_id) : undefined
   const domains = DOMAINS.filter((d) => data.domain_ids.includes(d.id))
   const matchedSouls = data.soul_ids
     .map((id) => souls.find((s) => s.id === id))
@@ -101,6 +105,19 @@ export function ReviewSummary({ data }: ReviewSummaryProps) {
               {domains.map((domain) => (
                 <Badge key={domain.id} variant="outline">{domain.name}</Badge>
               ))}
+            </dd>
+          </>
+        )}
+
+        {/* Glyph */}
+        {selectedMark && (
+          <>
+            <dt className="text-muted-foreground">Glyph</dt>
+            <dd>
+              <GlyphPreview
+                mark={selectedMark}
+                className="h-10 w-10"
+              />
             </dd>
           </>
         )}

--- a/components/record/StepGlyph.tsx
+++ b/components/record/StepGlyph.tsx
@@ -1,0 +1,247 @@
+"use client"
+
+import { useCallback, useMemo, useState } from "react"
+import { Check } from "lucide-react"
+import { PEBBLE_SHAPES } from "@/lib/config"
+import type { MarkStroke } from "@/lib/types"
+import { useMarks } from "@/lib/data/useMarks"
+import { useHaptics } from "@/lib/hooks/useHaptics"
+import { Button } from "@/components/ui/button"
+import { DrawingCanvas } from "@/components/carve/DrawingCanvas"
+import { CarveToolbar } from "@/components/carve/CarveToolbar"
+import { StampPicker } from "@/components/carve/StampPicker"
+import { GlyphPreview } from "@/components/glyphs/GlyphPreview"
+import { MarkSelector } from "@/components/record/MarkSelector"
+import type { RecordStepProps } from "@/components/record/types"
+
+type Mode = "draw" | "select"
+
+export function StepGlyph({ data, onUpdate }: RecordStepProps) {
+  const { marks, addMark } = useMarks()
+  const { vibrate } = useHaptics()
+
+  const [mode, setMode] = useState<Mode>("draw")
+  const [strokes, setStrokes] = useState<MarkStroke[]>([])
+  const [strokeWidth, setStrokeWidth] = useState(4)
+  const [saving, setSaving] = useState(false)
+  const [confirmed, setConfirmed] = useState(false)
+
+  const shape = useMemo(
+    () => PEBBLE_SHAPES[Math.floor(Math.random() * PEBBLE_SHAPES.length)],
+    [],
+  )
+
+  // Find the currently selected mark for preview
+  const selectedMark = useMemo(
+    () => marks.find((m) => m.id === data.mark_id),
+    [marks, data.mark_id],
+  )
+
+  const handleStrokeComplete = useCallback(
+    (stroke: MarkStroke) => {
+      setStrokes((prev) => [...prev, stroke])
+      vibrate(5)
+    },
+    [vibrate],
+  )
+
+  const handleUndo = useCallback(() => {
+    setStrokes((prev) => prev.slice(0, -1))
+    vibrate(5)
+  }, [vibrate])
+
+  const handleClear = useCallback(() => {
+    setStrokes([])
+    vibrate([5, 30, 5])
+  }, [vibrate])
+
+  const handleStampSelect = useCallback(
+    (stampStrokes: MarkStroke[]) => {
+      setStrokes((prev) => [...prev, ...stampStrokes])
+      vibrate(10)
+    },
+    [vibrate],
+  )
+
+  const handleConfirmDrawing = useCallback(async () => {
+    if (saving || strokes.length === 0) return
+    setSaving(true)
+    try {
+      const mark = await addMark({
+        shape_id: shape.id,
+        strokes,
+        viewBox: shape.viewBox,
+      })
+      vibrate([10, 50, 10])
+      onUpdate({ mark_id: mark.id })
+      setConfirmed(true)
+    } finally {
+      setSaving(false)
+    }
+  }, [saving, strokes, addMark, shape, vibrate, onUpdate])
+
+  const handleDrawAgain = useCallback(() => {
+    setStrokes([])
+    setConfirmed(false)
+    onUpdate({ mark_id: undefined })
+  }, [onUpdate])
+
+  const handleSelectMark = useCallback(
+    (markId: string) => {
+      onUpdate({ mark_id: markId })
+      vibrate(10)
+    },
+    [onUpdate, vibrate],
+  )
+
+  const handleModeChange = useCallback((newMode: Mode) => {
+    setMode(newMode)
+  }, [])
+
+  return (
+    <fieldset className="space-y-4">
+      <legend className="text-sm font-medium">
+        Draw or choose a glyph
+      </legend>
+      <p className="text-sm text-muted-foreground">
+        Add a symbol to your pebble. This step is optional.
+      </p>
+
+      {/* Mode tabs */}
+      <div role="tablist" aria-label="Glyph mode" className="flex gap-1">
+        <button
+          type="button"
+          role="tab"
+          id="tab-draw"
+          aria-selected={mode === "draw"}
+          aria-controls="panel-draw"
+          tabIndex={mode === "draw" ? 0 : -1}
+          onClick={() => handleModeChange("draw")}
+          onKeyDown={(e) => {
+            if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+              e.preventDefault()
+              handleModeChange(mode === "draw" ? "select" : "draw")
+            }
+          }}
+          className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+            mode === "draw"
+              ? "bg-primary text-primary-foreground"
+              : "bg-muted text-muted-foreground hover:bg-muted/80"
+          }`}
+        >
+          Draw
+        </button>
+        <button
+          type="button"
+          role="tab"
+          id="tab-select"
+          aria-selected={mode === "select"}
+          aria-controls="panel-select"
+          tabIndex={mode === "select" ? 0 : -1}
+          onClick={() => handleModeChange("select")}
+          onKeyDown={(e) => {
+            if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+              e.preventDefault()
+              handleModeChange(mode === "draw" ? "select" : "draw")
+            }
+          }}
+          className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+            mode === "select"
+              ? "bg-primary text-primary-foreground"
+              : "bg-muted text-muted-foreground hover:bg-muted/80"
+          }`}
+        >
+          Choose existing
+        </button>
+      </div>
+
+      {/* Draw panel */}
+      {mode === "draw" && (
+        <div
+          role="tabpanel"
+          id="panel-draw"
+          aria-labelledby="tab-draw"
+          className="space-y-4"
+        >
+          {confirmed && selectedMark ? (
+            <div className="flex flex-col items-center gap-4">
+              <p className="text-sm font-medium" aria-live="polite">
+                Glyph attached
+              </p>
+              <GlyphPreview
+                mark={selectedMark}
+                className="w-full max-w-[200px] aspect-square"
+              />
+              <button
+                type="button"
+                onClick={handleDrawAgain}
+                className="text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
+              >
+                Draw a different glyph
+              </button>
+            </div>
+          ) : (
+            <>
+              <figure className="flex flex-col items-center gap-2">
+                <DrawingCanvas
+                  shape={shape}
+                  strokes={strokes}
+                  strokeWidth={strokeWidth}
+                  onStrokeComplete={handleStrokeComplete}
+                />
+                <figcaption className="sr-only">
+                  Draw a symbol on the pebble surface. Your strokes are clipped
+                  to the stone outline.
+                </figcaption>
+              </figure>
+
+              <p className="sr-only" aria-live="polite">
+                {strokes.length === 0
+                  ? "No strokes drawn"
+                  : `${strokes.length} stroke${strokes.length === 1 ? "" : "s"} drawn`}
+              </p>
+
+              <CarveToolbar
+                strokeCount={strokes.length}
+                strokeWidth={strokeWidth}
+                onUndo={handleUndo}
+                onClear={handleClear}
+                onWidthChange={setStrokeWidth}
+                onSave={handleConfirmDrawing}
+                saving={saving}
+                showSave={false}
+              />
+
+              <StampPicker onSelect={handleStampSelect} />
+
+              <Button
+                onClick={() => void handleConfirmDrawing()}
+                disabled={strokes.length === 0 || saving}
+                className="h-11 w-full px-4 md:h-8 md:px-2.5"
+              >
+                <Check className="mr-1.5 h-4 w-4" />
+                {saving ? "Saving\u2026" : "Confirm glyph"}
+              </Button>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Select panel */}
+      {mode === "select" && (
+        <div
+          role="tabpanel"
+          id="panel-select"
+          aria-labelledby="tab-select"
+          className="space-y-3"
+        >
+          <MarkSelector
+            marks={marks}
+            selectedMarkId={data.mark_id}
+            onSelect={handleSelectMark}
+          />
+        </div>
+      )}
+    </fieldset>
+  )
+}

--- a/components/record/types.ts
+++ b/components/record/types.ts
@@ -9,6 +9,7 @@ export type RecordFormData = {
   emotion_id: string
   soul_ids: string[]
   domain_ids: string[]
+  mark_id?: string
   cards: PebbleCard[]
 }
 

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -6,7 +6,7 @@
     "root_node_id": "V-home",
     "metadata": { "view_card_variant": "large" },
     "created_at": "2026-04-01T00:00:00.000Z",
-    "updated_at": "2026-04-01T00:00:00.000Z"
+    "updated_at": "2026-04-02T00:00:00.000Z"
   },
   "nodes": [
     {
@@ -172,6 +172,15 @@
       "platforms": ["web", "ios", "android"]
     },
     {
+      "id": "V-glyph-attach",
+      "project_id": "pebbles",
+      "species": "view",
+      "title": "Attach Glyph",
+      "description": "Draw a new glyph or select an existing one to attach to a pebble during recording.",
+      "status": "development",
+      "platforms": ["web", "ios", "android"]
+    },
+    {
       "id": "V-bounce-tempo",
       "project_id": "pebbles",
       "species": "view",
@@ -318,6 +327,12 @@
               "if_false": []
             },
             { "type": "view", "view_id": "V-domain-attach" },
+            {
+              "type": "condition",
+              "label": "Attach a glyph?",
+              "if_true": [{ "type": "view", "view_id": "V-glyph-attach" }],
+              "if_false": []
+            },
             {
               "type": "condition",
               "label": "Add cards or thoughts?",
@@ -843,6 +858,7 @@
     { "id": "e-F-record-pebble-V-emotion-pearl", "project_id": "pebbles", "source_id": "F-record-pebble", "target_id": "V-emotion-pearl", "edge_type": "composes" },
     { "id": "e-F-record-pebble-V-soul-link", "project_id": "pebbles", "source_id": "F-record-pebble", "target_id": "V-soul-link", "edge_type": "composes" },
     { "id": "e-F-record-pebble-V-domain-attach", "project_id": "pebbles", "source_id": "F-record-pebble", "target_id": "V-domain-attach", "edge_type": "composes" },
+    { "id": "e-F-record-pebble-V-glyph-attach", "project_id": "pebbles", "source_id": "F-record-pebble", "target_id": "V-glyph-attach", "edge_type": "composes" },
     { "id": "e-F-record-pebble-V-cards-thoughts", "project_id": "pebbles", "source_id": "F-record-pebble", "target_id": "V-cards-thoughts", "edge_type": "composes" },
     { "id": "e-F-record-pebble-V-pebble-detail", "project_id": "pebbles", "source_id": "F-record-pebble", "target_id": "V-pebble-detail", "edge_type": "composes" },
 
@@ -957,6 +973,9 @@
     { "id": "e-V-glyph-detail-DM-mark", "project_id": "pebbles", "source_id": "V-glyph-detail", "target_id": "DM-mark", "edge_type": "displays" },
     { "id": "e-API-get-marks-DM-mark", "project_id": "pebbles", "source_id": "API-get-marks", "target_id": "DM-mark", "edge_type": "queries" },
     { "id": "e-API-create-mark-DM-mark", "project_id": "pebbles", "source_id": "API-create-mark", "target_id": "DM-mark", "edge_type": "queries" },
-    { "id": "e-API-delete-mark-DM-mark", "project_id": "pebbles", "source_id": "API-delete-mark", "target_id": "DM-mark", "edge_type": "queries" }
+    { "id": "e-API-delete-mark-DM-mark", "project_id": "pebbles", "source_id": "API-delete-mark", "target_id": "DM-mark", "edge_type": "queries" },
+    { "id": "e-V-glyph-attach-DM-mark", "project_id": "pebbles", "source_id": "V-glyph-attach", "target_id": "DM-mark", "edge_type": "displays" },
+    { "id": "e-V-glyph-attach-API-get-marks", "project_id": "pebbles", "source_id": "V-glyph-attach", "target_id": "API-get-marks", "edge_type": "calls" },
+    { "id": "e-V-glyph-attach-API-create-mark", "project_id": "pebbles", "source_id": "V-glyph-attach", "target_id": "API-create-mark", "edge_type": "calls" }
   ]
 }

--- a/lib/data/karma.ts
+++ b/lib/data/karma.ts
@@ -14,6 +14,7 @@ import type { CreatePebbleInput } from "@/lib/data/data-provider"
  * +1 per card with non-empty value
  * +1 if at least one soul attached
  * +1 if at least one domain attached
+ * +1 if a glyph is attached
  *
  * // TODO: account for instants (issue #66 follow-up)
  */
@@ -24,6 +25,7 @@ export function computeKarmaDelta(pebble: CreatePebbleInput): number {
   delta += pebble.cards.filter((c) => c.value.trim()).length
   if (pebble.soul_ids.length > 0) delta += 1
   if (pebble.domain_ids.length > 0) delta += 1
+  if (pebble.mark_id) delta += 1
 
   return delta
 }

--- a/lib/hooks/useRecordForm.ts
+++ b/lib/hooks/useRecordForm.ts
@@ -13,6 +13,7 @@ const INITIAL_DATA: RecordFormData = {
   emotion_id: "",
   soul_ids: [],
   domain_ids: [],
+  mark_id: undefined,
   cards: [],
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -23,6 +23,7 @@ export type Pebble = {
   emotion_id: string
   soul_ids: string[]
   domain_ids: string[]
+  mark_id?: string
   cards: PebbleCard[]
   created_at: string
   updated_at: string


### PR DESCRIPTION
Resolves #88

## Summary

- Adds a new optional "Glyph" step in the record wizard (after Domains, before Cards) where users can draw a new glyph or select an existing one to attach to their pebble
- Introduces `mark_id` on the `Pebble` type to link pebbles to marks
- Adds `MarkSelector` component (accessible radiogroup grid with roving tabindex) for choosing existing glyphs
- Adds `StepGlyph` component with draw/select tab modes, reusing `DrawingCanvas`, `CarveToolbar`, `StampPicker`, and `GlyphPreview`
- Adds `showSave` prop to `CarveToolbar` for conditional save button rendering
- Awards +1 karma for attaching a glyph
- Shows glyph preview in the review summary step
- Updates Arkaik bundle with `V-glyph-attach` view node and edges

## Key files

| File | Change |
|------|--------|
| `lib/types.ts` | Add `mark_id?: string` to `Pebble` |
| `components/record/types.ts` | Add `mark_id` to `RecordFormData` |
| `components/record/StepGlyph.tsx` | **New** — Glyph step with draw/select modes |
| `components/record/MarkSelector.tsx` | **New** — Selectable grid of existing marks |
| `components/carve/CarveToolbar.tsx` | Add `showSave` prop |
| `components/record/RecordStepper.tsx` | Insert glyph step at index 7 |
| `lib/data/karma.ts` | +1 karma for glyph |
| `components/record/ReviewSummary.tsx` | Show glyph thumbnail |

## Test plan

- [ ] Navigate to `/record` and verify glyph step appears after Domains
- [ ] Draw a glyph in draw mode, confirm it saves and attaches
- [ ] Switch to select mode and pick an existing glyph
- [ ] Skip the step entirely and verify pebble saves without mark_id
- [ ] Verify karma includes +1 when glyph is attached
- [ ] Verify glyph thumbnail appears in summary step
- [ ] Verify marks created during record appear in `/glyphs`
- [ ] Test keyboard navigation (tabs, radiogroup, drawing toolbar)

https://claude.ai/code/session_01CHfVC7QdtQVZeJcWPojjXz