### PR TITLE
fix(auth): handle missing profile row in onboarding flow

### DIFF
--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -33,6 +33,22 @@ export async function GET(request: Request) {
     .eq("user_id", user.id)
     .maybeSingle()
 
+  if (!profile) {
+    // Trigger may not have fired — create the profile row server-side.
+    const fullName = user.user_metadata?.full_name as string | undefined
+    const { error: insertError } = await supabase
+      .from("profiles")
+      .insert({
+        user_id: user.id,
+        display_name: fullName ?? "Pebbler",
+      })
+    if (insertError) {
+      // Log but don't fail — trigger might have created the row between
+      // our SELECT and INSERT (race condition)
+      console.warn("[auth/callback] profile insert failed:", insertError.message)
+    }
+  }
+
   const destination = profile?.onboarding_completed ? "/path" : "/onboarding"
   return NextResponse.redirect(`${origin}${destination}`)
 }

--- a/apps/web/components/onboarding/OnboardingGate.tsx
+++ b/apps/web/components/onboarding/OnboardingGate.tsx
@@ -7,15 +7,15 @@ import { useAuth } from "@/lib/data/auth-context"
 export function OnboardingGate() {
   const pathname = usePathname()
   const router = useRouter()
-  const { profile, isLoading } = useAuth()
+  const { profile, isAuthenticated, isLoading } = useAuth()
 
   useEffect(() => {
     if (isLoading) return
     if (pathname === "/" || pathname.startsWith("/onboarding") || pathname === "/login" || pathname === "/register" || pathname.startsWith("/docs")) return
-    if (profile && !profile.onboarding_completed) {
+    if (isAuthenticated && (!profile || !profile.onboarding_completed)) {
       router.replace("/onboarding")
     }
-  }, [pathname, router, profile, isLoading])
+  }, [pathname, router, profile, isAuthenticated, isLoading])
 
   return null
 }

--- a/apps/web/lib/data/useSupabaseAuth.ts
+++ b/apps/web/lib/data/useSupabaseAuth.ts
@@ -56,6 +56,10 @@ export function useSupabaseAuth(): AuthContextValue {
         if (!cancelled) setProfile(data as Profile | null)
       }
       if (!cancelled) setIsLoading(false)
+    }).catch((err: unknown) => {
+      if (cancelled) return
+      console.warn("[auth] getUser() rejected:", err)
+      setIsLoading(false)
     })
 
     const {
@@ -147,14 +151,30 @@ export function useSupabaseAuth(): AuthContextValue {
       const supabase = getSupabase()
       if (!supabase) throw new Error("Supabase client not available")
       if (!user) throw new Error("Not authenticated")
+
+      // Use maybeSingle so a missing row returns null instead of throwing
       const { data, error } = await supabase
         .from("profiles")
         .update(input)
         .eq("user_id", user.id)
         .select()
-        .single()
+        .maybeSingle()
       if (error) throw new Error(error.message)
-      const updated = data as Profile
+
+      let updated: Profile
+      if (data) {
+        updated = data as Profile
+      } else {
+        // Profile row does not exist — create it with the provided fields
+        const { data: inserted, error: insertError } = await supabase
+          .from("profiles")
+          .insert({ user_id: user.id, display_name: "Pebbler", ...input })
+          .select()
+          .single()
+        if (insertError) throw new Error(insertError.message)
+        updated = inserted as Profile
+      }
+
       setProfile(updated)
       return updated
     },

--- a/apps/web/lib/hooks/useOnboarding.ts
+++ b/apps/web/lib/hooks/useOnboarding.ts
@@ -12,12 +12,20 @@ export function useOnboarding(
   const router = useRouter()
 
   const complete = useCallback(async () => {
-    await onComplete()
+    try {
+      await onComplete()
+    } catch (err) {
+      console.error("[onboarding] Failed to complete:", err)
+    }
     router.push("/path")
   }, [onComplete, router])
 
   const skip = useCallback(async () => {
-    await onComplete()
+    try {
+      await onComplete()
+    } catch (err) {
+      console.error("[onboarding] Failed to skip:", err)
+    }
     router.push("/path")
   }, [onComplete, router])
 


### PR DESCRIPTION
updateProfile used .single() which threw when no profile row existed,
silently breaking the "Collect your first pebble" button. OnboardingGate
only checked `profile && !profile.onboarding_completed`, so null profiles
(missing rows) were never redirected to onboarding, causing blank screens.

- updateProfile: use .maybeSingle() with insert fallback for missing rows
- OnboardingGate: redirect authenticated users with null or incomplete profiles
- Auth callback: create profile server-side if trigger didn't fire
- useOnboarding: add try/catch so navigation always proceeds
- useSupabaseAuth: add .catch() on getUser() to prevent stuck loading state

https://claude.ai/code/session_018uqu1bG6f1TMcn3FK6q8LF