### PR TITLE
feat(auth): add login and register pages

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import { useState, useEffect, type FormEvent } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useAuth } from "@/lib/data/auth-context"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+export default function LoginPage() {
+  const { login, profile, isAuthenticated, isLoading } = useAuth()
+  const router = useRouter()
+
+  const [username, setUsername] = useState("")
+  const [password, setPassword] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      router.replace(profile?.onboarding_completed ? "/path" : "/onboarding")
+    }
+  }, [isLoading, isAuthenticated, profile, router])
+
+  if (isLoading || isAuthenticated) return null
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    if (!username.trim() || !password) {
+      setError("Please fill in all fields.")
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      await login({ username: username.trim(), password })
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Something went wrong."
+      setError(message)
+      setSubmitting(false)
+      return
+    }
+  }
+
+  return (
+    <section className="flex min-h-full flex-col items-center justify-center px-6 text-center">
+      <h1 className="text-4xl font-bold tracking-tight">Log in</h1>
+      <p className="mt-3 max-w-sm text-muted-foreground">
+        Welcome back. Pick up where you left off.
+      </p>
+
+      <form
+        onSubmit={handleSubmit}
+        className="mt-8 flex w-full max-w-xs flex-col gap-4"
+        noValidate
+      >
+        <div className="flex flex-col gap-1.5 text-left">
+          <label htmlFor="login-username" className="text-sm font-medium">
+            Username
+          </label>
+          <Input
+            id="login-username"
+            type="text"
+            autoComplete="username"
+            autoCapitalize="none"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            aria-invalid={error ? true : undefined}
+            disabled={submitting}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5 text-left">
+          <label htmlFor="login-password" className="text-sm font-medium">
+            Password
+          </label>
+          <Input
+            id="login-password"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            aria-invalid={error ? true : undefined}
+            disabled={submitting}
+          />
+        </div>
+
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+
+        <Button type="submit" size="lg" disabled={submitting}>
+          {submitting ? "Logging in\u2026" : "Log in"}
+        </Button>
+      </form>
+
+      <Link
+        href="/register"
+        className="mt-6 text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
+      >
+        Create account
+      </Link>
+    </section>
+  )
+}

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import { useState, useEffect, type FormEvent } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useAuth } from "@/lib/data/auth-context"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+export default function RegisterPage() {
+  const { register, isAuthenticated, isLoading } = useAuth()
+  const router = useRouter()
+
+  const [username, setUsername] = useState("")
+  const [password, setPassword] = useState("")
+  const [confirmPassword, setConfirmPassword] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      router.replace("/onboarding")
+    }
+  }, [isLoading, isAuthenticated, router])
+
+  if (isLoading || isAuthenticated) return null
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    if (!username.trim() || !password || !confirmPassword) {
+      setError("Please fill in all fields.")
+      return
+    }
+
+    if (password !== confirmPassword) {
+      setError("Passwords do not match.")
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      await register({ username: username.trim(), password })
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Something went wrong."
+      setError(message)
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <section className="flex min-h-full flex-col items-center justify-center px-6 text-center">
+      <h1 className="text-4xl font-bold tracking-tight">Create account</h1>
+      <p className="mt-3 max-w-sm text-muted-foreground">
+        Start collecting meaningful moments.
+      </p>
+
+      <form
+        onSubmit={handleSubmit}
+        className="mt-8 flex w-full max-w-xs flex-col gap-4"
+        noValidate
+      >
+        <div className="flex flex-col gap-1.5 text-left">
+          <label htmlFor="register-username" className="text-sm font-medium">
+            Username
+          </label>
+          <Input
+            id="register-username"
+            type="text"
+            autoComplete="username"
+            autoCapitalize="none"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            aria-invalid={error ? true : undefined}
+            disabled={submitting}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5 text-left">
+          <label htmlFor="register-password" className="text-sm font-medium">
+            Password
+          </label>
+          <Input
+            id="register-password"
+            type="password"
+            autoComplete="new-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            aria-invalid={error ? true : undefined}
+            disabled={submitting}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5 text-left">
+          <label htmlFor="register-confirm" className="text-sm font-medium">
+            Confirm password
+          </label>
+          <Input
+            id="register-confirm"
+            type="password"
+            autoComplete="new-password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            aria-invalid={error ? true : undefined}
+            disabled={submitting}
+          />
+        </div>
+
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+
+        <Button type="submit" size="lg" disabled={submitting}>
+          {submitting ? "Creating account\u2026" : "Create account"}
+        </Button>
+      </form>
+
+      <Link
+        href="/login"
+        className="mt-6 text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
+      >
+        Log in
+      </Link>
+    </section>
+  )
+}

--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -7,7 +7,7 @@ import { NAV_ITEMS } from "@/lib/config/navigation"
 
 export function BottomNav() {
   const pathname = usePathname()
-  const hidden = pathname === "/" || pathname.startsWith("/record") || pathname.startsWith("/onboarding")
+  const hidden = pathname === "/" || pathname.startsWith("/record") || pathname.startsWith("/onboarding") || pathname === "/login" || pathname === "/register"
 
   return (
     <nav

--- a/components/layout/MainContent.tsx
+++ b/components/layout/MainContent.tsx
@@ -12,7 +12,8 @@ export function MainContent({ children }: MainContentProps) {
   const pathname = usePathname()
   const isLanding = pathname === "/"
   const isOnboarding = pathname.startsWith("/onboarding")
-  const isFullScreen = isLanding || isOnboarding
+  const isAuth = pathname === "/login" || pathname === "/register"
+  const isFullScreen = isLanding || isOnboarding || isAuth
   const hideBottomNav = pathname.startsWith("/record") || isFullScreen
 
   return (
@@ -30,7 +31,7 @@ export function MainContent({ children }: MainContentProps) {
         ),
       )}
     >
-      {!isLanding && <OnboardingGate />}
+      {!isLanding && !isAuth && <OnboardingGate />}
       {isFullScreen ? children : <div className="mx-auto max-w-5xl">{children}</div>}
     </main>
   )

--- a/components/layout/MobileHeader.tsx
+++ b/components/layout/MobileHeader.tsx
@@ -10,7 +10,7 @@ export function MobileHeader() {
   const pathname = usePathname()
   const { isAuthenticated } = useAuth()
   const hidden =
-    pathname.startsWith("/record") || pathname.startsWith("/onboarding")
+    pathname.startsWith("/record") || pathname.startsWith("/onboarding") || pathname === "/login" || pathname === "/register"
 
   return (
     <header

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -13,7 +13,7 @@ import { ResetDataButton } from "@/components/layout/ResetDataButton"
 export function Sidebar() {
   const pathname = usePathname()
   const { isAuthenticated } = useAuth()
-  const hidden = pathname === "/" || pathname.startsWith("/onboarding")
+  const hidden = pathname === "/" || pathname.startsWith("/onboarding") || pathname === "/login" || pathname === "/register"
 
   return (
     <aside className={cn("hidden w-56 shrink-0 border-r border-border md:flex md:flex-col", hidden && "md:hidden")}>

--- a/components/onboarding/OnboardingGate.tsx
+++ b/components/onboarding/OnboardingGate.tsx
@@ -9,7 +9,7 @@ export function OnboardingGate() {
   const router = useRouter()
 
   useEffect(() => {
-    if (pathname === "/" || pathname.startsWith("/onboarding")) return
+    if (pathname === "/" || pathname.startsWith("/onboarding") || pathname === "/login" || pathname === "/register") return
     if (!isOnboardingCompleted()) {
       router.replace("/onboarding")
     }

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -19,6 +19,24 @@
       "platforms": ["web", "ios", "android"]
     },
     {
+      "id": "V-login",
+      "project_id": "pebbles",
+      "species": "view",
+      "title": "Login",
+      "description": "Login page with username and password form. Redirects to path or onboarding based on profile completion status.",
+      "status": "development",
+      "platforms": ["web", "ios", "android"]
+    },
+    {
+      "id": "V-register",
+      "project_id": "pebbles",
+      "species": "view",
+      "title": "Register",
+      "description": "Registration page with username, password, and confirm password form. Auto-logs in and redirects to onboarding on success.",
+      "status": "development",
+      "platforms": ["web", "ios", "android"]
+    },
+    {
       "id": "V-home",
       "project_id": "pebbles",
       "species": "view",
@@ -1047,8 +1065,12 @@
     { "id": "e-V-glyph-attach-API-create-mark", "project_id": "pebbles", "source_id": "V-glyph-attach", "target_id": "API-create-mark", "edge_type": "calls" },
     { "id": "e-V-home-V-mechanic-sheet", "project_id": "pebbles", "source_id": "V-home", "target_id": "V-mechanic-sheet", "edge_type": "composes" },
     { "id": "e-V-mechanic-sheet-DM-bounce", "project_id": "pebbles", "source_id": "V-mechanic-sheet", "target_id": "DM-bounce", "edge_type": "displays" },
-    { "id": "e-V-landing-V-home", "project_id": "pebbles", "source_id": "V-landing", "target_id": "V-home", "edge_type": "navigates" },
-    { "id": "e-V-landing-API-login", "project_id": "pebbles", "source_id": "V-landing", "target_id": "API-login", "edge_type": "calls" },
-    { "id": "e-V-landing-API-register", "project_id": "pebbles", "source_id": "V-landing", "target_id": "API-register", "edge_type": "calls" }
+    { "id": "e-V-landing-V-home", "project_id": "pebbles", "source_id": "V-landing", "target_id": "V-home", "edge_type": "composes" },
+    { "id": "e-V-landing-V-login", "project_id": "pebbles", "source_id": "V-landing", "target_id": "V-login", "edge_type": "composes" },
+    { "id": "e-V-landing-V-register", "project_id": "pebbles", "source_id": "V-landing", "target_id": "V-register", "edge_type": "composes" },
+    { "id": "e-V-login-V-register", "project_id": "pebbles", "source_id": "V-login", "target_id": "V-register", "edge_type": "composes" },
+    { "id": "e-V-register-V-login", "project_id": "pebbles", "source_id": "V-register", "target_id": "V-login", "edge_type": "composes" },
+    { "id": "e-V-login-API-login", "project_id": "pebbles", "source_id": "V-login", "target_id": "API-login", "edge_type": "calls" },
+    { "id": "e-V-register-API-register", "project_id": "pebbles", "source_id": "V-register", "target_id": "API-register", "edge_type": "calls" }
   ]
 }


### PR DESCRIPTION
Resolves #104 

## Changes

- **app/login/page.tsx** (new): Login page with username/password form. Redirects authenticated users to onboarding or home based on profile completion status.
- **app/register/page.tsx** (new): Registration page with username, password, and confirm password fields. Auto-redirects to onboarding on successful registration.
- **components/layout/MainContent.tsx**: Updated to treat auth pages (`/login`, `/register`) as full-screen layouts, hiding the bottom navigation and max-width container.
- **components/layout/BottomNav.tsx**: Hidden on auth pages.
- **components/layout/MobileHeader.tsx**: Hidden on auth pages.
- **components/layout/Sidebar.tsx**: Hidden on auth pages.
- **components/onboarding/OnboardingGate.tsx**: Bypassed for auth pages to prevent redirect loops.
- **docs/arkaik/bundle.json**: Added view definitions for login and register pages, updated navigation graph to reflect component composition and API dependencies.

## Notes

- Both pages use the `useAuth` hook for authentication logic and redirect handling
- Form validation includes field presence checks and password confirmation matching
- Error states are displayed with proper ARIA attributes for accessibility
- Submitting state prevents multiple submissions and provides user feedback
- Auth pages are excluded from the onboarding gate to allow unauthenticated access
- Layout components updated consistently to hide navigation elements on auth routes

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01HGBjesf8UPKfe8pRyyyCuT