### PR TITLE
quality(ui): extract record editor components into separate modules

### DIFF
--- a/components/collections/CollectionCard.tsx
+++ b/components/collections/CollectionCard.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import type { Collection } from "@/lib/types"
 import { ModeBadge } from "@/components/collections/ModeBadge"
+import { pluralize } from "@/lib/utils/formatters"
 
 type CollectionCardProps = {
   collection: Collection
@@ -19,9 +20,7 @@ export function CollectionCard({ collection }: CollectionCardProps) {
 
         <div className="mt-1.5 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
           <ModeBadge mode={collection.mode} />
-          <span>
-            {count} {count === 1 ? "pebble" : "pebbles"}
-          </span>
+          <span>{pluralize(count, "pebble")}</span>
         </div>
       </Link>
     </article>

--- a/components/collections/CollectionDetailHeader.tsx
+++ b/components/collections/CollectionDetailHeader.tsx
@@ -1,5 +1,6 @@
 import { Pencil } from "lucide-react"
 import type { Collection } from "@/lib/types"
+import { pluralize } from "@/lib/utils/formatters"
 import { ModeBadge } from "@/components/collections/ModeBadge"
 import { CollectionFormDialog } from "@/components/collections/CollectionFormDialog"
 import { Button } from "@/components/ui/button"
@@ -39,9 +40,7 @@ export function CollectionDetailHeader({
 
       <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
         <ModeBadge mode={collection.mode} />
-        <span>
-          {pebbleCount} {pebbleCount === 1 ? "pebble" : "pebbles"}
-        </span>
+        <span>{pluralize(pebbleCount, "pebble")}</span>
       </div>
     </header>
   )

--- a/components/glyphs/GlyphDetail.tsx
+++ b/components/glyphs/GlyphDetail.tsx
@@ -5,17 +5,7 @@ import { PEBBLE_SHAPES } from "@/lib/config"
 import type { Mark } from "@/lib/types"
 import { GlyphPreview } from "@/components/glyphs/GlyphPreview"
 import { Button } from "@/components/ui/button"
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog"
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
 
 type GlyphDetailProps = {
   mark: Mark
@@ -53,31 +43,18 @@ export function GlyphDetail({ mark, onDelete }: GlyphDetailProps) {
       </div>
 
       <div className="mt-8 flex justify-center">
-        <AlertDialog>
-          <AlertDialogTrigger
-            render={
-              <Button variant="outline" size="sm">
-                <Trash2 className="size-4" aria-hidden="true" />
-                Delete glyph
-              </Button>
-            }
-          />
-          <AlertDialogContent size="sm">
-            <AlertDialogHeader>
-              <AlertDialogTitle>Delete this glyph?</AlertDialogTitle>
-              <AlertDialogDescription>
-                This action cannot be undone. The glyph will be permanently
-                removed.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction variant="destructive" onClick={onDelete}>
-                Delete
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        <ConfirmDialog
+          trigger={
+            <Button variant="outline" size="sm">
+              <Trash2 className="size-4" aria-hidden="true" />
+              Delete glyph
+            </Button>
+          }
+          title="Delete this glyph?"
+          description="This action cannot be undone. The glyph will be permanently removed."
+          confirmLabel="Delete"
+          onConfirm={onDelete}
+        />
       </div>
     </article>
   )

--- a/components/glyphs/GlyphPickerGrid.tsx
+++ b/components/glyphs/GlyphPickerGrid.tsx
@@ -1,0 +1,50 @@
+import type { Mark } from "@/lib/types"
+import { cn } from "@/lib/utils"
+import { GlyphPreview } from "@/components/glyphs/GlyphPreview"
+
+type GlyphPickerGridProps = {
+  marks: Mark[]
+  selectedMarkId: string | undefined
+  onSelect: (id: string | undefined) => void
+}
+
+export function GlyphPickerGrid({ marks, selectedMarkId, onSelect }: GlyphPickerGridProps) {
+  if (marks.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No glyphs yet. Carve one from the Glyphs page.
+      </p>
+    )
+  }
+
+  return (
+    <ul
+      role="radiogroup"
+      aria-label="Glyphs"
+      className="grid grid-cols-4 gap-2"
+    >
+      {marks.map((mark) => {
+        const selected = selectedMarkId === mark.id
+        return (
+          <li key={mark.id}>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              aria-label={mark.name ?? `Glyph ${mark.id.slice(0, 4)}`}
+              onClick={() => onSelect(selected ? undefined : mark.id)}
+              className={cn(
+                "flex size-16 items-center justify-center rounded-lg border p-1 transition-all duration-100 outline-none focus-visible:ring-3 focus-visible:ring-ring/50 active:scale-95",
+                selected
+                  ? "border-primary bg-primary/10 ring-2 ring-primary"
+                  : "border-input hover:bg-muted",
+              )}
+            >
+              <GlyphPreview mark={mark} className="size-full" />
+            </button>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/components/layout/ResetDataButton.tsx
+++ b/components/layout/ResetDataButton.tsx
@@ -2,17 +2,7 @@
 
 import { RotateCcw } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog"
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
 import { useDataProvider } from "@/lib/data/provider-context"
 
 export function ResetDataButton() {
@@ -24,29 +14,16 @@ export function ResetDataButton() {
   }
 
   return (
-    <AlertDialog>
-      <AlertDialogTrigger
-        render={
-          <Button variant="ghost" size="icon" aria-label="Reset to seed data" />
-        }
-      >
-        <RotateCcw className="size-4" />
-      </AlertDialogTrigger>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Reset all data?</AlertDialogTitle>
-          <AlertDialogDescription>
-            This will replace your pebbles, souls, and collections with the
-            original seed data. This cannot be undone.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction variant="destructive" onClick={handleReset}>
-            Reset data
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <ConfirmDialog
+      trigger={
+        <Button variant="ghost" size="icon" aria-label="Reset to seed data">
+          <RotateCcw className="size-4" />
+        </Button>
+      }
+      title="Reset all data?"
+      description="This will replace your pebbles, souls, and collections with the original seed data. This cannot be undone."
+      confirmLabel="Reset data"
+      onConfirm={handleReset}
+    />
   )
 }

--- a/components/path/PebbleCard.tsx
+++ b/components/path/PebbleCard.tsx
@@ -1,6 +1,7 @@
 import type { Pebble, Emotion, Mark } from "@/lib/types"
 import { PebbleVisual } from "@/components/pebble/PebbleVisual"
 import { IntensityDots, PositivenessIndicator } from "@/components/pebble/PebbleIndicators"
+import { EmotionBadge } from "@/components/ui/EmotionBadge"
 import { timeFormatter } from "@/lib/utils/formatters"
 
 type PebbleCardProps = {
@@ -9,20 +10,6 @@ type PebbleCardProps = {
   mark?: Mark
   soulNames: string[]
   onSelect?: (id: string) => void
-}
-
-function EmotionBadge({ emotion }: { emotion: Emotion }) {
-  return (
-    <span
-      className="rounded-full px-2 py-0.5 text-xs font-medium"
-      style={{
-        backgroundColor: `${emotion.color}20`,
-        color: emotion.color,
-      }}
-    >
-      {emotion.name}
-    </span>
-  )
 }
 
 function MetadataRow({
@@ -109,7 +96,6 @@ export function PebbleCard({ pebble, emotion, mark, soulNames, onSelect }: Pebbl
 
               <div className="mt-1.5 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                 {emotion && <EmotionBadge emotion={emotion} />}
-
                 <IntensityDots intensity={pebble.intensity} size="xs" />
                 <PositivenessIndicator value={pebble.positiveness} size="xs" />
 

--- a/components/path/QuickPebbleEditor.tsx
+++ b/components/path/QuickPebbleEditor.tsx
@@ -4,16 +4,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   CalendarDays,
   Check,
-  Compass,
   Fingerprint,
   Image,
-  Layers,
-  Lock,
-  Globe,
-  Plus,
-  Search,
   Users,
-  X,
 } from "lucide-react"
 import { motion, useReducedMotion } from "framer-motion"
 import { usePebbles } from "@/lib/data/usePebbles"
@@ -24,33 +17,16 @@ import { useSouls } from "@/lib/data/useSouls"
 import { useCollections } from "@/lib/data/useCollections"
 import { useMarks } from "@/lib/data/useMarks"
 import { compressImage } from "@/lib/utils/image-compress"
-import { EMOTIONS } from "@/lib/config/emotions"
-import { DOMAINS } from "@/lib/config/domains"
 import { Button } from "@/components/ui/button"
-import {
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-} from "@/components/ui/popover"
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-  DialogClose,
-} from "@/components/ui/dialog"
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetClose,
-} from "@/components/ui/sheet"
-import { InlineDatePicker } from "@/components/record/InlineDatePicker"
-import { TimeStepPicker } from "@/components/record/TimeStepPicker"
 import { ValenceIntensityGrid } from "@/components/record/ValenceIntensityGrid"
 import { CustomizationTile } from "@/components/record/CustomizationTile"
+import { DomainPopover } from "@/components/record/DomainPopover"
+import { EmotionPopover } from "@/components/record/EmotionPopover"
+import { CollectionPopover } from "@/components/record/CollectionPopover"
+import { VisibilityPicker } from "@/components/record/VisibilityPicker"
+import { DatePickerDialog } from "@/components/record/DatePickerDialog"
+import { GlyphPickerDialog } from "@/components/record/GlyphPickerDialog"
+import { SoulsSheet } from "@/components/record/SoulsSheet"
 import { GlyphPreview } from "@/components/glyphs/GlyphPreview"
 import { cn } from "@/lib/utils"
 
@@ -98,14 +74,8 @@ export function QuickPebbleEditor({ onPebbleCreated }: QuickPebbleEditorProps) {
 
   // Dialog/sheet state
   const [dateOpen, setDateOpen] = useState(false)
-  const [tempDate, setTempDate] = useState(() => new Date())
   const [glyphOpen, setGlyphOpen] = useState(false)
-  const [localMarkId, setLocalMarkId] = useState<string | undefined>(undefined)
   const [soulsOpen, setSoulsOpen] = useState(false)
-
-  // Search state
-  const [emotionQuery, setEmotionQuery] = useState("")
-  const [soulQuery, setSoulQuery] = useState("")
 
   // File input ref
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -127,26 +97,7 @@ export function QuickPebbleEditor({ onPebbleCreated }: QuickPebbleEditorProps) {
     }
   }, [shouldAutoExpand, countLoading, bounceLoading])
 
-  const selectedEmotion = EMOTIONS.find((e) => e.id === emotionId)
-  const selectedDomains = DOMAINS.filter((d) => domainIds.includes(d.id))
   const selectedMark = marks.find((m) => m.id === markId)
-
-  const filteredEmotions = useMemo(() => {
-    if (!emotionQuery.trim()) return EMOTIONS
-    const q = emotionQuery.toLowerCase()
-    return EMOTIONS.filter((e) => e.name.toLowerCase().includes(q))
-  }, [emotionQuery])
-
-  const filteredSouls = useMemo(() => {
-    if (!soulQuery.trim()) return souls
-    const q = soulQuery.toLowerCase()
-    return souls.filter((s) => s.name.toLowerCase().includes(q))
-  }, [souls, soulQuery])
-
-  const canAddNewSoul = useMemo(() => {
-    if (!soulQuery.trim()) return false
-    return !souls.some((s) => s.name.toLowerCase() === soulQuery.trim().toLowerCase())
-  }, [souls, soulQuery])
 
   const resetForm = useCallback(() => {
     setName("")
@@ -210,43 +161,16 @@ export function QuickPebbleEditor({ onPebbleCreated }: QuickPebbleEditorProps) {
     saving, addPebble, collections, updateCollection, resetForm, onPebbleCreated,
   ])
 
-  const handleDateChange = useCallback((date: Date) => {
-    setTempDate(date)
-  }, [])
-
-  const handleTimeChange = useCallback((date: Date) => {
-    setTempDate((prev) => {
-      const next = new Date(prev)
-      next.setHours(date.getHours(), date.getMinutes(), 0, 0)
-      return next
-    })
-  }, [])
-
-  const toggleDomain = useCallback((id: string) => {
-    setDomainIds((prev) =>
-      prev.includes(id) ? prev.filter((d) => d !== id) : [...prev, id],
-    )
-  }, [])
-
   const toggleSoul = useCallback((id: string) => {
     setSoulIds((prev) =>
       prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id],
     )
   }, [])
 
-  const handleAddSoul = useCallback(async () => {
-    const trimmed = soulQuery.trim()
-    if (!trimmed) return
-    const soul = await addSoul({ name: trimmed })
+  const handleAddSoul = useCallback(async (soulName: string) => {
+    const soul = await addSoul({ name: soulName })
     setSoulIds((prev) => [...prev, soul.id])
-    setSoulQuery("")
-  }, [soulQuery, addSoul])
-
-  const toggleCollection = useCallback((id: string) => {
-    setCollectionIds((prev) =>
-      prev.includes(id) ? prev.filter((c) => c !== id) : [...prev, id],
-    )
-  }, [])
+  }, [addSoul])
 
   const handleFileChange = useCallback(async (files: FileList | null) => {
     if (!files || files.length === 0) return
@@ -314,7 +238,6 @@ export function QuickPebbleEditor({ onPebbleCreated }: QuickPebbleEditorProps) {
           <button
             type="button"
             onClick={() => {
-              setTempDate(new Date(happenedAt))
               setDateOpen(true)
             }}
             className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
@@ -362,120 +285,8 @@ export function QuickPebbleEditor({ onPebbleCreated }: QuickPebbleEditorProps) {
       >
       {/* Qualification pills: domain + emotion */}
       <div className="mb-3 flex items-center gap-2">
-        {/* Domain pill */}
-        <Popover>
-          <PopoverTrigger
-            className={cn(
-              "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
-              domainIds.length > 0
-                ? "border border-border bg-background text-foreground"
-                : "border border-dashed border-muted-foreground/30 text-muted-foreground hover:border-muted-foreground/50",
-            )}
-            aria-label={domainIds.length > 0 ? `Domains: ${selectedDomains.map((d) => d.name).join(", ")}` : "Pick domains"}
-          >
-            <Compass className="size-3.5" aria-hidden />
-            {selectedDomains.length > 0
-              ? selectedDomains.map((d) => d.name).join(", ")
-              : "Domain"}
-          </PopoverTrigger>
-          <PopoverContent align="start" className="min-w-[180px]">
-            {DOMAINS.map((domain) => {
-              const selected = domainIds.includes(domain.id)
-              return (
-                <button
-                  key={domain.id}
-                  type="button"
-                  onClick={() => toggleDomain(domain.id)}
-                  aria-pressed={selected}
-                  className={cn(
-                    "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-none transition-colors hover:bg-muted",
-                    selected && "font-medium",
-                  )}
-                >
-                  <span className="flex size-4 shrink-0 items-center justify-center">
-                    {selected && <Check className="size-4" />}
-                  </span>
-                  <span className="flex flex-col items-start">
-                    <span>{domain.name}</span>
-                    <span className="text-xs text-muted-foreground">{domain.label}</span>
-                  </span>
-                </button>
-              )
-            })}
-          </PopoverContent>
-        </Popover>
-
-        {/* Emotion pill */}
-        <Popover onOpenChange={(open) => { if (!open) setEmotionQuery("") }}>
-          <PopoverTrigger
-            className={cn(
-              "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
-              emotionId
-                ? "border border-border bg-background text-foreground"
-                : "border border-dashed border-muted-foreground/30 text-muted-foreground hover:border-muted-foreground/50",
-            )}
-            aria-label={selectedEmotion ? `Emotion: ${selectedEmotion.name}` : "Pick emotion"}
-          >
-            {selectedEmotion ? (
-              <>
-                <span
-                  className="size-2.5 rounded-full shrink-0"
-                  style={{ backgroundColor: selectedEmotion.color }}
-                  aria-hidden
-                />
-                {selectedEmotion.name}
-              </>
-            ) : (
-              <>
-                <span className="size-2.5 rounded-full shrink-0 border border-dashed border-muted-foreground/30" aria-hidden />
-                Emotion
-              </>
-            )}
-          </PopoverTrigger>
-          <PopoverContent align="start" className="min-w-[200px] p-2">
-            <div className="flex items-center gap-2 border-b border-border pb-2 mb-1">
-              <Search className="size-4 shrink-0 text-muted-foreground" aria-hidden />
-              <input
-                type="text"
-                value={emotionQuery}
-                onChange={(e) => setEmotionQuery(e.target.value)}
-                placeholder="Search emotions…"
-                className="h-7 w-full min-w-0 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-              />
-            </div>
-            <div className="max-h-[200px] overflow-y-auto">
-              {filteredEmotions.map((emotion) => {
-                const selected = emotionId === emotion.id
-                return (
-                  <button
-                    key={emotion.id}
-                    type="button"
-                    onClick={() => setEmotionId(emotion.id)}
-                    className={cn(
-                      "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-none transition-colors hover:bg-muted",
-                      selected && "font-medium",
-                    )}
-                  >
-                    <span className="flex size-4 shrink-0 items-center justify-center">
-                      {selected && <Check className="size-4" />}
-                    </span>
-                    <span
-                      className="size-3 rounded-full shrink-0"
-                      style={{ backgroundColor: emotion.color }}
-                      aria-hidden
-                    />
-                    {emotion.name}
-                  </button>
-                )
-              })}
-              {filteredEmotions.length === 0 && (
-                <p className="px-2 py-4 text-center text-sm text-muted-foreground">
-                  No emotions found
-                </p>
-              )}
-            </div>
-          </PopoverContent>
-        </Popover>
+        <DomainPopover value={domainIds} onChange={setDomainIds} />
+        <EmotionPopover value={emotionId} onChange={setEmotionId} />
       </div>
 
       {/* Description textarea */}
@@ -493,10 +304,7 @@ export function QuickPebbleEditor({ onPebbleCreated }: QuickPebbleEditorProps) {
         <CustomizationTile
           icon={Fingerprint}
           filled={!!selectedMark}
-          onClick={() => {
-            setLocalMarkId(markId)
-            setGlyphOpen(true)
-          }}
+          onClick={() => setGlyphOpen(true)}
           ariaLabel={selectedMark ? "Change glyph" : "Add glyph"}
         >
           {selectedMark && (
@@ -505,62 +313,17 @@ export function QuickPebbleEditor({ onPebbleCreated }: QuickPebbleEditorProps) {
         </CustomizationTile>
 
         {/* Collection tile */}
-        <Popover>
-          <PopoverTrigger
-            className={cn(
-              "relative flex aspect-square items-center justify-center rounded-xl transition-all duration-100 outline-none focus-visible:ring-2 focus-visible:ring-ring active:scale-95 overflow-hidden",
-              collectionIds.length > 0
-                ? "border border-border bg-muted/50"
-                : "border border-dashed border-muted-foreground/30 hover:border-muted-foreground/50 hover:bg-muted/30",
-            )}
-            aria-label={collectionIds.length > 0 ? `${collectionIds.length} collection(s) selected` : "Add to collection"}
-          >
-            {collectionIds.length > 0 ? (
-              <span className="text-xs font-medium text-muted-foreground">
-                {collectionIds.length}
-              </span>
-            ) : (
-              <Layers className="size-5 text-muted-foreground/50" aria-hidden />
-            )}
-          </PopoverTrigger>
-          <PopoverContent align="start" className="min-w-[180px]">
-            {collections.length === 0 ? (
-              <p className="px-2 py-4 text-center text-sm text-muted-foreground">
-                No collections yet
-              </p>
-            ) : (
-              collections.map((coll) => {
-                const selected = collectionIds.includes(coll.id)
-                return (
-                  <button
-                    key={coll.id}
-                    type="button"
-                    onClick={() => toggleCollection(coll.id)}
-                    aria-pressed={selected}
-                    className={cn(
-                      "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-none transition-colors hover:bg-muted",
-                      selected && "font-medium",
-                    )}
-                  >
-                    <span className="flex size-4 shrink-0 items-center justify-center">
-                      {selected && <Check className="size-4" />}
-                    </span>
-                    {coll.name}
-                  </button>
-                )
-              })
-            )}
-          </PopoverContent>
-        </Popover>
+        <CollectionPopover
+          value={collectionIds}
+          onChange={setCollectionIds}
+          collections={collections}
+        />
 
         {/* Souls tile */}
         <CustomizationTile
           icon={Users}
           filled={soulIds.length > 0}
-          onClick={() => {
-            setSoulQuery("")
-            setSoulsOpen(true)
-          }}
+          onClick={() => setSoulsOpen(true)}
           ariaLabel={soulIds.length > 0 ? `${soulIds.length} soul(s) selected` : "Add souls"}
         >
           {soulIds.length > 0 && (
@@ -609,43 +372,7 @@ export function QuickPebbleEditor({ onPebbleCreated }: QuickPebbleEditorProps) {
 
       {/* Footer: privacy picker + save button */}
       <div className="flex items-center justify-between">
-        <Popover>
-          <PopoverTrigger
-            className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            aria-label={`Visibility: ${visibility}`}
-          >
-            {visibility === "private" ? (
-              <Lock className="size-3.5" aria-hidden />
-            ) : (
-              <Globe className="size-3.5" aria-hidden />
-            )}
-            {visibility === "private" ? "Private" : "Public"}
-          </PopoverTrigger>
-          <PopoverContent align="start" className="min-w-[140px]">
-            <button
-              type="button"
-              onClick={() => setVisibility("private")}
-              className={cn(
-                "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-none transition-colors hover:bg-muted",
-                visibility === "private" && "font-medium",
-              )}
-            >
-              <Lock className="size-4 shrink-0" />
-              Private
-            </button>
-            <button
-              type="button"
-              onClick={() => setVisibility("public")}
-              className={cn(
-                "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-none transition-colors hover:bg-muted",
-                visibility === "public" && "font-medium",
-              )}
-            >
-              <Globe className="size-4 shrink-0" />
-              Public
-            </button>
-          </PopoverContent>
-        </Popover>
+        <VisibilityPicker value={visibility} onChange={setVisibility} />
 
         <Button
           variant="default"
@@ -661,189 +388,31 @@ export function QuickPebbleEditor({ onPebbleCreated }: QuickPebbleEditorProps) {
       </motion.div>
 
       {/* Date picker dialog */}
-      <Dialog open={dateOpen} onOpenChange={setDateOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>When</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4">
-            <InlineDatePicker value={tempDate} onChange={handleDateChange} />
-            <div className="flex items-center justify-center gap-3">
-              <TimeStepPicker value={tempDate} onChange={handleTimeChange} />
-              <Button
-                variant="outline"
-                onClick={() => setTempDate(new Date())}
-              >
-                Now
-              </Button>
-            </div>
-          </div>
-          <DialogFooter>
-            <DialogClose>Cancel</DialogClose>
-            <Button
-              onClick={() => {
-                setHappenedAt(tempDate.toISOString())
-                setDateOpen(false)
-              }}
-            >
-              Done
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <DatePickerDialog
+        open={dateOpen}
+        onOpenChange={setDateOpen}
+        initialDate={new Date(happenedAt)}
+        onSave={(date) => setHappenedAt(date.toISOString())}
+      />
 
       {/* Glyph picker dialog */}
-      <Dialog
+      <GlyphPickerDialog
         open={glyphOpen}
-        onOpenChange={(open) => {
-          setGlyphOpen(open)
-          if (open) setLocalMarkId(markId)
-        }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Glyph</DialogTitle>
-          </DialogHeader>
-
-          {marks.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No glyphs yet. Carve one from the Glyphs page.
-            </p>
-          ) : (
-            <ul
-              role="radiogroup"
-              aria-label="Glyphs"
-              className="grid grid-cols-4 gap-2"
-            >
-              {marks.map((mark) => {
-                const selected = localMarkId === mark.id
-                return (
-                  <li key={mark.id}>
-                    <button
-                      type="button"
-                      role="radio"
-                      aria-checked={selected}
-                      aria-label={mark.name ?? `Glyph ${mark.id.slice(0, 4)}`}
-                      onClick={() => setLocalMarkId((prev) => (prev === mark.id ? undefined : mark.id))}
-                      className={cn(
-                        "flex size-16 items-center justify-center rounded-lg border p-1 transition-all duration-100 outline-none focus-visible:ring-3 focus-visible:ring-ring/50 active:scale-95",
-                        selected
-                          ? "border-primary bg-primary/10 ring-2 ring-primary"
-                          : "border-input hover:bg-muted",
-                      )}
-                    >
-                      <GlyphPreview mark={mark} className="size-full" />
-                    </button>
-                  </li>
-                )
-              })}
-            </ul>
-          )}
-
-          <DialogFooter>
-            <DialogClose>Cancel</DialogClose>
-            <Button
-              onClick={() => {
-                setMarkId(localMarkId)
-                setGlyphOpen(false)
-              }}
-            >
-              Save
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        onOpenChange={setGlyphOpen}
+        marks={marks}
+        selectedMarkId={markId}
+        onSave={setMarkId}
+      />
 
       {/* Souls picker sheet */}
-      <Sheet open={soulsOpen} onOpenChange={setSoulsOpen}>
-        <SheetContent>
-          <SheetHeader>
-            <SheetTitle>Souls</SheetTitle>
-          </SheetHeader>
-          <div className="flex items-center gap-2 border-b border-border pb-2 mb-3">
-            <Search className="size-4 shrink-0 text-muted-foreground" aria-hidden />
-            <input
-              type="text"
-              value={soulQuery}
-              onChange={(e) => setSoulQuery(e.target.value)}
-              placeholder="Search souls…"
-              className="h-8 w-full min-w-0 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && canAddNewSoul) {
-                  e.preventDefault()
-                  void handleAddSoul()
-                }
-              }}
-            />
-          </div>
-
-          {/* Selected chips */}
-          {soulIds.length > 0 && (
-            <ul className="mb-3 flex flex-wrap gap-1.5" role="list" aria-label="Selected souls">
-              {soulIds.map((id) => {
-                const soul = souls.find((s) => s.id === id)
-                if (!soul) return null
-                return (
-                  <li key={id}>
-                    <button
-                      type="button"
-                      onClick={() => toggleSoul(id)}
-                      className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
-                      aria-label={`Remove ${soul.name}`}
-                    >
-                      {soul.name}
-                      <X className="size-3" aria-hidden />
-                    </button>
-                  </li>
-                )
-              })}
-            </ul>
-          )}
-
-          <div className="max-h-[300px] overflow-y-auto">
-            {filteredSouls.map((soul) => {
-              const selected = soulIds.includes(soul.id)
-              return (
-                <button
-                  key={soul.id}
-                  type="button"
-                  onClick={() => toggleSoul(soul.id)}
-                  className={cn(
-                    "flex w-full items-center gap-2 rounded-lg px-2 py-2 text-sm outline-none transition-colors hover:bg-muted",
-                    selected && "font-medium",
-                  )}
-                >
-                  <span className="flex size-4 shrink-0 items-center justify-center">
-                    {selected && <Check className="size-4" />}
-                  </span>
-                  {soul.name}
-                </button>
-              )
-            })}
-            {canAddNewSoul && (
-              <button
-                type="button"
-                onClick={() => void handleAddSoul()}
-                className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-sm text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground"
-              >
-                <Plus className="size-4 shrink-0" />
-                Add &quot;{soulQuery.trim()}&quot;
-              </button>
-            )}
-            {filteredSouls.length === 0 && !canAddNewSoul && (
-              <p className="px-2 py-4 text-center text-sm text-muted-foreground">
-                No souls found
-              </p>
-            )}
-          </div>
-
-          <div className="mt-4 flex justify-end">
-            <SheetClose aria-label="Done">
-              Done
-            </SheetClose>
-          </div>
-        </SheetContent>
-      </Sheet>
+      <SoulsSheet
+        open={soulsOpen}
+        onOpenChange={setSoulsOpen}
+        selectedIds={soulIds}
+        onToggle={toggleSoul}
+        souls={souls}
+        onAddSoul={handleAddSoul}
+      />
     </section>
   )
 }

--- a/components/pebble/GlyphSheet.tsx
+++ b/components/pebble/GlyphSheet.tsx
@@ -3,7 +3,6 @@
 import { useState, useCallback } from "react"
 import { Plus } from "lucide-react"
 import type { Mark } from "@/lib/types"
-import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -14,7 +13,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog"
-import { GlyphPreview } from "@/components/glyphs/GlyphPreview"
+import { GlyphPickerGrid } from "@/components/glyphs/GlyphPickerGrid"
 
 type GlyphSheetProps = {
   marks: Mark[]
@@ -34,8 +33,8 @@ export function GlyphSheet({ marks, selectedMarkId, onSave }: GlyphSheetProps) {
     [selectedMarkId],
   )
 
-  const handleSelect = useCallback((id: string) => {
-    setLocalMarkId((prev) => (prev === id ? undefined : id))
+  const handleSelect = useCallback((id: string | undefined) => {
+    setLocalMarkId(id)
   }, [])
 
   const handleSave = useCallback(() => {
@@ -61,40 +60,11 @@ export function GlyphSheet({ marks, selectedMarkId, onSave }: GlyphSheetProps) {
           <DialogTitle>Glyph</DialogTitle>
         </DialogHeader>
 
-        {marks.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            No glyphs yet. Carve one from the Carve page.
-          </p>
-        ) : (
-          <ul
-            role="radiogroup"
-            aria-label="Glyphs"
-            className="grid grid-cols-4 gap-2"
-          >
-            {marks.map((mark) => {
-              const selected = localMarkId === mark.id
-              return (
-                <li key={mark.id}>
-                  <button
-                    type="button"
-                    role="radio"
-                    aria-checked={selected}
-                    aria-label={mark.name ?? `Glyph ${mark.id.slice(0, 4)}`}
-                    onClick={() => handleSelect(mark.id)}
-                    className={cn(
-                      "flex size-16 items-center justify-center rounded-lg border p-1 transition-all duration-100 outline-none focus-visible:ring-3 focus-visible:ring-ring/50 active:scale-95",
-                      selected
-                        ? "border-primary bg-primary/10 ring-2 ring-primary"
-                        : "border-input hover:bg-muted",
-                    )}
-                  >
-                    <GlyphPreview mark={mark} className="size-full" />
-                  </button>
-                </li>
-              )
-            })}
-          </ul>
-        )}
+        <GlyphPickerGrid
+          marks={marks}
+          selectedMarkId={localMarkId}
+          onSelect={handleSelect}
+        />
 
         <DialogFooter>
           <DialogClose>Cancel</DialogClose>

--- a/components/pebble/PebbleDetail.tsx
+++ b/components/pebble/PebbleDetail.tsx
@@ -1,6 +1,7 @@
 import type { Pebble, Soul, Collection, Mark } from "@/lib/types"
 import type { UpdatePebbleInput, UpdateCollectionInput } from "@/lib/data/data-provider"
 import { EMOTIONS, DOMAINS, CARD_TYPES } from "@/lib/config"
+import { EmotionBadge } from "@/components/ui/EmotionBadge"
 import { IntensityDots, PositivenessIndicator } from "@/components/pebble/PebbleIndicators"
 import { DetailSection } from "@/components/pebble/DetailSection"
 import { GlyphPreview } from "@/components/glyphs/GlyphPreview"
@@ -8,7 +9,7 @@ import { SoulSheet } from "@/components/pebble/SoulSheet"
 import { DomainSheet } from "@/components/pebble/DomainSheet"
 import { CollectionSheet } from "@/components/pebble/CollectionSheet"
 import { GlyphSheet } from "@/components/pebble/GlyphSheet"
-import { Badge } from "@/components/ui/badge"
+import { TagList } from "@/components/ui/TagList"
 import { Button } from "@/components/ui/button"
 import { Plus } from "lucide-react"
 import { PebbleVisual } from "@/components/pebble/PebbleVisual"
@@ -59,16 +60,7 @@ export function PebbleDetail({
 
         <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
           {emotion ? (
-            <span
-              className="rounded-full px-2.5 py-0.5 text-sm font-medium"
-              style={{
-                backgroundColor: `${emotion.color}20`,
-                color: emotion.color,
-              }}
-              aria-label={`Emotion: ${emotion.name}`}
-            >
-              {emotion.name}
-            </span>
+            <EmotionBadge emotion={emotion} size="md" />
           ) : (
             <Button
               variant="ghost"
@@ -141,15 +133,7 @@ export function PebbleDetail({
           />
         }
       >
-        {matchedSouls.length > 0 && (
-          <ul className="mt-2 flex flex-wrap gap-2" role="list">
-            {matchedSouls.map((soul) => (
-              <li key={soul.id}>
-                <Badge variant="outline">{soul.name}</Badge>
-              </li>
-            ))}
-          </ul>
-        )}
+        <TagList items={matchedSouls} />
       </DetailSection>
 
       {/* Collections */}
@@ -165,15 +149,7 @@ export function PebbleDetail({
           />
         }
       >
-        {collections.length > 0 && (
-          <ul className="mt-2 flex flex-wrap gap-2" role="list">
-            {collections.map((collection) => (
-              <li key={collection.id}>
-                <Badge variant="outline">{collection.name}</Badge>
-              </li>
-            ))}
-          </ul>
-        )}
+        <TagList items={collections} />
       </DetailSection>
 
       {/* Domains */}
@@ -187,15 +163,7 @@ export function PebbleDetail({
           />
         }
       >
-        {domains.length > 0 && (
-          <ul className="mt-2 flex flex-wrap gap-2" role="list">
-            {domains.map((domain) => (
-              <li key={domain.id}>
-                <Badge variant="outline">{domain.name}</Badge>
-              </li>
-            ))}
-          </ul>
-        )}
+        <TagList items={domains} />
       </DetailSection>
 
       {/* Cards */}

--- a/components/record/CollectionPopover.tsx
+++ b/components/record/CollectionPopover.tsx
@@ -1,0 +1,62 @@
+import { Layers } from "lucide-react"
+import type { Collection } from "@/lib/types"
+import { SelectableItem } from "@/components/ui/SelectableItem"
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+
+type CollectionPopoverProps = {
+  value: string[]
+  onChange: (ids: string[]) => void
+  collections: Collection[]
+}
+
+export function CollectionPopover({ value, onChange, collections }: CollectionPopoverProps) {
+  const toggle = (id: string) => {
+    onChange(
+      value.includes(id) ? value.filter((c) => c !== id) : [...value, id],
+    )
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        className={cn(
+          "relative flex aspect-square items-center justify-center rounded-xl transition-all duration-100 outline-none focus-visible:ring-2 focus-visible:ring-ring active:scale-95 overflow-hidden",
+          value.length > 0
+            ? "border border-border bg-muted/50"
+            : "border border-dashed border-muted-foreground/30 hover:border-muted-foreground/50 hover:bg-muted/30",
+        )}
+        aria-label={value.length > 0 ? `${value.length} collection(s) selected` : "Add to collection"}
+      >
+        {value.length > 0 ? (
+          <span className="text-xs font-medium text-muted-foreground">
+            {value.length}
+          </span>
+        ) : (
+          <Layers className="size-5 text-muted-foreground/50" aria-hidden />
+        )}
+      </PopoverTrigger>
+      <PopoverContent align="start" className="min-w-[180px]">
+        {collections.length === 0 ? (
+          <p className="px-2 py-4 text-center text-sm text-muted-foreground">
+            No collections yet
+          </p>
+        ) : (
+          collections.map((coll) => (
+            <SelectableItem
+              key={coll.id}
+              selected={value.includes(coll.id)}
+              onSelect={() => toggle(coll.id)}
+            >
+              {coll.name}
+            </SelectableItem>
+          ))
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/components/record/DatePickerDialog.tsx
+++ b/components/record/DatePickerDialog.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog"
+import { InlineDatePicker } from "@/components/record/InlineDatePicker"
+import { TimeStepPicker } from "@/components/record/TimeStepPicker"
+
+type DatePickerDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  initialDate: Date
+  onSave: (date: Date) => void
+}
+
+export function DatePickerDialog({ open, onOpenChange, initialDate, onSave }: DatePickerDialogProps) {
+  const [tempDate, setTempDate] = useState(initialDate)
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      onOpenChange(nextOpen)
+      if (nextOpen) setTempDate(initialDate)
+    },
+    [initialDate, onOpenChange],
+  )
+
+  const handleDateChange = useCallback((date: Date) => {
+    setTempDate(date)
+  }, [])
+
+  const handleTimeChange = useCallback((date: Date) => {
+    setTempDate((prev) => {
+      const next = new Date(prev)
+      next.setHours(date.getHours(), date.getMinutes(), 0, 0)
+      return next
+    })
+  }, [])
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>When</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <InlineDatePicker value={tempDate} onChange={handleDateChange} />
+          <div className="flex items-center justify-center gap-3">
+            <TimeStepPicker value={tempDate} onChange={handleTimeChange} />
+            <Button
+              variant="outline"
+              onClick={() => setTempDate(new Date())}
+            >
+              Now
+            </Button>
+          </div>
+        </div>
+        <DialogFooter>
+          <DialogClose>Cancel</DialogClose>
+          <Button
+            onClick={() => {
+              onSave(tempDate)
+              onOpenChange(false)
+            }}
+          >
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/record/DomainPopover.tsx
+++ b/components/record/DomainPopover.tsx
@@ -1,0 +1,57 @@
+import { Compass } from "lucide-react"
+import { DOMAINS } from "@/lib/config/domains"
+import { SelectableItem } from "@/components/ui/SelectableItem"
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+
+type DomainPopoverProps = {
+  value: string[]
+  onChange: (ids: string[]) => void
+}
+
+export function DomainPopover({ value, onChange }: DomainPopoverProps) {
+  const selectedDomains = DOMAINS.filter((d) => value.includes(d.id))
+
+  const toggle = (id: string) => {
+    onChange(
+      value.includes(id) ? value.filter((d) => d !== id) : [...value, id],
+    )
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+          value.length > 0
+            ? "border border-border bg-background text-foreground"
+            : "border border-dashed border-muted-foreground/30 text-muted-foreground hover:border-muted-foreground/50",
+        )}
+        aria-label={value.length > 0 ? `Domains: ${selectedDomains.map((d) => d.name).join(", ")}` : "Pick domains"}
+      >
+        <Compass className="size-3.5" aria-hidden />
+        {selectedDomains.length > 0
+          ? selectedDomains.map((d) => d.name).join(", ")
+          : "Domain"}
+      </PopoverTrigger>
+      <PopoverContent align="start" className="min-w-[180px]">
+        {DOMAINS.map((domain) => (
+          <SelectableItem
+            key={domain.id}
+            selected={value.includes(domain.id)}
+            onSelect={() => toggle(domain.id)}
+          >
+            <span className="flex flex-col items-start">
+              <span>{domain.name}</span>
+              <span className="text-xs text-muted-foreground">{domain.label}</span>
+            </span>
+          </SelectableItem>
+        ))}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/components/record/EmotionPopover.tsx
+++ b/components/record/EmotionPopover.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { EMOTIONS } from "@/lib/config/emotions"
+import { SelectableItem } from "@/components/ui/SelectableItem"
+import { SearchableList } from "@/components/ui/SearchableList"
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+
+type EmotionPopoverProps = {
+  value: string
+  onChange: (id: string) => void
+}
+
+export function EmotionPopover({ value, onChange }: EmotionPopoverProps) {
+  const [query, setQuery] = useState("")
+  const selectedEmotion = EMOTIONS.find((e) => e.id === value)
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return EMOTIONS
+    const q = query.toLowerCase()
+    return EMOTIONS.filter((e) => e.name.toLowerCase().includes(q))
+  }, [query])
+
+  return (
+    <Popover onOpenChange={(open) => { if (!open) setQuery("") }}>
+      <PopoverTrigger
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+          value
+            ? "border border-border bg-background text-foreground"
+            : "border border-dashed border-muted-foreground/30 text-muted-foreground hover:border-muted-foreground/50",
+        )}
+        aria-label={selectedEmotion ? `Emotion: ${selectedEmotion.name}` : "Pick emotion"}
+      >
+        {selectedEmotion ? (
+          <>
+            <span
+              className="size-2.5 rounded-full shrink-0"
+              style={{ backgroundColor: selectedEmotion.color }}
+              aria-hidden
+            />
+            {selectedEmotion.name}
+          </>
+        ) : (
+          <>
+            <span className="size-2.5 rounded-full shrink-0 border border-dashed border-muted-foreground/30" aria-hidden />
+            Emotion
+          </>
+        )}
+      </PopoverTrigger>
+      <PopoverContent align="start" className="min-w-[200px] p-2">
+        <SearchableList
+          query={query}
+          onQueryChange={setQuery}
+          placeholder="Search emotions\u2026"
+          isEmpty={filtered.length === 0}
+          emptyMessage="No emotions found"
+        >
+          {filtered.map((emotion) => (
+            <SelectableItem
+              key={emotion.id}
+              selected={value === emotion.id}
+              onSelect={() => onChange(emotion.id)}
+            >
+              <span
+                className="size-3 rounded-full shrink-0"
+                style={{ backgroundColor: emotion.color }}
+                aria-hidden
+              />
+              {emotion.name}
+            </SelectableItem>
+          ))}
+        </SearchableList>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/components/record/GlyphPickerDialog.tsx
+++ b/components/record/GlyphPickerDialog.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import type { Mark } from "@/lib/types"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog"
+import { GlyphPickerGrid } from "@/components/glyphs/GlyphPickerGrid"
+
+type GlyphPickerDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  marks: Mark[]
+  selectedMarkId: string | undefined
+  onSave: (markId: string | undefined) => void
+}
+
+export function GlyphPickerDialog({
+  open,
+  onOpenChange,
+  marks,
+  selectedMarkId,
+  onSave,
+}: GlyphPickerDialogProps) {
+  const [localMarkId, setLocalMarkId] = useState<string | undefined>(selectedMarkId)
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      onOpenChange(nextOpen)
+      if (nextOpen) setLocalMarkId(selectedMarkId)
+    },
+    [selectedMarkId, onOpenChange],
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Glyph</DialogTitle>
+        </DialogHeader>
+
+        <GlyphPickerGrid
+          marks={marks}
+          selectedMarkId={localMarkId}
+          onSelect={setLocalMarkId}
+        />
+
+        <DialogFooter>
+          <DialogClose>Cancel</DialogClose>
+          <Button
+            onClick={() => {
+              onSave(localMarkId)
+              onOpenChange(false)
+            }}
+          >
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/record/SoulsSheet.tsx
+++ b/components/record/SoulsSheet.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Plus, X } from "lucide-react"
+import type { Soul } from "@/lib/types"
+import { SelectableItem } from "@/components/ui/SelectableItem"
+import { SearchableList } from "@/components/ui/SearchableList"
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetClose,
+} from "@/components/ui/sheet"
+
+type SoulsSheetProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  selectedIds: string[]
+  onToggle: (id: string) => void
+  souls: Soul[]
+  onAddSoul: (name: string) => Promise<void>
+}
+
+export function SoulsSheet({
+  open,
+  onOpenChange,
+  selectedIds,
+  onToggle,
+  souls,
+  onAddSoul,
+}: SoulsSheetProps) {
+  const [query, setQuery] = useState("")
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return souls
+    const q = query.toLowerCase()
+    return souls.filter((s) => s.name.toLowerCase().includes(q))
+  }, [souls, query])
+
+  const canAddNew = useMemo(() => {
+    if (!query.trim()) return false
+    return !souls.some((s) => s.name.toLowerCase() === query.trim().toLowerCase())
+  }, [souls, query])
+
+  const handleAdd = async () => {
+    const trimmed = query.trim()
+    if (!trimmed) return
+    await onAddSoul(trimmed)
+    setQuery("")
+  }
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    onOpenChange(nextOpen)
+    if (nextOpen) setQuery("")
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Souls</SheetTitle>
+        </SheetHeader>
+
+        <SearchableList
+          query={query}
+          onQueryChange={setQuery}
+          placeholder="Search souls\u2026"
+          isEmpty={filtered.length === 0 && !canAddNew}
+          emptyMessage="No souls found"
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && canAddNew) {
+              e.preventDefault()
+              void handleAdd()
+            }
+          }}
+        >
+          {/* Selected chips */}
+          {selectedIds.length > 0 && (
+            <ul className="mb-3 flex flex-wrap gap-1.5" role="list" aria-label="Selected souls">
+              {selectedIds.map((id) => {
+                const soul = souls.find((s) => s.id === id)
+                if (!soul) return null
+                return (
+                  <li key={id}>
+                    <button
+                      type="button"
+                      onClick={() => onToggle(id)}
+                      className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+                      aria-label={`Remove ${soul.name}`}
+                    >
+                      {soul.name}
+                      <X className="size-3" aria-hidden />
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+
+          {filtered.map((soul) => (
+            <SelectableItem
+              key={soul.id}
+              selected={selectedIds.includes(soul.id)}
+              onSelect={() => onToggle(soul.id)}
+              className="py-2"
+            >
+              {soul.name}
+            </SelectableItem>
+          ))}
+
+          {canAddNew && (
+            <button
+              type="button"
+              onClick={() => void handleAdd()}
+              className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-sm text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <Plus className="size-4 shrink-0" />
+              Add &quot;{query.trim()}&quot;
+            </button>
+          )}
+        </SearchableList>
+
+        <div className="mt-4 flex justify-end">
+          <SheetClose aria-label="Done">
+            Done
+          </SheetClose>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/components/record/VisibilityPicker.tsx
+++ b/components/record/VisibilityPicker.tsx
@@ -1,0 +1,46 @@
+import { Lock, Globe } from "lucide-react"
+import { SelectableItem } from "@/components/ui/SelectableItem"
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover"
+
+type VisibilityPickerProps = {
+  value: "private" | "public"
+  onChange: (value: "private" | "public") => void
+}
+
+export function VisibilityPicker({ value, onChange }: VisibilityPickerProps) {
+  return (
+    <Popover>
+      <PopoverTrigger
+        className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        aria-label={`Visibility: ${value}`}
+      >
+        {value === "private" ? (
+          <Lock className="size-3.5" aria-hidden />
+        ) : (
+          <Globe className="size-3.5" aria-hidden />
+        )}
+        {value === "private" ? "Private" : "Public"}
+      </PopoverTrigger>
+      <PopoverContent align="start" className="min-w-[140px]">
+        <SelectableItem
+          selected={value === "private"}
+          onSelect={() => onChange("private")}
+        >
+          <Lock className="size-4 shrink-0" />
+          Private
+        </SelectableItem>
+        <SelectableItem
+          selected={value === "public"}
+          onSelect={() => onChange("public")}
+        >
+          <Globe className="size-4 shrink-0" />
+          Public
+        </SelectableItem>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/components/souls/DeleteSoulDialog.tsx
+++ b/components/souls/DeleteSoulDialog.tsx
@@ -2,17 +2,7 @@
 
 import { Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog"
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
 
 type DeleteSoulDialogProps = {
   soulName: string
@@ -21,33 +11,20 @@ type DeleteSoulDialogProps = {
 
 export function DeleteSoulDialog({ soulName, onConfirm }: DeleteSoulDialogProps) {
   return (
-    <AlertDialog>
-      <AlertDialogTrigger
-        render={
-          <Button
-            variant="ghost"
-            size="icon-xs"
-            aria-label={`Delete ${soulName}`}
-          />
-        }
-      >
-        <Trash2 className="size-3.5" />
-      </AlertDialogTrigger>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Delete soul?</AlertDialogTitle>
-          <AlertDialogDescription>
-            This will remove {soulName} from your directory and unlink them from
-            all pebbles. This cannot be undone.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction variant="destructive" onClick={onConfirm}>
-            Delete
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <ConfirmDialog
+      trigger={
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          aria-label={`Delete ${soulName}`}
+        >
+          <Trash2 className="size-3.5" />
+        </Button>
+      }
+      title="Delete soul?"
+      description={`This will remove ${soulName} from your directory and unlink them from all pebbles. This cannot be undone.`}
+      confirmLabel="Delete"
+      onConfirm={onConfirm}
+    />
   )
 }

--- a/components/souls/SoulDetailHeader.tsx
+++ b/components/souls/SoulDetailHeader.tsx
@@ -5,6 +5,7 @@ import { Pencil } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import type { Soul } from "@/lib/types"
+import { pluralize } from "@/lib/utils/formatters"
 
 type SoulDetailHeaderProps = {
   soul: Soul
@@ -83,7 +84,7 @@ export function SoulDetailHeader({
       )}
 
       <p className="mt-2 text-sm text-muted-foreground">
-        {pebbleCount} {pebbleCount === 1 ? "pebble" : "pebbles"}
+        {pluralize(pebbleCount, "pebble")}
       </p>
     </header>
   )

--- a/components/ui/ConfirmDialog.tsx
+++ b/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,50 @@
+import type { ReactElement } from "react"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+
+type ConfirmDialogProps = {
+  trigger: ReactElement
+  title: string
+  description: string
+  confirmLabel?: string
+  cancelLabel?: string
+  variant?: "destructive" | "default"
+  onConfirm: () => void
+}
+
+export function ConfirmDialog({
+  trigger,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  variant = "destructive",
+  onConfirm,
+}: ConfirmDialogProps) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger render={trigger} />
+      <AlertDialogContent size="sm">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{cancelLabel}</AlertDialogCancel>
+          <AlertDialogAction variant={variant} onClick={onConfirm}>
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/components/ui/EmotionBadge.tsx
+++ b/components/ui/EmotionBadge.tsx
@@ -1,0 +1,20 @@
+import type { Emotion } from "@/lib/config"
+
+type EmotionBadgeProps = {
+  emotion: Emotion
+  size?: "sm" | "md"
+}
+
+export function EmotionBadge({ emotion, size = "sm" }: EmotionBadgeProps) {
+  return (
+    <span
+      className={`rounded-full font-medium ${size === "sm" ? "px-2 py-0.5 text-xs" : "px-2.5 py-0.5 text-sm"}`}
+      style={{
+        backgroundColor: `${emotion.color}20`,
+        color: emotion.color,
+      }}
+    >
+      {emotion.name}
+    </span>
+  )
+}

--- a/components/ui/SearchableList.tsx
+++ b/components/ui/SearchableList.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react"
+import { Search } from "lucide-react"
+
+type SearchableListProps = {
+  query: string
+  onQueryChange: (query: string) => void
+  placeholder?: string
+  children: ReactNode
+  emptyMessage?: string
+  isEmpty?: boolean
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
+}
+
+export function SearchableList({
+  query,
+  onQueryChange,
+  placeholder = "Search\u2026",
+  children,
+  emptyMessage = "No results found",
+  isEmpty,
+  onKeyDown,
+}: SearchableListProps) {
+  return (
+    <>
+      <div className="flex items-center gap-2 border-b border-border pb-2 mb-1">
+        <Search className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          placeholder={placeholder}
+          className="h-7 w-full min-w-0 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          onKeyDown={onKeyDown}
+        />
+      </div>
+      <div className="max-h-[200px] overflow-y-auto">
+        {children}
+        {isEmpty && (
+          <p className="px-2 py-4 text-center text-sm text-muted-foreground">
+            {emptyMessage}
+          </p>
+        )}
+      </div>
+    </>
+  )
+}

--- a/components/ui/SelectableItem.tsx
+++ b/components/ui/SelectableItem.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react"
+import { Check } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+type SelectableItemProps = {
+  selected: boolean
+  onSelect: () => void
+  children: ReactNode
+  role?: "option" | "radio" | "menuitemradio"
+  className?: string
+}
+
+export function SelectableItem({
+  selected,
+  onSelect,
+  children,
+  role,
+  className,
+}: SelectableItemProps) {
+  const ariaProps = role === "option"
+    ? { role: "option" as const, "aria-selected": selected }
+    : role === "radio"
+      ? { role: "radio" as const, "aria-checked": selected }
+      : role === "menuitemradio"
+        ? { role: "menuitemradio" as const, "aria-checked": selected }
+        : { "aria-pressed": selected }
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-none transition-colors hover:bg-muted",
+        selected && "font-medium",
+        className,
+      )}
+      {...ariaProps}
+    >
+      <span className="flex size-4 shrink-0 items-center justify-center">
+        {selected && <Check className="size-4" />}
+      </span>
+      {children}
+    </button>
+  )
+}

--- a/components/ui/TagList.tsx
+++ b/components/ui/TagList.tsx
@@ -1,0 +1,20 @@
+import { Badge } from "@/components/ui/badge"
+
+type TagListProps = {
+  items: { id: string; name: string }[]
+  className?: string
+}
+
+export function TagList({ items, className }: TagListProps) {
+  if (items.length === 0) return null
+
+  return (
+    <ul className={className ?? "mt-2 flex flex-wrap gap-2"} role="list">
+      {items.map((item) => (
+        <li key={item.id}>
+          <Badge variant="outline">{item.name}</Badge>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/lib/utils/formatters.ts
+++ b/lib/utils/formatters.ts
@@ -23,3 +23,9 @@ export const timeFormatter = new Intl.DateTimeFormat("en-US", {
   hour: "numeric",
   minute: "numeric",
 })
+
+/** Pluralize a word based on count: pluralize(3, "pebble") → "3 pebbles" */
+export function pluralize(count: number, singular: string, plural?: string): string {
+  const word = count === 1 ? singular : (plural ?? `${singular}s`)
+  return `${count} ${word}`
+}


### PR DESCRIPTION
## Changes

Refactored `QuickPebbleEditor` by extracting UI components and logic into dedicated, reusable modules:

**New Components:**
- `DomainPopover` - Domain selection popover
- `EmotionPopover` - Emotion selection with search
- `CollectionPopover` - Collection selection
- `VisibilityPicker` - Privacy setting picker
- `DatePickerDialog` - Date/time picker dialog
- `GlyphPickerDialog` - Glyph selection dialog
- `SoulsSheet` - Souls selection sheet with add capability
- `GlyphPickerGrid` - Reusable glyph grid component
- `SelectableItem` - Standardized selectable list item
- `SearchableList` - Reusable searchable list container
- `ConfirmDialog` - Reusable confirmation dialog
- `EmotionBadge` - Emotion display badge
- `TagList` - Generic tag/badge list renderer

**Modified Components:**
- `QuickPebbleEditor` - Simplified by delegating to new components
- `DeleteSoulDialog` - Now uses `ConfirmDialog`
- `GlyphDetail` - Now uses `ConfirmDialog`
- `ResetDataButton` - Now uses `ConfirmDialog`
- `GlyphSheet` - Now uses `GlyphPickerGrid`
- `PebbleDetail` - Now uses `EmotionBadge` and `TagList`
- `PebbleCard` - Now uses `EmotionBadge`

**Utilities:**
- Added `pluralize()` helper to `formatters.ts`

## Notes

- Extracted complex inline UI logic into focused, single-responsibility components
- Created reusable primitives (`SelectableItem`, `SearchableList`, `ConfirmDialog`) to reduce duplication across the codebase
- Maintained all existing functionality while improving code organization and maintainability
- Components follow consistent patterns for state management and prop interfaces
- `ConfirmDialog` replaces repetitive `AlertDialog` patterns throughout the app

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_017rPHq9cvVmXfdRhNqEgXZb