### PR TITLE
fix(auth): add proxy for supabase session refresh

### DIFF
--- a/apps/web/lib/supabase/middleware.ts
+++ b/apps/web/lib/supabase/middleware.ts
@@ -1,0 +1,48 @@
+import { createServerClient } from "@supabase/ssr"
+import { NextResponse, type NextRequest } from "next/server"
+
+/**
+ * Refreshes the Supabase auth session on every request.
+ *
+ * This is essential for Supabase SSR: without it, the JWT stored in cookies
+ * expires (default 1 h) and all authenticated requests start returning 401.
+ *
+ * The proxy achieves three things:
+ * 1. Refreshes the auth token (via getClaims / getUser).
+ * 2. Passes the refreshed token to Server Components through request cookies.
+ * 3. Passes the refreshed token to the browser through response cookies.
+ */
+export async function updateSession(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({ request })
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll()
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value),
+          )
+          supabaseResponse = NextResponse.next({ request })
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options),
+          )
+        },
+      },
+    },
+  )
+
+  // IMPORTANT: Do not add code between createServerClient and getUser().
+  // A simple mistake could cause users to be randomly logged out.
+
+  // getUser() sends a request to the Supabase Auth server every time to
+  // revalidate the Auth token. Never trust getSession() here — it only
+  // reads from cookies without validation.
+  await supabase.auth.getUser()
+
+  return supabaseResponse
+}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,0 +1,20 @@
+import { type NextRequest } from "next/server"
+import { updateSession } from "@/lib/supabase/middleware"
+
+export async function proxy(request: NextRequest) {
+  return await updateSession(request)
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except:
+     * - _next/static (static files)
+     * - _next/image (image optimization)
+     * - favicon.ico
+     * - Static assets (svg, png, jpg, jpeg, gif, webp, ico, webmanifest)
+     * - Service worker paths (sw.js, sw/*)
+     */
+    "/((?!_next/static|_next/image|favicon.ico|sw\\.js|sw/|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|webmanifest)$).*)",
+  ],
+}


### PR DESCRIPTION
Resolves #232

## Summary

Adds the missing Next.js 16 proxy file (`proxy.ts`, formerly `middleware.ts`) that refreshes Supabase auth cookies on every server request.

Without it, the JWT (1h TTL) expires silently — causing 401 errors, blank pages on protected routes, and session loss on page refresh or after onboarding.

## Key files

- `apps/web/proxy.ts` — Next.js 16 proxy entry point (matcher excludes static assets and SW)
- `apps/web/lib/supabase/middleware.ts` — `updateSession()` utility: creates a request-scoped Supabase client, refreshes the auth token via `getUser()`, and syncs cookies between request and response

## Why this fixes #232

The onboarding completion redirect failed because the session cookie was never refreshed server-side. After signup, the first `getUser()` from the browser client succeeded, but on subsequent navigations (especially the redirect after onboarding), the server had no fresh token → the user appeared unauthenticated → `AuthGate` rendered nothing.