### PR TITLE
feat(auth): add AuthProvider and useAuth hook for session management

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "@/components/layout/ThemeProvider";
 import { ColorWorldProvider } from "@/components/layout/ColorWorldProvider";
 import { ThemeColorSync } from "@/components/layout/ThemeColorSync";
 import { DataProvider } from "@/components/layout/DataProvider";
+import { AuthProvider } from "@/components/layout/AuthProvider";
 import { SerwistRegistration } from "@/components/layout/SerwistRegistration";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { BottomNav } from "@/components/layout/BottomNav";
@@ -93,6 +94,7 @@ export default function RootLayout({
         />
         <SerwistRegistration>
           <DataProvider>
+            <AuthProvider>
             <ColorWorldProvider>
               <ThemeProvider>
                 <ThemeColorSync />
@@ -103,6 +105,7 @@ export default function RootLayout({
                 <BottomNav />
               </ThemeProvider>
             </ColorWorldProvider>
+            </AuthProvider>
           </DataProvider>
         </SerwistRegistration>
       </body>

--- a/components/layout/AuthProvider.tsx
+++ b/components/layout/AuthProvider.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import { AuthContext, type AuthContextValue } from "@/lib/data/auth-context"
+import { useDataProvider } from "@/lib/data/provider-context"
+import type {
+  Account,
+  Profile,
+  LoginInput,
+  RegisterInput,
+  UpdateProfileInput,
+} from "@/lib/types"
+
+/**
+ * Client-only wrapper that manages auth state (user, profile, session) and
+ * exposes it to the React tree via AuthContext.
+ *
+ * Must be rendered inside <DataProvider> — it reads the provider instance
+ * from DataContext to delegate all auth operations.
+ *
+ * On mount it rehydrates the session from localStorage (via the provider's
+ * getSession / getAccount / getProfile methods) so returning users are
+ * automatically logged in.
+ */
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const { provider } = useDataProvider()
+
+  const [user, setUser] = useState<Account | null>(null)
+  const [profile, setProfile] = useState<Profile | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  // -------------------------------------------------------------------------
+  // Session rehydration — runs once on mount.
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    async function rehydrate() {
+      const session = provider.getSession()
+      if (session) {
+        const [account, prof] = await Promise.all([
+          provider.getAccount(),
+          provider.getProfile(),
+        ])
+        setUser(account ?? null)
+        setProfile(prof ?? null)
+      }
+      setIsLoading(false)
+    }
+    rehydrate()
+  }, [provider])
+
+  // -------------------------------------------------------------------------
+  // Auth actions
+  // -------------------------------------------------------------------------
+
+  const login = useCallback(
+    async (input: LoginInput) => {
+      await provider.login(input)
+      const [account, prof] = await Promise.all([
+        provider.getAccount(),
+        provider.getProfile(),
+      ])
+      setUser(account ?? null)
+      setProfile(prof ?? null)
+    },
+    [provider],
+  )
+
+  const register = useCallback(
+    async (input: RegisterInput) => {
+      await provider.register(input)
+      const [account, prof] = await Promise.all([
+        provider.getAccount(),
+        provider.getProfile(),
+      ])
+      setUser(account ?? null)
+      setProfile(prof ?? null)
+    },
+    [provider],
+  )
+
+  const logout = useCallback(async () => {
+    await provider.logout()
+    setUser(null)
+    setProfile(null)
+  }, [provider])
+
+  const updateProfileFn = useCallback(
+    async (input: UpdateProfileInput): Promise<Profile> => {
+      const updated = await provider.updateProfile(input)
+      setProfile(updated)
+      return updated
+    },
+    [provider],
+  )
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  const value: AuthContextValue = {
+    user,
+    profile,
+    isAuthenticated: user !== null,
+    isLoading,
+    login,
+    register,
+    logout,
+    updateProfile: updateProfileFn,
+  }
+
+  return (
+    <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+  )
+}

--- a/lib/data/auth-context.ts
+++ b/lib/data/auth-context.ts
@@ -1,0 +1,42 @@
+"use client"
+
+import { createContext, useContext } from "react"
+import type {
+  Account,
+  Profile,
+  LoginInput,
+  RegisterInput,
+  UpdateProfileInput,
+} from "@/lib/types"
+
+// ---------------------------------------------------------------------------
+// Context value — exposes auth state and actions to the React tree.
+// Separate from DataContext so auth concerns stay decoupled from content data.
+// ---------------------------------------------------------------------------
+
+export type AuthContextValue = {
+  /** The logged-in account, or null when unauthenticated. */
+  user: Account | null
+  /** The logged-in user's profile, or null when unauthenticated. */
+  profile: Profile | null
+  /** Convenience flag — equivalent to `user !== null`. */
+  isAuthenticated: boolean
+  /** True while the initial session is being rehydrated from localStorage. */
+  isLoading: boolean
+  login(input: LoginInput): Promise<void>
+  register(input: RegisterInput): Promise<void>
+  logout(): Promise<void>
+  updateProfile(input: UpdateProfileInput): Promise<Profile>
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null)
+
+/**
+ * Consume the auth context.
+ * Must be called inside a component tree wrapped by <AuthProvider>.
+ */
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error("useAuth must be used within <AuthProvider>")
+  return ctx
+}

--- a/lib/data/data-provider.ts
+++ b/lib/data/data-provider.ts
@@ -113,6 +113,7 @@ export interface DataProvider {
   login(input: LoginInput): Promise<Session>
   logout(): Promise<void>
   getSession(): Session | null
+  getAccount(): Promise<Account | undefined>
   getProfile(): Promise<Profile | undefined>
   updateProfile(input: UpdateProfileInput): Promise<Profile>
 }

--- a/lib/data/local-provider.ts
+++ b/lib/data/local-provider.ts
@@ -603,6 +603,13 @@ export class LocalProvider implements DataProvider {
     return this.session
   }
 
+  async getAccount(): Promise<Account | undefined> {
+    if (!this.session) return undefined
+    return this.authStore.accounts.find(
+      (a) => a.id === this.session!.account_id,
+    )
+  }
+
   async getProfile(): Promise<Profile | undefined> {
     if (!this.session) return undefined
     return this.authStore.profiles.find(


### PR DESCRIPTION
Resolves #102 

## Changes

- **components/layout/AuthProvider.tsx** (new): Client-side provider component that manages authentication state (user, profile, session) and exposes it via AuthContext. Handles session rehydration on mount and delegates all auth operations to the DataProvider.
- **lib/data/auth-context.ts** (new): Defines AuthContextValue type and exports useAuth() hook for consuming auth state throughout the component tree.
- **lib/data/local-provider.ts**: Added `getAccount()` method to retrieve the current logged-in account from the auth store.
- **lib/data/data-provider.ts**: Added `getAccount()` method signature to the DataProvider interface.
- **app/layout.tsx**: Wrapped the component tree with `<AuthProvider>` inside `<DataProvider>` to enable auth context availability.

## Notes

- AuthProvider is a client-only component ("use client") and must be rendered inside DataProvider to access the provider instance.
- Session rehydration happens automatically on mount via localStorage, so returning users are logged in without explicit action.
- Auth state is kept separate from content data via a dedicated AuthContext, maintaining clean separation of concerns.
- All auth mutations (login, register, logout, updateProfile) fetch fresh account and profile data after the operation completes.

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01NCprNyVp7mpgHdUMZF2pbG