### PR TITLE
refactor(nav): simplify navigation items styling

### DIFF
--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -20,23 +20,22 @@ export function BottomNav() {
       )}
     >
       <ul className="flex items-center justify-around py-2">
-        {NAV_ITEMS.map(({ href, label, icon: Icon, primary }) => {
+        {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
           const isActive = pathname.startsWith(href)
           return (
-            <li key={href}>
+            <li key={href} className="flex-1 flex justify-center">
               <Link
                 href={href}
                 className={cn(
                   "flex flex-col items-center gap-0.5 px-3 py-1 text-xs font-medium transition-opacity duration-75 active:opacity-70",
                   isActive
-                    ? "text-foreground"
+                    ? "text-primary"
                     : "text-muted-foreground",
-                  primary && !isActive && "text-primary",
                 )}
                 aria-current={isActive ? "page" : undefined}
                 tabIndex={hidden ? -1 : undefined}
               >
-                <Icon className={cn("size-5", primary && "size-6")} />
+                <Icon className="size-5" />
                 {label}
               </Link>
             </li>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -19,7 +19,7 @@ export function Sidebar() {
 
       <nav aria-label="Main navigation" className="flex-1 px-2 py-2">
         <ul className="flex flex-col gap-1">
-          {NAV_ITEMS.map(({ href, label, icon: Icon, primary }) => {
+          {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
             const isActive = pathname.startsWith(href)
             return (
               <li key={href}>
@@ -28,9 +28,8 @@ export function Sidebar() {
                   className={cn(
                     "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
                     isActive
-                      ? "bg-muted text-foreground"
+                      ? "bg-muted text-primary"
                       : "text-muted-foreground hover:bg-muted hover:text-foreground",
-                    primary && !isActive && "text-primary hover:text-primary",
                   )}
                   aria-current={isActive ? "page" : undefined}
                 >

--- a/lib/config/navigation.ts
+++ b/lib/config/navigation.ts
@@ -4,10 +4,9 @@ export const NAV_ITEMS: ReadonlyArray<{
   href: string
   label: string
   icon: typeof Route
-  primary?: true
 }> = [
   { href: "/path", label: "Path", icon: Route },
-  { href: "/record", label: "Record", icon: CirclePlus, primary: true },
+  { href: "/record", label: "Record", icon: CirclePlus },
   { href: "/collections", label: "Collections", icon: FolderOpen },
   { href: "/souls", label: "Souls", icon: Users },
   { href: "/glyphs", label: "Glyphs", icon: Fingerprint },


### PR DESCRIPTION
Resolves #98 

## Changes
- **lib/config/navigation.ts**: Removed `primary` property from `NAV_ITEMS` type definition and the Record navigation item
- **components/layout/BottomNav.tsx**: 
  - Removed `primary` prop destructuring and conditional styling logic
  - Changed active state text color from `text-foreground` to `text-primary`
  - Removed dynamic icon sizing based on `primary` flag (now always `size-5`)
  - Added `flex-1 flex justify-center` to list items for better spacing
- **components/layout/Sidebar.tsx**:
  - Removed `primary` prop destructuring and conditional styling logic
  - Changed active state text color from `text-foreground` to `text-primary`
  - Removed conditional primary styling for inactive states

## Notes
This refactor simplifies the navigation system by removing the special-case `primary` flag that was only applied to the Record navigation item. The styling is now more consistent across all navigation items, with active states using `text-primary` instead of `text-foreground`. The visual distinction for the Record item is removed in favor of uniform navigation styling.

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01UE7U9xLksLCR3pwgx7SSS2