### PR TITLE
feat(engine): add type definitions and parameter transformation

### DIFF
--- a/lib/engine/index.ts
+++ b/lib/engine/index.ts
@@ -1,2 +1,12 @@
 export { hashUUID } from "./seed"
 export { type PRNG, createPRNG } from "./prng"
+export { toPebbleParams } from "./params"
+export type {
+  PebbleParams,
+  Glyph,
+  RenderTier,
+  RenderOutput,
+  Point,
+  BBox,
+  Rect,
+} from "./types"

--- a/lib/engine/params.ts
+++ b/lib/engine/params.ts
@@ -1,0 +1,42 @@
+import type { Pebble, Mark } from "@/lib/types"
+import type { PebbleParams, Glyph } from "./types"
+import { EMOTIONS } from "@/lib/config/emotions"
+
+/** 28 days in milliseconds. */
+const RETROACTIVE_THRESHOLD_MS = 28 * 24 * 60 * 60 * 1000
+
+/** Fallback color when the emotion ID is unrecognized. */
+const NEUTRAL_GRAY = "#9CA3AF"
+
+function resolveEmotionColor(emotionId: string): string {
+  const emotion = EMOTIONS.find((e) => e.id === emotionId)
+  return emotion?.color ?? NEUTRAL_GRAY
+}
+
+function isRetroactive(happenedAt: string, createdAt: string): boolean {
+  const elapsed =
+    new Date(createdAt).getTime() - new Date(happenedAt).getTime()
+  return elapsed > RETROACTIVE_THRESHOLD_MS
+}
+
+function extractGlyph(mark: Mark | null): Glyph | null {
+  if (!mark) return null
+  return { strokes: mark.strokes, viewBox: mark.viewBox }
+}
+
+/**
+ * Transforms a domain Pebble (and its optional Mark) into the engine's
+ * input contract. Pure, deterministic, and side-effect-free.
+ */
+export function toPebbleParams(
+  pebble: Pebble,
+  mark: Mark | null,
+): PebbleParams {
+  return {
+    intensity: pebble.intensity,
+    positiveness: pebble.positiveness,
+    emotionColor: resolveEmotionColor(pebble.emotion_id),
+    retroactive: isRetroactive(pebble.happened_at, pebble.created_at),
+    glyph: extractGlyph(mark),
+  }
+}

--- a/lib/engine/types.ts
+++ b/lib/engine/types.ts
@@ -1,0 +1,47 @@
+import type { Pebble, MarkStroke } from "@/lib/types"
+
+// ── Geometry primitives ────────────────────────────────────────────
+
+export type Point = { x: number; y: number }
+
+export type BBox = {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
+
+export type Rect = {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+// ── Glyph (mark rendering data) ───────────────────────────────────
+
+export type Glyph = {
+  strokes: MarkStroke[]
+  viewBox: string
+}
+
+// ── Render tier ───────────────────────────────────────────────────
+
+export type RenderTier = "thumbnail" | "detail"
+
+// ── Render output ─────────────────────────────────────────────────
+
+export type RenderOutput = {
+  svg: string
+  viewBox: string
+}
+
+// ── PebbleParams (engine input contract) ──────────────────────────
+
+export type PebbleParams = {
+  intensity: Pebble["intensity"]
+  positiveness: Pebble["positiveness"]
+  emotionColor: string
+  retroactive: boolean
+  glyph: Glyph | null
+}


### PR DESCRIPTION
Resolves #125 

## Changes

- **lib/engine/types.ts** (new): Defines core type contracts for the rendering engine
  - Geometry primitives: `Point`, `BBox`, `Rect`
  - `Glyph`: mark rendering data structure
  - `RenderTier`: thumbnail vs detail rendering modes
  - `RenderOutput`: SVG render result
  - `PebbleParams`: engine input contract derived from domain models

- **lib/engine/params.ts** (new): Pure transformation function to convert domain models to engine input
  - `toPebbleParams()`: transforms `Pebble` + optional `Mark` into `PebbleParams`
  - Resolves emotion colors from config with fallback
  - Determines retroactive status based on 28-day threshold
  - Extracts glyph data from marks

- **lib/engine/index.ts** (modified): Exports new types and transformation function

## Notes

- `toPebbleParams()` is pure and deterministic—no side effects or external dependencies beyond config lookup
- Emotion color resolution includes a neutral gray fallback for unrecognized emotion IDs
- Retroactive threshold is hardcoded to 28 days; consider extracting to config if this becomes configurable
- Types are designed to decouple the rendering engine from domain model details

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01EgxSqBCCGXq6v3gFSNsY2S