### PR TITLE
feat(engagement): enhance landing page with features section

### DIFF
--- a/components/landing/LandingPage.tsx
+++ b/components/landing/LandingPage.tsx
@@ -45,15 +45,15 @@ export function LandingPage() {
   if (isLoading || isAuthenticated) return null
 
   return (
-    <section className="flex min-h-full flex-col items-center justify-center px-6 text-center">
-      <h1 className="text-5xl font-heading font-bold tracking-tight">
-        pbbls
+    <section className="flex min-h-screen flex-col items-center justify-center px-6 text-center">
+      <h1 className="text-2xl font-heading font-bold tracking-tight">
+        Pebbles
       </h1>
       <p className="mt-3 max-w-sm text-lg text-muted-foreground">
-        Collect meaningful moments, one pebble at a time.
+        Collect meaningful moments.
       </p>
 
-      <ul className="mt-10 flex max-w-sm flex-col gap-3 text-left">
+      <ul className="mt-10 flex max-w-sm flex-col gap-3 text-left border rounded-lg p-6 bg-card">
         {FEATURES.map((feature) => (
           <li key={feature.title} className="flex items-start gap-3">
             <feature.icon

--- a/components/landing/LandingPage.tsx
+++ b/components/landing/LandingPage.tsx
@@ -3,8 +3,34 @@
 import { useEffect } from "react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
+import { Clock, Sparkles, Route } from "lucide-react"
 import { useAuth } from "@/lib/data/auth-context"
 import { Button } from "@/components/ui/button"
+
+import type { LucideIcon } from "lucide-react"
+
+const FEATURES: ReadonlyArray<{
+  icon: LucideIcon
+  title: string
+  description: string
+}> = [
+  {
+    icon: Clock,
+    title: "Record in seconds",
+    description:
+      "Capture moments as they happen \u2014 no blank page, no pressure.",
+  },
+  {
+    icon: Sparkles,
+    title: "Enrich with meaning",
+    description: "Add emotions, people, and reflections to each pebble.",
+  },
+  {
+    icon: Route,
+    title: "Grow your path",
+    description: "Look back at your journey, at your own pace.",
+  },
+]
 
 export function LandingPage() {
   const { isAuthenticated, isLoading } = useAuth()
@@ -20,21 +46,43 @@ export function LandingPage() {
 
   return (
     <section className="flex min-h-full flex-col items-center justify-center px-6 text-center">
-      <h1 className="text-4xl font-bold tracking-tight">pbbls</h1>
-      <p className="mt-3 max-w-sm text-muted-foreground">
+      <h1 className="text-5xl font-heading font-bold tracking-tight">
+        pbbls
+      </h1>
+      <p className="mt-3 max-w-sm text-lg text-muted-foreground">
         Collect meaningful moments, one pebble at a time.
       </p>
 
-      <div className="mt-8 flex flex-col items-center gap-3">
-        <Button size="lg" render={<Link href="/login" />}>
-          Log in
+      <ul className="mt-10 flex max-w-sm flex-col gap-3 text-left">
+        {FEATURES.map((feature) => (
+          <li key={feature.title} className="flex items-start gap-3">
+            <feature.icon
+              aria-hidden="true"
+              className="mt-0.5 size-5 shrink-0 text-primary"
+            />
+            <div>
+              <p className="text-sm font-semibold">{feature.title}</p>
+              <p className="text-sm text-muted-foreground">
+                {feature.description}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <div className="mt-10 flex flex-col items-center gap-3">
+        <Button size="lg" render={<Link href="/register" />}>
+          Get started
         </Button>
-        <Link
-          href="/register"
-          className="text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
-        >
-          Create account
-        </Link>
+        <p className="text-sm text-muted-foreground">
+          Already have an account?{" "}
+          <Link
+            href="/login"
+            className="text-foreground underline underline-offset-4 hover:text-primary"
+          >
+            Log in
+          </Link>
+        </p>
       </div>
     </section>
   )


### PR DESCRIPTION
Resolves #165 

## Changes

**components/landing/LandingPage.tsx**
- Added feature cards section displaying three key features (Record in seconds, Enrich with meaning, Grow your path) with Lucide icons
- Introduced `FEATURES` constant with structured feature data (icon, title, description)
- Enhanced visual hierarchy: increased heading size to `text-5xl` and added `font-heading` class
- Improved typography: increased description text size to `text-lg`
- Reorganized CTA buttons: changed primary action from "Log in" to "Get started" (linking to `/register`)
- Moved "Log in" to secondary action within a text paragraph for existing users
- Updated button spacing and layout for better visual balance
- Enhanced link styling with improved hover states

## Notes

- The feature list is defined as a readonly constant to prevent accidental mutations
- Icons are marked with `aria-hidden="true"` since they're decorative and the text provides context
- The primary CTA now directs new users to registration first, with login available as a secondary option
- Spacing increased from `mt-8` to `mt-10` for better visual breathing room

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01RjPLyrsBhfzMMCuAVaEeAC