### PR TITLE
feat(legal): add terms and privacy policy consent to registration

### DIFF
--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useAuth } from "@/lib/data/auth-context"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 
 export default function RegisterPage() {
@@ -14,6 +15,8 @@ export default function RegisterPage() {
   const [username, setUsername] = useState("")
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
+  const [termsAccepted, setTermsAccepted] = useState(false)
+  const [privacyAccepted, setPrivacyAccepted] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
 
@@ -39,9 +42,19 @@ export default function RegisterPage() {
       return
     }
 
+    if (!termsAccepted || !privacyAccepted) {
+      setError("You must accept the Terms of Service and Privacy Policy.")
+      return
+    }
+
     setSubmitting(true)
     try {
-      await register({ username: username.trim(), password })
+      await register({
+        username: username.trim(),
+        password,
+        terms_accepted: termsAccepted,
+        privacy_accepted: privacyAccepted,
+      })
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Something went wrong."
@@ -108,13 +121,65 @@ export default function RegisterPage() {
           />
         </div>
 
+        <div className="flex items-start gap-2 text-left">
+          <Checkbox
+            id="register-terms"
+            checked={termsAccepted}
+            onCheckedChange={(checked) => setTermsAccepted(checked)}
+            disabled={submitting}
+            required
+          />
+          <label
+            htmlFor="register-terms"
+            className="text-sm text-muted-foreground"
+          >
+            I accept the{" "}
+            <Link
+              href="/docs/terms"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-4 hover:text-foreground"
+            >
+              Terms of Service
+            </Link>
+          </label>
+        </div>
+
+        <div className="flex items-start gap-2 text-left">
+          <Checkbox
+            id="register-privacy"
+            checked={privacyAccepted}
+            onCheckedChange={(checked) => setPrivacyAccepted(checked)}
+            disabled={submitting}
+            required
+          />
+          <label
+            htmlFor="register-privacy"
+            className="text-sm text-muted-foreground"
+          >
+            I accept the{" "}
+            <Link
+              href="/docs/privacy"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-4 hover:text-foreground"
+            >
+              Privacy Policy
+            </Link>
+          </label>
+        </div>
+
         {error && (
           <p role="alert" className="text-sm text-destructive">
             {error}
           </p>
         )}
 
-        <Button type="submit" size="lg" disabled={submitting}>
+        <Button
+          type="submit"
+          size="lg"
+          disabled={submitting || !termsAccepted || !privacyAccepted}
+        >
           {submitting ? "Creating account\u2026" : "Create account"}
         </Button>
       </form>

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as React from "react"
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer size-4 shrink-0 rounded-sm border border-input bg-transparent transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 data-[checked]:border-primary data-[checked]:bg-primary data-[checked]:text-primary-foreground aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+        <Check className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -32,7 +32,7 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Register",
-      "description": "Registration page with username, password, and confirm password form. Auto-logs in and redirects to onboarding on success.",
+      "description": "Registration page with username, password, confirm password, and consent checkboxes (terms + privacy). Auto-logs in and redirects to onboarding on success.",
       "status": "development",
       "platforms": ["web", "ios", "android"]
     },
@@ -592,7 +592,7 @@
       "project_id": "pebbles",
       "species": "data-model",
       "title": "Profile",
-      "description": "User profile with display name, onboarding state, and color world preference.",
+      "description": "User profile with display name, onboarding state, color world preference, and consent timestamps (terms + privacy).",
       "status": "development",
       "platforms": ["web", "ios", "android"]
     },

--- a/lib/data/local-provider.ts
+++ b/lib/data/local-provider.ts
@@ -207,7 +207,19 @@ export class LocalProvider implements DataProvider {
     try {
       const raw = localStorage.getItem(AUTH_STORAGE_KEY)
       if (!raw) return EMPTY_AUTH_STORE
-      return JSON.parse(raw) as AuthStore
+      const parsed = JSON.parse(raw) as AuthStore
+
+      // Backfill consent fields for profiles created before this feature
+      for (const profile of parsed.profiles) {
+        if (profile.terms_accepted_at === undefined) {
+          profile.terms_accepted_at = null
+        }
+        if (profile.privacy_accepted_at === undefined) {
+          profile.privacy_accepted_at = null
+        }
+      }
+
+      return parsed
     } catch {
       return EMPTY_AUTH_STORE
     }
@@ -570,6 +582,12 @@ export class LocalProvider implements DataProvider {
   // ---------------------------------------------------------------------------
 
   async register(input: RegisterInput): Promise<Session> {
+    if (!input.terms_accepted || !input.privacy_accepted) {
+      throw new Error(
+        "You must accept the Terms of Service and Privacy Policy.",
+      )
+    }
+
     const existing = this.authStore.accounts.find(
       (a) => a.username === input.username,
     )
@@ -596,6 +614,8 @@ export class LocalProvider implements DataProvider {
       display_name: input.username,
       onboarding_completed: legacyOnboarding,
       color_world: "blush-quartz",
+      terms_accepted_at: input.terms_accepted ? now : null,
+      privacy_accepted_at: input.privacy_accepted ? now : null,
       created_at: now,
       updated_at: now,
     }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -86,6 +86,8 @@ export type Profile = {
   display_name: string
   onboarding_completed: boolean
   color_world: ColorWorld
+  terms_accepted_at: string | null
+  privacy_accepted_at: string | null
   created_at: string
   updated_at: string
 }
@@ -96,7 +98,12 @@ export type Session = {
   created_at: string
 }
 
-export type RegisterInput = { username: string; password: string }
+export type RegisterInput = {
+  username: string
+  password: string
+  terms_accepted: boolean
+  privacy_accepted: boolean
+}
 export type LoginInput = { username: string; password: string }
 export type UpdateProfileInput = Partial<
   Omit<Profile, "id" | "account_id" | "created_at" | "updated_at">

--- a/package-lock.json
+++ b/package-lock.json
@@ -744,6 +744,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
       "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1033,6 +1034,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1055,6 +1057,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1077,6 +1080,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1093,6 +1097,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1109,6 +1114,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1125,6 +1131,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1141,6 +1148,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1157,6 +1165,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1173,6 +1182,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1189,6 +1199,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1205,6 +1216,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1221,6 +1233,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1237,6 +1250,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1259,6 +1273,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1281,6 +1296,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1303,6 +1319,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1325,6 +1342,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1347,6 +1365,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1369,6 +1388,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1391,6 +1411,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1413,6 +1434,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1432,6 +1454,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1451,6 +1474,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1470,6 +1494,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2168,6 +2193,17 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@serwist/turbopack/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@serwist/turbopack/node_modules/semver": {


### PR DESCRIPTION
Resolves #180 

## Changes

- **app/register/page.tsx**: Added two checkbox form fields for Terms of Service and Privacy Policy acceptance. Both checkboxes are required before account creation, and the submit button is disabled until both are checked. Added validation to ensure both consents are accepted before submission.

- **components/ui/checkbox.tsx**: New checkbox component built on Base UI's checkbox primitive with Lucide's Check icon. Includes styling for checked/disabled/focus states and accessibility features.

- **lib/types.ts**: Extended `Profile` type with `terms_accepted_at` and `privacy_accepted_at` timestamp fields. Updated `RegisterInput` type to include `terms_accepted` and `privacy_accepted` boolean flags.

- **lib/data/local-provider.ts**: Updated `register()` method to validate consent flags and store acceptance timestamps. Added backfill logic in `loadAuthStore()` to set null values for consent fields on profiles created before this feature (backward compatibility).

- **docs/arkaik/bundle.json**: Updated Register view and Profile data model descriptions to reflect new consent functionality.

## Notes

- Consent timestamps are stored as ISO strings (or null if not accepted) to maintain audit trail of when users accepted policies
- Backfill logic ensures existing user profiles don't break when loading; they'll have null consent timestamps
- Submit button is disabled both during submission and when consents aren't checked, providing clear UX feedback
- Links to `/docs/terms` and `/docs/privacy` open in new tabs with security attributes
- Validation occurs both client-side (form state) and server-side (register method)

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01N8wiCzQyjHiG731qUM8w3s