### PR TITLE
feat(engine): add shape generation with geometry utilities

### DIFF
--- a/lib/engine/geometry.ts
+++ b/lib/engine/geometry.ts
@@ -1,0 +1,67 @@
+import type { Point } from "./types"
+import type { PRNG } from "./prng"
+
+/**
+ * Convert polar coordinates to Cartesian.
+ */
+export function polarToCartesian(
+  cx: number,
+  cy: number,
+  radius: number,
+  angleRad: number,
+): Point {
+  return {
+    x: cx + radius * Math.cos(angleRad),
+    y: cy + radius * Math.sin(angleRad),
+  }
+}
+
+/**
+ * Displace a point by a random offset in both axes, bounded by `amount`.
+ * Uses the provided PRNG for deterministic results.
+ */
+export function displacePoint(
+  point: Point,
+  amount: number,
+  rng: PRNG,
+): Point {
+  return {
+    x: point.x + rng.nextFloat(-amount, amount),
+    y: point.y + rng.nextFloat(-amount, amount),
+  }
+}
+
+/**
+ * Convert a closed polygon into a smooth SVG path using cubic Bézier curves.
+ *
+ * Uses Catmull-Rom to cubic Bézier conversion: for each segment P[i] → P[i+1],
+ * control points are derived from adjacent vertices to produce smooth contours.
+ */
+export function bezierSmooth(vertices: Point[]): string {
+  const n = vertices.length
+  if (n < 3) {
+    throw new Error("bezierSmooth requires at least 3 vertices")
+  }
+
+  const at = (i: number) => vertices[((i % n) + n) % n]
+
+  const first = at(0)
+  let d = `M${first.x},${first.y}`
+
+  for (let i = 0; i < n; i++) {
+    const p0 = at(i - 1)
+    const p1 = at(i)
+    const p2 = at(i + 1)
+    const p3 = at(i + 2)
+
+    const cp1x = p1.x + (p2.x - p0.x) / 6
+    const cp1y = p1.y + (p2.y - p0.y) / 6
+    const cp2x = p2.x - (p3.x - p1.x) / 6
+    const cp2y = p2.y - (p3.y - p1.y) / 6
+
+    d += ` C${cp1x},${cp1y} ${cp2x},${cp2y} ${p2.x},${p2.y}`
+  }
+
+  d += " Z"
+  return d
+}

--- a/lib/engine/index.ts
+++ b/lib/engine/index.ts
@@ -1,11 +1,14 @@
 export { hashUUID } from "./seed"
 export { type PRNG, createPRNG } from "./prng"
 export { toPebbleParams } from "./params"
+export { polarToCartesian, displacePoint, bezierSmooth } from "./geometry"
+export { generateShape } from "./shape"
 export type {
   PebbleParams,
   Glyph,
   RenderTier,
   RenderOutput,
+  ShapeOutput,
   Point,
   BBox,
   Rect,

--- a/lib/engine/shape.ts
+++ b/lib/engine/shape.ts
@@ -1,0 +1,71 @@
+import type { Pebble } from "@/lib/types"
+import type { Point, BBox, ShapeOutput } from "./types"
+import type { PRNG } from "./prng"
+import { polarToCartesian, displacePoint, bezierSmooth } from "./geometry"
+
+// ── Intensity-to-shape configuration ─────────────────────────────
+
+type ShapeConfig = {
+  vertexCount: number
+  radius: number
+  startAngle: number
+  displacement: number
+}
+
+const SHAPE_CONFIGS: Record<Pebble["intensity"], ShapeConfig> = {
+  1: { vertexCount: 8, radius: 30, startAngle: 0, displacement: 4 },
+  2: { vertexCount: 3, radius: 40, startAngle: -Math.PI / 2, displacement: 6 },
+  3: { vertexCount: 4, radius: 50, startAngle: -Math.PI / 2, displacement: 8 },
+}
+
+// ── Shape generator ──────────────────────────────────────────────
+
+/**
+ * Generate a deterministic pebble contour from intensity and PRNG state.
+ *
+ * - Intensity 1: rounded (8-vertex polygon, small radius)
+ * - Intensity 2: triangular (3 vertices, medium radius)
+ * - Intensity 3: diamond (4 vertices, large radius)
+ *
+ * Shapes are centered at the origin. The consumer translates/scales as needed.
+ */
+export function generateShape(
+  rng: PRNG,
+  intensity: Pebble["intensity"],
+): ShapeOutput {
+  const config = SHAPE_CONFIGS[intensity]
+  const step = (2 * Math.PI) / config.vertexCount
+
+  const baseVertices: Point[] = []
+  for (let i = 0; i < config.vertexCount; i++) {
+    const angle = config.startAngle + step * i
+    baseVertices.push(polarToCartesian(0, 0, config.radius, angle))
+  }
+
+  const vertices = baseVertices.map((v) =>
+    displacePoint(v, config.displacement, rng),
+  )
+
+  const path = bezierSmooth(vertices)
+  const bbox = computeBBox(vertices)
+
+  return { path, bbox, vertices }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function computeBBox(points: Point[]): BBox {
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+
+  for (const p of points) {
+    if (p.x < minX) minX = p.x
+    if (p.y < minY) minY = p.y
+    if (p.x > maxX) maxX = p.x
+    if (p.y > maxY) maxY = p.y
+  }
+
+  return { minX, minY, maxX, maxY }
+}

--- a/lib/engine/types.ts
+++ b/lib/engine/types.ts
@@ -18,6 +18,14 @@ export type Rect = {
   height: number
 }
 
+// ── Shape output ─────────────────────────────────────────────────
+
+export type ShapeOutput = {
+  path: string
+  bbox: BBox
+  vertices: Point[]
+}
+
 // ── Glyph (mark rendering data) ───────────────────────────────────
 
 export type Glyph = {


### PR DESCRIPTION
Resolves #126 

## Changes

- **lib/engine/shape.ts** (new): Added `generateShape()` function that generates deterministic pebble contours based on intensity level (1–3), with intensity-specific configurations for vertex count, radius, and displacement
- **lib/engine/geometry.ts** (new): Added geometry utilities:
  - `polarToCartesian()`: Convert polar to Cartesian coordinates
  - `displacePoint()`: Apply random displacement to a point using PRNG
  - `bezierSmooth()`: Convert closed polygon vertices to smooth SVG path using Catmull-Rom to cubic Bézier conversion
- **lib/engine/types.ts**: Added `ShapeOutput` type to represent generated shape data (path, bounding box, vertices)
- **lib/engine/index.ts**: Exported new shape and geometry functions and types

## Notes

- Shapes are generated centered at the origin; consumers are responsible for translation and scaling
- Intensity mapping:
  - Intensity 1: 8-vertex rounded polygon (radius 30, displacement 4)
  - Intensity 2: 3-vertex triangle (radius 40, displacement 6)
  - Intensity 3: 4-vertex diamond (radius 50, displacement 8)
- All shape generation is deterministic via the provided PRNG, enabling reproducible pebble rendering from seed
- Bézier smoothing uses Catmull-Rom control point derivation for natural-looking contours

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01821btoHYBu3HqQa19xtmB7