### PR TITLE
fix(iOS): auto-generate the project on ci build

### DIFF
--- a/apps/ios/ci_scripts/ci_post_clone.sh
+++ b/apps/ios/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+# Install XcodeGen
+brew install xcodegen
+
+# Create Secrets.xcconfig from Xcode Cloud environment variables.
+# Set PBBLS_SUPABASE_URL and PBBLS_SUPABASE_ANON_KEY as secret variables
+# in the Xcode Cloud workflow (App Store Connect → Xcode Cloud → Environment).
+# Note: Xcode Cloud forbids names starting with CI_ or TEST_RUNNER_.
+cat > "$CI_PRIMARY_REPOSITORY_PATH/apps/ios/Config/Secrets.xcconfig" <<EOF
+SUPABASE_URL = ${PBBLS_SUPABASE_URL}
+SUPABASE_ANON_KEY = ${PBBLS_SUPABASE_ANON_KEY}
+EOF
+
+# Generate Pebbles.xcodeproj from project.yml
+cd "$CI_PRIMARY_REPOSITORY_PATH/apps/ios"
+xcodegen generate


### PR DESCRIPTION
The .gitignore has *.xcodeproj which intentionally ignores the generated project file. project.yml (XcodeGen) is the source of truth, and Pebbles.xcodeproj is treated as a build artifact.

Xcode Cloud needs to run xcodegen generate before archiving. You need to add a pre-build script in your Xcode Cloud workflow to generate the project.

The fix is to add a ci_post_clone.sh script (Xcode Cloud's hook for custom pre-build steps)