### PR TITLE
feat(legal): add legal documents section to profile page

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/lib/data/auth-context"
 import { ProfileCard } from "@/components/profile/ProfileCard"
 import { LogoutButton } from "@/components/profile/LogoutButton"
 import { AppearanceSection } from "@/components/profile/AppearanceSection"
+import { LegalSection } from "@/components/profile/LegalSection"
 import { PageLayout } from "@/components/layout/PageLayout"
 import { PathProfileCard } from "@/components/path/PathProfileCard"
 import { BackPath } from "@/components/ui/BackPath"
@@ -77,6 +78,8 @@ export default function ProfilePage() {
         </nav>
 
           <AppearanceSection />
+
+          <LegalSection />
 
           <LogoutButton onLogout={handleLogout} />
         </div>

--- a/components/profile/LegalSection.tsx
+++ b/components/profile/LegalSection.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link"
+import { Scale, ChevronRight } from "lucide-react"
+
+const LEGAL_LINKS = [
+  { label: "Legal Notice", href: "/docs/legal-notice" },
+  { label: "Terms of Service", href: "/docs/terms" },
+  { label: "Privacy Policy", href: "/docs/privacy" },
+]
+
+export function LegalSection() {
+  return (
+    <nav aria-label="Legal">
+      <ul className="divide-y divide-border rounded-xl border border-border">
+        {LEGAL_LINKS.map((link) => (
+          <li key={link.href}>
+            <Link
+              href={link.href}
+              className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/50 first:rounded-t-xl last:rounded-b-xl"
+            >
+              <Scale className="size-5 text-muted-foreground" aria-hidden />
+              <span className="flex-1 text-sm font-medium">{link.label}</span>
+              <ChevronRight className="size-4 text-muted-foreground" aria-hidden />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -375,7 +375,7 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Profile",
-      "description": "User profile page displaying account info, appearance settings, and logout functionality.",
+      "description": "User profile page displaying account info, appearance settings, legal document links, and logout functionality.",
       "status": "development",
       "platforms": ["web", "ios", "android"]
     },


### PR DESCRIPTION
Resolves #179 

## Changes
- **components/profile/LegalSection.tsx** (new): Created a new reusable legal navigation component that displays links to Legal Notice, Terms of Service, and Privacy Policy documents with consistent styling and accessibility features
- **app/profile/page.tsx**: Imported and integrated `LegalSection` component into the profile page, positioned between appearance settings and logout button
- **docs/arkaik/bundle.json**: Updated profile page description to reflect the addition of legal document links

## Notes
- The `LegalSection` component uses a consistent list-based navigation pattern matching existing profile sections
- Links are configured to route to `/docs/legal-notice`, `/docs/terms`, and `/docs/privacy` pages
- Includes proper accessibility attributes (`aria-label`, `aria-hidden`) for semantic HTML and icon handling
- Uses existing design tokens (border, muted colors) to maintain visual consistency with the rest of the profile page
- The component is self-contained and reusable if needed elsewhere in the application

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01Y54mDdGqVWZdYWgVSM2aqg