### PR TITLE
feat(engine): add surface generation with gradients and filters

### DIFF
--- a/lib/engine/filters.ts
+++ b/lib/engine/filters.ts
@@ -1,0 +1,96 @@
+import type { Pebble } from "@/lib/types"
+import type { FilterDef } from "./types"
+import type { PRNG } from "./prng"
+
+// ── Turbulence parameters by positiveness band ──────────────────
+
+type TurbulenceProfile = {
+  type: "fractalNoise" | "turbulence"
+  baseFrequency: [number, number]
+  numOctaves: number
+}
+
+const TURBULENCE_PROFILES: Record<Pebble["positiveness"], TurbulenceProfile> = {
+  "-2": { type: "fractalNoise", baseFrequency: [0.06, 0.08], numOctaves: 5 },
+  "-1": { type: "fractalNoise", baseFrequency: [0.04, 0.06], numOctaves: 4 },
+  "0": { type: "turbulence", baseFrequency: [0.02, 0.04], numOctaves: 3 },
+  "1": { type: "turbulence", baseFrequency: [0.015, 0.025], numOctaves: 2 },
+  "2": { type: "turbulence", baseFrequency: [0.01, 0.02], numOctaves: 2 },
+}
+
+// ── Specular parameters by positiveness band ────────────────────
+
+type SpecularProfile = {
+  surfaceScale: [number, number]
+  specularExponent: [number, number]
+  specularConstant: number
+}
+
+const SPECULAR_PROFILES: Record<Pebble["positiveness"], SpecularProfile> = {
+  "-2": { surfaceScale: [1, 2], specularExponent: [5, 10], specularConstant: 0.3 },
+  "-1": { surfaceScale: [1, 3], specularExponent: [8, 12], specularConstant: 0.4 },
+  "0": { surfaceScale: [2, 4], specularExponent: [10, 15], specularConstant: 0.5 },
+  "1": { surfaceScale: [3, 6], specularExponent: [20, 30], specularConstant: 0.7 },
+  "2": { surfaceScale: [5, 8], specularExponent: [30, 40], specularConstant: 0.9 },
+}
+
+// ── Filter builders ─────────────────────────────────────────────
+
+/**
+ * Build a turbulence texture filter.
+ *
+ * Produces an `<feTurbulence>` noise composited onto the source graphic.
+ * Parameters vary by positiveness: negative values produce heavy fractal noise,
+ * positive values produce subtle smooth turbulence.
+ */
+export function turbulenceFilter(
+  id: string,
+  rng: PRNG,
+  positiveness: Pebble["positiveness"],
+): FilterDef {
+  const profile = TURBULENCE_PROFILES[positiveness]
+  const freq = rng.nextFloat(profile.baseFrequency[0], profile.baseFrequency[1])
+  const seed = rng.nextInt(0, 10000)
+
+  const svg = [
+    `<filter id="${id}" x="0%" y="0%" width="100%" height="100%">`,
+    `<feTurbulence type="${profile.type}" baseFrequency="${freq}" numOctaves="${profile.numOctaves}" seed="${seed}" result="noise"/>`,
+    `<feColorMatrix type="saturate" values="0" in="noise" result="mono"/>`,
+    `<feBlend in="SourceGraphic" in2="mono" mode="multiply"/>`,
+    `</filter>`,
+  ].join("")
+
+  return { id, svg }
+}
+
+/**
+ * Build a specular lighting filter for highlight effects.
+ *
+ * Produces `<feSpecularLighting>` with a point light, composited
+ * additively over the source graphic. Light position is PRNG-jittered
+ * for per-pebble uniqueness.
+ */
+export function specularFilter(
+  id: string,
+  rng: PRNG,
+  positiveness: Pebble["positiveness"],
+): FilterDef {
+  const profile = SPECULAR_PROFILES[positiveness]
+  const surfaceScale = rng.nextFloat(profile.surfaceScale[0], profile.surfaceScale[1])
+  const exponent = rng.nextFloat(profile.specularExponent[0], profile.specularExponent[1])
+
+  const lightX = rng.nextFloat(-50, 50)
+  const lightY = rng.nextFloat(-80, -20)
+  const lightZ = rng.nextFloat(80, 150)
+
+  const svg = [
+    `<filter id="${id}" x="-20%" y="-20%" width="140%" height="140%">`,
+    `<feSpecularLighting surfaceScale="${surfaceScale}" specularConstant="${profile.specularConstant}" specularExponent="${exponent}" in="SourceGraphic" result="specular">`,
+    `<fePointLight x="${lightX}" y="${lightY}" z="${lightZ}"/>`,
+    `</feSpecularLighting>`,
+    `<feComposite in="specular" in2="SourceGraphic" operator="arithmetic" k1="0" k2="1" k3="1" k4="0"/>`,
+    `</filter>`,
+  ].join("")
+
+  return { id, svg }
+}

--- a/lib/engine/index.ts
+++ b/lib/engine/index.ts
@@ -3,6 +3,8 @@ export { type PRNG, createPRNG } from "./prng"
 export { toPebbleParams } from "./params"
 export { polarToCartesian, displacePoint, bezierSmooth } from "./geometry"
 export { generateShape } from "./shape"
+export { turbulenceFilter, specularFilter } from "./filters"
+export { generateSurface } from "./surface"
 export type {
   PebbleParams,
   Glyph,
@@ -12,4 +14,6 @@ export type {
   Point,
   BBox,
   Rect,
+  FilterDef,
+  SurfaceOutput,
 } from "./types"

--- a/lib/engine/surface.ts
+++ b/lib/engine/surface.ts
@@ -1,0 +1,200 @@
+import type { Pebble } from "@/lib/types"
+import type { Rect, SurfaceOutput, RenderTier } from "./types"
+import type { PRNG } from "./prng"
+import { turbulenceFilter, specularFilter } from "./filters"
+
+// ── Edge noise ranges by positiveness ───────────────────────────
+
+const EDGE_NOISE_RANGE: Record<Pebble["positiveness"], [number, number]> = {
+  "-2": [0.7, 1.0],
+  "-1": [0.5, 0.7],
+  "0": [0.3, 0.5],
+  "1": [0.1, 0.3],
+  "2": [0.0, 0.15],
+}
+
+// ── Gradient builders ───────────────────────────────────────────
+
+function gradientCoords(
+  rng: PRNG,
+  vb: Rect,
+): { x1: string; y1: string; x2: string; y2: string } {
+  const angle = rng.nextFloat(0, Math.PI)
+  const cx = vb.x + vb.width / 2
+  const cy = vb.y + vb.height / 2
+  const halfDiag = Math.sqrt(vb.width ** 2 + vb.height ** 2) / 2
+
+  const dx = Math.cos(angle) * halfDiag
+  const dy = Math.sin(angle) * halfDiag
+
+  return {
+    x1: `${cx - dx}`,
+    y1: `${cy - dy}`,
+    x2: `${cx + dx}`,
+    y2: `${cy + dy}`,
+  }
+}
+
+function buildNegativeGradient(
+  rng: PRNG,
+  uid: number,
+  vb: Rect,
+  positiveness: -2 | -1,
+): string {
+  const coords = gradientCoords(rng, vb)
+  const gradId = `grad-${uid}`
+
+  const darkBase = positiveness === -2 ? "#1a1a1a" : "#2d2d2d"
+  const darkEnd = positiveness === -2 ? "#0d0d0d" : "#1a1a1a"
+  const midStop = rng.nextFloat(0.4, 0.6)
+
+  let defs = [
+    `<linearGradient id="${gradId}" gradientUnits="userSpaceOnUse" x1="${coords.x1}" y1="${coords.y1}" x2="${coords.x2}" y2="${coords.y2}">`,
+    `<stop offset="0" stop-color="${darkBase}"/>`,
+    `<stop offset="${midStop}" stop-color="${darkEnd}"/>`,
+    `<stop offset="1" stop-color="${darkBase}"/>`,
+    `</linearGradient>`,
+  ].join("")
+
+  if (positiveness === -2) {
+    const vigId = `vig-${uid}`
+    const vcx = vb.x + vb.width / 2 + rng.nextFloat(-5, 5)
+    const vcy = vb.y + vb.height / 2 + rng.nextFloat(-5, 5)
+
+    defs += [
+      `<radialGradient id="${vigId}" gradientUnits="userSpaceOnUse" cx="${vcx}" cy="${vcy}" r="${Math.max(vb.width, vb.height) / 2}">`,
+      `<stop offset="0" stop-color="#000000" stop-opacity="0.4"/>`,
+      `<stop offset="1" stop-color="#000000" stop-opacity="0"/>`,
+      `</radialGradient>`,
+    ].join("")
+  }
+
+  return defs
+}
+
+function buildNeutralGradient(
+  rng: PRNG,
+  uid: number,
+  vb: Rect,
+): string {
+  const coords = gradientCoords(rng, vb)
+  const gradId = `grad-${uid}`
+  const midStop = rng.nextFloat(0.45, 0.55)
+
+  return [
+    `<linearGradient id="${gradId}" gradientUnits="userSpaceOnUse" x1="${coords.x1}" y1="${coords.y1}" x2="${coords.x2}" y2="${coords.y2}">`,
+    `<stop offset="0" stop-color="#9CA3AF"/>`,
+    `<stop offset="${midStop}" stop-color="#6B7280"/>`,
+    `<stop offset="1" stop-color="#9CA3AF"/>`,
+    `</linearGradient>`,
+  ].join("")
+}
+
+function buildPositiveGradient(
+  rng: PRNG,
+  uid: number,
+  vb: Rect,
+  positiveness: 1 | 2,
+): string {
+  const coords = gradientCoords(rng, vb)
+  const gradId = `grad-${uid}`
+
+  const stopCount = positiveness === 2 ? 6 : 4
+  const startHue = rng.nextFloat(0, 360)
+  const hueStep = rng.nextFloat(40, 80)
+  const saturation = rng.nextFloat(70, 90)
+  const lightness = rng.nextFloat(60, 80)
+
+  const stops: string[] = []
+  for (let i = 0; i < stopCount; i++) {
+    const offset = i / (stopCount - 1)
+    const hue = (startHue + hueStep * i) % 360
+    stops.push(
+      `<stop offset="${offset}" stop-color="hsl(${hue}, ${saturation}%, ${lightness}%)"/>`,
+    )
+  }
+
+  let defs = [
+    `<linearGradient id="${gradId}" gradientUnits="userSpaceOnUse" x1="${coords.x1}" y1="${coords.y1}" x2="${coords.x2}" y2="${coords.y2}">`,
+    ...stops,
+    `</linearGradient>`,
+  ].join("")
+
+  if (positiveness === 2) {
+    const specId = `glow-${uid}`
+    const cx = vb.x + vb.width / 2 + rng.nextFloat(-10, 10)
+    const cy = vb.y + vb.height / 2 + rng.nextFloat(-15, -5)
+
+    defs += [
+      `<radialGradient id="${specId}" gradientUnits="userSpaceOnUse" cx="${cx}" cy="${cy}" r="${Math.max(vb.width, vb.height) * 0.4}">`,
+      `<stop offset="0" stop-color="#ffffff" stop-opacity="0.35"/>`,
+      `<stop offset="1" stop-color="#ffffff" stop-opacity="0"/>`,
+      `</radialGradient>`,
+    ].join("")
+  }
+
+  return defs
+}
+
+// ── Surface generator ───────────────────────────────────────────
+
+/**
+ * Generate surface treatment for a pebble based on its positiveness.
+ *
+ * Returns SVG defs (gradients + optional filters), a fill attribute,
+ * an optional filter reference, and an edge noise value.
+ *
+ * - Negative values → dark gradients, heavy noise, rough texture
+ * - Neutral → muted greys, medium noise
+ * - Positive → iridescent multi-stop gradients, specular highlights, smooth edges
+ *
+ * Filters are only included when `tier` is `"detail"`.
+ * Output is fully deterministic for identical PRNG state.
+ */
+export function generateSurface(
+  positiveness: Pebble["positiveness"],
+  rng: PRNG,
+  viewBox: Rect,
+  tier: RenderTier,
+): SurfaceOutput {
+  const uid = rng.nextInt(1000, 9999)
+
+  // Build gradient defs based on positiveness band
+  let gradientDefs: string
+  if (positiveness <= -1) {
+    gradientDefs = buildNegativeGradient(rng, uid, viewBox, positiveness as -2 | -1)
+  } else if (positiveness === 0) {
+    gradientDefs = buildNeutralGradient(rng, uid, viewBox)
+  } else {
+    gradientDefs = buildPositiveGradient(rng, uid, viewBox, positiveness as 1 | 2)
+  }
+
+  // Build filters (detail tier only)
+  let filterDefs = ""
+  let filterRef: string | null = null
+
+  if (tier === "detail") {
+    const turbId = `turb-${uid}`
+    const turb = turbulenceFilter(turbId, rng, positiveness)
+    filterDefs += turb.svg
+    filterRef = `url(#${turb.id})`
+
+    if (positiveness >= 1) {
+      const specId = `spec-${uid}`
+      const spec = specularFilter(specId, rng, positiveness)
+      filterDefs += spec.svg
+      filterRef = `url(#${spec.id})`
+    }
+  }
+
+  // Compute edge noise
+  const [lo, hi] = EDGE_NOISE_RANGE[positiveness]
+  const edgeNoise = rng.nextFloat(lo, hi)
+
+  return {
+    defs: gradientDefs + filterDefs,
+    fill: `url(#grad-${uid})`,
+    filterRef,
+    edgeNoise,
+  }
+}

--- a/lib/engine/types.ts
+++ b/lib/engine/types.ts
@@ -44,6 +44,28 @@ export type RenderOutput = {
   viewBox: string
 }
 
+// ── Filter definition ────────────────────────────────────────────
+
+export type FilterDef = {
+  /** Unique filter ID for referencing in style attributes. */
+  id: string
+  /** Complete <filter>...</filter> SVG element string. */
+  svg: string
+}
+
+// ── Surface output ──────────────────────────────────────────────
+
+export type SurfaceOutput = {
+  /** SVG string fragments for a <defs> block (gradients + filters). */
+  defs: string
+  /** Fill attribute value (e.g. "url(#grad-1234)" or a solid color). */
+  fill: string
+  /** CSS filter reference (e.g. "url(#turb-1234)"). Null when filters are skipped. */
+  filterRef: string | null
+  /** Edge noise magnitude [0, 1] for downstream shape displacement. */
+  edgeNoise: number
+}
+
 // ── PebbleParams (engine input contract) ──────────────────────────
 
 export type PebbleParams = {


### PR DESCRIPTION
Resolves #127 

## Changes

- **lib/engine/surface.ts** (new): Core surface generation module that produces SVG gradients and filter references based on pebble positiveness. Includes three gradient builders (negative, neutral, positive) with positiveness-aware styling and optional specular highlights.

- **lib/engine/filters.ts** (new): Filter effect generators for turbulence and specular lighting. Each filter type has positiveness-dependent profiles controlling frequency, octaves, surface scale, and light positioning for deterministic per-pebble variation.

- **lib/engine/types.ts**: Added `FilterDef` and `SurfaceOutput` type definitions to support filter and surface generation contracts.

- **lib/engine/index.ts**: Exported new `generateSurface`, `turbulenceFilter`, `specularFilter` functions and their types.

## Notes

- Surface generation is fully deterministic: identical PRNG state produces identical output
- Filters (turbulence + specular) are only generated when `tier === "detail"` to optimize for lower render tiers
- Edge noise values are computed from positiveness-dependent ranges to control shape displacement downstream
- Gradient coordinates use random angles and diagonal calculations to avoid repetitive patterns
- Specular lighting uses PRNG-jittered light positions for per-pebble uniqueness while maintaining determinism
- All SVG strings are concatenated directly (no DOM dependencies) for server-side rendering compatibility

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01RHLxSAJGx1mFK82FHxxESd