### PR TITLE
feat(landing): add public landing page with auth redirect

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,5 @@
-import { redirect } from "next/navigation"
+import { LandingPage } from "@/components/landing/LandingPage"
 
 export default function Home() {
-  redirect("/path")
+  return <LandingPage />
 }
-

--- a/components/landing/LandingPage.tsx
+++ b/components/landing/LandingPage.tsx
@@ -1,0 +1,41 @@
+"use client"
+
+import { useEffect } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useAuth } from "@/lib/data/auth-context"
+import { Button } from "@/components/ui/button"
+
+export function LandingPage() {
+  const { isAuthenticated, isLoading } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      router.replace("/path")
+    }
+  }, [isLoading, isAuthenticated, router])
+
+  if (isLoading || isAuthenticated) return null
+
+  return (
+    <section className="flex min-h-full flex-col items-center justify-center px-6 text-center">
+      <h1 className="text-4xl font-bold tracking-tight">pbbls</h1>
+      <p className="mt-3 max-w-sm text-muted-foreground">
+        Collect meaningful moments, one pebble at a time.
+      </p>
+
+      <div className="mt-8 flex flex-col items-center gap-3">
+        <Button size="lg" render={<Link href="/login" />}>
+          Log in
+        </Button>
+        <Link
+          href="/register"
+          className="text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
+        >
+          Create account
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -7,7 +7,7 @@ import { NAV_ITEMS } from "@/lib/config/navigation"
 
 export function BottomNav() {
   const pathname = usePathname()
-  const hidden = pathname.startsWith("/record") || pathname.startsWith("/onboarding")
+  const hidden = pathname === "/" || pathname.startsWith("/record") || pathname.startsWith("/onboarding")
 
   return (
     <nav

--- a/components/layout/MainContent.tsx
+++ b/components/layout/MainContent.tsx
@@ -10,26 +10,28 @@ interface MainContentProps {
 
 export function MainContent({ children }: MainContentProps) {
   const pathname = usePathname()
+  const isLanding = pathname === "/"
   const isOnboarding = pathname.startsWith("/onboarding")
-  const hideBottomNav = pathname.startsWith("/record") || isOnboarding
+  const isFullScreen = isLanding || isOnboarding
+  const hideBottomNav = pathname.startsWith("/record") || isFullScreen
 
   return (
     <main
       className={cn(
         "min-w-0 flex-1 touch-pan-y overflow-x-hidden overflow-y-auto",
         "transition-[padding-bottom] duration-300 ease-in-out motion-reduce:transition-none",
-        isOnboarding
+        isFullScreen
           ? "flex flex-col"
           : "px-4 pt-[calc(2rem+var(--safe-area-top))] pb-8 md:pb-8",
-        !isOnboarding && (
+        !isFullScreen && (
           hideBottomNav
             ? "pb-[calc(2rem+var(--safe-area-bottom))]"
             : "pb-[calc(5rem+var(--safe-area-bottom))]"
         ),
       )}
     >
-      <OnboardingGate />
-      {isOnboarding ? children : <div className="mx-auto max-w-5xl">{children}</div>}
+      {!isLanding && <OnboardingGate />}
+      {isFullScreen ? children : <div className="mx-auto max-w-5xl">{children}</div>}
     </main>
   )
 }

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -10,7 +10,7 @@ import { ResetDataButton } from "@/components/layout/ResetDataButton"
 
 export function Sidebar() {
   const pathname = usePathname()
-  const hidden = pathname.startsWith("/onboarding")
+  const hidden = pathname === "/" || pathname.startsWith("/onboarding")
 
   return (
     <aside className={cn("hidden w-56 shrink-0 border-r border-border md:flex md:flex-col", hidden && "md:hidden")}>

--- a/components/onboarding/OnboardingGate.tsx
+++ b/components/onboarding/OnboardingGate.tsx
@@ -9,7 +9,7 @@ export function OnboardingGate() {
   const router = useRouter()
 
   useEffect(() => {
-    if (pathname.startsWith("/onboarding")) return
+    if (pathname === "/" || pathname.startsWith("/onboarding")) return
     if (!isOnboardingCompleted()) {
       router.replace("/onboarding")
     }

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -3,12 +3,21 @@
     "id": "pebbles",
     "title": "Pebbles",
     "description": "Pebbles is an atomic diary app allowing to record memories and enrich them with emotions, instants, thoughts, related to people and get weekly and monthly wraps.",
-    "root_node_id": "V-home",
+    "root_node_id": "V-landing",
     "metadata": { "view_card_variant": "large" },
     "created_at": "2026-04-01T00:00:00.000Z",
     "updated_at": "2026-04-03T12:00:00.000Z"
   },
   "nodes": [
+    {
+      "id": "V-landing",
+      "project_id": "pebbles",
+      "species": "view",
+      "title": "Landing",
+      "description": "Public landing page with app branding, login button, and create-account link. Redirects authenticated users to the home view.",
+      "status": "development",
+      "platforms": ["web", "ios", "android"]
+    },
     {
       "id": "V-home",
       "project_id": "pebbles",
@@ -1037,6 +1046,9 @@
     { "id": "e-V-glyph-attach-API-get-marks", "project_id": "pebbles", "source_id": "V-glyph-attach", "target_id": "API-get-marks", "edge_type": "calls" },
     { "id": "e-V-glyph-attach-API-create-mark", "project_id": "pebbles", "source_id": "V-glyph-attach", "target_id": "API-create-mark", "edge_type": "calls" },
     { "id": "e-V-home-V-mechanic-sheet", "project_id": "pebbles", "source_id": "V-home", "target_id": "V-mechanic-sheet", "edge_type": "composes" },
-    { "id": "e-V-mechanic-sheet-DM-bounce", "project_id": "pebbles", "source_id": "V-mechanic-sheet", "target_id": "DM-bounce", "edge_type": "displays" }
+    { "id": "e-V-mechanic-sheet-DM-bounce", "project_id": "pebbles", "source_id": "V-mechanic-sheet", "target_id": "DM-bounce", "edge_type": "displays" },
+    { "id": "e-V-landing-V-home", "project_id": "pebbles", "source_id": "V-landing", "target_id": "V-home", "edge_type": "navigates" },
+    { "id": "e-V-landing-API-login", "project_id": "pebbles", "source_id": "V-landing", "target_id": "API-login", "edge_type": "calls" },
+    { "id": "e-V-landing-API-register", "project_id": "pebbles", "source_id": "V-landing", "target_id": "API-register", "edge_type": "calls" }
   ]
 }


### PR DESCRIPTION
Resolves #103 

## Changes

- **New Component**: Created `LandingPage` component that displays app branding, login/register buttons, and redirects authenticated users to home
- **Root Route**: Updated `app/page.tsx` to render `LandingPage` instead of redirecting to `/path`
- **Layout Updates**: Modified `MainContent`, `BottomNav`, `Sidebar`, and `OnboardingGate` to hide navigation elements on landing page (`/`)
- **Documentation**: Added landing view node to `bundle.json` and connected it to home view and auth APIs

## Notes

- Landing page uses `useAuth()` hook to check authentication status and automatically redirects authenticated users to `/path`
- Landing page is treated as a full-screen view (like onboarding) with no sidebar/bottom nav
- The landing page returns `null` while loading or if user is authenticated to prevent flash of content
- Navigation components now check for `pathname === "/"` to hide themselves on the landing page
- `OnboardingGate` is skipped on landing page to prevent redirecting unauthenticated users away

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01Rc1M2BpZHdhbq9z8nze9Ky