### PR TITLE
feat(core): redirect onboarding completion to home instead of record

### DIFF
--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -410,7 +410,7 @@
             { "type": "view", "view_id": "V-onboarding-welcome" },
             { "type": "view", "view_id": "V-onboarding-collect" },
             { "type": "view", "view_id": "V-onboarding-activate" },
-            { "type": "flow", "flow_id": "F-record-pebble" }
+            { "type": "view", "view_id": "V-home" }
           ]
         }
       }
@@ -1002,7 +1002,7 @@
     { "id": "e-F-onboarding-V-onboarding-welcome", "project_id": "pebbles", "source_id": "F-onboarding", "target_id": "V-onboarding-welcome", "edge_type": "composes" },
     { "id": "e-F-onboarding-V-onboarding-collect", "project_id": "pebbles", "source_id": "F-onboarding", "target_id": "V-onboarding-collect", "edge_type": "composes" },
     { "id": "e-F-onboarding-V-onboarding-activate", "project_id": "pebbles", "source_id": "F-onboarding", "target_id": "V-onboarding-activate", "edge_type": "composes" },
-    { "id": "e-F-onboarding-F-record-pebble", "project_id": "pebbles", "source_id": "F-onboarding", "target_id": "F-record-pebble", "edge_type": "composes" },
+    { "id": "e-F-onboarding-V-home", "project_id": "pebbles", "source_id": "F-onboarding", "target_id": "V-home", "edge_type": "composes" },
 
     { "id": "e-F-manage-collections-V-collections-list", "project_id": "pebbles", "source_id": "F-manage-collections", "target_id": "V-collections-list", "edge_type": "composes" },
     { "id": "e-F-manage-collections-V-collection-detail", "project_id": "pebbles", "source_id": "F-manage-collections", "target_id": "V-collection-detail", "edge_type": "composes" },
@@ -1046,7 +1046,7 @@
     { "id": "e-V-achievements-API-get-achievements", "project_id": "pebbles", "source_id": "V-achievements", "target_id": "API-get-achievements", "edge_type": "calls" },
     { "id": "e-V-weekly-cairn-API-get-weekly-cairn", "project_id": "pebbles", "source_id": "V-weekly-cairn", "target_id": "API-get-weekly-cairn", "edge_type": "calls" },
     { "id": "e-V-monthly-cairn-API-get-monthly-cairn", "project_id": "pebbles", "source_id": "V-monthly-cairn", "target_id": "API-get-monthly-cairn", "edge_type": "calls" },
-    { "id": "e-V-onboarding-activate-F-record-pebble", "project_id": "pebbles", "source_id": "V-onboarding-activate", "target_id": "F-record-pebble", "edge_type": "composes" },
+    { "id": "e-V-onboarding-activate-V-home", "project_id": "pebbles", "source_id": "V-onboarding-activate", "target_id": "V-home", "edge_type": "composes" },
 
     { "id": "e-V-home-DM-pebble", "project_id": "pebbles", "source_id": "V-home", "target_id": "DM-pebble", "edge_type": "displays" },
     { "id": "e-V-home-DM-bounce", "project_id": "pebbles", "source_id": "V-home", "target_id": "DM-bounce", "edge_type": "displays" },

--- a/lib/hooks/useOnboarding.ts
+++ b/lib/hooks/useOnboarding.ts
@@ -13,12 +13,12 @@ export function useOnboarding(
 
   const complete = useCallback(async () => {
     await onComplete()
-    router.push("/record")
+    router.push("/path")
   }, [onComplete, router])
 
   const skip = useCallback(async () => {
     await onComplete()
-    router.push("/record")
+    router.push("/path")
   }, [onComplete, router])
 
   return {


### PR DESCRIPTION
Resolves #163 

## Changes
- Updated `useOnboarding.ts` hook to redirect users to `/path` instead of `/record` upon onboarding completion (both `complete()` and `skip()` callbacks)
- Updated `bundle.json` to replace the `F-record-pebble` flow reference with `V-home` view in the onboarding flow composition
- Updated corresponding edge definitions in `bundle.json` to reflect the new navigation target

## Notes
The changes consolidate the post-onboarding user journey to direct users to the home view rather than a separate record flow. This simplifies the navigation structure and likely improves the onboarding-to-home transition experience.

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01KVA16j8gm5vDVbEb4urBrC