### PR TITLE
feat(onboarding): implement guided onboarding flow with stepper

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { OnboardingStepper } from "@/components/onboarding/OnboardingStepper"
+
+export default function OnboardingPage() {
+  return <OnboardingStepper />
+}

--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -7,7 +7,7 @@ import { NAV_ITEMS } from "@/lib/config/navigation"
 
 export function BottomNav() {
   const pathname = usePathname()
-  const hidden = pathname.startsWith("/record")
+  const hidden = pathname.startsWith("/record") || pathname.startsWith("/onboarding")
 
   return (
     <nav

--- a/components/layout/MainContent.tsx
+++ b/components/layout/MainContent.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
+import { OnboardingGate } from "@/components/onboarding/OnboardingGate"
 
 interface MainContentProps {
   children: React.ReactNode
@@ -9,17 +10,26 @@ interface MainContentProps {
 
 export function MainContent({ children }: MainContentProps) {
   const pathname = usePathname()
-  const hideBottomNav = pathname.startsWith("/record")
+  const isOnboarding = pathname.startsWith("/onboarding")
+  const hideBottomNav = pathname.startsWith("/record") || isOnboarding
 
   return (
     <main
       className={cn(
-        "min-w-0 flex-1 touch-pan-y overflow-x-hidden overflow-y-auto px-4 pt-[calc(2rem+var(--safe-area-top))] pb-8 md:pb-8",
+        "min-w-0 flex-1 touch-pan-y overflow-x-hidden overflow-y-auto",
         "transition-[padding-bottom] duration-300 ease-in-out motion-reduce:transition-none",
-        hideBottomNav ? "pb-[calc(2rem+var(--safe-area-bottom))]" : "pb-[calc(5rem+var(--safe-area-bottom))]",
+        isOnboarding
+          ? "flex flex-col"
+          : "px-4 pt-[calc(2rem+var(--safe-area-top))] pb-8 md:pb-8",
+        !isOnboarding && (
+          hideBottomNav
+            ? "pb-[calc(2rem+var(--safe-area-bottom))]"
+            : "pb-[calc(5rem+var(--safe-area-bottom))]"
+        ),
       )}
     >
-      <div className="mx-auto max-w-5xl">{children}</div>
+      <OnboardingGate />
+      {isOnboarding ? children : <div className="mx-auto max-w-5xl">{children}</div>}
     </main>
   )
 }

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -10,9 +10,10 @@ import { ResetDataButton } from "@/components/layout/ResetDataButton"
 
 export function Sidebar() {
   const pathname = usePathname()
+  const hidden = pathname.startsWith("/onboarding")
 
   return (
-    <aside className="hidden w-56 shrink-0 border-r border-border md:flex md:flex-col">
+    <aside className={cn("hidden w-56 shrink-0 border-r border-border md:flex md:flex-col", hidden && "md:hidden")}>
       <div className="flex h-14 items-center px-4 text-lg font-semibold">
         pbbls
       </div>

--- a/components/onboarding/OnboardingGate.tsx
+++ b/components/onboarding/OnboardingGate.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { useEffect } from "react"
+import { usePathname, useRouter } from "next/navigation"
+import { isOnboardingCompleted } from "@/lib/hooks/useOnboarding"
+
+export function OnboardingGate() {
+  const pathname = usePathname()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (pathname.startsWith("/onboarding")) return
+    if (!isOnboardingCompleted()) {
+      router.replace("/onboarding")
+    }
+  }, [pathname, router])
+
+  return null
+}

--- a/components/onboarding/OnboardingScreen.tsx
+++ b/components/onboarding/OnboardingScreen.tsx
@@ -1,0 +1,24 @@
+import type { OnboardingStepConfig } from "@/lib/config/onboarding-steps"
+
+interface OnboardingScreenProps {
+  step: OnboardingStepConfig
+}
+
+export function OnboardingScreen({ step }: OnboardingScreenProps) {
+  return (
+    <section
+      className="flex flex-1 flex-col items-center justify-center px-6 text-center"
+      aria-labelledby={`onboarding-heading-${step.id}`}
+    >
+      <h1
+        id={`onboarding-heading-${step.id}`}
+        className="mb-4 text-3xl font-bold tracking-tight"
+      >
+        {step.heading}
+      </h1>
+      <p className="max-w-sm text-lg text-muted-foreground">
+        {step.body}
+      </p>
+    </section>
+  )
+}

--- a/components/onboarding/OnboardingStepper.tsx
+++ b/components/onboarding/OnboardingStepper.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import { useEffect } from "react"
+import { ONBOARDING_STEPS } from "@/lib/config/onboarding-steps"
+import { useOnboarding } from "@/lib/hooks/useOnboarding"
+import { useHaptics } from "@/lib/hooks/useHaptics"
+import { Button } from "@/components/ui/button"
+import { OnboardingScreen } from "@/components/onboarding/OnboardingScreen"
+import { cn } from "@/lib/utils"
+
+export function OnboardingStepper() {
+  const {
+    currentStep,
+    isFirstStep,
+    isLastStep,
+    step,
+    back,
+    next,
+    skip,
+    complete,
+  } = useOnboarding(ONBOARDING_STEPS)
+
+  const { vibrate } = useHaptics()
+
+  const advance = isLastStep ? complete : next
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      const tag = (e.target as HTMLElement).tagName
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return
+
+      if (e.key === "Enter" || e.key === "ArrowRight") {
+        e.preventDefault()
+        vibrate(10)
+        advance()
+      } else if (e.key === "Escape" || e.key === "ArrowLeft") {
+        e.preventDefault()
+        back()
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [advance, back, vibrate])
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Skip link — always visible */}
+      <nav className="flex justify-end p-4 pt-[calc(1rem+var(--safe-area-top))]" aria-label="Onboarding controls">
+        <button
+          type="button"
+          onClick={skip}
+          className="text-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          Skip
+        </button>
+      </nav>
+
+      {/* Active screen */}
+      <OnboardingScreen step={step} />
+
+      {/* Progress dots and navigation */}
+      <div className="flex flex-col items-center gap-4 p-6 pb-[calc(1.5rem+var(--safe-area-bottom))]">
+        {/* Dots */}
+        <ol className="flex gap-2" aria-label="Onboarding progress">
+          {ONBOARDING_STEPS.map((s, i) => (
+            <li
+              key={s.id}
+              aria-current={i === currentStep ? "step" : undefined}
+              aria-label={`Step ${i + 1} of ${ONBOARDING_STEPS.length}`}
+              className={cn(
+                "size-2 rounded-full transition-colors",
+                i === currentStep ? "bg-primary" : "bg-muted",
+              )}
+            />
+          ))}
+        </ol>
+
+        {/* Buttons */}
+        <div className="flex w-full max-w-sm items-center justify-between">
+          {!isFirstStep ? (
+            <Button variant="ghost" className="h-11 px-4" onClick={back}>
+              Back
+            </Button>
+          ) : (
+            <span />
+          )}
+
+          {isLastStep ? (
+            <Button className="h-11 px-6" onClick={complete}>
+              Collect your first pebble
+            </Button>
+          ) : (
+            <Button className="h-11 px-6" onClick={() => { vibrate(10); next() }}>
+              Next
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -6,7 +6,7 @@
     "root_node_id": "V-home",
     "metadata": { "view_card_variant": "large" },
     "created_at": "2026-04-01T00:00:00.000Z",
-    "updated_at": "2026-04-02T12:00:00.000Z"
+    "updated_at": "2026-04-03T12:00:00.000Z"
   },
   "nodes": [
     {
@@ -265,27 +265,27 @@
       "id": "V-onboarding-welcome",
       "project_id": "pebbles",
       "species": "view",
-      "title": "Welcome",
-      "description": "First screen introducing Pebbles to new users.",
-      "status": "idea",
+      "title": "Onboarding — Your Life Is a Path",
+      "description": "First onboarding screen introducing the pebble/path metaphor.",
+      "status": "development",
       "platforms": ["web", "ios", "android"]
     },
     {
-      "id": "V-onboarding-profile",
+      "id": "V-onboarding-collect",
       "project_id": "pebbles",
       "species": "view",
-      "title": "Setup Profile",
-      "description": "Set name and preferences during onboarding.",
-      "status": "idea",
+      "title": "Onboarding — Drop a Pebble",
+      "description": "Second onboarding screen framing the user as a collector.",
+      "status": "development",
       "platforms": ["web", "ios", "android"]
     },
     {
-      "id": "V-onboarding-first-pebble",
+      "id": "V-onboarding-activate",
       "project_id": "pebbles",
       "species": "view",
-      "title": "First Pebble Prompt",
-      "description": "Guided prompt to record the very first pebble.",
-      "status": "idea",
+      "title": "Onboarding — Build Your Path",
+      "description": "Third onboarding screen with CTA to record first pebble.",
+      "status": "development",
       "platforms": ["web", "ios", "android"]
     },
     {
@@ -350,14 +350,14 @@
       "species": "flow",
       "title": "Onboarding",
       "description": "New user onboarding journey ending with first pebble.",
-      "status": "idea",
+      "status": "development",
       "platforms": ["web", "ios", "android"],
       "metadata": {
         "playlist": {
           "entries": [
             { "type": "view", "view_id": "V-onboarding-welcome" },
-            { "type": "view", "view_id": "V-onboarding-profile" },
-            { "type": "view", "view_id": "V-onboarding-first-pebble" },
+            { "type": "view", "view_id": "V-onboarding-collect" },
+            { "type": "view", "view_id": "V-onboarding-activate" },
             { "type": "flow", "flow_id": "F-record-pebble" }
           ]
         }
@@ -872,8 +872,8 @@
     { "id": "e-F-record-pebble-V-pebble-detail", "project_id": "pebbles", "source_id": "F-record-pebble", "target_id": "V-pebble-detail", "edge_type": "composes" },
 
     { "id": "e-F-onboarding-V-onboarding-welcome", "project_id": "pebbles", "source_id": "F-onboarding", "target_id": "V-onboarding-welcome", "edge_type": "composes" },
-    { "id": "e-F-onboarding-V-onboarding-profile", "project_id": "pebbles", "source_id": "F-onboarding", "target_id": "V-onboarding-profile", "edge_type": "composes" },
-    { "id": "e-F-onboarding-V-onboarding-first-pebble", "project_id": "pebbles", "source_id": "F-onboarding", "target_id": "V-onboarding-first-pebble", "edge_type": "composes" },
+    { "id": "e-F-onboarding-V-onboarding-collect", "project_id": "pebbles", "source_id": "F-onboarding", "target_id": "V-onboarding-collect", "edge_type": "composes" },
+    { "id": "e-F-onboarding-V-onboarding-activate", "project_id": "pebbles", "source_id": "F-onboarding", "target_id": "V-onboarding-activate", "edge_type": "composes" },
     { "id": "e-F-onboarding-F-record-pebble", "project_id": "pebbles", "source_id": "F-onboarding", "target_id": "F-record-pebble", "edge_type": "composes" },
 
     { "id": "e-F-manage-collections-V-collections-list", "project_id": "pebbles", "source_id": "F-manage-collections", "target_id": "V-collections-list", "edge_type": "composes" },
@@ -918,7 +918,7 @@
     { "id": "e-V-achievements-API-get-achievements", "project_id": "pebbles", "source_id": "V-achievements", "target_id": "API-get-achievements", "edge_type": "calls" },
     { "id": "e-V-weekly-cairn-API-get-weekly-cairn", "project_id": "pebbles", "source_id": "V-weekly-cairn", "target_id": "API-get-weekly-cairn", "edge_type": "calls" },
     { "id": "e-V-monthly-cairn-API-get-monthly-cairn", "project_id": "pebbles", "source_id": "V-monthly-cairn", "target_id": "API-get-monthly-cairn", "edge_type": "calls" },
-    { "id": "e-V-onboarding-profile-API-register", "project_id": "pebbles", "source_id": "V-onboarding-profile", "target_id": "API-register", "edge_type": "calls" },
+    { "id": "e-V-onboarding-activate-F-record-pebble", "project_id": "pebbles", "source_id": "V-onboarding-activate", "target_id": "F-record-pebble", "edge_type": "composes" },
 
     { "id": "e-V-home-DM-pebble", "project_id": "pebbles", "source_id": "V-home", "target_id": "DM-pebble", "edge_type": "displays" },
     { "id": "e-V-home-DM-bounce", "project_id": "pebbles", "source_id": "V-home", "target_id": "DM-bounce", "edge_type": "displays" },

--- a/lib/config/onboarding-steps.ts
+++ b/lib/config/onboarding-steps.ts
@@ -1,0 +1,23 @@
+export type OnboardingStepConfig = {
+  id: string
+  heading: string
+  body: string
+}
+
+export const ONBOARDING_STEPS: OnboardingStepConfig[] = [
+  {
+    id: "path",
+    heading: "Your life is a path",
+    body: "Every moment matters \u2014 the big ones and the quiet ones. But most of them slip away before you even notice. Pebbles helps you collect them, one by one.",
+  },
+  {
+    id: "pebble",
+    heading: "Drop a pebble, keep the moment",
+    body: "A coffee with a friend. A concert that gave you chills. A tough conversation. Record it in seconds \u2014 no blank page, no pressure, no audience.",
+  },
+  {
+    id: "ritual",
+    heading: "Build your path, at your own pace",
+    body: "No streak to protect, no feed to scroll. Just a calm ritual that grows with you.",
+  },
+]

--- a/lib/hooks/useOnboarding.ts
+++ b/lib/hooks/useOnboarding.ts
@@ -1,0 +1,38 @@
+import { useCallback } from "react"
+import { useRouter } from "next/navigation"
+import { useStepNavigation } from "@/lib/hooks/useStepNavigation"
+import type { OnboardingStepConfig } from "@/lib/config/onboarding-steps"
+
+const ONBOARDING_KEY = "pebbles_onboarding_completed"
+
+export function useOnboarding(steps: OnboardingStepConfig[]) {
+  const { currentStep, isFirstStep, isLastStep, goBack, goNext } =
+    useStepNavigation(steps.length)
+  const router = useRouter()
+
+  const complete = useCallback(() => {
+    localStorage.setItem(ONBOARDING_KEY, "true")
+    router.push("/record")
+  }, [router])
+
+  const skip = useCallback(() => {
+    localStorage.setItem(ONBOARDING_KEY, "true")
+    router.push("/record")
+  }, [router])
+
+  return {
+    currentStep,
+    isFirstStep,
+    isLastStep,
+    step: steps[currentStep],
+    back: goBack,
+    next: goNext,
+    skip,
+    complete,
+  }
+}
+
+export function isOnboardingCompleted(): boolean {
+  if (typeof window === "undefined") return true
+  return localStorage.getItem(ONBOARDING_KEY) === "true"
+}


### PR DESCRIPTION
Resolves #97 

## Changes

**New Components:**
- `components/onboarding/OnboardingStepper.tsx` - Main stepper component with keyboard navigation (Enter/ArrowRight to advance, Escape/ArrowLeft to go back), progress dots, and navigation buttons
- `components/onboarding/OnboardingScreen.tsx` - Reusable screen component for displaying onboarding step content
- `components/onboarding/OnboardingGate.tsx` - Client-side gate that redirects incomplete onboarding users to `/onboarding`
- `app/onboarding/page.tsx` - Onboarding page route

**New Hooks:**
- `lib/hooks/useOnboarding.ts` - Custom hook managing onboarding state, step navigation, and completion (stores flag in localStorage, redirects to `/record` on completion)
- Uses existing `useStepNavigation` hook for step management

**New Config:**
- `lib/config/onboarding-steps.ts` - Defines three onboarding steps with metaphor-driven messaging (path → pebble → ritual)

**Modified Components:**
- `components/layout/MainContent.tsx` - Added OnboardingGate, conditional layout for onboarding (full-height flex layout vs. standard padding)
- `components/layout/Sidebar.tsx` - Hidden during onboarding
- `components/layout/BottomNav.tsx` - Hidden during onboarding
- `docs/arkaik/bundle.json` - Updated design documentation with new onboarding view titles and flow status

## Notes

- Onboarding completion is persisted in localStorage with key `pebbles_onboarding_completed`
- Keyboard navigation is disabled when focus is on form inputs (INPUT, TEXTAREA, SELECT)
- Haptic feedback (10ms vibration) on navigation actions
- Skip button always visible; Back button hidden on first step
- Final button text changes to "Collect your first pebble" on last step
- Uses semantic HTML with proper ARIA labels for accessibility
- OnboardingGate prevents access to protected routes until onboarding is complete

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01HsxBmh2wPqsWFBbGvzFg4s