### PR TITLE
feat(record): add pebble revelation screen between save and celebration

### DIFF
--- a/components/record/PebbleRevelation.tsx
+++ b/components/record/PebbleRevelation.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { useEffect } from "react"
+import { motion, useReducedMotion } from "framer-motion"
+import { usePebble } from "@/lib/data/usePebble"
+import { useMark } from "@/lib/data/useMark"
+import { useHaptics } from "@/lib/hooks/useHaptics"
+import { Button } from "@/components/ui/button"
+import { PebbleVisual } from "@/components/pebble/PebbleVisual"
+
+interface PebbleRevelationProps {
+  pebbleId: string
+  pebbleName: string
+  onContinue: () => void
+}
+
+export function PebbleRevelation({
+  pebbleId,
+  pebbleName,
+  onContinue,
+}: PebbleRevelationProps) {
+  const { pebble } = usePebble(pebbleId)
+  const { mark } = useMark(pebble?.mark_id ?? "")
+  const { vibrate } = useHaptics()
+  const prefersReducedMotion = useReducedMotion()
+
+  useEffect(() => {
+    vibrate([10, 50, 20])
+  }, [vibrate])
+
+  if (!pebble) return null
+
+  return (
+    <section aria-label="Pebble revelation" className="flex flex-col items-center gap-8 py-12 text-center">
+      <motion.div
+        initial={prefersReducedMotion ? false : { scale: 0.5, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        transition={{ type: "spring", stiffness: 300, damping: 20 }}
+      >
+        <PebbleVisual
+          pebble={pebble}
+          mark={mark}
+          tier="detail"
+          className="size-[200px]"
+        />
+      </motion.div>
+
+      <motion.h1
+        className="text-4xl font-bold"
+        initial={prefersReducedMotion ? false : { opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ type: "spring", stiffness: 260, damping: 20, delay: 0.3 }}
+        aria-live="polite"
+      >
+        {pebbleName}
+      </motion.h1>
+
+      <motion.div
+        initial={prefersReducedMotion ? false : { opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.3, ease: "easeOut", delay: 0.5 }}
+      >
+        <Button className="h-11 px-6" onClick={onContinue}>
+          Continue
+        </Button>
+      </motion.div>
+    </section>
+  )
+}

--- a/components/record/RecordStepper.tsx
+++ b/components/record/RecordStepper.tsx
@@ -9,7 +9,7 @@ import { useStepNavigation } from "@/lib/hooks/useStepNavigation"
 import { useHaptics } from "@/lib/hooks/useHaptics"
 import { useKeyboardOffset } from "@/lib/hooks/useKeyboardOffset"
 import { Button } from "@/components/ui/button"
-import type { CelebrationData, RecordFormData, RecordStepProps, StepConfig } from "@/components/record/types"
+import type { CelebrationData, RevelationData, RecordFormData, RecordStepProps, StepConfig } from "@/components/record/types"
 import { StepDateTime } from "@/components/record/StepDateTime"
 import { StepName } from "@/components/record/StepName"
 import { StepDescription } from "@/components/record/StepDescription"
@@ -22,6 +22,7 @@ import { StepGlyph, getGlyphPendingSave } from "@/components/record/StepGlyph"
 import { StepCardPicker } from "@/components/record/StepCardPicker"
 import { StepCardFiller } from "@/components/record/StepCardFiller"
 import { StepSummary } from "@/components/record/StepSummary"
+import { PebbleRevelation } from "@/components/record/PebbleRevelation"
 import { RecordCelebration } from "@/components/record/RecordCelebration"
 import { RecordComposer } from "@/components/record/RecordComposer"
 
@@ -95,13 +96,18 @@ function makeComposerPatch(field: string, value: string, data: RecordFormData): 
 
 export function RecordStepper() {
   const router = useRouter()
+  const [revelationData, setRevelationData] = useState<RevelationData | null>(null)
+  const [savedData, setSavedData] = useState<CelebrationData | null>(null)
   const [celebrationData, setCelebrationData] = useState<CelebrationData | null>(null)
 
   const { vibrate } = useHaptics()
   const keyboardOffset = useKeyboardOffset()
 
   const { formData, handleUpdate, handleSave, saving, error } = useRecordForm(
-    (data) => setCelebrationData(data),
+    (data) => {
+      setSavedData(data)
+      setRevelationData({ pebbleId: data.pebbleId, pebbleName: data.pebbleName })
+    },
   )
 
   // Derive step list only when the set of selected card types changes,
@@ -164,6 +170,16 @@ export function RecordStepper() {
   }, [handleAdvance, goBack])
 
   const { Component: ActiveStep } = steps[currentStep]
+
+  if (revelationData && savedData && !celebrationData) {
+    return (
+      <PebbleRevelation
+        pebbleId={revelationData.pebbleId}
+        pebbleName={revelationData.pebbleName}
+        onContinue={() => setCelebrationData(savedData)}
+      />
+    )
+  }
 
   if (celebrationData) {
     return (

--- a/components/record/types.ts
+++ b/components/record/types.ts
@@ -40,8 +40,14 @@ export type StepConfig = {
   composer?: StepComposer
 }
 
+export type RevelationData = {
+  pebbleId: string
+  pebbleName: string
+}
+
 export type CelebrationData = {
   pebbleId: string
+  pebbleName: string
   karmaDelta: number
   bounceBefore: number
   bounceAfter: number

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -6,7 +6,7 @@
     "root_node_id": "V-landing",
     "metadata": { "view_card_variant": "large" },
     "created_at": "2026-04-01T00:00:00.000Z",
-    "updated_at": "2026-04-04T12:00:00.000Z"
+    "updated_at": "2026-04-05T12:00:00.000Z"
   },
   "nodes": [
     {
@@ -123,6 +123,15 @@
       "species": "view",
       "title": "Pebble Detail",
       "description": "Full view of a recorded pebble with all enrichments.",
+      "status": "idea",
+      "platforms": ["web", "ios", "android"]
+    },
+    {
+      "id": "V-record-revelation",
+      "project_id": "pebbles",
+      "species": "view",
+      "title": "Record Revelation",
+      "description": "Intermediate screen after save that reveals the generated pebble SVG visual for the first time, before transitioning to celebration.",
       "status": "idea",
       "platforms": ["web", "ios", "android"]
     },
@@ -381,7 +390,8 @@
               "if_true": [{ "type": "view", "view_id": "V-cards-thoughts" }],
               "if_false": []
             },
-            { "type": "view", "view_id": "V-pebble-detail" }
+            { "type": "view", "view_id": "V-pebble-detail" },
+            { "type": "view", "view_id": "V-record-revelation" }
           ]
         }
       }
@@ -967,6 +977,7 @@
     { "id": "e-F-record-pebble-V-glyph-attach", "project_id": "pebbles", "source_id": "F-record-pebble", "target_id": "V-glyph-attach", "edge_type": "composes" },
     { "id": "e-F-record-pebble-V-cards-thoughts", "project_id": "pebbles", "source_id": "F-record-pebble", "target_id": "V-cards-thoughts", "edge_type": "composes" },
     { "id": "e-F-record-pebble-V-pebble-detail", "project_id": "pebbles", "source_id": "F-record-pebble", "target_id": "V-pebble-detail", "edge_type": "composes" },
+    { "id": "e-F-record-pebble-V-record-revelation", "project_id": "pebbles", "source_id": "F-record-pebble", "target_id": "V-record-revelation", "edge_type": "composes" },
 
     { "id": "e-F-onboarding-V-onboarding-welcome", "project_id": "pebbles", "source_id": "F-onboarding", "target_id": "V-onboarding-welcome", "edge_type": "composes" },
     { "id": "e-F-onboarding-V-onboarding-collect", "project_id": "pebbles", "source_id": "F-onboarding", "target_id": "V-onboarding-collect", "edge_type": "composes" },

--- a/lib/hooks/useRecordForm.ts
+++ b/lib/hooks/useRecordForm.ts
@@ -43,6 +43,7 @@ export function useRecordForm(onSaveSuccess: (data: CelebrationData) => void) {
       const pebble = await addPebble(cleanedData)
       onSaveSuccess({
         pebbleId: pebble.id,
+        pebbleName: formData.name,
         karmaDelta,
         bounceBefore,
         bounceAfter: store.bounce,


### PR DESCRIPTION
Resolves #132 

## Changes

- **New Component**: `PebbleRevelation.tsx` - Intermediate screen that displays the newly generated pebble visual for the first time after saving, with animated entrance and haptic feedback before transitioning to celebration
- **Updated `RecordStepper.tsx`** - Added state management for revelation flow (`revelationData`, `savedData`) and conditional rendering to show `PebbleRevelation` between form save and celebration
- **Updated `types.ts`** - Added `RevelationData` type and added `pebbleName` field to `CelebrationData`
- **Updated `useRecordForm.ts`** - Now passes `pebbleName` to the success callback alongside `pebbleId`
- **Updated `bundle.json`** - Added `V-record-revelation` view node and composed it into the record pebble flow

## Notes

The revelation screen serves as a moment of delight, allowing users to see their generated pebble visual for the first time with smooth animations and haptic feedback before the celebration screen. The flow is:

1. User completes form and saves → `revelationData` and `savedData` are set
2. `PebbleRevelation` renders with animated pebble visual and name
3. User clicks "Continue" → `celebrationData` is set, triggering `RecordCelebration`

The component respects `prefers-reduced-motion` for accessibility. Haptic feedback is triggered on mount to enhance the reveal moment.

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_0118oMj1XFRTGSjjh6AJmJt5