### PR TITLE
feat(pebble): add visual rendering hook and component

### DIFF
--- a/components/pebble/PebbleVisual.tsx
+++ b/components/pebble/PebbleVisual.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import type { Mark, Pebble } from "@/lib/types"
+import type { RenderTier } from "@/lib/engine"
+import { EMOTIONS } from "@/lib/config/emotions"
+import { usePebbleVisual } from "@/lib/hooks/usePebbleVisual"
+import { cn } from "@/lib/utils"
+
+type PebbleVisualProps = {
+  pebble: Pebble
+  mark?: Mark | null
+  tier?: RenderTier
+  className?: string
+}
+
+export function PebbleVisual({
+  pebble,
+  mark = null,
+  tier = "thumbnail",
+  className,
+}: PebbleVisualProps) {
+  const { svg } = usePebbleVisual(pebble, mark, tier)
+
+  const emotionName =
+    EMOTIONS.find((e) => e.id === pebble.emotion_id)?.name ?? "Unknown"
+
+  return (
+    <div
+      data-slot="pebble-visual"
+      role="img"
+      aria-label={`Pebble: ${pebble.name}, ${emotionName}, intensity ${pebble.intensity}`}
+      className={cn(className)}
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  )
+}

--- a/lib/hooks/usePebbleVisual.ts
+++ b/lib/hooks/usePebbleVisual.ts
@@ -1,0 +1,41 @@
+"use client"
+
+import { useMemo } from "react"
+
+import type { Mark, Pebble } from "@/lib/types"
+import { hashUUID, renderPebble, toPebbleParams } from "@/lib/engine"
+import type { RenderTier } from "@/lib/engine"
+
+type UsePebbleVisualResult = {
+  svg: string
+  viewBox: string
+}
+
+export function usePebbleVisual(
+  pebble: Pebble,
+  mark: Mark | null,
+  tier: RenderTier,
+): UsePebbleVisualResult {
+  const strokesKey = JSON.stringify(mark?.strokes ?? null)
+
+  // Only visual-relevant scalar properties are listed as deps to avoid
+  // recomputation when non-visual fields (e.g. updated_at, soul_ids) change.
+  /* eslint-disable react-hooks/exhaustive-deps */
+  return useMemo(() => {
+    const params = toPebbleParams(pebble, mark)
+    const seed = hashUUID(pebble.id)
+    return renderPebble(params, seed, tier)
+  }, [
+    pebble.id,
+    pebble.intensity,
+    pebble.positiveness,
+    pebble.emotion_id,
+    pebble.mark_id,
+    pebble.created_at,
+    pebble.happened_at,
+    mark?.viewBox,
+    strokesKey,
+    tier,
+  ])
+  /* eslint-enable react-hooks/exhaustive-deps */
+}


### PR DESCRIPTION
Resolves #131 

## Changes

- **lib/hooks/usePebbleVisual.ts** (new): Custom React hook that memoizes pebble visual rendering. Computes SVG output and viewBox based on pebble properties, marks, and render tier. Carefully scoped dependencies to only visual-relevant fields to avoid unnecessary recomputation when non-visual metadata changes.

- **components/pebble/PebbleVisual.tsx** (new): React component that renders a pebble's visual representation. Uses `usePebbleVisual` hook to generate SVG, resolves emotion name for accessibility, and renders with proper ARIA labels and semantic markup.

## Notes

- The `usePebbleVisual` hook intentionally excludes non-visual fields (e.g., `updated_at`, `soul_ids`) from its dependency array to optimize performance and prevent unnecessary re-renders when metadata changes.
- `strokesKey` is stringified to ensure proper dependency tracking for mark stroke changes.
- The `PebbleVisual` component uses `dangerouslySetInnerHTML` to render the generated SVG, which is safe here since the SVG is generated internally by the rendering engine.
- Default values: `mark = null`, `tier = "thumbnail"` provide sensible defaults for common use cases.

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01DrJHQYh4zBCvT8VxV7Amut