### PR TITLE
fix(auth): exclude supabase from service worker cache and harden auth callback

### DIFF
--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -5,29 +5,34 @@ export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get("code")
 
-  if (code) {
-    const supabase = await createServerSupabaseClient()
-    const { error } = await supabase.auth.exchangeCodeForSession(code)
-
-    if (!error) {
-      // Check if user needs onboarding
-      const {
-        data: { user },
-      } = await supabase.auth.getUser()
-
-      if (user) {
-        const { data: profile } = await supabase
-          .from("profiles")
-          .select("onboarding_completed")
-          .eq("user_id", user.id)
-          .single()
-
-        const destination = profile?.onboarding_completed ? "/path" : "/onboarding"
-        return NextResponse.redirect(`${origin}${destination}`)
-      }
-    }
+  if (!code) {
+    console.error("[auth/callback] No code parameter in callback URL")
+    return NextResponse.redirect(`${origin}/login?error=auth_callback_failed`)
   }
 
-  // If something went wrong, redirect to login with error
-  return NextResponse.redirect(`${origin}/login?error=auth_callback_failed`)
+  const supabase = await createServerSupabaseClient()
+  const { error } = await supabase.auth.exchangeCodeForSession(code)
+
+  if (error) {
+    console.error("[auth/callback] exchangeCodeForSession failed:", error.message)
+    return NextResponse.redirect(`${origin}/login?error=auth_callback_failed`)
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    console.error("[auth/callback] getUser() returned null after successful code exchange")
+    return NextResponse.redirect(`${origin}/login?error=auth_callback_failed`)
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("onboarding_completed")
+    .eq("user_id", user.id)
+    .maybeSingle()
+
+  const destination = profile?.onboarding_completed ? "/path" : "/onboarding"
+  return NextResponse.redirect(`${origin}${destination}`)
 }

--- a/apps/web/app/sw.ts
+++ b/apps/web/app/sw.ts
@@ -1,6 +1,6 @@
 import { defaultCache } from "@serwist/turbopack/worker";
 import type { PrecacheEntry, SerwistGlobalConfig } from "serwist";
-import { Serwist } from "serwist";
+import { NetworkOnly, Serwist } from "serwist";
 
 declare global {
   interface WorkerGlobalScope extends SerwistGlobalConfig {
@@ -10,13 +10,28 @@ declare global {
 
 declare const self: ServiceWorkerGlobalScope & typeof globalThis;
 
+// defaultCache includes a cross-origin NetworkFirst rule that caches ALL
+// requests to *.supabase.co (auth, data, storage) for up to 1 hour with
+// a 10 s network timeout fallback. This means a cached 401 from before
+// sign-in can be served back after login, causing permanent blank pages.
+//
+// Fix: prepend a NetworkOnly rule for Supabase so auth and data requests
+// always hit the network and are never served from the SW cache.
+const runtimeCaching = [
+  {
+    matcher: ({ url }: { url: URL }) => url.hostname.endsWith(".supabase.co"),
+    handler: new NetworkOnly(),
+  },
+  ...defaultCache,
+];
+
 const serwist = new Serwist({
   precacheEntries: self.__SW_MANIFEST,
   precacheOptions: { cleanupOutdatedCaches: true },
   skipWaiting: true,
   clientsClaim: true,
   navigationPreload: true,
-  runtimeCaching: defaultCache,
+  runtimeCaching,
   fallbacks: {
     entries: [
       {

--- a/apps/web/components/layout/SerwistRegistration.tsx
+++ b/apps/web/components/layout/SerwistRegistration.tsx
@@ -8,7 +8,6 @@ export function SerwistRegistration({ children }: { children: React.ReactNode })
       swUrl="/sw.js"
       disable={process.env.NODE_ENV === "development"}
       reloadOnOnline
-      cacheOnNavigation
     >
       {children}
     </SerwistProvider>

--- a/apps/web/lib/data/useSupabaseAuth.ts
+++ b/apps/web/lib/data/useSupabaseAuth.ts
@@ -37,8 +37,11 @@ export function useSupabaseAuth(): AuthContextValue {
     // the Supabase Auth server and refreshes if expired. getSession() only
     // reads from cookies without validation, which can return stale/invalid
     // tokens that cause 401 on subsequent API calls.
-    supabase.auth.getUser().then(async ({ data: { user: supabaseUser } }) => {
+    supabase.auth.getUser().then(async ({ data: { user: supabaseUser }, error }) => {
       if (cancelled) return
+      if (error) {
+        console.warn("[auth] getUser() failed on mount:", error.message)
+      }
       if (supabaseUser) {
         setUser({
           id: supabaseUser.id,

--- a/apps/web/lib/supabase/server.ts
+++ b/apps/web/lib/supabase/server.ts
@@ -23,11 +23,14 @@ export async function createServerSupabaseClient() {
           for (const { name, value, options } of cookiesToSet) {
             cookieStore.set(name, value, options)
           }
-        } catch {
-          // setAll is called by supabase-ssr to persist refreshed tokens.
+        } catch (error) {
           // In Server Components the cookie store is read-only, so the
-          // set call throws — safely ignored since the middleware or
-          // Route Handler will handle the write on the next request.
+          // set call throws. This is expected and safe — the Route Handler
+          // (e.g. /auth/callback) will handle the write.
+          // Log a warning so cookie failures in Route Handlers are visible.
+          if (process.env.NODE_ENV === "development") {
+            console.warn("[supabase/server] setAll failed:", error)
+          }
         }
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -832,6 +832,7 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1122,6 +1123,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1144,6 +1146,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1166,6 +1169,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1182,6 +1186,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1198,6 +1203,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1214,6 +1220,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1230,6 +1237,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1246,6 +1254,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1262,6 +1271,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1278,6 +1288,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1294,6 +1305,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1310,6 +1322,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1326,6 +1339,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1348,6 +1362,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1370,6 +1385,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1392,6 +1408,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1414,6 +1431,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1436,6 +1454,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1458,6 +1477,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1480,6 +1500,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1502,6 +1523,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1521,6 +1543,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1540,6 +1563,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1559,6 +1583,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [


### PR DESCRIPTION
The service worker's defaultCache includes a cross-origin NetworkFirst
rule that caches ALL requests to *.supabase.co for up to 1 hour with a
10-second network timeout fallback. This means a cached 401 response
from before sign-in can be served back after login, causing permanent
blank pages and session loss on refresh.

- Prepend a NetworkOnly rule for *.supabase.co in sw.ts so auth and
  data requests always hit the network
- Remove cacheOnNavigation from SerwistRegistration to prevent caching
  auth callback redirect responses
- Flatten auth callback control flow with early returns and explicit
  error logging for each failure mode
- Use .maybeSingle() instead of .single() in auth callback profile
  query (new users may not have a profile row yet)
- Log getUser() failures in useSupabaseAuth so 401s are visible in
  the console instead of silently producing a blank page
- Surface cookie write errors in server.ts during development

https://claude.ai/code/session_01CtFBgJLW2HP44m9iV8xM2s