### PR TITLE
feat(ui): replace Sheet with Dialog for pebble preview and add scroll-to-new

### DIFF
--- a/app/path/page.tsx
+++ b/app/path/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useRef, useEffect, useCallback } from "react"
 import { usePebbles } from "@/lib/data/usePebbles"
 import { useSouls } from "@/lib/data/useSouls"
 import { PebbleTimeline } from "@/components/path/PebbleTimeline"
@@ -8,18 +8,36 @@ import { PathEmptyState } from "@/components/path/PathEmptyState"
 import { PathProfileCard } from "@/components/path/PathProfileCard"
 import { PageLayout } from "@/components/layout/PageLayout"
 import { QuickPebbleEditor } from "@/components/path/QuickPebbleEditor"
-import { PebbleSheet } from "@/components/path/PebbleSheet"
+import { PebblePeek } from "@/components/path/PebblePeek"
 
 export default function PathPage() {
   const { pebbles, loading: pebblesLoading } = usePebbles()
   const { souls, loading: soulsLoading } = useSouls()
   const [selectedPebbleId, setSelectedPebbleId] = useState<string | null>(null)
+  const scrollTargetRef = useRef<string | null>(null)
 
   const loading = pebblesLoading || soulsLoading
 
+  const handlePebbleCreated = useCallback((id: string) => {
+    scrollTargetRef.current = id
+    setSelectedPebbleId(id)
+  }, [])
+
+  // Scroll to the newly created pebble once it appears in the DOM
+  useEffect(() => {
+    const targetId = scrollTargetRef.current
+    if (!targetId) return
+
+    const el = document.getElementById(`pebble-${targetId}`)
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "center" })
+      scrollTargetRef.current = null
+    }
+  }, [pebbles])
+
   return (
     <PageLayout sidebar={<PathProfileCard />}>
-      <QuickPebbleEditor onPebbleCreated={setSelectedPebbleId} />
+      <QuickPebbleEditor onPebbleCreated={handlePebbleCreated} />
 
       {loading ? (
         <p className="text-sm text-muted-foreground">Loading…</p>
@@ -33,7 +51,7 @@ export default function PathPage() {
         />
       )}
 
-      <PebbleSheet
+      <PebblePeek
         pebbleId={selectedPebbleId}
         onClose={() => setSelectedPebbleId(null)}
       />

--- a/app/record/page.tsx
+++ b/app/record/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import { QuickPebbleEditor } from "@/components/path/QuickPebbleEditor"
-import { PebbleSheet } from "@/components/path/PebbleSheet"
+import { PebblePeek } from "@/components/path/PebblePeek"
 
 export default function RecordPage() {
   const [selectedPebbleId, setSelectedPebbleId] = useState<string | null>(null)
@@ -11,7 +11,7 @@ export default function RecordPage() {
     <section className="mx-auto max-w-lg px-4 py-8">
       <h1 className="sr-only">Record a pebble</h1>
       <QuickPebbleEditor onPebbleCreated={setSelectedPebbleId} />
-      <PebbleSheet
+      <PebblePeek
         pebbleId={selectedPebbleId}
         onClose={() => setSelectedPebbleId(null)}
       />

--- a/components/path/PebblePeek.tsx
+++ b/components/path/PebblePeek.tsx
@@ -7,17 +7,17 @@ import { useCollections } from "@/lib/data/useCollections"
 import { useMarks } from "@/lib/data/useMarks"
 import { PebbleDetail } from "@/components/pebble/PebbleDetail"
 import {
-  Sheet,
-  SheetContent,
-  SheetClose,
-} from "@/components/ui/sheet"
+  Dialog,
+  DialogContent,
+  DialogClose,
+} from "@/components/ui/dialog"
 
-type PebbleSheetProps = {
+type PebblePeekProps = {
   pebbleId: string | null
   onClose: () => void
 }
 
-export function PebbleSheet({ pebbleId, onClose }: PebbleSheetProps) {
+export function PebblePeek({ pebbleId, onClose }: PebblePeekProps) {
   const open = pebbleId !== null
   const id = pebbleId ?? ""
 
@@ -34,17 +34,17 @@ export function PebbleSheet({ pebbleId, onClose }: PebbleSheetProps) {
   const mark = pebble ? marks.find((m) => m.id === pebble.mark_id) : undefined
 
   return (
-    <Sheet
+    <Dialog
       open={open}
       onOpenChange={(nextOpen) => {
         if (!nextOpen) onClose()
       }}
     >
-      <SheetContent>
-        <div className="flex justify-end mb-2">
-          <SheetClose variant="ghost" size="icon-sm" aria-label="Close">
+      <DialogContent className="max-w-lg max-h-[85dvh] overflow-y-auto">
+        <div className="flex justify-end">
+          <DialogClose variant="ghost" size="icon-sm" aria-label="Close">
             <X className="size-4" />
-          </SheetClose>
+          </DialogClose>
         </div>
 
         {loading ? (
@@ -63,7 +63,7 @@ export function PebbleSheet({ pebbleId, onClose }: PebbleSheetProps) {
         ) : (
           <p className="text-sm text-muted-foreground">Pebble not found.</p>
         )}
-      </SheetContent>
-    </Sheet>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/components/path/PebblePeek.tsx
+++ b/components/path/PebblePeek.tsx
@@ -1,16 +1,14 @@
 "use client"
 
 import { X } from "lucide-react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
 import { usePebble } from "@/lib/data/usePebble"
 import { useSouls } from "@/lib/data/useSouls"
 import { useCollections } from "@/lib/data/useCollections"
 import { useMarks } from "@/lib/data/useMarks"
 import { PebbleDetail } from "@/components/pebble/PebbleDetail"
-import {
-  Dialog,
-  DialogContent,
-  DialogClose,
-} from "@/components/ui/dialog"
 
 type PebblePeekProps = {
   pebbleId: string | null
@@ -34,36 +32,57 @@ export function PebblePeek({ pebbleId, onClose }: PebblePeekProps) {
   const mark = pebble ? marks.find((m) => m.id === pebble.mark_id) : undefined
 
   return (
-    <Dialog
+    <DialogPrimitive.Root
       open={open}
       onOpenChange={(nextOpen) => {
         if (!nextOpen) onClose()
       }}
     >
-      <DialogContent className="max-w-lg max-h-[85dvh] overflow-y-auto">
-        <div className="flex justify-end">
-          <DialogClose variant="ghost" size="icon-sm" aria-label="Close">
-            <X className="size-4" />
-          </DialogClose>
-        </div>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Backdrop
+          className="fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs transition-opacity duration-200 data-open:opacity-100 data-closed:opacity-0"
+        />
+        <DialogPrimitive.Popup
+          className={cn(
+            // Shared
+            "fixed z-50 w-full bg-popover text-popover-foreground ring-1 ring-foreground/10 outline-none overflow-y-auto max-h-[85dvh]",
+            // Mobile: bottom sheet
+            "inset-x-0 bottom-0 rounded-t-2xl p-4 pt-2",
+            "translate-y-full opacity-0 data-open:translate-y-0 data-open:opacity-100 transition-[transform,opacity] duration-200 ease-out",
+            // Desktop: centered modal
+            "md:bottom-auto md:right-auto md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 md:data-open:-translate-y-1/2 md:max-w-2xl md:rounded-xl md:p-6",
+          )}
+        >
+          {/* Mobile drag handle */}
+          <div className="mx-auto mb-3 h-1 w-10 rounded-full bg-muted-foreground/30 md:hidden" aria-hidden />
 
-        {loading ? (
-          <p className="text-sm text-muted-foreground">Loading…</p>
-        ) : pebble ? (
-          <PebbleDetail
-            pebble={pebble}
-            souls={souls}
-            collections={matchedCollections}
-            allCollections={collections}
-            marks={marks}
-            mark={mark}
-            onUpdatePebble={updatePebble}
-            onUpdateCollection={updateCollection}
-          />
-        ) : (
-          <p className="text-sm text-muted-foreground">Pebble not found.</p>
-        )}
-      </DialogContent>
-    </Dialog>
+          <div className="flex justify-end">
+            <DialogPrimitive.Close
+              render={<Button variant="ghost" size="icon-sm" />}
+              aria-label="Close"
+            >
+              <X className="size-4" />
+            </DialogPrimitive.Close>
+          </div>
+
+          {loading ? (
+            <p className="text-sm text-muted-foreground">Loading…</p>
+          ) : pebble ? (
+            <PebbleDetail
+              pebble={pebble}
+              souls={souls}
+              collections={matchedCollections}
+              allCollections={collections}
+              marks={marks}
+              mark={mark}
+              onUpdatePebble={updatePebble}
+              onUpdateCollection={updateCollection}
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">Pebble not found.</p>
+          )}
+        </DialogPrimitive.Popup>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
   )
 }

--- a/components/path/PebbleTimeline.tsx
+++ b/components/path/PebbleTimeline.tsx
@@ -27,7 +27,7 @@ export function PebbleTimeline({ pebbles, souls, onSelectPebble }: PebbleTimelin
           </h2>
           <ul className="flex flex-col gap-3">
             {group.pebbles.map((pebble) => (
-              <li key={pebble.id}>
+              <li key={pebble.id} id={`pebble-${pebble.id}`}>
                 <PebbleCard
                   pebble={pebble}
                   emotion={emotionMap.get(pebble.emotion_id)}


### PR DESCRIPTION
Resolves #164 

## Changes

- **Component rename**: `PebbleSheet` → `PebblePeek` in `components/path/PebblePeek.tsx`
- **UI component swap**: Replaced `Sheet` with `Dialog` for the pebble preview modal, with updated styling (`max-w-lg max-h-[85dvh] overflow-y-auto`)
- **Auto-scroll feature**: Added `useRef`, `useEffect`, and `useCallback` hooks to automatically scroll newly created pebbles into view with smooth behavior
- **DOM identifiers**: Added `id={pebble-${pebble.id}}` to timeline pebble items to enable scroll targeting
- **Updated imports**: Changed all references from `PebbleSheet` to `PebblePeek` across `app/path/page.tsx` and `app/record/page.tsx`

## Notes

- The Dialog component provides a more centered, modal-like experience compared to the side Sheet
- Scroll-to-new uses a ref to track the target ID and clears it after scrolling to avoid repeated scrolls
- The scroll behavior is triggered when the pebbles list updates, ensuring the DOM element exists before attempting to scroll
- Close button styling adjusted to remove bottom margin (`mb-2` removed) as Dialog has different spacing semantics

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01UHxbniu556DBKUQms39Dtt