### PR TITLE
feat(engine): add vein generation for pebble emotion visualization

### DIFF
--- a/lib/engine/geometry.ts
+++ b/lib/engine/geometry.ts
@@ -65,3 +65,55 @@ export function bezierSmooth(vertices: Point[]): string {
   d += " Z"
   return d
 }
+
+/**
+ * Convert an ordered sequence of points into a smooth open SVG path
+ * using cubic Bézier curves.
+ *
+ * Uses the same Catmull-Rom to cubic Bézier conversion as `bezierSmooth`,
+ * but handles endpoints with phantom (reflected) points instead of wrapping.
+ */
+export function openBezierPath(points: Point[]): string {
+  const n = points.length
+  if (n < 2) {
+    throw new Error("openBezierPath requires at least 2 points")
+  }
+
+  if (n === 2) {
+    return `M${points[0].x},${points[0].y} L${points[1].x},${points[1].y}`
+  }
+
+  // Phantom points: reflect the neighbour through the endpoint
+  const phantom0: Point = {
+    x: 2 * points[0].x - points[1].x,
+    y: 2 * points[0].y - points[1].y,
+  }
+  const phantomN: Point = {
+    x: 2 * points[n - 1].x - points[n - 2].x,
+    y: 2 * points[n - 1].y - points[n - 2].y,
+  }
+
+  const at = (i: number): Point => {
+    if (i === -1) return phantom0
+    if (i === n) return phantomN
+    return points[i]
+  }
+
+  let d = `M${points[0].x},${points[0].y}`
+
+  for (let i = 0; i < n - 1; i++) {
+    const p0 = at(i - 1)
+    const p1 = at(i)
+    const p2 = at(i + 1)
+    const p3 = at(i + 2)
+
+    const cp1x = p1.x + (p2.x - p0.x) / 6
+    const cp1y = p1.y + (p2.y - p0.y) / 6
+    const cp2x = p2.x - (p3.x - p1.x) / 6
+    const cp2y = p2.y - (p3.y - p1.y) / 6
+
+    d += ` C${cp1x},${cp1y} ${cp2x},${cp2y} ${p2.x},${p2.y}`
+  }
+
+  return d
+}

--- a/lib/engine/index.ts
+++ b/lib/engine/index.ts
@@ -1,10 +1,11 @@
 export { hashUUID } from "./seed"
 export { type PRNG, createPRNG } from "./prng"
 export { toPebbleParams } from "./params"
-export { polarToCartesian, displacePoint, bezierSmooth } from "./geometry"
+export { polarToCartesian, displacePoint, bezierSmooth, openBezierPath } from "./geometry"
 export { generateShape } from "./shape"
 export { turbulenceFilter, specularFilter } from "./filters"
 export { generateSurface } from "./surface"
+export { generateVeins } from "./veins"
 export type {
   PebbleParams,
   Glyph,
@@ -16,4 +17,6 @@ export type {
   Rect,
   FilterDef,
   SurfaceOutput,
+  VeinParams,
+  VeinOutput,
 } from "./types"

--- a/lib/engine/types.ts
+++ b/lib/engine/types.ts
@@ -66,6 +66,26 @@ export type SurfaceOutput = {
   edgeNoise: number
 }
 
+// ── Vein output ─────────────────────────────────────────────────
+
+export type VeinParams = {
+  emotionColor: string
+  intensity: 1 | 2 | 3
+  bounds: BBox
+  exclusionZones: Rect[]
+  /** Pebble shape SVG path string, used to build a clip path. */
+  shapePath: string
+}
+
+export type VeinOutput = {
+  /** SVG <clipPath> element string for a <defs> block. */
+  defs: string
+  /** Individual <path> element strings, each a complete vein with stroke attributes. */
+  paths: string[]
+  /** Clip path ID for the consumer to apply to a <g> wrapping the veins. */
+  clipId: string
+}
+
 // ── PebbleParams (engine input contract) ──────────────────────────
 
 export type PebbleParams = {

--- a/lib/engine/veins.ts
+++ b/lib/engine/veins.ts
@@ -1,0 +1,205 @@
+import type { Pebble } from "@/lib/types"
+import type { Point, BBox, Rect, VeinParams, VeinOutput } from "./types"
+import type { PRNG } from "./prng"
+import { openBezierPath } from "./geometry"
+
+// ── Intensity-to-vein configuration ─────────────────────────────
+
+type VeinConfig = {
+  minCount: number
+  maxCount: number
+  waypointRange: [number, number]
+  widthRange: [number, number]
+  opacityRange: [number, number]
+  wanderFactor: number
+}
+
+const VEIN_CONFIGS: Record<Pebble["intensity"], VeinConfig> = {
+  1: {
+    minCount: 1,
+    maxCount: 1,
+    waypointRange: [2, 3],
+    widthRange: [0.8, 1.5],
+    opacityRange: [0.4, 0.6],
+    wanderFactor: 0.15,
+  },
+  2: {
+    minCount: 1,
+    maxCount: 2,
+    waypointRange: [2, 4],
+    widthRange: [0.5, 1.8],
+    opacityRange: [0.3, 0.65],
+    wanderFactor: 0.2,
+  },
+  3: {
+    minCount: 1,
+    maxCount: 3,
+    waypointRange: [3, 5],
+    widthRange: [0.4, 2.0],
+    opacityRange: [0.25, 0.7],
+    wanderFactor: 0.25,
+  },
+}
+
+// ── Edge helpers ────────────────────────────────────────────────
+
+type Edge = 0 | 1 | 2 | 3 // top, right, bottom, left
+
+const EDGES: readonly Edge[] = [0, 1, 2, 3]
+
+/**
+ * Pick a point along a bounding-box edge, inset by ~15 % so the
+ * vein starts/ends within the pebble body rather than at the extreme corner.
+ */
+function pickEdgePoint(edge: Edge, bounds: BBox, rng: PRNG): Point {
+  const w = bounds.maxX - bounds.minX
+  const h = bounds.maxY - bounds.minY
+  const insetX = w * 0.15
+  const insetY = h * 0.15
+
+  switch (edge) {
+    case 0: // top
+      return { x: rng.nextFloat(bounds.minX + insetX, bounds.maxX - insetX), y: bounds.minY }
+    case 1: // right
+      return { x: bounds.maxX, y: rng.nextFloat(bounds.minY + insetY, bounds.maxY - insetY) }
+    case 2: // bottom
+      return { x: rng.nextFloat(bounds.minX + insetX, bounds.maxX - insetX), y: bounds.maxY }
+    case 3: // left
+      return { x: bounds.minX, y: rng.nextFloat(bounds.minY + insetY, bounds.maxY - insetY) }
+  }
+}
+
+// ── Exclusion zone avoidance ────────────────────────────────────
+
+const EXCLUSION_PADDING = 3
+
+function isInsideRect(point: Point, rect: Rect, padding: number): boolean {
+  return (
+    point.x >= rect.x - padding &&
+    point.x <= rect.x + rect.width + padding &&
+    point.y >= rect.y - padding &&
+    point.y <= rect.y + rect.height + padding
+  )
+}
+
+/**
+ * Push a waypoint away from any overlapping exclusion zone.
+ * Applies a small random jitter so avoidance paths don't look mechanical.
+ */
+function avoidExclusions(point: Point, zones: Rect[], rng: PRNG): Point {
+  let { x, y } = point
+
+  for (const zone of zones) {
+    if (!isInsideRect({ x, y }, zone, EXCLUSION_PADDING)) continue
+
+    const cx = zone.x + zone.width / 2
+    const cy = zone.y + zone.height / 2
+    let dx = x - cx
+    let dy = y - cy
+
+    // If the point is at the exact centre, pick a random direction
+    if (dx === 0 && dy === 0) {
+      dx = rng.nextFloat(-1, 1)
+      dy = rng.nextFloat(-1, 1)
+    }
+
+    const len = Math.sqrt(dx * dx + dy * dy)
+    const nx = dx / len
+    const ny = dy / len
+
+    // Push outward past the zone boundary + padding + jitter
+    const escapeDistance =
+      Math.max(zone.width, zone.height) / 2 + EXCLUSION_PADDING + rng.nextFloat(1, 3)
+    x = cx + nx * escapeDistance
+    y = cy + ny * escapeDistance
+  }
+
+  return { x, y }
+}
+
+// ── Single vein generation ──────────────────────────────────────
+
+function generateSingleVein(
+  rng: PRNG,
+  params: VeinParams,
+  config: VeinConfig,
+): string {
+  const { emotionColor, bounds, exclusionZones } = params
+
+  // Pick two different edges for entry and exit
+  const entryEdge = rng.pick(EDGES)
+  let exitEdge = rng.pick(EDGES)
+  while (exitEdge === entryEdge) {
+    exitEdge = rng.pick(EDGES)
+  }
+
+  const start = pickEdgePoint(entryEdge, bounds, rng)
+  const end = pickEdgePoint(exitEdge, bounds, rng)
+
+  // Generate intermediate waypoints
+  const waypointCount = rng.nextInt(config.waypointRange[0], config.waypointRange[1])
+  const pebbleSize = Math.max(bounds.maxX - bounds.minX, bounds.maxY - bounds.minY)
+  const wanderAmount = config.wanderFactor * pebbleSize
+
+  // Perpendicular direction to the start→end vector
+  const vx = end.x - start.x
+  const vy = end.y - start.y
+  const vLen = Math.sqrt(vx * vx + vy * vy) || 1
+  const perpX = -vy / vLen
+  const perpY = vx / vLen
+
+  const waypoints: Point[] = []
+  for (let i = 0; i < waypointCount; i++) {
+    const t = (i + 1) / (waypointCount + 1)
+    const baseX = start.x + vx * t
+    const baseY = start.y + vy * t
+    const offset = rng.nextFloat(-wanderAmount, wanderAmount)
+
+    const raw: Point = {
+      x: baseX + perpX * offset,
+      y: baseY + perpY * offset,
+    }
+
+    waypoints.push(avoidExclusions(raw, exclusionZones, rng))
+  }
+
+  const allPoints = [start, ...waypoints, end]
+  const pathData = openBezierPath(allPoints)
+
+  const strokeWidth = rng.nextFloat(config.widthRange[0], config.widthRange[1])
+  const strokeOpacity = rng.nextFloat(config.opacityRange[0], config.opacityRange[1])
+
+  return `<path d="${pathData}" stroke="${emotionColor}" stroke-width="${strokeWidth}" stroke-opacity="${strokeOpacity}" fill="none" stroke-linecap="round"/>`
+}
+
+// ── Public API ──────────────────────────────────────────────────
+
+/**
+ * Generate deterministic emotion veins for a pebble.
+ *
+ * Veins are coloured Bézier curves that flow across the pebble surface.
+ * Quantity scales with intensity (1 → 1, 2 → 1-2, 3 → 1-3).
+ * All veins share the single emotion colour (V1).
+ *
+ * Output paths are clipped to the pebble boundary via a `<clipPath>` in
+ * `defs`. The consumer wraps the paths in a `<g clip-path="url(#clipId)">`.
+ *
+ * Pure function — no DOM or React dependencies. Deterministic for
+ * identical PRNG state.
+ */
+export function generateVeins(rng: PRNG, params: VeinParams): VeinOutput {
+  const uid = rng.nextInt(1000, 9999)
+  const config = VEIN_CONFIGS[params.intensity]
+
+  const veinCount = rng.nextInt(config.minCount, config.maxCount)
+  const clipId = `vein-clip-${uid}`
+
+  const defs = `<clipPath id="${clipId}"><path d="${params.shapePath}"/></clipPath>`
+
+  const paths: string[] = []
+  for (let i = 0; i < veinCount; i++) {
+    paths.push(generateSingleVein(rng, params, config))
+  }
+
+  return { defs, paths, clipId }
+}


### PR DESCRIPTION
Resolves #128 

## Changes

- **lib/engine/veins.ts** (new): Core vein generation system
  - `generateVeins()`: Main public API that generates deterministic emotion veins for a pebble
  - `generateSingleVein()`: Creates individual Bézier curve veins with configurable wandering and exclusion zone avoidance
  - `VEIN_CONFIGS`: Intensity-based configuration mapping (1→1 vein, 2→1-2 veins, 3→1-3 veins) with tunable stroke width, opacity, and waypoint counts
  - Edge-picking and exclusion zone avoidance helpers to keep veins within pebble bounds and away from other visual elements

- **lib/engine/geometry.ts**: Added `openBezierPath()` function
  - Converts ordered point sequences into smooth open SVG paths using cubic Bézier curves
  - Uses phantom point reflection at endpoints (unlike the closed `bezierSmooth()`)
  - Reuses Catmull-Rom to cubic Bézier conversion logic for consistency

- **lib/engine/types.ts**: Added type definitions
  - `VeinParams`: Input contract (emotion color, intensity, bounds, exclusion zones, shape path)
  - `VeinOutput`: Output structure (SVG clipPath defs, individual path elements, clip ID)

- **lib/engine/index.ts**: Updated exports
  - Exported `generateVeins` and `openBezierPath`
  - Added `VeinParams` and `VeinOutput` type exports

## Notes

- Veins are colored Bézier curves that flow across the pebble surface, scaled by emotion intensity
- All veins share a single emotion color (V1) and are clipped to the pebble boundary via SVG `<clipPath>`
- Waypoints are generated perpendicular to the start→end vector with configurable wander, then pushed away from exclusion zones to avoid overlaps
- Pure function with no DOM or React dependencies; deterministic for identical PRNG state
- Edge points are inset by ~15% to keep veins within the pebble body rather than at extreme corners

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01RyFeLxH5xVcbSMDoZxbWfC