### PR TITLE
feat(engine): add deterministic PRNG and UUID seeding utilities

### DIFF
--- a/lib/engine/index.ts
+++ b/lib/engine/index.ts
@@ -1,0 +1,2 @@
+export { hashUUID } from "./seed"
+export { type PRNG, createPRNG } from "./prng"

--- a/lib/engine/prng.ts
+++ b/lib/engine/prng.ts
@@ -1,0 +1,56 @@
+/**
+ * Deterministic seeded PRNG using the mulberry32 algorithm.
+ *
+ * Identical seeds produce identical sequences across invocations.
+ * No DOM or React dependencies — pure TypeScript.
+ */
+
+export type PRNG = {
+  /** Random float in [0, 1). */
+  next(): number
+  /** Random integer in [min, max] (inclusive). */
+  nextInt(min: number, max: number): number
+  /** Random float in [min, max). */
+  nextFloat(min: number, max: number): number
+  /** Select a random element from a non-empty array. Throws if empty. */
+  pick<T>(array: readonly T[]): T
+}
+
+/**
+ * Create a deterministic PRNG seeded with a 32-bit integer.
+ *
+ * Uses the mulberry32 algorithm. Pair with `hashUUID` to derive a seed
+ * from a pebble ID:
+ *
+ * ```ts
+ * const rng = createPRNG(hashUUID(pebble.id))
+ * const hue = rng.nextInt(0, 360)
+ * ```
+ */
+export function createPRNG(seed: number): PRNG {
+  let state = seed | 0
+
+  function next(): number {
+    state = (state + 0x6d2b79f5) | 0
+    let t = Math.imul(state ^ (state >>> 15), 1 | state)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 0x100000000
+  }
+
+  function nextInt(min: number, max: number): number {
+    return min + Math.floor(next() * (max - min + 1))
+  }
+
+  function nextFloat(min: number, max: number): number {
+    return min + next() * (max - min)
+  }
+
+  function pick<T>(array: readonly T[]): T {
+    if (array.length === 0) {
+      throw new Error("Cannot pick from an empty array")
+    }
+    return array[nextInt(0, array.length - 1)]
+  }
+
+  return { next, nextInt, nextFloat, pick }
+}

--- a/lib/engine/seed.ts
+++ b/lib/engine/seed.ts
@@ -1,0 +1,24 @@
+/**
+ * Deterministic UUID-to-seed hashing using FNV-1a.
+ *
+ * Converts any UUID string into a 32-bit unsigned integer suitable as a PRNG
+ * seed. Identical inputs always produce identical outputs across invocations.
+ */
+
+/** FNV-1a 32-bit offset basis. */
+const FNV_OFFSET = 0x811c9dc5
+/** FNV-1a 32-bit prime. */
+const FNV_PRIME = 0x01000193
+
+/**
+ * Hash a UUID string into a deterministic 32-bit unsigned integer
+ * using the FNV-1a algorithm.
+ */
+export function hashUUID(uuid: string): number {
+  let hash = FNV_OFFSET
+  for (let i = 0; i < uuid.length; i++) {
+    hash ^= uuid.charCodeAt(i)
+    hash = Math.imul(hash, FNV_PRIME)
+  }
+  return hash >>> 0
+}


### PR DESCRIPTION
Resolves #124

## Changes

- **lib/engine/prng.ts** (new): Implements a deterministic PRNG using the mulberry32 algorithm with a `PRNG` type and `createPRNG()` factory function. Provides methods for generating random floats, integers, and picking from arrays.
- **lib/engine/seed.ts** (new): Implements UUID-to-seed hashing using the FNV-1a algorithm via `hashUUID()` function, converting UUID strings into 32-bit unsigned integers suitable for PRNG seeding.
- **lib/engine/index.ts** (new): Exports the public API (`hashUUID` and `createPRNG`).

## Notes

- Both utilities are pure TypeScript with no DOM or React dependencies, enabling deterministic randomness across invocations with identical seeds.
- The mulberry32 algorithm provides good statistical properties for general-purpose use while remaining lightweight.
- FNV-1a hashing ensures consistent seed derivation from UUID strings, enabling reproducible randomness per entity (e.g., pebble IDs).
- Typical usage pattern: `const rng = createPRNG(hashUUID(pebble.id))` to generate deterministic but unique sequences per entity.

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01EDcUxqUMEjuKp1cnEKPFjC