### PR TITLE
feat(profile): add user profile page with logout functionality

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import { AuthProvider } from "@/components/layout/AuthProvider";
 import { SerwistRegistration } from "@/components/layout/SerwistRegistration";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { BottomNav } from "@/components/layout/BottomNav";
+import { MobileHeader } from "@/components/layout/MobileHeader";
 import { MainContent } from "@/components/layout/MainContent";
 import "./globals.css";
 
@@ -98,6 +99,7 @@ export default function RootLayout({
             <ColorWorldProvider>
               <ThemeProvider>
                 <ThemeColorSync />
+                <MobileHeader />
                 <div className="flex h-full pl-[var(--safe-area-left)] pr-[var(--safe-area-right)]">
                   <Sidebar />
                   <MainContent>{children}</MainContent>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useAuth } from "@/lib/data/auth-context"
+import { ProfileCard } from "@/components/profile/ProfileCard"
+import { LogoutButton } from "@/components/profile/LogoutButton"
+
+export default function ProfilePage() {
+  const { user, profile, isAuthenticated, isLoading, logout } = useAuth()
+  const router = useRouter()
+
+  const handleLogout = async () => {
+    await logout()
+    router.push("/")
+  }
+
+  if (isLoading) {
+    return (
+      <section>
+        <h1 className="mb-6 text-2xl font-semibold">Profile</h1>
+        <p className="text-sm text-muted-foreground">Loading\u2026</p>
+      </section>
+    )
+  }
+
+  if (!isAuthenticated || !user || !profile) {
+    return (
+      <section>
+        <h1 className="mb-6 text-2xl font-semibold">Profile</h1>
+        <p className="text-sm text-muted-foreground">
+          Sign in to view your profile.
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section>
+      <h1 className="mb-6 text-2xl font-semibold">Profile</h1>
+      <div className="space-y-6">
+        <ProfileCard user={user} profile={profile} />
+        <LogoutButton onLogout={handleLogout} />
+      </div>
+    </section>
+  )
+}

--- a/components/layout/MainContent.tsx
+++ b/components/layout/MainContent.tsx
@@ -22,7 +22,7 @@ export function MainContent({ children }: MainContentProps) {
         "transition-[padding-bottom] duration-300 ease-in-out motion-reduce:transition-none",
         isFullScreen
           ? "flex flex-col"
-          : "px-4 pt-[calc(2rem+var(--safe-area-top))] pb-8 md:pb-8",
+          : "px-4 pt-[calc(4rem+var(--safe-area-top))] md:pt-[calc(2rem+var(--safe-area-top))] pb-8 md:pb-8",
         !isFullScreen && (
           hideBottomNav
             ? "pb-[calc(2rem+var(--safe-area-bottom))]"

--- a/components/layout/MobileHeader.tsx
+++ b/components/layout/MobileHeader.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { CircleUser } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { useAuth } from "@/lib/data/auth-context"
+
+export function MobileHeader() {
+  const pathname = usePathname()
+  const { isAuthenticated } = useAuth()
+  const hidden =
+    pathname.startsWith("/record") || pathname.startsWith("/onboarding")
+
+  return (
+    <header
+      aria-hidden={hidden}
+      className={cn(
+        "fixed inset-x-0 top-0 z-50 flex h-12 items-center justify-between bg-background px-4 pt-[var(--safe-area-top)] md:hidden",
+        hidden && "hidden",
+      )}
+    >
+      <span className="text-lg font-semibold">pbbls</span>
+
+      {isAuthenticated && (
+        <Link
+          href="/profile"
+          className={cn(
+            "flex items-center justify-center rounded-lg p-2 transition-colors",
+            pathname.startsWith("/profile")
+              ? "text-primary"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+          aria-label="Profile"
+          aria-current={pathname.startsWith("/profile") ? "page" : undefined}
+        >
+          <CircleUser className="size-5" />
+        </Link>
+      )}
+    </header>
+  )
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -2,14 +2,17 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
+import { CircleUser } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { NAV_ITEMS } from "@/lib/config/navigation"
+import { useAuth } from "@/lib/data/auth-context"
 import { ThemeToggle } from "@/components/layout/ThemeToggle"
 import { HapticsToggle } from "@/components/layout/HapticsToggle"
 import { ResetDataButton } from "@/components/layout/ResetDataButton"
 
 export function Sidebar() {
   const pathname = usePathname()
+  const { isAuthenticated } = useAuth()
   const hidden = pathname === "/" || pathname.startsWith("/onboarding")
 
   return (
@@ -44,6 +47,22 @@ export function Sidebar() {
       </nav>
 
       <div className="flex items-center gap-1 border-t border-border px-4 py-3">
+        {isAuthenticated && (
+          <Link
+            href="/profile"
+            className={cn(
+              "inline-flex size-8 items-center justify-center rounded-lg transition-colors",
+              pathname.startsWith("/profile")
+                ? "bg-muted text-primary"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground",
+            )}
+            aria-label="Profile"
+            aria-current={pathname.startsWith("/profile") ? "page" : undefined}
+          >
+            <CircleUser className="size-4" />
+          </Link>
+        )}
+        <div className="flex-1" />
         <ResetDataButton />
         <ThemeToggle />
         <HapticsToggle />

--- a/components/profile/LogoutButton.tsx
+++ b/components/profile/LogoutButton.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { useState } from "react"
+import { LogOut } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+interface LogoutButtonProps {
+  onLogout: () => Promise<void>
+}
+
+export function LogoutButton({ onLogout }: LogoutButtonProps) {
+  const [isLoggingOut, setIsLoggingOut] = useState(false)
+
+  const handleLogout = async () => {
+    setIsLoggingOut(true)
+    try {
+      await onLogout()
+    } finally {
+      setIsLoggingOut(false)
+    }
+  }
+
+  return (
+    <Button
+      variant="destructive"
+      disabled={isLoggingOut}
+      onClick={handleLogout}
+    >
+      <LogOut data-icon="inline-start" />
+      {isLoggingOut ? "Logging out\u2026" : "Log out"}
+    </Button>
+  )
+}

--- a/components/profile/ProfileCard.tsx
+++ b/components/profile/ProfileCard.tsx
@@ -1,0 +1,38 @@
+import type { Account, Profile } from "@/lib/types"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+interface ProfileCardProps {
+  user: Account
+  profile: Profile
+}
+
+export function ProfileCard({ user, profile }: ProfileCardProps) {
+  const memberSince = new Intl.DateTimeFormat(undefined, {
+    dateStyle: "long",
+  }).format(new Date(user.created_at))
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">{profile.display_name}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <dl className="space-y-3 text-sm">
+          <div>
+            <dt className="text-muted-foreground">Username</dt>
+            <dd className="font-medium">@{user.username}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Member since</dt>
+            <dd className="font-medium">{memberSince}</dd>
+          </div>
+        </dl>
+      </CardContent>
+    </Card>
+  )
+}

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -311,8 +311,8 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Profile",
-      "description": "User profile with stats, bounce tempo, and public/private toggle.",
-      "status": "idea",
+      "description": "User profile page displaying account info with logout functionality.",
+      "status": "development",
       "platforms": ["web", "ios", "android"]
     },
     {


### PR DESCRIPTION
Resolves #106 

## Changes

- **app/profile/page.tsx** (new): Created profile page displaying authenticated user information with loading and unauthenticated states
- **components/profile/ProfileCard.tsx** (new): Card component displaying user account info (display name, username, member since date)
- **components/profile/LogoutButton.tsx** (new): Logout button with loading state and error handling
- **components/layout/MobileHeader.tsx** (new): Mobile-only header with profile navigation link for authenticated users
- **components/layout/Sidebar.tsx**: Added profile link in footer for authenticated users with active state styling
- **components/layout/MainContent.tsx**: Adjusted padding to account for mobile header (4rem on mobile, 2rem on desktop)
- **app/layout.tsx**: Integrated MobileHeader component into root layout
- **docs/arkaik/bundle.json**: Updated Profile feature status from "idea" to "development" with revised description

## Notes

- Profile page requires authentication; unauthenticated users see a sign-in prompt
- Mobile header is hidden on record and onboarding routes to maintain full-screen experience
- Profile link appears in both sidebar (desktop) and mobile header (mobile) for authenticated users
- Logout flow clears auth state and redirects to home page
- Member since date uses locale-aware formatting via `Intl.DateTimeFormat`
- Mobile header respects safe area insets for notched devices

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_011xz3TQrEh6SGPZ3nApyLJ4