### PR TITLE
feat: implement per-profile data storage and auth gates

### DIFF
--- a/components/auth/AuthGate.tsx
+++ b/components/auth/AuthGate.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { useEffect } from "react"
+import { usePathname, useRouter } from "next/navigation"
+import { useAuth } from "@/lib/data/auth-context"
+
+const PROTECTED_PREFIXES = [
+  "/path",
+  "/record",
+  "/pebble",
+  "/collections",
+  "/souls",
+  "/glyphs",
+  "/carve",
+  "/profile",
+]
+
+export function AuthGate() {
+  const pathname = usePathname()
+  const router = useRouter()
+  const { isAuthenticated, isLoading } = useAuth()
+
+  useEffect(() => {
+    if (isLoading) return
+    if (!isAuthenticated && PROTECTED_PREFIXES.some((p) => pathname === p || pathname.startsWith(p + "/"))) {
+      router.replace("/")
+    }
+  }, [pathname, router, isAuthenticated, isLoading])
+
+  return null
+}

--- a/components/layout/AuthProvider.tsx
+++ b/components/layout/AuthProvider.tsx
@@ -23,7 +23,7 @@ import type {
  * automatically logged in.
  */
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const { provider } = useDataProvider()
+  const { provider, setStore } = useDataProvider()
 
   const [user, setUser] = useState<Account | null>(null)
   const [profile, setProfile] = useState<Profile | null>(null)
@@ -55,6 +55,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const login = useCallback(
     async (input: LoginInput) => {
       await provider.login(input)
+      setStore(provider.reloadStore())
       const [account, prof] = await Promise.all([
         provider.getAccount(),
         provider.getProfile(),
@@ -62,12 +63,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setUser(account ?? null)
       setProfile(prof ?? null)
     },
-    [provider],
+    [provider, setStore],
   )
 
   const register = useCallback(
     async (input: RegisterInput) => {
       await provider.register(input)
+      setStore(provider.reloadStore())
       const [account, prof] = await Promise.all([
         provider.getAccount(),
         provider.getProfile(),
@@ -75,14 +77,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setUser(account ?? null)
       setProfile(prof ?? null)
     },
-    [provider],
+    [provider, setStore],
   )
 
   const logout = useCallback(async () => {
     await provider.logout()
+    setStore(provider.reloadStore())
     setUser(null)
     setProfile(null)
-  }, [provider])
+  }, [provider, setStore])
 
   const updateProfileFn = useCallback(
     async (input: UpdateProfileInput): Promise<Profile> => {

--- a/components/layout/MainContent.tsx
+++ b/components/layout/MainContent.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
+import { AuthGate } from "@/components/auth/AuthGate"
 import { OnboardingGate } from "@/components/onboarding/OnboardingGate"
 
 interface MainContentProps {
@@ -31,6 +32,7 @@ export function MainContent({ children }: MainContentProps) {
         ),
       )}
     >
+      {!isLanding && !isAuth && <AuthGate />}
       {!isLanding && !isAuth && <OnboardingGate />}
       {isFullScreen ? children : <div className="mx-auto max-w-5xl">{children}</div>}
     </main>

--- a/lib/data/data-provider.ts
+++ b/lib/data/data-provider.ts
@@ -65,6 +65,9 @@ export interface DataProvider {
   /** Return the current in-memory store snapshot. */
   getStore(): Store
 
+  /** Re-read the content store after a session change (login/register/logout). */
+  reloadStore(): Store
+
   /** Overwrite store with seed data and return the new snapshot. */
   reset(): Promise<Store>
 

--- a/lib/data/local-provider.ts
+++ b/lib/data/local-provider.ts
@@ -57,14 +57,25 @@ export class LocalProvider implements DataProvider {
   private session: Session | null
 
   constructor() {
-    this.store = this.load()
     this.authStore = this.loadAuth()
     this.session = this.loadSession()
+    this.store = this.load()
   }
 
   // ---------------------------------------------------------------------------
   // Internal helpers
   // ---------------------------------------------------------------------------
+
+  /**
+   * Return the localStorage key for content data. When a session is active the
+   * key is scoped to the profile so each account has its own pebbles, souls,
+   * collections, etc. Falls back to the unscoped key when no session exists.
+   */
+  private getStorageKey(): string {
+    return this.session?.profile_id
+      ? `${STORAGE_KEY}:${this.session.profile_id}`
+      : STORAGE_KEY
+  }
 
   private load(): Store {
     // localStorage is not available during SSR — return an empty store so the
@@ -73,7 +84,7 @@ export class LocalProvider implements DataProvider {
     if (typeof window === "undefined") return EMPTY_STORE
 
     try {
-      const raw = localStorage.getItem(STORAGE_KEY)
+      const raw = localStorage.getItem(this.getStorageKey())
       if (!raw) {
         // Return seed in-memory only; the DataProvider mounts a useEffect to
         // persist via persistIfNeeded() after the first render. This keeps
@@ -123,7 +134,7 @@ export class LocalProvider implements DataProvider {
    */
   persistIfNeeded(): void {
     if (typeof window === "undefined") return
-    if (localStorage.getItem(STORAGE_KEY) !== null) return
+    if (localStorage.getItem(this.getStorageKey()) !== null) return
     this.writeToStorage(this.store)
   }
 
@@ -164,7 +175,7 @@ export class LocalProvider implements DataProvider {
   private writeToStorage(store: Store): void {
     if (typeof window === "undefined") return
     try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(store))
+      localStorage.setItem(this.getStorageKey(), JSON.stringify(store))
     } catch {
       console.warn("[LocalProvider] Could not write to localStorage.")
     }
@@ -229,11 +240,36 @@ export class LocalProvider implements DataProvider {
     this.writeAuthToStorage(authStore)
   }
 
+  /**
+   * Copy unscoped `pbbls:store` data to a profile-scoped key on first
+   * login/register so existing pebbles are not lost. No-op if the scoped key
+   * already exists or there is no unscoped data to migrate.
+   */
+  private migrateUnscopedData(profileId: string): void {
+    if (typeof window === "undefined") return
+    const scopedKey = `${STORAGE_KEY}:${profileId}`
+    if (localStorage.getItem(scopedKey) !== null) return
+    const unscopedData = localStorage.getItem(STORAGE_KEY)
+    if (!unscopedData) return
+    localStorage.setItem(scopedKey, unscopedData)
+    localStorage.removeItem(STORAGE_KEY)
+  }
+
   // ---------------------------------------------------------------------------
   // DataProvider public API
   // ---------------------------------------------------------------------------
 
   getStore(): Store {
+    return this.store
+  }
+
+  /**
+   * Re-read the content store from localStorage using the current session's
+   * storage key. Call this after login/register/logout to switch to the
+   * correct per-profile data.
+   */
+  reloadStore(): Store {
+    this.store = this.load()
     return this.store
   }
 
@@ -565,6 +601,7 @@ export class LocalProvider implements DataProvider {
     }
     this.session = session
     this.writeSessionToStorage(session)
+    this.migrateUnscopedData(profile.id)
 
     return session
   }
@@ -590,6 +627,7 @@ export class LocalProvider implements DataProvider {
     }
     this.session = session
     this.writeSessionToStorage(session)
+    this.migrateUnscopedData(profile.id)
 
     return session
   }


### PR DESCRIPTION
Resolves #105 

## Changes

**lib/data/local-provider.ts**
- Reordered constructor to initialize `authStore` and `session` before `store` so session context is available during store initialization
- Added `getStorageKey()` helper that returns a profile-scoped localStorage key when a session exists, falling back to the unscoped key otherwise
- Updated `load()`, `persistIfNeeded()`, and `writeToStorage()` to use the scoped storage key
- Added `migrateUnscopedData()` method to copy unscoped data to profile-scoped keys on first login/register, preventing data loss when switching accounts
- Added `reloadStore()` public method to re-read the store from localStorage after session changes

**lib/data/data-provider.ts**
- Added `reloadStore()` method signature to the DataProvider interface

**components/layout/AuthProvider.tsx**
- Updated `login()`, `register()`, and `logout()` callbacks to call `setStore(provider.reloadStore())` after session changes, ensuring the UI reflects the correct per-profile data

**components/auth/AuthGate.tsx** (new file)
- Added route protection component that redirects unauthenticated users away from protected paths (`/path`, `/record`, `/pebble`, `/collections`, `/souls`, `/glyphs`, `/carve`, `/profile`)

**components/layout/MainContent.tsx**
- Integrated `AuthGate` component alongside existing `OnboardingGate`

## Notes

- Storage is now scoped per profile using the format `pbbls:store:{profile_id}`, allowing each account to maintain separate pebbles, souls, and collections
- The `migrateUnscopedData()` function ensures backward compatibility by copying existing unscoped data to the new profile-scoped key on first login, then cleaning up the old key
- Constructor initialization order matters: session must be loaded before store so `getStorageKey()` can access the session context
- `AuthGate` is a client-side protection layer; server-side route protection should be implemented separately if needed
- The `reloadStore()` call after auth state changes ensures the UI immediately reflects the correct per-profile data without requiring a full page refresh

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01QtWaHVkV5sTKimbJnwva58