### PR TITLE
feat(auth): wire onboarding to profile flag instead of localStorage

### DIFF
--- a/components/onboarding/OnboardingGate.tsx
+++ b/components/onboarding/OnboardingGate.tsx
@@ -2,18 +2,20 @@
 
 import { useEffect } from "react"
 import { usePathname, useRouter } from "next/navigation"
-import { isOnboardingCompleted } from "@/lib/hooks/useOnboarding"
+import { useAuth } from "@/lib/data/auth-context"
 
 export function OnboardingGate() {
   const pathname = usePathname()
   const router = useRouter()
+  const { profile, isLoading } = useAuth()
 
   useEffect(() => {
+    if (isLoading) return
     if (pathname === "/" || pathname.startsWith("/onboarding") || pathname === "/login" || pathname === "/register") return
-    if (!isOnboardingCompleted()) {
+    if (profile && !profile.onboarding_completed) {
       router.replace("/onboarding")
     }
-  }, [pathname, router])
+  }, [pathname, router, profile, isLoading])
 
   return null
 }

--- a/components/onboarding/OnboardingStepper.tsx
+++ b/components/onboarding/OnboardingStepper.tsx
@@ -1,14 +1,21 @@
 "use client"
 
-import { useEffect } from "react"
+import { useCallback, useEffect } from "react"
 import { ONBOARDING_STEPS } from "@/lib/config/onboarding-steps"
 import { useOnboarding } from "@/lib/hooks/useOnboarding"
+import { useAuth } from "@/lib/data/auth-context"
 import { useHaptics } from "@/lib/hooks/useHaptics"
 import { Button } from "@/components/ui/button"
 import { OnboardingScreen } from "@/components/onboarding/OnboardingScreen"
 import { cn } from "@/lib/utils"
 
 export function OnboardingStepper() {
+  const { updateProfile } = useAuth()
+
+  const handleComplete = useCallback(async () => {
+    await updateProfile({ onboarding_completed: true })
+  }, [updateProfile])
+
   const {
     currentStep,
     isFirstStep,
@@ -18,7 +25,7 @@ export function OnboardingStepper() {
     next,
     skip,
     complete,
-  } = useOnboarding(ONBOARDING_STEPS)
+  } = useOnboarding(ONBOARDING_STEPS, handleComplete)
 
   const { vibrate } = useHaptics()
 

--- a/lib/hooks/useOnboarding.ts
+++ b/lib/hooks/useOnboarding.ts
@@ -3,22 +3,23 @@ import { useRouter } from "next/navigation"
 import { useStepNavigation } from "@/lib/hooks/useStepNavigation"
 import type { OnboardingStepConfig } from "@/lib/config/onboarding-steps"
 
-const ONBOARDING_KEY = "pebbles_onboarding_completed"
-
-export function useOnboarding(steps: OnboardingStepConfig[]) {
+export function useOnboarding(
+  steps: OnboardingStepConfig[],
+  onComplete: () => Promise<void> | void,
+) {
   const { currentStep, isFirstStep, isLastStep, goBack, goNext } =
     useStepNavigation(steps.length)
   const router = useRouter()
 
-  const complete = useCallback(() => {
-    localStorage.setItem(ONBOARDING_KEY, "true")
+  const complete = useCallback(async () => {
+    await onComplete()
     router.push("/record")
-  }, [router])
+  }, [onComplete, router])
 
-  const skip = useCallback(() => {
-    localStorage.setItem(ONBOARDING_KEY, "true")
+  const skip = useCallback(async () => {
+    await onComplete()
     router.push("/record")
-  }, [router])
+  }, [onComplete, router])
 
   return {
     currentStep,
@@ -30,9 +31,4 @@ export function useOnboarding(steps: OnboardingStepConfig[]) {
     skip,
     complete,
   }
-}
-
-export function isOnboardingCompleted(): boolean {
-  if (typeof window === "undefined") return true
-  return localStorage.getItem(ONBOARDING_KEY) === "true"
 }


### PR DESCRIPTION
Replace the legacy `pebbles_onboarding_completed` localStorage check
with the `profile.onboarding_completed` flag from the auth system.
OnboardingGate now reads from auth context, and useOnboarding accepts
an `onComplete` callback wired through OnboardingStepper to
`updateProfile()`.

Resolves #107

https://claude.ai/code/session_014k2qu7wSWvzmADfugmhqXu