### PR TITLE
feat(ui): add theme switcher to profile page

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -6,6 +6,7 @@ import { ChevronRight } from "lucide-react"
 import { useAuth } from "@/lib/data/auth-context"
 import { ProfileCard } from "@/components/profile/ProfileCard"
 import { LogoutButton } from "@/components/profile/LogoutButton"
+import { AppearanceSection } from "@/components/profile/AppearanceSection"
 import { PageLayout } from "@/components/layout/PageLayout"
 import { PathProfileCard } from "@/components/path/PathProfileCard"
 import { BackPath } from "@/components/ui/BackPath"
@@ -74,6 +75,8 @@ export default function ProfilePage() {
             })}
           </ul>
         </nav>
+
+          <AppearanceSection />
 
           <LogoutButton onLogout={handleLogout} />
         </div>

--- a/components/layout/ThemeToggle.tsx
+++ b/components/layout/ThemeToggle.tsx
@@ -1,21 +1,42 @@
 "use client"
 
 import { useTheme } from "next-themes"
-import { Moon, Sun } from "lucide-react"
+import { Moon, Sun, Monitor } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 
 export function ThemeToggle() {
-  const { setTheme, resolvedTheme } = useTheme()
+  const { setTheme } = useTheme()
 
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      aria-label="Toggle theme"
-      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
-    >
-      <Sun className="size-4 scale-100 rotate-0 transition-transform dark:scale-0 dark:-rotate-90" />
-      <Moon className="absolute size-4 scale-0 rotate-90 transition-transform dark:scale-100 dark:rotate-0" />
-    </Button>
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button variant="ghost" size="icon" aria-label="Toggle theme" />
+        }
+      >
+        <Sun className="size-4 scale-100 rotate-0 transition-transform dark:scale-0 dark:-rotate-90" />
+        <Moon className="absolute size-4 scale-0 rotate-90 transition-transform dark:scale-100 dark:rotate-0" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          <Sun className="size-4" />
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          <Moon className="size-4" />
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          <Monitor className="size-4" />
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }

--- a/components/profile/AppearanceSection.tsx
+++ b/components/profile/AppearanceSection.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { Sun } from "lucide-react"
+import { ThemeToggle } from "@/components/layout/ThemeToggle"
+
+export function AppearanceSection() {
+  return (
+    <div className="divide-y divide-border rounded-xl border border-border">
+      <div className="flex items-center gap-3 px-4 py-3">
+        <Sun className="size-5 text-muted-foreground" aria-hidden />
+        <span className="flex-1 text-sm font-medium">Appearance</span>
+        <ThemeToggle />
+      </div>
+    </div>
+  )
+}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import * as React from "react"
+import { Menu as MenuPrimitive } from "@base-ui/react/menu"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+}
+
+function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
+  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 6,
+  align = "start",
+  ...props
+}: MenuPrimitive.Popup.Props & {
+  sideOffset?: number
+  align?: "start" | "center" | "end"
+}) {
+  return (
+    <DropdownMenuPortal>
+      <MenuPrimitive.Positioner
+        data-slot="dropdown-menu-positioner"
+        sideOffset={sideOffset}
+        align={align}
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn(
+            "z-50 min-w-[8rem] overflow-y-auto rounded-xl bg-popover p-1 text-popover-foreground ring-1 ring-foreground/10 shadow-lg outline-none",
+            "origin-[var(--transform-origin)] transition-[transform,opacity] duration-100",
+            "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
+            "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className,
+          )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </DropdownMenuPortal>
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  ...props
+}: MenuPrimitive.Item.Props) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-none select-none",
+        "data-highlighted:bg-muted data-highlighted:text-foreground",
+        "data-disabled:pointer-events-none data-disabled:opacity-50",
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: MenuPrimitive.RadioGroup.Props) {
+  return (
+    <MenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: MenuPrimitive.RadioItem.Props) {
+  return (
+    <MenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-lg py-1.5 pr-2 pl-8 text-sm outline-none select-none",
+        "data-highlighted:bg-muted data-highlighted:text-foreground",
+        "data-disabled:pointer-events-none data-disabled:opacity-50",
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-4 items-center justify-center">
+        <MenuPrimitive.RadioItemIndicator>
+          <Check className="size-4" />
+        </MenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof MenuPrimitive.Separator>) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+}

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -375,7 +375,7 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Profile",
-      "description": "User profile page displaying account info with logout functionality.",
+      "description": "User profile page displaying account info, appearance settings, and logout functionality.",
       "status": "development",
       "platforms": ["web", "ios", "android"]
     },


### PR DESCRIPTION
Resolves #166

## Summary
- Added `dropdown-menu` shadcn/ui component using `@base-ui/react/menu` primitives
- Updated `ThemeToggle` to use the shadcn dropdown pattern with Light/Dark/System options (restoring system preference support)
- Created `AppearanceSection` component and placed it on the profile page between the nav list and logout button
- Updated Arkaik bundle description for `V-profile`

## Key files
- `components/ui/dropdown-menu.tsx` — new UI primitive
- `components/layout/ThemeToggle.tsx` — updated to dropdown pattern
- `components/profile/AppearanceSection.tsx` — new settings row
- `app/profile/page.tsx` — added appearance section

## Test plan
- [ ] Open /profile page while authenticated
- [ ] Click the theme toggle button (sun/moon icon)
- [ ] Verify dropdown shows Light, Dark, System options
- [ ] Select each option and confirm theme changes correctly
- [ ] Verify keyboard navigation (Tab, Enter, arrow keys)
