### PR TITLE
feat(auth): implement local authentication with account and profile models

### DIFF
--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -527,12 +527,21 @@
       }
     },
     {
-      "id": "DM-user",
+      "id": "DM-account",
       "project_id": "pebbles",
       "species": "data-model",
-      "title": "User",
-      "description": "User account with profile, preferences, and privacy settings.",
-      "status": "idea",
+      "title": "Account",
+      "description": "User account with username and hashed password credentials.",
+      "status": "development",
+      "platforms": ["web", "ios", "android"]
+    },
+    {
+      "id": "DM-profile",
+      "project_id": "pebbles",
+      "species": "data-model",
+      "title": "Profile",
+      "description": "User profile with display name, onboarding state, and color world preference.",
+      "status": "development",
       "platforms": ["web", "ios", "android"]
     },
     {
@@ -820,7 +829,7 @@
       "species": "api-endpoint",
       "title": "POST /auth/register",
       "description": "Register a new user account.",
-      "status": "idea",
+      "status": "development",
       "platforms": ["web", "ios", "android"]
     },
     {
@@ -829,7 +838,43 @@
       "species": "api-endpoint",
       "title": "POST /auth/login",
       "description": "Authenticate an existing user.",
-      "status": "idea",
+      "status": "development",
+      "platforms": ["web", "ios", "android"]
+    },
+    {
+      "id": "API-logout",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "POST /auth/logout",
+      "description": "End the current user session.",
+      "status": "development",
+      "platforms": ["web", "ios", "android"]
+    },
+    {
+      "id": "API-get-session",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "GET /auth/session",
+      "description": "Retrieve the current session.",
+      "status": "development",
+      "platforms": ["web", "ios", "android"]
+    },
+    {
+      "id": "API-get-profile",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "GET /profile",
+      "description": "Retrieve the current user profile.",
+      "status": "development",
+      "platforms": ["web", "ios", "android"]
+    },
+    {
+      "id": "API-update-profile",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "PATCH /profile",
+      "description": "Update the current user profile.",
+      "status": "development",
       "platforms": ["web", "ios", "android"]
     },
     {
@@ -944,7 +989,7 @@
     { "id": "e-V-weekly-cairn-DM-pebble", "project_id": "pebbles", "source_id": "V-weekly-cairn", "target_id": "DM-pebble", "edge_type": "displays" },
     { "id": "e-V-monthly-cairn-DM-cairn", "project_id": "pebbles", "source_id": "V-monthly-cairn", "target_id": "DM-cairn", "edge_type": "displays" },
     { "id": "e-V-monthly-cairn-DM-pebble", "project_id": "pebbles", "source_id": "V-monthly-cairn", "target_id": "DM-pebble", "edge_type": "displays" },
-    { "id": "e-V-profile-DM-user", "project_id": "pebbles", "source_id": "V-profile", "target_id": "DM-user", "edge_type": "displays" },
+    { "id": "e-V-profile-DM-profile", "project_id": "pebbles", "source_id": "V-profile", "target_id": "DM-profile", "edge_type": "displays" },
     { "id": "e-V-profile-DM-bounce", "project_id": "pebbles", "source_id": "V-profile", "target_id": "DM-bounce", "edge_type": "displays" },
 
     { "id": "e-API-create-pebble-DM-pebble", "project_id": "pebbles", "source_id": "API-create-pebble", "target_id": "DM-pebble", "edge_type": "queries" },
@@ -968,8 +1013,13 @@
     { "id": "e-API-get-weekly-cairn-DM-pebble", "project_id": "pebbles", "source_id": "API-get-weekly-cairn", "target_id": "DM-pebble", "edge_type": "queries" },
     { "id": "e-API-get-monthly-cairn-DM-cairn", "project_id": "pebbles", "source_id": "API-get-monthly-cairn", "target_id": "DM-cairn", "edge_type": "queries" },
     { "id": "e-API-get-monthly-cairn-DM-pebble", "project_id": "pebbles", "source_id": "API-get-monthly-cairn", "target_id": "DM-pebble", "edge_type": "queries" },
-    { "id": "e-API-register-DM-user", "project_id": "pebbles", "source_id": "API-register", "target_id": "DM-user", "edge_type": "queries" },
-    { "id": "e-API-login-DM-user", "project_id": "pebbles", "source_id": "API-login", "target_id": "DM-user", "edge_type": "queries" },
+    { "id": "e-API-register-DM-account", "project_id": "pebbles", "source_id": "API-register", "target_id": "DM-account", "edge_type": "queries" },
+    { "id": "e-API-register-DM-profile", "project_id": "pebbles", "source_id": "API-register", "target_id": "DM-profile", "edge_type": "queries" },
+    { "id": "e-API-login-DM-account", "project_id": "pebbles", "source_id": "API-login", "target_id": "DM-account", "edge_type": "queries" },
+    { "id": "e-API-logout-DM-account", "project_id": "pebbles", "source_id": "API-logout", "target_id": "DM-account", "edge_type": "queries" },
+    { "id": "e-API-get-session-DM-account", "project_id": "pebbles", "source_id": "API-get-session", "target_id": "DM-account", "edge_type": "queries" },
+    { "id": "e-API-get-profile-DM-profile", "project_id": "pebbles", "source_id": "API-get-profile", "target_id": "DM-profile", "edge_type": "queries" },
+    { "id": "e-API-update-profile-DM-profile", "project_id": "pebbles", "source_id": "API-update-profile", "target_id": "DM-profile", "edge_type": "queries" },
     { "id": "e-API-get-collection-rise-DM-collection", "project_id": "pebbles", "source_id": "API-get-collection-rise", "target_id": "DM-collection", "edge_type": "queries" },
     { "id": "e-V-home-F-manage-glyphs", "project_id": "pebbles", "source_id": "V-home", "target_id": "F-manage-glyphs", "edge_type": "composes" },
     { "id": "e-F-manage-glyphs-V-glyphs-list", "project_id": "pebbles", "source_id": "F-manage-glyphs", "target_id": "V-glyphs-list", "edge_type": "composes" },

--- a/lib/data/data-provider.ts
+++ b/lib/data/data-provider.ts
@@ -1,4 +1,16 @@
-import type { Pebble, Soul, Collection, KarmaEvent, Mark } from "@/lib/types"
+import type {
+  Pebble,
+  Soul,
+  Collection,
+  KarmaEvent,
+  Mark,
+  Account,
+  Profile,
+  Session,
+  RegisterInput,
+  LoginInput,
+  UpdateProfileInput,
+} from "@/lib/types"
 
 // ---------------------------------------------------------------------------
 // Store snapshot — the in-memory representation of all persisted data.
@@ -15,6 +27,16 @@ export type Store = {
   karma_log: KarmaEvent[]
   bounce: number
   bounce_window: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Auth store — persisted separately from content data so auth maps cleanly
+// to Supabase Auth while content maps to Supabase DB tables.
+// ---------------------------------------------------------------------------
+
+export type AuthStore = {
+  accounts: Account[]
+  profiles: Profile[]
 }
 
 // ---------------------------------------------------------------------------
@@ -85,4 +107,12 @@ export interface DataProvider {
   createMark(input: CreateMarkInput): Promise<Mark>
   updateMark(id: string, input: UpdateMarkInput): Promise<Mark>
   deleteMark(id: string): Promise<void>
+
+  // Auth
+  register(input: RegisterInput): Promise<Session>
+  login(input: LoginInput): Promise<Session>
+  logout(): Promise<void>
+  getSession(): Session | null
+  getProfile(): Promise<Profile | undefined>
+  updateProfile(input: UpdateProfileInput): Promise<Profile>
 }

--- a/lib/data/local-provider.ts
+++ b/lib/data/local-provider.ts
@@ -1,6 +1,7 @@
 import type {
   DataProvider,
   Store,
+  AuthStore,
   CreatePebbleInput,
   UpdatePebbleInput,
   CreateSoulInput,
@@ -10,12 +11,33 @@ import type {
   CreateMarkInput,
   UpdateMarkInput,
 } from "@/lib/data/data-provider"
-import type { Pebble, Soul, Collection, KarmaEvent, Mark } from "@/lib/types"
+import type {
+  Pebble,
+  Soul,
+  Collection,
+  KarmaEvent,
+  Mark,
+  Account,
+  Profile,
+  Session,
+  RegisterInput,
+  LoginInput,
+  UpdateProfileInput,
+} from "@/lib/types"
+import { hashPassword, verifyPassword } from "@/lib/data/password"
 import { SEED_PEBBLES, SEED_SOULS, SEED_COLLECTIONS } from "@/lib/seed/seed-data"
 import { refreshBounceWindow, decayBounceWindow, todayLocal } from "@/lib/data/bounce-levels"
 import { computeKarmaDelta } from "@/lib/data/karma"
 
 const STORAGE_KEY = "pbbls:store"
+const AUTH_STORAGE_KEY = "pbbls:auth"
+const SESSION_STORAGE_KEY = "pbbls:session"
+const ONBOARDING_LEGACY_KEY = "pebbles_onboarding_completed"
+
+const EMPTY_AUTH_STORE: AuthStore = {
+  accounts: [],
+  profiles: [],
+}
 
 const EMPTY_STORE: Store = {
   pebbles: [],
@@ -31,9 +53,13 @@ const EMPTY_STORE: Store = {
 
 export class LocalProvider implements DataProvider {
   private store: Store
+  private authStore: AuthStore
+  private session: Session | null
 
   constructor() {
     this.store = this.load()
+    this.authStore = this.loadAuth()
+    this.session = this.loadSession()
   }
 
   // ---------------------------------------------------------------------------
@@ -148,6 +174,59 @@ export class LocalProvider implements DataProvider {
   private mutate(store: Store): void {
     this.store = store
     this.writeToStorage(store)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Auth storage helpers
+  // ---------------------------------------------------------------------------
+
+  private loadAuth(): AuthStore {
+    if (typeof window === "undefined") return EMPTY_AUTH_STORE
+    try {
+      const raw = localStorage.getItem(AUTH_STORAGE_KEY)
+      if (!raw) return EMPTY_AUTH_STORE
+      return JSON.parse(raw) as AuthStore
+    } catch {
+      return EMPTY_AUTH_STORE
+    }
+  }
+
+  private loadSession(): Session | null {
+    if (typeof window === "undefined") return null
+    try {
+      const raw = localStorage.getItem(SESSION_STORAGE_KEY)
+      if (!raw) return null
+      return JSON.parse(raw) as Session
+    } catch {
+      return null
+    }
+  }
+
+  private writeAuthToStorage(authStore: AuthStore): void {
+    if (typeof window === "undefined") return
+    try {
+      localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(authStore))
+    } catch {
+      console.warn("[LocalProvider] Could not write auth to localStorage.")
+    }
+  }
+
+  private writeSessionToStorage(session: Session | null): void {
+    if (typeof window === "undefined") return
+    try {
+      if (session) {
+        localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(session))
+      } else {
+        localStorage.removeItem(SESSION_STORAGE_KEY)
+      }
+    } catch {
+      console.warn("[LocalProvider] Could not write session to localStorage.")
+    }
+  }
+
+  private mutateAuth(authStore: AuthStore): void {
+    this.authStore = authStore
+    this.writeAuthToStorage(authStore)
   }
 
   // ---------------------------------------------------------------------------
@@ -437,5 +516,117 @@ export class LocalProvider implements DataProvider {
   async deleteMark(id: string): Promise<void> {
     const marks = this.store.marks.filter((m) => m.id !== id)
     this.mutate({ ...this.store, marks })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Auth
+  // ---------------------------------------------------------------------------
+
+  async register(input: RegisterInput): Promise<Session> {
+    const existing = this.authStore.accounts.find(
+      (a) => a.username === input.username,
+    )
+    if (existing) throw new Error("Username already taken")
+
+    const now = new Date().toISOString()
+    const passwordHash = await hashPassword(input.password)
+
+    const account: Account = {
+      id: crypto.randomUUID(),
+      username: input.username,
+      password_hash: passwordHash,
+      created_at: now,
+    }
+
+    // Migrate the legacy onboarding flag into the new profile if it exists.
+    const legacyOnboarding =
+      typeof window !== "undefined" &&
+      localStorage.getItem(ONBOARDING_LEGACY_KEY) === "true"
+
+    const profile: Profile = {
+      id: crypto.randomUUID(),
+      account_id: account.id,
+      display_name: input.username,
+      onboarding_completed: legacyOnboarding,
+      color_world: "blush-quartz",
+      created_at: now,
+      updated_at: now,
+    }
+
+    this.mutateAuth({
+      accounts: [...this.authStore.accounts, account],
+      profiles: [...this.authStore.profiles, profile],
+    })
+
+    const session: Session = {
+      account_id: account.id,
+      profile_id: profile.id,
+      created_at: now,
+    }
+    this.session = session
+    this.writeSessionToStorage(session)
+
+    return session
+  }
+
+  async login(input: LoginInput): Promise<Session> {
+    const account = this.authStore.accounts.find(
+      (a) => a.username === input.username,
+    )
+    if (!account) throw new Error("Invalid username or password")
+
+    const valid = await verifyPassword(input.password, account.password_hash)
+    if (!valid) throw new Error("Invalid username or password")
+
+    const profile = this.authStore.profiles.find(
+      (p) => p.account_id === account.id,
+    )
+    if (!profile) throw new Error("Profile not found")
+
+    const session: Session = {
+      account_id: account.id,
+      profile_id: profile.id,
+      created_at: new Date().toISOString(),
+    }
+    this.session = session
+    this.writeSessionToStorage(session)
+
+    return session
+  }
+
+  async logout(): Promise<void> {
+    this.session = null
+    this.writeSessionToStorage(null)
+  }
+
+  getSession(): Session | null {
+    return this.session
+  }
+
+  async getProfile(): Promise<Profile | undefined> {
+    if (!this.session) return undefined
+    return this.authStore.profiles.find(
+      (p) => p.id === this.session!.profile_id,
+    )
+  }
+
+  async updateProfile(input: UpdateProfileInput): Promise<Profile> {
+    if (!this.session) throw new Error("No active session")
+
+    const idx = this.authStore.profiles.findIndex(
+      (p) => p.id === this.session!.profile_id,
+    )
+    if (idx === -1) throw new Error("Profile not found")
+
+    const updated: Profile = {
+      ...this.authStore.profiles[idx],
+      ...input,
+      updated_at: new Date().toISOString(),
+    }
+    const profiles = [...this.authStore.profiles]
+    profiles[idx] = updated
+    this.mutateAuth({ ...this.authStore, profiles })
+
+    return updated
   }
 }

--- a/lib/data/password.ts
+++ b/lib/data/password.ts
@@ -1,0 +1,29 @@
+/**
+ * Simple password hashing using the Web Crypto API (SHA-256).
+ *
+ * This is intentionally lightweight — passwords are stored in localStorage and
+ * this auth layer is temporary scaffolding for a future Supabase migration
+ * where server-side bcrypt/argon2 will take over.
+ */
+
+const SALT_PREFIX = "pbbls:"
+
+function toHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+}
+
+export async function hashPassword(password: string): Promise<string> {
+  const data = new TextEncoder().encode(SALT_PREFIX + password)
+  const digest = await crypto.subtle.digest("SHA-256", data)
+  return toHex(digest)
+}
+
+export async function verifyPassword(
+  password: string,
+  hash: string,
+): Promise<boolean> {
+  const computed = await hashPassword(password)
+  return computed === hash
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -66,3 +66,36 @@ export type Mark = {
   created_at: string
   updated_at: string
 }
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+export type Account = {
+  id: string
+  username: string
+  password_hash: string
+  created_at: string
+}
+
+export type Profile = {
+  id: string
+  account_id: string
+  display_name: string
+  onboarding_completed: boolean
+  color_world: ColorWorld
+  created_at: string
+  updated_at: string
+}
+
+export type Session = {
+  account_id: string
+  profile_id: string
+  created_at: string
+}
+
+export type RegisterInput = { username: string; password: string }
+export type LoginInput = { username: string; password: string }
+export type UpdateProfileInput = Partial<
+  Omit<Profile, "id" | "account_id" | "created_at" | "updated_at">
+>


### PR DESCRIPTION
Resolves #101 

## Changes

**Core Authentication Implementation**
- Added `Account` and `Profile` types to replace generic `User` model, separating credentials from user metadata
- Implemented `register()`, `login()`, `logout()`, `getSession()`, `getProfile()`, and `updateProfile()` methods in `LocalProvider`
- Added password hashing utilities using Web Crypto API SHA-256 with salt prefix
- Implemented session persistence in localStorage with separate storage keys for auth data and active sessions

**Data Model Updates**
- `Account`: Stores username and hashed password credentials
- `Profile`: Stores display name, onboarding state, and color world preference; linked to Account via `account_id`
- `Session`: Lightweight session object with account and profile IDs
- Added `AuthStore` type to separate auth data from content data (mirrors future Supabase Auth/DB split)

**Storage Architecture**
- Separated auth storage (`pbbls:auth`) from content storage (`pbbls:store`)
- Added session storage (`pbbls:session`) for active user context
- Migrates legacy onboarding flag from localStorage into new Profile model on registration

**Documentation Updates**
- Updated `bundle.json` to reflect new data models and API endpoints
- Changed `DM-user` to `DM-account` and added `DM-profile` as separate entity
- Updated auth endpoints (`register`, `login`) and added new endpoints (`logout`, `get-session`, `get-profile`, `update-profile`) with development status
- Updated graph edges to reflect Account/Profile relationship

## Notes

- Password hashing uses SHA-256 with a simple salt prefix. This is intentionally lightweight scaffolding for a future Supabase migration where server-side bcrypt/argon2 will handle password security.
- Auth data is stored separately from content data to cleanly map to Supabase's architecture (Auth service vs. Database tables).
- Session is stored in memory and localStorage, allowing persistence across page reloads.
- `getProfile()` is async to match the `DataProvider` interface, though current implementation is synchronous.
- Server-side validation and HTTPS enforcement will be required before production use.

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_018cGZU3cKWo86eNXBiTLvm6