### PR TITLE
refactor(record): redesign time picker with calendar and step controls

### DIFF
--- a/components/record/InlineDatePicker.tsx
+++ b/components/record/InlineDatePicker.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { Calendar } from "@/components/ui/calendar"
+
+type InlineDatePickerProps = {
+  value: Date
+  onChange: (date: Date) => void
+}
+
+export function InlineDatePicker({ value, onChange }: InlineDatePickerProps) {
+  return (
+    <div className="flex justify-center">
+      <Calendar
+        mode="single"
+        selected={value}
+        onSelect={(date) => {
+          if (date) onChange(date)
+        }}
+        defaultMonth={value}
+        aria-label="Select date"
+      />
+    </div>
+  )
+}

--- a/components/record/TimePicker.tsx
+++ b/components/record/TimePicker.tsx
@@ -2,87 +2,57 @@
 
 import { useCallback, useMemo } from "react"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
+import { InlineDatePicker } from "@/components/record/InlineDatePicker"
+import { TimeStepPicker } from "@/components/record/TimeStepPicker"
 
 type TimePickerProps = {
   value: string
   onChange: (iso: string) => void
 }
 
-function toLocalDate(iso: string): string {
-  const d = new Date(iso)
-  const year = d.getFullYear()
-  const month = String(d.getMonth() + 1).padStart(2, "0")
-  const day = String(d.getDate()).padStart(2, "0")
-  return `${year}-${month}-${day}`
-}
-
-function toLocalTime(iso: string): string {
-  const d = new Date(iso)
-  const hours = String(d.getHours()).padStart(2, "0")
-  const minutes = String(d.getMinutes()).padStart(2, "0")
-  return `${hours}:${minutes}`
+function roundToQuarterHour(date: Date): Date {
+  const d = new Date(date)
+  d.setMinutes(Math.round(d.getMinutes() / 15) * 15, 0, 0)
+  return d
 }
 
 export function TimePicker({ value, onChange }: TimePickerProps) {
-  const dateValue = useMemo(() => toLocalDate(value), [value])
-  const timeValue = useMemo(() => toLocalTime(value), [value])
+  const dateObj = useMemo(() => new Date(value), [value])
 
   const handleDateChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const [year, month, day] = e.target.value.split("-").map(Number)
-      const d = new Date(value)
-      d.setFullYear(year, month - 1, day)
-      onChange(d.toISOString())
+    (date: Date) => {
+      const next = new Date(dateObj)
+      next.setFullYear(date.getFullYear(), date.getMonth(), date.getDate())
+      onChange(next.toISOString())
     },
-    [value, onChange]
+    [dateObj, onChange]
   )
 
   const handleTimeChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const [hours, minutes] = e.target.value.split(":").map(Number)
-      const d = new Date(value)
-      d.setHours(hours, minutes)
-      onChange(d.toISOString())
+    (date: Date) => {
+      const next = new Date(dateObj)
+      next.setHours(date.getHours(), date.getMinutes(), 0, 0)
+      onChange(next.toISOString())
     },
-    [value, onChange]
+    [dateObj, onChange]
   )
 
   const handleNow = useCallback(() => {
-    onChange(new Date().toISOString())
+    onChange(roundToQuarterHour(new Date()).toISOString())
   }, [onChange])
 
   return (
     <fieldset>
       <legend className="text-sm font-medium">When</legend>
-      <div className="mt-2 grid grid-cols-1 gap-3 sm:grid-cols-[1fr_1fr_auto]">
-        <div>
-          <label htmlFor="record-date" className="sr-only">
-            Date
-          </label>
-          <Input
-            id="record-date"
-            type="date"
-            className="h-11 w-full text-base md:h-8 md:text-sm"
-            value={dateValue}
-            onChange={handleDateChange}
-          />
+      <div className="mt-2 space-y-4">
+        <InlineDatePicker value={dateObj} onChange={handleDateChange} />
+
+        <div className="flex items-center justify-center gap-3">
+          <TimeStepPicker value={dateObj} onChange={handleTimeChange} />
+          <Button variant="outline" className="h-11 md:h-8" onClick={handleNow}>
+            Now
+          </Button>
         </div>
-        <div>
-          <label htmlFor="record-time" className="sr-only">
-            Time
-          </label>
-          <Input
-            id="record-time"
-            type="time"
-            className="h-11 w-full text-base md:h-8 md:text-sm"
-            value={timeValue}
-            onChange={handleTimeChange}
-          />
-        </div>
-        <Button variant="outline" className="h-11 sm:h-8" onClick={handleNow}>
-          Now
-        </Button>
       </div>
     </fieldset>
   )

--- a/components/record/TimeStepPicker.tsx
+++ b/components/record/TimeStepPicker.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { useCallback, useRef } from "react"
+import { Minus, Plus } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+type TimeStepPickerProps = {
+  value: Date
+  onChange: (date: Date) => void
+}
+
+const STEP_MINUTES = 15
+
+function formatTime(date: Date): string {
+  const hours = String(date.getHours()).padStart(2, "0")
+  const minutes = String(date.getMinutes()).padStart(2, "0")
+  return `${hours}:${minutes}`
+}
+
+export function TimeStepPicker({ value, onChange }: TimeStepPickerProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const step = useCallback(
+    (direction: 1 | -1) => {
+      const next = new Date(value)
+      next.setMinutes(next.getMinutes() + direction * STEP_MINUTES)
+      // Keep same calendar date: if stepping crossed midnight, revert the date
+      if (next.getDate() !== value.getDate()) {
+        next.setFullYear(value.getFullYear(), value.getMonth(), value.getDate())
+      }
+      onChange(next)
+    },
+    [value, onChange]
+  )
+
+  const handleNativeChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const [hours, minutes] = e.target.value.split(":").map(Number)
+      const next = new Date(value)
+      next.setHours(hours, minutes)
+      onChange(next)
+    },
+    [value, onChange]
+  )
+
+  return (
+    <div role="group" aria-label="Time" className="flex items-center gap-2">
+      <Button
+        variant="outline"
+        size="icon"
+        aria-label="Subtract 15 minutes"
+        onClick={() => step(-1)}
+      >
+        <Minus />
+      </Button>
+
+      <button
+        type="button"
+        className="relative flex h-11 items-center justify-center rounded-lg border border-input bg-transparent px-4 text-lg font-medium tabular-nums transition-colors hover:bg-muted focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 outline-none md:h-8 md:text-sm"
+        onClick={() => inputRef.current?.showPicker()}
+        aria-label="Select time"
+      >
+        <span aria-hidden="true">{formatTime(value)}</span>
+        <input
+          ref={inputRef}
+          type="time"
+          className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+          value={formatTime(value)}
+          onChange={handleNativeChange}
+          tabIndex={-1}
+          aria-hidden="true"
+        />
+      </button>
+
+      <Button
+        variant="outline"
+        size="icon"
+        aria-label="Add 15 minutes"
+        onClick={() => step(1)}
+      >
+        <Plus />
+      </Button>
+    </div>
+  )
+}

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import {
+  DayPicker,
+  type DayPickerProps,
+  UI,
+  DayFlag,
+  SelectionState,
+} from "react-day-picker"
+import { ChevronLeft, ChevronRight } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const classNames = {
+  [UI.Root]: "p-3",
+  [UI.Months]: "flex flex-col",
+  [UI.Month]: "space-y-4",
+  [UI.MonthCaption]: "flex items-center justify-center pt-1 relative",
+  [UI.CaptionLabel]: "text-sm font-medium",
+  [UI.Nav]: "flex items-center justify-between absolute inset-x-0",
+  [UI.PreviousMonthButton]:
+    "inline-flex size-7 items-center justify-center rounded-md border border-input bg-transparent hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 outline-none disabled:pointer-events-none disabled:opacity-50",
+  [UI.NextMonthButton]:
+    "inline-flex size-7 items-center justify-center rounded-md border border-input bg-transparent hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 outline-none disabled:pointer-events-none disabled:opacity-50",
+  [UI.MonthGrid]: "w-full border-collapse space-y-1",
+  [UI.Weekdays]: "flex",
+  [UI.Weekday]:
+    "w-9 text-[0.8rem] font-normal text-muted-foreground rounded-md",
+  [UI.Week]: "flex w-full mt-2",
+  [UI.Day]:
+    "relative size-9 p-0 text-center text-sm focus-within:z-20",
+  [UI.DayButton]:
+    "inline-flex size-9 items-center justify-center rounded-md text-sm font-normal transition-colors hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 outline-none aria-selected:opacity-100",
+  [DayFlag.today]: "bg-muted text-foreground font-medium",
+  [DayFlag.outside]: "text-muted-foreground/50",
+  [DayFlag.disabled]: "text-muted-foreground/50 opacity-50",
+  [DayFlag.hidden]: "invisible",
+  [SelectionState.selected]:
+    "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground rounded-md",
+}
+
+function Calendar({ className, showOutsideDays = true, ...props }: DayPickerProps) {
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn(classNames[UI.Root], className)}
+      classNames={classNames}
+      components={{
+        Chevron: ({ orientation }) =>
+          orientation === "left" ? (
+            <ChevronLeft className="size-4" />
+          ) : (
+            <ChevronRight className="size-4" />
+          ),
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Calendar }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "next": "16.2.0",
         "next-themes": "^0.4.6",
         "react": "19.2.4",
+        "react-day-picker": "^9.14.0",
         "react-dom": "19.2.4",
         "serwist": "^9.5.7",
         "shadcn": "^4.1.0",
@@ -516,6 +517,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.57.2",
@@ -2421,6 +2428,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@tabby_ai/hijri-converter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
+      "integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -4373,6 +4389,22 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -8570,6 +8602,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
+      "integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "@tabby_ai/hijri-converter": "1.0.5",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "next": "16.2.0",
     "next-themes": "^0.4.6",
     "react": "19.2.4",
+    "react-day-picker": "^9.14.0",
     "react-dom": "19.2.4",
     "serwist": "^9.5.7",
     "shadcn": "^4.1.0",


### PR DESCRIPTION
Resolves #119

## Changes

- **New component: `TimeStepPicker`** - Replaces native time input with custom controls featuring +/- buttons for 15-minute increments and a clickable time display that opens the native time picker
- **New component: `InlineDatePicker`** - Replaces native date input with an inline calendar widget using `react-day-picker`
- **New UI component: `Calendar`** - Wrapper around `react-day-picker`'s `DayPicker` with custom styling and navigation controls
- **Refactored `TimePicker`** - Restructured to compose the new `InlineDatePicker` and `TimeStepPicker` components; now rounds "Now" button to nearest quarter hour
- **Added dependency** - `react-day-picker@^9.14.0` for calendar functionality

## Notes

- The `TimeStepPicker` prevents crossing midnight boundaries when stepping minutes, keeping the calendar date consistent
- Time values are rounded to 15-minute intervals when using the "Now" button for consistency with the step increment
- The native time input is hidden but still functional, allowing keyboard input and native picker access via the visible button
- Layout changed from a horizontal grid to a vertical stack with centered controls for better mobile responsiveness
- All date/time handling uses `Date` objects internally with ISO string conversion at the component boundary

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01YKQhn7LJRg1UNQzVaRMAt4