### PR TITLE
feat(engine): add zone allocation, fossil rendering, and glyph placement

### DIFF
--- a/lib/engine/fossil.ts
+++ b/lib/engine/fossil.ts
@@ -1,0 +1,121 @@
+import type { Point, Rect } from "./types"
+import type { PRNG } from "./prng"
+import { openBezierPath } from "./geometry"
+
+// ── Constants ──────────────────────────────────────────────────────
+
+/** Number of sample points along the spiral. */
+const SPIRAL_STEPS = 40
+
+/** How much of the zone radius the spiral may occupy. */
+const FIT_RATIO = 0.45
+
+// ── Spiral math ────────────────────────────────────────────────────
+
+/**
+ * Sample a logarithmic spiral: r = a · e^(b · θ).
+ * Returns raw points centred at the origin.
+ */
+function sampleSpiral(
+  initialRadius: number,
+  growthRate: number,
+  totalAngle: number,
+  steps: number,
+): Point[] {
+  const points: Point[] = []
+  for (let i = 0; i <= steps; i++) {
+    const theta = (i / steps) * totalAngle
+    const r = initialRadius * Math.exp(growthRate * theta)
+    points.push({ x: r * Math.cos(theta), y: r * Math.sin(theta) })
+  }
+  return points
+}
+
+/**
+ * Scale and translate raw spiral points to fit within `zone`.
+ */
+function fitToZone(points: Point[], zone: Rect): Point[] {
+  if (points.length === 0) return []
+
+  let pMinX = Infinity
+  let pMinY = Infinity
+  let pMaxX = -Infinity
+  let pMaxY = -Infinity
+
+  for (const p of points) {
+    if (p.x < pMinX) pMinX = p.x
+    if (p.y < pMinY) pMinY = p.y
+    if (p.x > pMaxX) pMaxX = p.x
+    if (p.y > pMaxY) pMaxY = p.y
+  }
+
+  const rawW = pMaxX - pMinX || 1
+  const rawH = pMaxY - pMinY || 1
+  const maxExtent = Math.min(zone.width, zone.height) * FIT_RATIO
+  const scale = Math.min(maxExtent / rawW, maxExtent / rawH)
+
+  const cx = zone.x + zone.width / 2
+  const cy = zone.y + zone.height / 2
+  const rawCx = (pMinX + pMaxX) / 2
+  const rawCy = (pMinY + pMaxY) / 2
+
+  return points.map((p) => ({
+    x: cx + (p.x - rawCx) * scale,
+    y: cy + (p.y - rawCy) * scale,
+  }))
+}
+
+// ── Public API ─────────────────────────────────────────────────────
+
+/**
+ * Render a fossil ammonite spiral as an SVG `<g>` element.
+ *
+ * Only produces output when `retroactive` is true — otherwise returns
+ * an empty string and consumes no PRNG values.
+ *
+ * The spiral uses a logarithmic curve with seeded variation in rotation,
+ * turn count, growth rate, and colouring. Output is deterministic for
+ * identical PRNG state.
+ *
+ * Pure function — no DOM or React dependencies.
+ */
+export function renderFossil(
+  rng: PRNG,
+  zone: Rect,
+  retroactive: boolean,
+): string {
+  if (!retroactive) return ""
+
+  // ── Spiral parameters from PRNG ─────────────────────────────────
+  const rotation = rng.nextFloat(0, 2 * Math.PI)
+  const turnCount = rng.nextFloat(2.5, 4.5)
+  const growthRate = rng.nextFloat(0.12, 0.22)
+  const baseRadius = Math.min(zone.width, zone.height) * rng.nextFloat(0.03, 0.06)
+
+  const totalAngle = turnCount * 2 * Math.PI
+  const rawPoints = sampleSpiral(baseRadius, growthRate, totalAngle, SPIRAL_STEPS)
+  const points = fitToZone(rawPoints, zone)
+
+  if (points.length < 2) return ""
+
+  const pathData = openBezierPath(points)
+
+  // ── Stone-like colouring ────────────────────────────────────────
+  const hue = rng.nextInt(25, 50)
+  const sat = rng.nextInt(10, 25)
+  const light = rng.nextInt(40, 55)
+  const opacity = rng.nextFloat(0.15, 0.35)
+  const strokeWidth = rng.nextFloat(0.5, 1.2)
+
+  const color = `hsl(${hue}, ${sat}%, ${light}%)`
+  const rotDeg = (rotation * 180) / Math.PI
+  const cx = zone.x + zone.width / 2
+  const cy = zone.y + zone.height / 2
+
+  return (
+    `<g transform="rotate(${rotDeg}, ${cx}, ${cy})">` +
+    `<path d="${pathData}" stroke="${color}" stroke-width="${strokeWidth}" ` +
+    `stroke-opacity="${opacity}" fill="none" stroke-linecap="round"/>` +
+    `</g>`
+  )
+}

--- a/lib/engine/glyph.ts
+++ b/lib/engine/glyph.ts
@@ -1,0 +1,72 @@
+import type { Rect, Glyph } from "./types"
+
+// ── Constants ──────────────────────────────────────────────────────
+
+/** Inset colour for the shadow layer of the emboss effect. */
+const SHADOW_COLOR = "rgba(0,0,0,0.25)"
+
+/** Offset in viewBox units for the emboss shadow. */
+const EMBOSS_OFFSET = 0.5
+
+/** Opacity applied to the main glyph strokes. */
+const STROKE_OPACITY = 0.6
+
+// ── ViewBox parsing ────────────────────────────────────────────────
+
+function parseViewBox(vb: string): { x: number; y: number; w: number; h: number } {
+  const parts = vb.split(/\s+/).map(Number)
+  return { x: parts[0], y: parts[1], w: parts[2], h: parts[3] }
+}
+
+// ── Public API ─────────────────────────────────────────────────────
+
+/**
+ * Scale, centre, and render a user-drawn glyph (mark) within a zone.
+ *
+ * Returns an SVG `<g>` element containing transformed `<path>` elements
+ * for each stroke. A subtle dual-path emboss effect gives the glyph an
+ * inset / relief appearance without requiring SVG filters.
+ *
+ * Pure function — no PRNG, DOM, or React dependencies.
+ */
+export function renderGlyph(
+  glyph: Glyph,
+  zone: Rect,
+): string {
+  if (glyph.strokes.length === 0) return ""
+
+  const vb = parseViewBox(glyph.viewBox)
+
+  // Uniform scale preserving aspect ratio
+  const scale = Math.min(zone.width / vb.w, zone.height / vb.h)
+
+  // Translation to centre the scaled glyph in the zone
+  const offsetX = zone.x + (zone.width - vb.w * scale) / 2 - vb.x * scale
+  const offsetY = zone.y + (zone.height - vb.h * scale) / 2 - vb.y * scale
+
+  const paths: string[] = []
+
+  for (const stroke of glyph.strokes) {
+    // Shadow layer (slight offset for emboss)
+    paths.push(
+      `<path d="${stroke.d}" stroke="${SHADOW_COLOR}" ` +
+      `stroke-width="${stroke.width}" fill="none" ` +
+      `stroke-linecap="round" stroke-linejoin="round" ` +
+      `transform="translate(${EMBOSS_OFFSET}, ${EMBOSS_OFFSET})"/>`,
+    )
+
+    // Main stroke layer
+    paths.push(
+      `<path d="${stroke.d}" stroke="rgba(255,255,255,0.5)" ` +
+      `stroke-width="${stroke.width}" fill="none" ` +
+      `stroke-linecap="round" stroke-linejoin="round"/>`,
+    )
+  }
+
+  return (
+    `<g transform="translate(${offsetX}, ${offsetY}) scale(${scale})" ` +
+    `opacity="${STROKE_OPACITY}">` +
+    paths.join("") +
+    `</g>`
+  )
+}

--- a/lib/engine/index.ts
+++ b/lib/engine/index.ts
@@ -5,6 +5,9 @@ export { polarToCartesian, displacePoint, bezierSmooth, openBezierPath } from ".
 export { generateShape } from "./shape"
 export { turbulenceFilter, specularFilter } from "./filters"
 export { generateSurface } from "./surface"
+export { allocateZones } from "./zones"
+export { renderFossil } from "./fossil"
+export { renderGlyph } from "./glyph"
 export { generateVeins } from "./veins"
 export type {
   PebbleParams,
@@ -17,6 +20,7 @@ export type {
   Rect,
   FilterDef,
   SurfaceOutput,
+  ZoneAllocation,
   VeinParams,
   VeinOutput,
 } from "./types"

--- a/lib/engine/types.ts
+++ b/lib/engine/types.ts
@@ -86,6 +86,14 @@ export type VeinOutput = {
   clipId: string
 }
 
+// ── Zone allocation ─────────────────────────────────────────────
+
+export type ZoneAllocation = {
+  glyphZone: Rect | null
+  fossilZone: Rect | null
+  exclusionZones: Rect[]
+}
+
 // ── PebbleParams (engine input contract) ──────────────────────────
 
 export type PebbleParams = {

--- a/lib/engine/zones.ts
+++ b/lib/engine/zones.ts
@@ -1,0 +1,87 @@
+import type { BBox, Rect, ZoneAllocation } from "./types"
+
+// ── Constants ──────────────────────────────────────────────────────
+
+/** Glyph zone occupies 35 % of bbox (midpoint of 30–40 % spec). */
+const GLYPH_RATIO = 0.35
+
+/** Fossil zone width as a fraction of bbox. */
+const FOSSIL_WIDTH_RATIO = 0.4
+
+/** Fossil zone height as a fraction of bbox. */
+const FOSSIL_HEIGHT_RATIO = 0.35
+
+/** Vertical start of the fossil zone (60 % down → bottom quadrant). */
+const FOSSIL_Y_OFFSET = 0.6
+
+/** Minimum gap between glyph and fossil zones. */
+const ZONE_PADDING = 2
+
+// ── Public API ─────────────────────────────────────────────────────
+
+/**
+ * Divide a pebble bounding box into non-overlapping zones for
+ * glyph placement, fossil rendering, and vein exclusion.
+ *
+ * Pure function — no PRNG, no DOM dependencies.
+ */
+export function allocateZones(
+  bbox: BBox,
+  hasGlyph: boolean,
+  hasFossil: boolean,
+): ZoneAllocation {
+  const w = bbox.maxX - bbox.minX
+  const h = bbox.maxY - bbox.minY
+
+  const glyphZone = hasGlyph ? buildGlyphZone(bbox, w, h) : null
+  const fossilZone = hasFossil ? buildFossilZone(bbox, w, h, glyphZone) : null
+
+  const exclusionZones: Rect[] = []
+  if (glyphZone) exclusionZones.push(glyphZone)
+  if (fossilZone) exclusionZones.push(fossilZone)
+
+  return { glyphZone, fossilZone, exclusionZones }
+}
+
+// ── Zone builders ──────────────────────────────────────────────────
+
+function buildGlyphZone(bbox: BBox, w: number, h: number): Rect {
+  const zoneW = w * GLYPH_RATIO
+  const zoneH = h * GLYPH_RATIO
+
+  return {
+    x: bbox.minX + (w - zoneW) / 2,
+    y: bbox.minY + (h - zoneH) / 2,
+    width: zoneW,
+    height: zoneH,
+  }
+}
+
+function buildFossilZone(
+  bbox: BBox,
+  w: number,
+  h: number,
+  glyphZone: Rect | null,
+): Rect {
+  const zoneW = w * FOSSIL_WIDTH_RATIO
+  const zoneH = h * FOSSIL_HEIGHT_RATIO
+
+  let y = bbox.minY + h * FOSSIL_Y_OFFSET
+  const x = bbox.minX + (w - zoneW) / 2
+
+  // Shift below glyph zone if they overlap
+  if (glyphZone) {
+    const glyphBottom = glyphZone.y + glyphZone.height
+    if (y < glyphBottom + ZONE_PADDING) {
+      y = glyphBottom + ZONE_PADDING
+    }
+  }
+
+  // Clamp so the fossil zone stays within the bbox
+  const maxY = bbox.maxY - zoneH
+  if (y > maxY) {
+    y = maxY
+  }
+
+  return { x, y, width: zoneW, height: zoneH }
+}


### PR DESCRIPTION
Resolves #129 

## Changes

- **lib/engine/zones.ts** (new): Implements `allocateZones()` to divide pebble bounding boxes into non-overlapping regions for glyph placement, fossil rendering, and vein exclusion. Handles collision detection and clamping to keep zones within bounds.

- **lib/engine/fossil.ts** (new): Implements `renderFossil()` to render logarithmic spiral ammonite fossils as SVG. Includes spiral sampling, zone-fitting geometry, and seeded variation in rotation, growth rate, and stone-like coloring via PRNG.

- **lib/engine/glyph.ts** (new): Implements `renderGlyph()` to scale and center user-drawn glyphs within zones. Applies uniform aspect-ratio-preserving scaling and an emboss effect via dual-path rendering (shadow + main stroke).

- **lib/engine/types.ts**: Added `ZoneAllocation` type to represent allocated glyph, fossil, and exclusion zones.

- **lib/engine/index.ts**: Exported new functions and types (`allocateZones`, `renderFossil`, `renderGlyph`, `ZoneAllocation`).

## Notes

- All three new modules are pure functions with no DOM, React, or PRNG dependencies (except `renderFossil` which consumes PRNG for deterministic variation).
- Zone allocation is collision-aware: fossil zones shift downward if they overlap the glyph zone, and clamp to stay within the bounding box.
- Fossil rendering only produces output when `retroactive` is true, consuming no PRNG values otherwise.
- Glyph rendering uses an emboss effect (offset shadow + main stroke) to create visual depth without SVG filters.

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_017mGmcRsEQ9bzdFDWRg3eST