### PR TITLE
fix(ios): resolve swift packages in ci_post_clone for xcode cloud

### DIFF
--- a/apps/ios/ci_scripts/ci_post_clone.sh
+++ b/apps/ios/ci_scripts/ci_post_clone.sh
@@ -16,3 +16,11 @@ EOF
 # Generate Pebbles.xcodeproj from project.yml
 cd "$CI_PRIMARY_REPOSITORY_PATH/apps/ios"
 xcodegen generate
+
+# Resolve Swift Package dependencies so Xcode Cloud's build step finds Package.resolved.
+# Xcode Cloud disables automatic SPM resolution during the build phase and requires
+# Package.resolved to exist at <project>/project.xcworkspace/xcshareddata/swiftpm/.
+xcodebuild -resolvePackageDependencies \
+  -project Pebbles.xcodeproj \
+  -scheme Pebbles \
+  -clonedSourcePackagesDirPath SourcePackages


### PR DESCRIPTION
Resolves #246

## Summary

- Xcode Cloud disables automatic Swift Package resolution during its build phase and fails with `a resolved file is required when automatic dependency resolution is disabled` because our `.xcodeproj` (and therefore `Package.resolved` inside it) is gitignored — XcodeGen is the source of truth, per `apps/ios/CLAUDE.md`.
- Fix: run `xcodebuild -resolvePackageDependencies` inside `ci_post_clone.sh`, right after `xcodegen generate`. Xcode Cloud only disables resolution in the *build* phase, so doing it ourselves in `ci_post_clone` produces `Package.resolved` on disk before the build phase starts.
- Keeps `project.yml` as the only source of truth; no gitignore or committed-pbxproj workarounds.

## Files changed

- `apps/ios/ci_scripts/ci_post_clone.sh` — adds the explicit package resolution step

## Test plan

- [x] `npm run lint` passes (pre-existing SwiftLint line-length warnings in `AppEnvironment.swift` unrelated to this change)
- [x] `npm run build` passes
- [ ] Trigger an Xcode Cloud build on this branch and confirm:
  - `ci_post_clone.sh` runs to completion
  - `Package.resolved` is created under `apps/ios/Pebbles.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/`
  - Build phase no longer errors on missing resolved file
  - Archive step succeeds

## Follow-ups (out of scope)

- Local Xcode archive → TestFlight "missing Apple Distribution Profile" issue. Preferred path is to let Xcode Cloud handle distribution via a TestFlight post-action once this PR unblocks CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)