### PR TITLE
fix(ui): convert title input to textarea

### DIFF
--- a/components/path/QuickPebbleEditor.tsx
+++ b/components/path/QuickPebbleEditor.tsx
@@ -78,7 +78,7 @@ export function QuickPebbleEditor({ onPebbleCreated }: QuickPebbleEditorProps) {
   // Collapse state
   const [expanded, setExpanded] = useState(false)
   const sectionRef = useRef<HTMLElement>(null)
-  const titleInputRef = useRef<HTMLInputElement>(null)
+  const titleInputRef = useRef<HTMLTextAreaElement>(null)
   const hasAutoExpanded = useRef(false)
 
   // Form state
@@ -333,16 +333,16 @@ export function QuickPebbleEditor({ onPebbleCreated }: QuickPebbleEditorProps) {
       </motion.div>
 
       {/* Title input — always visible */}
-      <input
+      <textarea
         ref={titleInputRef}
-        type="text"
         value={name}
         onChange={(e) => setName(e.target.value)}
         placeholder="What happened?"
         className={cn(
-          "w-full border-none bg-transparent font-heading text-xl font-semibold text-foreground outline-none placeholder:text-muted-foreground/50",
+          "w-full resize-none border-none bg-transparent font-heading text-xl font-semibold text-foreground outline-none field-sizing-content placeholder:text-muted-foreground/50",
           expanded && "mb-2",
         )}
+        rows={1}
         onKeyDown={(e) => {
           if (e.key === "Enter" && !e.shiftKey) {
             e.preventDefault()


### PR DESCRIPTION
Resolves #170 

## Changes
- Changed title input from `<input type="text">` to `<textarea>` in QuickPebbleEditor component
- Updated `titleInputRef` type from `HTMLInputElement` to `HTMLTextAreaElement`
- Added `resize-none` and `field-sizing-content` CSS classes for proper textarea styling
- Set `rows={1}` to maintain single-line appearance by default
- Preserved existing Enter key behavior (submit on Enter without Shift)

## Notes
The `field-sizing-content` class enables automatic height adjustment as content grows, allowing the title field to expand vertically when needed while maintaining a compact single-line appearance initially. The `resize-none` class prevents manual resizing. The Enter key handler remains unchanged, preventing form submission when Shift+Enter is used (allowing multi-line input).

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01DB5sTbVjo8VrHDPQegucck