### PR TITLE
refactor(engine): extract render pipeline into dedicated module

### DIFF
--- a/lib/engine/index.ts
+++ b/lib/engine/index.ts
@@ -1,26 +1,4 @@
-export { hashUUID } from "./seed"
-export { type PRNG, createPRNG } from "./prng"
+export { renderPebble } from "./render"
 export { toPebbleParams } from "./params"
-export { polarToCartesian, displacePoint, bezierSmooth, openBezierPath } from "./geometry"
-export { generateShape } from "./shape"
-export { turbulenceFilter, specularFilter } from "./filters"
-export { generateSurface } from "./surface"
-export { allocateZones } from "./zones"
-export { renderFossil } from "./fossil"
-export { renderGlyph } from "./glyph"
-export { generateVeins } from "./veins"
-export type {
-  PebbleParams,
-  Glyph,
-  RenderTier,
-  RenderOutput,
-  ShapeOutput,
-  Point,
-  BBox,
-  Rect,
-  FilterDef,
-  SurfaceOutput,
-  ZoneAllocation,
-  VeinParams,
-  VeinOutput,
-} from "./types"
+export { hashUUID } from "./seed"
+export type { PebbleParams, RenderTier, EngineOutput } from "./types"

--- a/lib/engine/render.ts
+++ b/lib/engine/render.ts
@@ -1,0 +1,103 @@
+import type { PebbleParams, RenderTier, EngineOutput, Rect, VeinParams } from "./types"
+import { createPRNG } from "./prng"
+import { generateShape } from "./shape"
+import { generateSurface } from "./surface"
+import { allocateZones } from "./zones"
+import { generateVeins } from "./veins"
+import { renderFossil } from "./fossil"
+import { renderGlyph } from "./glyph"
+
+// ── Constants ──────────────────────────────────────────────────────
+
+/** Padding ratio applied to the shape bounding box for the SVG viewBox. */
+const VIEWBOX_PAD = 0.15
+
+// ── Pipeline ──────────────────────────────────────────────────────
+
+/**
+ * Render a complete pebble as a self-contained SVG string.
+ *
+ * Orchestrates all engine modules in a fixed sequence so the PRNG
+ * produces identical output for identical inputs:
+ *
+ *   seed → shape → zones → surface → veins → fossil → glyph → SVG
+ *
+ * Pure function — no DOM or React dependencies.
+ */
+export function renderPebble(
+  params: PebbleParams,
+  seed: number,
+  tier: RenderTier,
+): EngineOutput {
+  // 1. Create deterministic PRNG
+  const rng = createPRNG(seed)
+
+  // 2. Generate base shape from intensity
+  const shape = generateShape(rng, params.intensity)
+
+  // 3. Compute padded viewBox rect
+  const bw = shape.bbox.maxX - shape.bbox.minX
+  const bh = shape.bbox.maxY - shape.bbox.minY
+  const padX = bw * VIEWBOX_PAD
+  const padY = bh * VIEWBOX_PAD
+
+  const viewBoxRect: Rect = {
+    x: shape.bbox.minX - padX,
+    y: shape.bbox.minY - padY,
+    width: bw + padX * 2,
+    height: bh + padY * 2,
+  }
+
+  const viewBox = `${viewBoxRect.x} ${viewBoxRect.y} ${viewBoxRect.width} ${viewBoxRect.height}`
+
+  // 4. Allocate zones for glyph and fossil (pure, no PRNG)
+  const zones = allocateZones(
+    shape.bbox,
+    params.glyph !== null,
+    params.retroactive,
+  )
+
+  // 5. Generate surface treatment (gradients, filters)
+  const surface = generateSurface(params.positiveness, rng, viewBoxRect, tier)
+
+  // 6. Generate veins
+  const veinParams: VeinParams = {
+    emotionColor: params.emotionColor,
+    intensity: params.intensity,
+    bounds: shape.bbox,
+    exclusionZones: zones.exclusionZones,
+    shapePath: shape.path,
+  }
+  const veins = generateVeins(rng, veinParams)
+
+  // 7. Render fossil (no-op when not retroactive)
+  const fossilSvg = zones.fossilZone
+    ? renderFossil(rng, zones.fossilZone, params.retroactive)
+    : ""
+
+  // 8. Render glyph (no PRNG dependency)
+  const glyphSvg =
+    params.glyph && zones.glyphZone
+      ? renderGlyph(params.glyph, zones.glyphZone)
+      : ""
+
+  // 9. Assemble final SVG
+  const filterAttr = surface.filterRef ? ` filter="${surface.filterRef}"` : ""
+
+  const svg = [
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBox}">`,
+    `<defs>`,
+    surface.defs,
+    veins.defs,
+    `</defs>`,
+    `<path d="${shape.path}" fill="${surface.fill}"${filterAttr}/>`,
+    `<g clip-path="url(#${veins.clipId})">`,
+    ...veins.paths,
+    `</g>`,
+    fossilSvg,
+    glyphSvg,
+    `</svg>`,
+  ].join("")
+
+  return { svg, viewBox }
+}

--- a/lib/engine/types.ts
+++ b/lib/engine/types.ts
@@ -39,7 +39,7 @@ export type RenderTier = "thumbnail" | "detail"
 
 // ── Render output ─────────────────────────────────────────────────
 
-export type RenderOutput = {
+export type EngineOutput = {
   svg: string
   viewBox: string
 }


### PR DESCRIPTION
Resolves #130 

## Changes

- **lib/engine/render.ts** (new): Created dedicated render pipeline module that orchestrates all engine modules in a fixed sequence (`seed → shape → zones → surface → veins → fossil → glyph → SVG`). This is the main entry point for rendering pebbles as self-contained SVG strings.

- **lib/engine/index.ts**: Refactored public API to export only high-level interfaces:
  - Exports `renderPebble` as the primary rendering function
  - Keeps `toPebbleParams` and `hashUUID` as utility exports
  - Removes internal module exports (shape, surface, veins, fossil, glyph, geometry, filters, etc.)
  - Simplifies type exports to only `PebbleParams`, `RenderTier`, and `EngineOutput`

- **lib/engine/types.ts**: Renamed `RenderOutput` to `EngineOutput` for clarity and consistency with the new public API.

## Notes

This refactor improves the engine's public interface by:
- Centralizing the render orchestration logic in a single, well-documented module
- Hiding internal implementation details and reducing API surface
- Making it clear that `renderPebble` is the intended entry point for consumers
- Maintaining deterministic output through a fixed PRNG sequence documented in code comments
- Pure function with no DOM or React dependencies, suitable for server-side rendering

The pipeline is intentionally sequential to ensure identical output for identical inputs, which is critical for reproducible pebble generation.

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01J8XXKGWyAhYsUNhGAYWXQi