### PR TITLE
feat(auth): add Google Sign-In

### DIFF
--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 
 export default function LoginPage() {
-  const { login, signInWithApple, profile, isAuthenticated, isLoading } =
+  const { login, signInWithApple, signInWithGoogle, profile, isAuthenticated, isLoading } =
     useAuth()
   const router = useRouter()
 
@@ -48,6 +48,17 @@ export default function LoginPage() {
         err instanceof Error ? err.message : "Something went wrong."
       setError(message)
       setSubmitting(false)
+    }
+  }
+
+  const handleGoogleSignIn = async () => {
+    setError(null)
+    try {
+      await signInWithGoogle()
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Something went wrong."
+      setError(message)
     }
   }
 
@@ -143,6 +154,29 @@ export default function LoginPage() {
             <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
           </svg>
           Sign in with Apple
+        </Button>
+
+        <Button
+          variant="outline"
+          size="lg"
+          onClick={handleGoogleSignIn}
+          disabled={submitting}
+          aria-label="Sign in with Google"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            className="mr-2"
+            aria-hidden="true"
+          >
+            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
+            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+          </svg>
+          Sign in with Google
         </Button>
       </div>
 

--- a/apps/web/app/register/page.tsx
+++ b/apps/web/app/register/page.tsx
@@ -9,7 +9,7 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 
 export default function RegisterPage() {
-  const { register, signInWithApple, isAuthenticated, isLoading } = useAuth()
+  const { register, signInWithApple, signInWithGoogle, isAuthenticated, isLoading } = useAuth()
   const router = useRouter()
 
   const [email, setEmail] = useState("")
@@ -60,6 +60,17 @@ export default function RegisterPage() {
         err instanceof Error ? err.message : "Something went wrong."
       setError(message)
       setSubmitting(false)
+    }
+  }
+
+  const handleGoogleSignIn = async () => {
+    setError(null)
+    try {
+      await signInWithGoogle()
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Something went wrong."
+      setError(message)
     }
   }
 
@@ -222,6 +233,29 @@ export default function RegisterPage() {
             <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
           </svg>
           Sign up with Apple
+        </Button>
+
+        <Button
+          variant="outline"
+          size="lg"
+          onClick={handleGoogleSignIn}
+          disabled={submitting}
+          aria-label="Sign up with Google"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            className="mr-2"
+            aria-hidden="true"
+          >
+            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
+            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+          </svg>
+          Sign up with Google
         </Button>
       </div>
 

--- a/apps/web/lib/data/auth-context.ts
+++ b/apps/web/lib/data/auth-context.ts
@@ -26,6 +26,7 @@ export type AuthContextValue = {
   login(input: LoginInput): Promise<void>
   register(input: RegisterInput): Promise<void>
   signInWithApple(): Promise<void>
+  signInWithGoogle(): Promise<void>
   logout(): Promise<void>
   updateProfile(input: UpdateProfileInput): Promise<Profile>
 }

--- a/apps/web/lib/data/useSupabaseAuth.ts
+++ b/apps/web/lib/data/useSupabaseAuth.ts
@@ -153,6 +153,19 @@ export function useSupabaseAuth(): AuthContextValue {
     if (error) throw new Error(error.message)
   }, [])
 
+  const signInWithGoogle = useCallback(async () => {
+    const supabase = getSupabase()
+    if (!supabase) throw new Error("Supabase client not available")
+
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    })
+    if (error) throw new Error(error.message)
+  }, [])
+
   const logout = useCallback(async () => {
     const supabase = getSupabase()
     if (!supabase) throw new Error("Supabase client not available")
@@ -191,6 +204,7 @@ export function useSupabaseAuth(): AuthContextValue {
     login,
     register,
     signInWithApple,
+    signInWithGoogle,
     logout,
     updateProfile,
   }


### PR DESCRIPTION
## Summary

- Add `signInWithGoogle()` method to `AuthContextValue` and `useSupabaseAuth` hook
- Add "Sign in with Google" button to login page
- Add "Sign up with Google" button to register page

Uses the same OAuth flow as Apple Sign-In — the callback route and profile trigger handle Google identically. Google provider is already configured in the Supabase dashboard.

## Key files

| File | Change |
|---|---|
| `apps/web/lib/data/auth-context.ts` | Added `signInWithGoogle` to type |
| `apps/web/lib/data/useSupabaseAuth.ts` | Added `signInWithGoogle` implementation |
| `apps/web/app/login/page.tsx` | Added Google button |
| `apps/web/app/register/page.tsx` | Added Google button |

## Test plan

- [ ] Verify Google Sign-In redirects to Google OAuth consent screen
- [ ] Verify callback redirects to `/onboarding` (new user) or `/path` (existing)
- [ ] Verify profile is auto-created via the `handle_new_user` trigger
- [ ] Verify build and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)