### PR TITLE
feat(ios): pebble detail sheet (#253)

### DIFF
--- a/apps/ios/Pebbles/Features/Path/Models/PebbleDetail.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/PebbleDetail.swift
@@ -1,12 +1,5 @@
 import Foundation
 
-// MARK: - Decodable conformance for shared types
-
-// `Visibility` is a String-backed enum without an explicit Decodable conformance.
-// Swift synthesizes Decodable for RawRepresentable enums only when the conformance
-// is declared — so we declare it here to keep Visibility.swift untouched.
-extension Visibility: Decodable {}
-
 // MARK: - Ref types (detail-view-local; intentionally not reusing the picker models)
 
 struct EmotionRef: Decodable, Hashable, Identifiable {

--- a/apps/ios/Pebbles/Features/Path/Models/PebbleDetail.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/PebbleDetail.swift
@@ -1,6 +1,16 @@
 import Foundation
+import os
 
-// MARK: - Ref types (detail-view-local; intentionally not reusing the picker models)
+// MARK: - Ref types
+//
+// `EmotionRef` and `DomainRef` exist because the PostgREST select in
+// `PebbleDetailSheet.load()` restricts columns to what the detail UI actually
+// renders:
+//     emotion:emotions(id, name, color)
+//     pebble_domains(domain:domains(id, name))
+// Reusing the full `Emotion`/`Domain` models would fail to decode the missing
+// `slug`/`label` fields. `Soul` and `PebbleCollection` are reused directly
+// because their full shapes match the detail select.
 
 struct EmotionRef: Decodable, Hashable, Identifiable {
     let id: UUID
@@ -9,16 +19,6 @@ struct EmotionRef: Decodable, Hashable, Identifiable {
 }
 
 struct DomainRef: Decodable, Hashable, Identifiable {
-    let id: UUID
-    let name: String
-}
-
-struct SoulRef: Decodable, Hashable, Identifiable {
-    let id: UUID
-    let name: String
-}
-
-struct CollectionRef: Decodable, Hashable, Identifiable {
     let id: UUID
     let name: String
 }
@@ -38,8 +38,8 @@ struct PebbleDetail: Identifiable, Decodable, Hashable {
     let visibility: Visibility
     let emotion: EmotionRef
     let domains: [DomainRef]
-    let souls: [SoulRef]
-    let collections: [CollectionRef]
+    let souls: [Soul]
+    let collections: [PebbleCollection]
 
     /// Derived from `intensity` + `positiveness`. DB remains source of truth.
     var valence: Valence {
@@ -53,7 +53,10 @@ struct PebbleDetail: Identifiable, Decodable, Hashable {
         case (1, 1):  return .highlightSmall
         case (1, 2):  return .highlightMedium
         case (1, 3):  return .highlightLarge
-        default:      return .neutralMedium // DB has CHECK constraints; this is defensive only
+        default:
+            Logger(subsystem: "app.pbbls.ios", category: "pebble-detail")
+                .warning("unexpected (positiveness, intensity) pair: (\(positiveness, privacy: .public), \(intensity, privacy: .public)) — falling back to .neutralMedium")
+            return .neutralMedium
         }
     }
 
@@ -74,8 +77,8 @@ struct PebbleDetail: Identifiable, Decodable, Hashable {
     }
 
     private struct DomainWrapper: Decodable { let domain: DomainRef }
-    private struct SoulWrapper: Decodable { let soul: SoulRef }
-    private struct CollectionWrapper: Decodable { let collection: CollectionRef }
+    private struct SoulWrapper: Decodable { let soul: Soul }
+    private struct CollectionWrapper: Decodable { let collection: PebbleCollection }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)

--- a/apps/ios/Pebbles/Features/Path/Models/PebbleDetail.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/PebbleDetail.swift
@@ -55,7 +55,11 @@ struct PebbleDetail: Identifiable, Decodable, Hashable {
         case (1, 3):  return .highlightLarge
         default:
             Logger(subsystem: "app.pbbls.ios", category: "pebble-detail")
-                .warning("unexpected (positiveness, intensity) pair: (\(positiveness, privacy: .public), \(intensity, privacy: .public)) — falling back to .neutralMedium")
+                .warning("""
+                    unexpected (positiveness, intensity) pair: \
+                    (\(positiveness, privacy: .public), \(intensity, privacy: .public)) \
+                    — falling back to .neutralMedium
+                    """)
             return .neutralMedium
         }
     }
@@ -81,23 +85,24 @@ struct PebbleDetail: Identifiable, Decodable, Hashable {
     private struct CollectionWrapper: Decodable { let collection: PebbleCollection }
 
     init(from decoder: Decoder) throws {
-        let c = try decoder.container(keyedBy: CodingKeys.self)
-        self.id = try c.decode(UUID.self, forKey: .id)
-        self.name = try c.decode(String.self, forKey: .name)
-        self.description = try c.decodeIfPresent(String.self, forKey: .description)
-        self.happenedAt = try c.decode(Date.self, forKey: .happenedAt)
-        self.intensity = try c.decode(Int.self, forKey: .intensity)
-        self.positiveness = try c.decode(Int.self, forKey: .positiveness)
-        self.visibility = try c.decode(Visibility.self, forKey: .visibility)
-        self.emotion = try c.decode(EmotionRef.self, forKey: .emotion)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.description = try container.decodeIfPresent(String.self, forKey: .description)
+        self.happenedAt = try container.decode(Date.self, forKey: .happenedAt)
+        self.intensity = try container.decode(Int.self, forKey: .intensity)
+        self.positiveness = try container.decode(Int.self, forKey: .positiveness)
+        self.visibility = try container.decode(Visibility.self, forKey: .visibility)
+        self.emotion = try container.decode(EmotionRef.self, forKey: .emotion)
 
-        let domainWrappers = try c.decodeIfPresent([DomainWrapper].self, forKey: .pebbleDomains) ?? []
+        let domainWrappers = try container.decodeIfPresent([DomainWrapper].self, forKey: .pebbleDomains) ?? []
         self.domains = domainWrappers.map(\.domain)
 
-        let soulWrappers = try c.decodeIfPresent([SoulWrapper].self, forKey: .pebbleSouls) ?? []
+        let soulWrappers = try container.decodeIfPresent([SoulWrapper].self, forKey: .pebbleSouls) ?? []
         self.souls = soulWrappers.map(\.soul)
 
-        let collectionWrappers = try c.decodeIfPresent([CollectionWrapper].self, forKey: .collectionPebbles) ?? []
+        let collectionWrappers = try container
+            .decodeIfPresent([CollectionWrapper].self, forKey: .collectionPebbles) ?? []
         self.collections = collectionWrappers.map(\.collection)
     }
 }

--- a/apps/ios/Pebbles/Features/Path/Models/PebbleDetail.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/PebbleDetail.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+// MARK: - Decodable conformance for shared types
+
+// `Visibility` is a String-backed enum without an explicit Decodable conformance.
+// Swift synthesizes Decodable for RawRepresentable enums only when the conformance
+// is declared — so we declare it here to keep Visibility.swift untouched.
+extension Visibility: Decodable {}
+
+// MARK: - Ref types (detail-view-local; intentionally not reusing the picker models)
+
+struct EmotionRef: Decodable, Hashable, Identifiable {
+    let id: UUID
+    let name: String
+    let color: String
+}
+
+struct DomainRef: Decodable, Hashable, Identifiable {
+    let id: UUID
+    let name: String
+}
+
+struct SoulRef: Decodable, Hashable, Identifiable {
+    let id: UUID
+    let name: String
+}
+
+struct CollectionRef: Decodable, Hashable, Identifiable {
+    let id: UUID
+    let name: String
+}
+
+// MARK: - PebbleDetail
+
+/// Read model for the detail sheet. Decodes a single pebble row with embedded
+/// relations via PostgREST. Junction-table wrappers are flattened during
+/// decoding so the view sees clean `domains`/`souls`/`collections` arrays.
+struct PebbleDetail: Identifiable, Decodable, Hashable {
+    let id: UUID
+    let name: String
+    let description: String?
+    let happenedAt: Date
+    let intensity: Int
+    let positiveness: Int
+    let visibility: Visibility
+    let emotion: EmotionRef
+    let domains: [DomainRef]
+    let souls: [SoulRef]
+    let collections: [CollectionRef]
+
+    /// Derived from `intensity` + `positiveness`. DB remains source of truth.
+    var valence: Valence {
+        switch (positiveness, intensity) {
+        case (-1, 1): return .lowlightSmall
+        case (-1, 2): return .lowlightMedium
+        case (-1, 3): return .lowlightLarge
+        case (0, 1):  return .neutralSmall
+        case (0, 2):  return .neutralMedium
+        case (0, 3):  return .neutralLarge
+        case (1, 1):  return .highlightSmall
+        case (1, 2):  return .highlightMedium
+        case (1, 3):  return .highlightLarge
+        default:      return .neutralMedium // DB has CHECK constraints; this is defensive only
+        }
+    }
+
+    // MARK: Decoding
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case description
+        case happenedAt = "happened_at"
+        case intensity
+        case positiveness
+        case visibility
+        case emotion
+        case pebbleDomains = "pebble_domains"
+        case pebbleSouls = "pebble_souls"
+        case collectionPebbles = "collection_pebbles"
+    }
+
+    private struct DomainWrapper: Decodable { let domain: DomainRef }
+    private struct SoulWrapper: Decodable { let soul: SoulRef }
+    private struct CollectionWrapper: Decodable { let collection: CollectionRef }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(UUID.self, forKey: .id)
+        self.name = try c.decode(String.self, forKey: .name)
+        self.description = try c.decodeIfPresent(String.self, forKey: .description)
+        self.happenedAt = try c.decode(Date.self, forKey: .happenedAt)
+        self.intensity = try c.decode(Int.self, forKey: .intensity)
+        self.positiveness = try c.decode(Int.self, forKey: .positiveness)
+        self.visibility = try c.decode(Visibility.self, forKey: .visibility)
+        self.emotion = try c.decode(EmotionRef.self, forKey: .emotion)
+
+        let domainWrappers = try c.decodeIfPresent([DomainWrapper].self, forKey: .pebbleDomains) ?? []
+        self.domains = domainWrappers.map(\.domain)
+
+        let soulWrappers = try c.decodeIfPresent([SoulWrapper].self, forKey: .pebbleSouls) ?? []
+        self.souls = soulWrappers.map(\.soul)
+
+        let collectionWrappers = try c.decodeIfPresent([CollectionWrapper].self, forKey: .collectionPebbles) ?? []
+        self.collections = collectionWrappers.map(\.collection)
+    }
+}

--- a/apps/ios/Pebbles/Features/Path/Models/Visibility.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/Visibility.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum Visibility: String, CaseIterable, Identifiable, Hashable {
+enum Visibility: String, CaseIterable, Identifiable, Hashable, Decodable {
     case `private` = "private"
     case `public` = "public"
 

--- a/apps/ios/Pebbles/Features/Path/PathView.swift
+++ b/apps/ios/Pebbles/Features/Path/PathView.swift
@@ -7,6 +7,7 @@ struct PathView: View {
     @State private var isLoading = true
     @State private var loadError: String?
     @State private var isPresentingCreate = false
+    @State private var selectedPebbleId: UUID?
 
     private let logger = Logger(subsystem: "app.pbbls.ios", category: "path")
 
@@ -20,6 +21,9 @@ struct PathView: View {
             CreatePebbleSheet { newPebble in
                 handleCreated(newPebble)
             }
+        }
+        .sheet(item: $selectedPebbleId) { id in
+            PebbleDetailSheet(pebbleId: id)
         }
     }
 
@@ -42,12 +46,17 @@ struct PathView: View {
 
                 Section("Path") {
                     ForEach(pebbles) { pebble in
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(pebble.name).font(.body)
-                            Text(pebble.happenedAt, style: .date)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                        Button {
+                            selectedPebbleId = pebble.id
+                        } label: {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(pebble.name).font(.body)
+                                Text(pebble.happenedAt, style: .date)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
                         }
+                        .buttonStyle(.plain)
                     }
                 }
             }

--- a/apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift
@@ -122,13 +122,13 @@ struct PebbleDetailSheet: View {
 // Returns nil on malformed input; the view falls back to `.secondary`.
 private extension Color {
     init?(hex: String) {
-        var s = hex.trimmingCharacters(in: .whitespacesAndNewlines)
-        if s.hasPrefix("#") { s.removeFirst() }
-        guard s.count == 6, let value = UInt32(s, radix: 16) else { return nil }
-        let r = Double((value >> 16) & 0xFF) / 255.0
-        let g = Double((value >> 8) & 0xFF) / 255.0
-        let b = Double(value & 0xFF) / 255.0
-        self = Color(red: r, green: g, blue: b)
+        var sanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if sanitized.hasPrefix("#") { sanitized.removeFirst() }
+        guard sanitized.count == 6, let value = UInt32(sanitized, radix: 16) else { return nil }
+        let red = Double((value >> 16) & 0xFF) / 255.0
+        let green = Double((value >> 8) & 0xFF) / 255.0
+        let blue = Double(value & 0xFF) / 255.0
+        self = Color(red: red, green: green, blue: blue)
     }
 }
 

--- a/apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+import os
+
+struct PebbleDetailSheet: View {
+    let pebbleId: UUID
+
+    @Environment(SupabaseService.self) private var supabase
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var detail: PebbleDetail?
+    @State private var isLoading = true
+    @State private var loadError: String?
+
+    private let logger = Logger(subsystem: "app.pbbls.ios", category: "pebble-detail")
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle(detail?.name ?? "Pebble")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done") { dismiss() }
+                    }
+                }
+        }
+        .task { await load() }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isLoading {
+            ProgressView()
+        } else if let loadError {
+            VStack(spacing: 12) {
+                Text(loadError).foregroundStyle(.secondary)
+                Button("Retry") {
+                    Task { await load() }
+                }
+            }
+            .padding()
+        } else if let detail {
+            loadedForm(detail)
+        }
+    }
+
+    @ViewBuilder
+    private func loadedForm(_ detail: PebbleDetail) -> some View {
+        Form {
+            Section {
+                LabeledContent("When", value: detail.happenedAt.formatted(date: .abbreviated, time: .shortened))
+                if let description = detail.description, !description.isEmpty {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Description")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(description)
+                    }
+                }
+            }
+
+            Section("Mood") {
+                LabeledContent("Emotion") {
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(Color(hex: detail.emotion.color) ?? .secondary)
+                            .frame(width: 10, height: 10)
+                        Text(detail.emotion.name)
+                    }
+                }
+                if !detail.domains.isEmpty {
+                    LabeledContent("Domain", value: detail.domains.map(\.name).joined(separator: ", "))
+                }
+                LabeledContent("Valence", value: detail.valence.label)
+            }
+
+            if !detail.souls.isEmpty || !detail.collections.isEmpty {
+                Section("Optional") {
+                    if !detail.souls.isEmpty {
+                        LabeledContent("Soul", value: detail.souls.map(\.name).joined(separator: ", "))
+                    }
+                    if !detail.collections.isEmpty {
+                        LabeledContent("Collection", value: detail.collections.map(\.name).joined(separator: ", "))
+                    }
+                }
+            }
+
+            Section("Privacy") {
+                LabeledContent("Privacy", value: detail.visibility.label)
+            }
+        }
+    }
+
+    private func load() async {
+        isLoading = true
+        loadError = nil
+        do {
+            let fetched: PebbleDetail = try await supabase.client
+                .from("pebbles")
+                .select("""
+                    id, name, description, happened_at, intensity, positiveness, visibility,
+                    emotion:emotions(id, name, color),
+                    pebble_domains(domain:domains(id, name)),
+                    pebble_souls(soul:souls(id, name)),
+                    collection_pebbles(collection:collections(id, name))
+                """)
+                .eq("id", value: pebbleId)
+                .single()
+                .execute()
+                .value
+            self.detail = fetched
+            self.isLoading = false
+        } catch {
+            logger.error("pebble detail fetch failed: \(error.localizedDescription, privacy: .private)")
+            self.loadError = "Couldn't load this pebble."
+            self.isLoading = false
+        }
+    }
+}
+
+// Small helper so we can render the emotion color string ("#RRGGBB") as a SwiftUI Color.
+// Returns nil on malformed input; the view falls back to `.secondary`.
+private extension Color {
+    init?(hex: String) {
+        var s = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if s.hasPrefix("#") { s.removeFirst() }
+        guard s.count == 6, let value = UInt32(s, radix: 16) else { return nil }
+        let r = Double((value >> 16) & 0xFF) / 255.0
+        let g = Double((value >> 8) & 0xFF) / 255.0
+        let b = Double(value & 0xFF) / 255.0
+        self = Color(red: r, green: g, blue: b)
+    }
+}
+
+#Preview {
+    PebbleDetailSheet(pebbleId: UUID())
+        .environment(SupabaseService())
+}

--- a/apps/ios/Pebbles/Services/UUID+Identifiable.swift
+++ b/apps/ios/Pebbles/Services/UUID+Identifiable.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension UUID: @retroactive Identifiable {
+    public var id: UUID { self }
+}

--- a/apps/ios/PebblesTests/PebbleDetailDecodingTests.swift
+++ b/apps/ios/PebblesTests/PebbleDetailDecodingTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+@testable import Pebbles
+
+@Suite("PebbleDetail decoding")
+struct PebbleDetailDecodingTests {
+
+    private func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let string = try container.decode(String.self)
+            if let date = formatter.date(from: string) { return date }
+            formatter.formatOptions = [.withInternetDateTime]
+            if let date = formatter.date(from: string) { return date }
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid ISO8601: \(string)"
+            )
+        }
+        return decoder
+    }
+
+    private let fullJSON = """
+    {
+      "id": "11111111-1111-1111-1111-111111111111",
+      "name": "Shipped the thing",
+      "description": "Finally.",
+      "happened_at": "2026-04-14T15:42:00Z",
+      "intensity": 3,
+      "positiveness": 1,
+      "visibility": "private",
+      "emotion": {
+        "id": "22222222-2222-2222-2222-222222222222",
+        "name": "Joy",
+        "color": "#FFD166"
+      },
+      "pebble_domains": [
+        { "domain": { "id": "33333333-3333-3333-3333-333333333333", "name": "Work" } }
+      ],
+      "pebble_souls": [
+        { "soul": { "id": "44444444-4444-4444-4444-444444444444", "name": "Alex" } }
+      ],
+      "collection_pebbles": [
+        { "collection": { "id": "55555555-5555-5555-5555-555555555555", "name": "Wins" } }
+      ]
+    }
+    """.data(using: .utf8)!
+
+    @Test("decodes a full row with one of each relation")
+    func decodesFullRow() throws {
+        let detail = try makeDecoder().decode(PebbleDetail.self, from: fullJSON)
+
+        #expect(detail.name == "Shipped the thing")
+        #expect(detail.description == "Finally.")
+        #expect(detail.intensity == 3)
+        #expect(detail.positiveness == 1)
+        #expect(detail.visibility == .private)
+        #expect(detail.emotion.name == "Joy")
+        #expect(detail.emotion.color == "#FFD166")
+        #expect(detail.domains.map(\.name) == ["Work"])
+        #expect(detail.souls.map(\.name) == ["Alex"])
+        #expect(detail.collections.map(\.name) == ["Wins"])
+    }
+
+    @Test("valence is derived from intensity + positiveness")
+    func derivesValence() throws {
+        let detail = try makeDecoder().decode(PebbleDetail.self, from: fullJSON)
+        #expect(detail.valence == .highlightLarge)
+    }
+
+    @Test("empty join arrays decode as empty")
+    func decodesEmptyRelations() throws {
+        let json = """
+        {
+          "id": "11111111-1111-1111-1111-111111111111",
+          "name": "Quiet moment",
+          "description": null,
+          "happened_at": "2026-04-14T08:00:00Z",
+          "intensity": 1,
+          "positiveness": 0,
+          "visibility": "private",
+          "emotion": {
+            "id": "22222222-2222-2222-2222-222222222222",
+            "name": "Calm",
+            "color": "#88CCEE"
+          },
+          "pebble_domains": [],
+          "pebble_souls": [],
+          "collection_pebbles": []
+        }
+        """.data(using: .utf8)!
+
+        let detail = try makeDecoder().decode(PebbleDetail.self, from: json)
+
+        #expect(detail.description == nil)
+        #expect(detail.domains.isEmpty)
+        #expect(detail.souls.isEmpty)
+        #expect(detail.collections.isEmpty)
+        #expect(detail.valence == .neutralSmall)
+    }
+
+    @Test("multiple domains flatten cleanly")
+    func decodesMultipleDomains() throws {
+        let json = """
+        {
+          "id": "11111111-1111-1111-1111-111111111111",
+          "name": "Cross-domain moment",
+          "description": null,
+          "happened_at": "2026-04-14T08:00:00Z",
+          "intensity": 2,
+          "positiveness": -1,
+          "visibility": "public",
+          "emotion": {
+            "id": "22222222-2222-2222-2222-222222222222",
+            "name": "Sad",
+            "color": "#6699CC"
+          },
+          "pebble_domains": [
+            { "domain": { "id": "33333333-3333-3333-3333-333333333333", "name": "Work" } },
+            { "domain": { "id": "44444444-4444-4444-4444-444444444444", "name": "Health" } }
+          ],
+          "pebble_souls": [],
+          "collection_pebbles": []
+        }
+        """.data(using: .utf8)!
+
+        let detail = try makeDecoder().decode(PebbleDetail.self, from: json)
+
+        #expect(detail.domains.map(\.name) == ["Work", "Health"])
+        #expect(detail.visibility == .public)
+        #expect(detail.valence == .lowlightMedium)
+    }
+}

--- a/apps/ios/PebblesTests/PebbleDetailDecodingTests.swift
+++ b/apps/ios/PebblesTests/PebbleDetailDecodingTests.swift
@@ -23,7 +23,7 @@ struct PebbleDetailDecodingTests {
         return decoder
     }
 
-    private let fullJSON = """
+    private let fullJSON = Data("""
     {
       "id": "11111111-1111-1111-1111-111111111111",
       "name": "Shipped the thing",
@@ -47,7 +47,7 @@ struct PebbleDetailDecodingTests {
         { "collection": { "id": "55555555-5555-5555-5555-555555555555", "name": "Wins" } }
       ]
     }
-    """.data(using: .utf8)!
+    """.utf8)
 
     @Test("decodes a full row with one of each relation")
     func decodesFullRow() throws {
@@ -73,7 +73,7 @@ struct PebbleDetailDecodingTests {
 
     @Test("empty join arrays decode as empty")
     func decodesEmptyRelations() throws {
-        let json = """
+        let json = Data("""
         {
           "id": "11111111-1111-1111-1111-111111111111",
           "name": "Quiet moment",
@@ -91,7 +91,7 @@ struct PebbleDetailDecodingTests {
           "pebble_souls": [],
           "collection_pebbles": []
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         let detail = try makeDecoder().decode(PebbleDetail.self, from: json)
 
@@ -104,7 +104,7 @@ struct PebbleDetailDecodingTests {
 
     @Test("multiple domains flatten cleanly")
     func decodesMultipleDomains() throws {
-        let json = """
+        let json = Data("""
         {
           "id": "11111111-1111-1111-1111-111111111111",
           "name": "Cross-domain moment",
@@ -125,7 +125,7 @@ struct PebbleDetailDecodingTests {
           "pebble_souls": [],
           "collection_pebbles": []
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         let detail = try makeDecoder().decode(PebbleDetail.self, from: json)
 

--- a/docs/superpowers/plans/2026-04-14-ios-pebble-detail-sheet.md
+++ b/docs/superpowers/plans/2026-04-14-ios-pebble-detail-sheet.md
@@ -1,0 +1,818 @@
+# iOS — Pebble Detail Sheet Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a native SwiftUI sheet on iOS that opens when the user taps a pebble in the path, showing the full pebble with its emotion, domain(s), soul(s), and collection(s).
+
+**Architecture:** A new `PebbleDetailSheet` view takes a `pebbleId: UUID`, fetches a rich `PebbleDetail` struct via a single embedded PostgREST query (joining `emotions`, `pebble_domains`, `pebble_souls`, `collection_pebbles`), and renders it as a read-only `Form` mirroring `CreatePebbleSheet`'s structure. `PathView` wraps each row in a `Button` that sets `selectedPebbleId`, presenting the sheet via `.sheet(item:)`.
+
+**Tech Stack:** SwiftUI (iOS 17+), `@Environment(SupabaseService.self)`, supabase-swift 2.x, Swift Testing, xcodegen.
+
+**Spec:** `docs/superpowers/specs/2026-04-14-ios-pebble-detail-sheet-design.md`. Read it before starting.
+
+## Important context for the executor
+
+- **Issue:** #253. Milestone: M19 · iOS ShameVP. Labels to apply to the PR: `feat`, `core`, `ios`.
+- **Branch:** Work on `feat/253-pebble-detail-sheet`. Create it at the start (see Task 0). Never rely on an auto-generated branch name.
+- **xcodegen handles file inclusion.** `apps/ios/project.yml` declares `sources: [path: Pebbles]`, which globs the whole folder. After adding any new `.swift` file under `Pebbles/`, run `npm run generate --workspace=@pbbls/ios` from the repo root to refresh the `.xcodeproj`. Never hand-edit the `.pbxproj`.
+- **Build command:** `npm run build --workspace=@pbbls/ios` from the repo root. Runs `xcodegen generate && xcodebuild -scheme Pebbles -destination 'generic/platform=iOS Simulator' build`.
+- **Lint command:** `npm run lint --workspace=@pbbls/ios` (swiftlint).
+- **Test command:** `npm run test --workspace=@pbbls/ios` (runs Swift Testing suites). One unit test for `PebbleDetail` decoding is included in this plan — the rest is build + manual smoke.
+- **Trust RLS.** The `pebbles_select` policy already scopes reads to the authenticated user. Do not pass `user_id` in client filters.
+- **Logging discipline.** Every `catch` block must log via `os.Logger` with `privacy: .private` on user-derived strings. Mirror the existing pattern in `apps/ios/Pebbles/Features/Path/PathView.swift`. No empty catches.
+- **Supabase PostgREST embedding:** the detail fetch uses relation names directly in `.select(...)`. The supabase-swift client passes this through to PostgREST. Format:
+  ```
+  select("
+      id, name, description, happened_at, intensity, positiveness, visibility,
+      emotion:emotions(id, name, color),
+      pebble_domains(domain:domains(id, name)),
+      pebble_souls(soul:souls(id, name)),
+      collection_pebbles(collection:collections(id, name))
+  ")
+  ```
+  Junction tables (`pebble_domains`, `pebble_souls`, `collection_pebbles`) return as arrays of objects each holding the embedded target row. We flatten these in Swift via a custom `init(from:)`.
+
+## File structure
+
+All work is scoped to the existing Path feature, with one new utilities file under Services.
+
+```
+apps/ios/Pebbles/
+├── Services/
+│   └── UUID+Identifiable.swift      (NEW — one-line extension so UUID works with .sheet(item:))
+└── Features/Path/
+    ├── Models/
+    │   ├── PebbleDetail.swift        (NEW — rich read model + *Ref types + custom decoding)
+    │   └── (existing files unchanged)
+    ├── PebbleDetailSheet.swift       (NEW — the sheet view)
+    └── PathView.swift                (MODIFY — tap row → present sheet)
+
+apps/ios/PebblesTests/
+└── PebbleDetailDecodingTests.swift   (NEW — decoding + valence derivation)
+```
+
+Each file has one clear responsibility. `PebbleDetail` is the only file that knows about the PostgREST junction-row shape; the view only sees clean flat arrays.
+
+---
+
+### Task 0: Create the feature branch
+
+**Files:** none
+
+- [ ] **Step 1: From repo root, confirm clean working tree and current branch**
+
+Run:
+```bash
+git status
+git branch --show-current
+```
+Expected: clean tree, current branch is `main` (or whichever branch you brainstormed from — the spec commit should already be on it).
+
+- [ ] **Step 2: Create and check out the feature branch**
+
+Run:
+```bash
+git checkout -b feat/253-pebble-detail-sheet
+```
+Expected: `Switched to a new branch 'feat/253-pebble-detail-sheet'`
+
+---
+
+### Task 1: Add `UUID+Identifiable` extension
+
+**Why:** SwiftUI's `.sheet(item:)` requires an `Identifiable` binding. `UUID` is not `Identifiable` out of the box. A one-line extension unblocks the pattern cleanly and is a common, harmless addition.
+
+**Files:**
+- Create: `apps/ios/Pebbles/Services/UUID+Identifiable.swift`
+
+- [ ] **Step 1: Create the extension file**
+
+Write `apps/ios/Pebbles/Services/UUID+Identifiable.swift`:
+
+```swift
+import Foundation
+
+extension UUID: @retroactive Identifiable {
+    public var id: UUID { self }
+}
+```
+
+Note: `@retroactive` silences the Swift 6 warning about conforming a type from another module to a protocol from another module. Required on Xcode 15.3+.
+
+- [ ] **Step 2: Regenerate the Xcode project**
+
+Run from repo root:
+```bash
+npm run generate --workspace=@pbbls/ios
+```
+Expected: `Created project at ...Pebbles.xcodeproj`, no errors.
+
+- [ ] **Step 3: Build to confirm the extension compiles**
+
+Run from repo root:
+```bash
+npm run build --workspace=@pbbls/ios
+```
+Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/ios/Pebbles/Services/UUID+Identifiable.swift apps/ios/Pebbles.xcodeproj
+git commit -m "feat(ios): add UUID Identifiable extension for sheet(item:)"
+```
+
+---
+
+### Task 2: Add the `PebbleDetail` model
+
+**Why:** A dedicated read model for the detail sheet keeps the list's lightweight `Pebble` unchanged and isolates PostgREST junction-row decoding in one place. The view will only ever see clean arrays (`domains: [DomainRef]`).
+
+**Files:**
+- Create: `apps/ios/Pebbles/Features/Path/Models/PebbleDetail.swift`
+
+- [ ] **Step 1: Write the file**
+
+Write `apps/ios/Pebbles/Features/Path/Models/PebbleDetail.swift`:
+
+```swift
+import Foundation
+
+// MARK: - Ref types (detail-view-local; intentionally not reusing the picker models)
+
+struct EmotionRef: Decodable, Hashable, Identifiable {
+    let id: UUID
+    let name: String
+    let color: String
+}
+
+struct DomainRef: Decodable, Hashable, Identifiable {
+    let id: UUID
+    let name: String
+}
+
+struct SoulRef: Decodable, Hashable, Identifiable {
+    let id: UUID
+    let name: String
+}
+
+struct CollectionRef: Decodable, Hashable, Identifiable {
+    let id: UUID
+    let name: String
+}
+
+// MARK: - PebbleDetail
+
+/// Read model for the detail sheet. Decodes a single pebble row with embedded
+/// relations via PostgREST. Junction-table wrappers are flattened during
+/// decoding so the view sees clean `domains`/`souls`/`collections` arrays.
+struct PebbleDetail: Identifiable, Decodable, Hashable {
+    let id: UUID
+    let name: String
+    let description: String?
+    let happenedAt: Date
+    let intensity: Int
+    let positiveness: Int
+    let visibility: Visibility
+    let emotion: EmotionRef
+    let domains: [DomainRef]
+    let souls: [SoulRef]
+    let collections: [CollectionRef]
+
+    /// Derived from `intensity` + `positiveness`. DB remains source of truth.
+    var valence: Valence {
+        switch (positiveness, intensity) {
+        case (-1, 1): return .lowlightSmall
+        case (-1, 2): return .lowlightMedium
+        case (-1, 3): return .lowlightLarge
+        case (0, 1):  return .neutralSmall
+        case (0, 2):  return .neutralMedium
+        case (0, 3):  return .neutralLarge
+        case (1, 1):  return .highlightSmall
+        case (1, 2):  return .highlightMedium
+        case (1, 3):  return .highlightLarge
+        default:      return .neutralMedium // DB has CHECK constraints; this is defensive only
+        }
+    }
+
+    // MARK: Decoding
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case description
+        case happenedAt = "happened_at"
+        case intensity
+        case positiveness
+        case visibility
+        case emotion
+        case pebbleDomains = "pebble_domains"
+        case pebbleSouls = "pebble_souls"
+        case collectionPebbles = "collection_pebbles"
+    }
+
+    private struct DomainWrapper: Decodable { let domain: DomainRef }
+    private struct SoulWrapper: Decodable { let soul: SoulRef }
+    private struct CollectionWrapper: Decodable { let collection: CollectionRef }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(UUID.self, forKey: .id)
+        self.name = try c.decode(String.self, forKey: .name)
+        self.description = try c.decodeIfPresent(String.self, forKey: .description)
+        self.happenedAt = try c.decode(Date.self, forKey: .happenedAt)
+        self.intensity = try c.decode(Int.self, forKey: .intensity)
+        self.positiveness = try c.decode(Int.self, forKey: .positiveness)
+        self.visibility = try c.decode(Visibility.self, forKey: .visibility)
+        self.emotion = try c.decode(EmotionRef.self, forKey: .emotion)
+
+        let domainWrappers = try c.decodeIfPresent([DomainWrapper].self, forKey: .pebbleDomains) ?? []
+        self.domains = domainWrappers.map(\.domain)
+
+        let soulWrappers = try c.decodeIfPresent([SoulWrapper].self, forKey: .pebbleSouls) ?? []
+        self.souls = soulWrappers.map(\.soul)
+
+        let collectionWrappers = try c.decodeIfPresent([CollectionWrapper].self, forKey: .collectionPebbles) ?? []
+        self.collections = collectionWrappers.map(\.collection)
+    }
+}
+```
+
+Note: `Visibility` is `Decodable` automatically because it's a `String`-backed `RawRepresentable` enum.
+
+- [ ] **Step 2: Regenerate and build**
+
+Run from repo root:
+```bash
+npm run generate --workspace=@pbbls/ios
+npm run build --workspace=@pbbls/ios
+```
+Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Path/Models/PebbleDetail.swift apps/ios/Pebbles.xcodeproj
+git commit -m "feat(ios): add PebbleDetail read model with junction-row decoding"
+```
+
+---
+
+### Task 3: Unit test `PebbleDetail` decoding and valence derivation
+
+**Why:** `PebbleDetail.init(from:)` flattens junction rows and `valence` is a pure mapping. Both are easy to test and the only logic in this feature worth testing without UI infrastructure.
+
+**Files:**
+- Create: `apps/ios/PebblesTests/PebbleDetailDecodingTests.swift`
+
+- [ ] **Step 1: Write the test file**
+
+Write `apps/ios/PebblesTests/PebbleDetailDecodingTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import Pebbles
+
+@Suite("PebbleDetail decoding")
+struct PebbleDetailDecodingTests {
+
+    private func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let string = try container.decode(String.self)
+            if let date = formatter.date(from: string) { return date }
+            formatter.formatOptions = [.withInternetDateTime]
+            if let date = formatter.date(from: string) { return date }
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid ISO8601: \(string)"
+            )
+        }
+        return decoder
+    }
+
+    private let fullJSON = """
+    {
+      "id": "11111111-1111-1111-1111-111111111111",
+      "name": "Shipped the thing",
+      "description": "Finally.",
+      "happened_at": "2026-04-14T15:42:00Z",
+      "intensity": 3,
+      "positiveness": 1,
+      "visibility": "private",
+      "emotion": {
+        "id": "22222222-2222-2222-2222-222222222222",
+        "name": "Joy",
+        "color": "#FFD166"
+      },
+      "pebble_domains": [
+        { "domain": { "id": "33333333-3333-3333-3333-333333333333", "name": "Work" } }
+      ],
+      "pebble_souls": [
+        { "soul": { "id": "44444444-4444-4444-4444-444444444444", "name": "Alex" } }
+      ],
+      "collection_pebbles": [
+        { "collection": { "id": "55555555-5555-5555-5555-555555555555", "name": "Wins" } }
+      ]
+    }
+    """.data(using: .utf8)!
+
+    @Test("decodes a full row with one of each relation")
+    func decodesFullRow() throws {
+        let detail = try makeDecoder().decode(PebbleDetail.self, from: fullJSON)
+
+        #expect(detail.name == "Shipped the thing")
+        #expect(detail.description == "Finally.")
+        #expect(detail.intensity == 3)
+        #expect(detail.positiveness == 1)
+        #expect(detail.visibility == .private)
+        #expect(detail.emotion.name == "Joy")
+        #expect(detail.emotion.color == "#FFD166")
+        #expect(detail.domains.map(\.name) == ["Work"])
+        #expect(detail.souls.map(\.name) == ["Alex"])
+        #expect(detail.collections.map(\.name) == ["Wins"])
+    }
+
+    @Test("valence is derived from intensity + positiveness")
+    func derivesValence() throws {
+        let detail = try makeDecoder().decode(PebbleDetail.self, from: fullJSON)
+        #expect(detail.valence == .highlightLarge)
+    }
+
+    @Test("empty join arrays decode as empty")
+    func decodesEmptyRelations() throws {
+        let json = """
+        {
+          "id": "11111111-1111-1111-1111-111111111111",
+          "name": "Quiet moment",
+          "description": null,
+          "happened_at": "2026-04-14T08:00:00Z",
+          "intensity": 1,
+          "positiveness": 0,
+          "visibility": "private",
+          "emotion": {
+            "id": "22222222-2222-2222-2222-222222222222",
+            "name": "Calm",
+            "color": "#88CCEE"
+          },
+          "pebble_domains": [],
+          "pebble_souls": [],
+          "collection_pebbles": []
+        }
+        """.data(using: .utf8)!
+
+        let detail = try makeDecoder().decode(PebbleDetail.self, from: json)
+
+        #expect(detail.description == nil)
+        #expect(detail.domains.isEmpty)
+        #expect(detail.souls.isEmpty)
+        #expect(detail.collections.isEmpty)
+        #expect(detail.valence == .neutralSmall)
+    }
+
+    @Test("multiple domains flatten cleanly")
+    func decodesMultipleDomains() throws {
+        let json = """
+        {
+          "id": "11111111-1111-1111-1111-111111111111",
+          "name": "Cross-domain moment",
+          "description": null,
+          "happened_at": "2026-04-14T08:00:00Z",
+          "intensity": 2,
+          "positiveness": -1,
+          "visibility": "public",
+          "emotion": {
+            "id": "22222222-2222-2222-2222-222222222222",
+            "name": "Sad",
+            "color": "#6699CC"
+          },
+          "pebble_domains": [
+            { "domain": { "id": "33333333-3333-3333-3333-333333333333", "name": "Work" } },
+            { "domain": { "id": "44444444-4444-4444-4444-444444444444", "name": "Health" } }
+          ],
+          "pebble_souls": [],
+          "collection_pebbles": []
+        }
+        """.data(using: .utf8)!
+
+        let detail = try makeDecoder().decode(PebbleDetail.self, from: json)
+
+        #expect(detail.domains.map(\.name) == ["Work", "Health"])
+        #expect(detail.visibility == .public)
+        #expect(detail.valence == .lowlightMedium)
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate and run the tests**
+
+Run from repo root:
+```bash
+npm run generate --workspace=@pbbls/ios
+npm run test --workspace=@pbbls/ios
+```
+Expected: all four `PebbleDetail decoding` tests pass, plus the existing smoke test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/ios/PebblesTests/PebbleDetailDecodingTests.swift apps/ios/Pebbles.xcodeproj
+git commit -m "test(ios): cover PebbleDetail decoding and valence derivation"
+```
+
+---
+
+### Task 4: Build `PebbleDetailSheet`
+
+**Why:** The actual read UI. Loads the pebble by id via a single embedded PostgREST query, renders three view states (loading / error / loaded), and uses `LabeledContent` inside a `Form` for the settings-style layout.
+
+**Files:**
+- Create: `apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift`
+
+- [ ] **Step 1: Write the file**
+
+Write `apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift`:
+
+```swift
+import SwiftUI
+import os
+
+struct PebbleDetailSheet: View {
+    let pebbleId: UUID
+
+    @Environment(SupabaseService.self) private var supabase
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var detail: PebbleDetail?
+    @State private var isLoading = true
+    @State private var loadError: String?
+
+    private let logger = Logger(subsystem: "app.pbbls.ios", category: "pebble-detail")
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle(detail?.name ?? "Pebble")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done") { dismiss() }
+                    }
+                }
+        }
+        .task { await load() }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isLoading {
+            ProgressView()
+        } else if let loadError {
+            VStack(spacing: 12) {
+                Text(loadError).foregroundStyle(.secondary)
+                Button("Retry") {
+                    Task { await load() }
+                }
+            }
+            .padding()
+        } else if let detail {
+            loadedForm(detail)
+        }
+    }
+
+    @ViewBuilder
+    private func loadedForm(_ detail: PebbleDetail) -> some View {
+        Form {
+            Section {
+                LabeledContent("When", value: detail.happenedAt.formatted(date: .abbreviated, time: .shortened))
+                if let description = detail.description, !description.isEmpty {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Description")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(description)
+                    }
+                }
+            }
+
+            Section("Mood") {
+                LabeledContent("Emotion") {
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(Color(hex: detail.emotion.color) ?? .secondary)
+                            .frame(width: 10, height: 10)
+                        Text(detail.emotion.name)
+                    }
+                }
+                if !detail.domains.isEmpty {
+                    LabeledContent("Domain", value: detail.domains.map(\.name).joined(separator: ", "))
+                }
+                LabeledContent("Valence", value: detail.valence.label)
+            }
+
+            if !detail.souls.isEmpty || !detail.collections.isEmpty {
+                Section("Optional") {
+                    if !detail.souls.isEmpty {
+                        LabeledContent("Soul", value: detail.souls.map(\.name).joined(separator: ", "))
+                    }
+                    if !detail.collections.isEmpty {
+                        LabeledContent("Collection", value: detail.collections.map(\.name).joined(separator: ", "))
+                    }
+                }
+            }
+
+            Section("Privacy") {
+                LabeledContent("Privacy", value: detail.visibility.label)
+            }
+        }
+    }
+
+    private func load() async {
+        isLoading = true
+        loadError = nil
+        do {
+            let fetched: PebbleDetail = try await supabase.client
+                .from("pebbles")
+                .select("""
+                    id, name, description, happened_at, intensity, positiveness, visibility,
+                    emotion:emotions(id, name, color),
+                    pebble_domains(domain:domains(id, name)),
+                    pebble_souls(soul:souls(id, name)),
+                    collection_pebbles(collection:collections(id, name))
+                """)
+                .eq("id", value: pebbleId)
+                .single()
+                .execute()
+                .value
+            self.detail = fetched
+            self.isLoading = false
+        } catch {
+            logger.error("pebble detail fetch failed: \(error.localizedDescription, privacy: .private)")
+            self.loadError = "Couldn't load this pebble."
+            self.isLoading = false
+        }
+    }
+}
+
+// Small helper so we can render the emotion color string ("#RRGGBB") as a SwiftUI Color.
+// Returns nil on malformed input; the view falls back to `.secondary`.
+private extension Color {
+    init?(hex: String) {
+        var s = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if s.hasPrefix("#") { s.removeFirst() }
+        guard s.count == 6, let value = UInt32(s, radix: 16) else { return nil }
+        let r = Double((value >> 16) & 0xFF) / 255.0
+        let g = Double((value >> 8) & 0xFF) / 255.0
+        let b = Double(value & 0xFF) / 255.0
+        self = Color(red: r, green: g, blue: b)
+    }
+}
+
+#Preview {
+    PebbleDetailSheet(pebbleId: UUID())
+        .environment(SupabaseService())
+}
+```
+
+- [ ] **Step 2: Regenerate and build**
+
+Run from repo root:
+```bash
+npm run generate --workspace=@pbbls/ios
+npm run build --workspace=@pbbls/ios
+```
+Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift apps/ios/Pebbles.xcodeproj
+git commit -m "feat(ios): add PebbleDetailSheet with embedded PostgREST fetch"
+```
+
+---
+
+### Task 5: Wire `PathView` to present the sheet on row tap
+
+**Why:** The connective tissue. A tap sets `selectedPebbleId`, SwiftUI's `.sheet(item:)` observes the optional binding and presents the detail sheet, and `.buttonStyle(.plain)` preserves the existing row appearance.
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/PathView.swift`
+
+- [ ] **Step 1: Replace the file contents**
+
+Rewrite `apps/ios/Pebbles/Features/Path/PathView.swift` to:
+
+```swift
+import SwiftUI
+import os
+
+struct PathView: View {
+    @Environment(SupabaseService.self) private var supabase
+    @State private var pebbles: [Pebble] = []
+    @State private var isLoading = true
+    @State private var loadError: String?
+    @State private var isPresentingCreate = false
+    @State private var selectedPebbleId: UUID?
+
+    private let logger = Logger(subsystem: "app.pbbls.ios", category: "path")
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Path")
+        }
+        .task { await load() }
+        .sheet(isPresented: $isPresentingCreate) {
+            CreatePebbleSheet { newPebble in
+                handleCreated(newPebble)
+            }
+        }
+        .sheet(item: $selectedPebbleId) { id in
+            PebbleDetailSheet(pebbleId: id)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isLoading {
+            ProgressView()
+        } else if let loadError {
+            Text(loadError).foregroundStyle(.secondary)
+        } else {
+            List {
+                Section {
+                    Button {
+                        isPresentingCreate = true
+                    } label: {
+                        Label("Record a pebble", systemImage: "plus.circle.fill")
+                            .font(.headline)
+                    }
+                }
+
+                Section("Path") {
+                    ForEach(pebbles) { pebble in
+                        Button {
+                            selectedPebbleId = pebble.id
+                        } label: {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(pebble.name).font(.body)
+                                Text(pebble.happenedAt, style: .date)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+    }
+
+    private func handleCreated(_ pebble: Pebble) {
+        pebbles.append(pebble)
+        pebbles.sort { $0.happenedAt > $1.happenedAt }
+    }
+
+    private func load() async {
+        do {
+            let result: [Pebble] = try await supabase.client
+                .from("pebbles")
+                .select("id, name, happened_at")
+                .order("happened_at", ascending: false)
+                .execute()
+                .value
+            self.pebbles = result
+            self.isLoading = false
+        } catch {
+            logger.error("path fetch failed: \(error.localizedDescription, privacy: .private)")
+            self.loadError = "Couldn't load your pebbles."
+            self.isLoading = false
+        }
+    }
+}
+
+#Preview {
+    PathView()
+        .environment(SupabaseService())
+}
+```
+
+- [ ] **Step 2: Build and lint**
+
+Run from repo root:
+```bash
+npm run build --workspace=@pbbls/ios
+npm run lint --workspace=@pbbls/ios
+```
+Expected: both succeed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Path/PathView.swift
+git commit -m "feat(ios): present PebbleDetailSheet on path row tap (#253)"
+```
+
+---
+
+### Task 6: Manual smoke test in the simulator
+
+**Why:** The unit tests cover decoding, not user flow. Confirm the whole loop end-to-end before opening the PR.
+
+**Files:** none
+
+- [ ] **Step 1: Run the app on a simulator**
+
+Open `apps/ios/Pebbles.xcodeproj` in Xcode, pick any iPhone simulator, press ⌘R.
+
+- [ ] **Step 2: Verify the happy path**
+
+- Sign in with your dev account.
+- On the Path screen, tap an existing pebble row.
+- Expected: a sheet slides up showing a `ProgressView` briefly, then a `Form` with the pebble's name in the navbar, the "When" row, description (if any), emotion (name + colored dot), domain(s), valence label, optional soul/collection rows, and privacy.
+- Tap "Done". Expected: sheet dismisses, list state is unchanged.
+
+- [ ] **Step 3: Verify a pebble with no description and no optional relations**
+
+- Create a new pebble via the existing create flow with only the required fields filled (name, emotion, domain, valence) — no description, no soul, no collection.
+- Tap the new row.
+- Expected: Description row is absent. "Optional" section is absent entirely. No crashes, no empty placeholder rows.
+
+- [ ] **Step 4: Verify the error path**
+
+- In Airplane Mode (Settings → Airplane Mode on in the simulator, or Features → Network Link Conditioner → 100% Loss), tap a pebble row.
+- Expected: sheet shows the error text "Couldn't load this pebble." with a Retry button. Turn network back on and tap Retry — it loads.
+- Check the Xcode console: a log line from category `pebble-detail` should appear for the failed fetch. No silent catches.
+
+- [ ] **Step 5: Verify no regression in Create**
+
+- Turn networking back on. Tap "Record a pebble", fill the form, save.
+- Expected: the sheet closes and the new pebble appears at the top of the path, same as before.
+
+---
+
+### Task 7: Open the pull request
+
+**Why:** Ship it.
+
+**Files:** none
+
+- [ ] **Step 1: Push the branch**
+
+Run:
+```bash
+git push -u origin feat/253-pebble-detail-sheet
+```
+
+- [ ] **Step 2: Create the PR**
+
+Run:
+```bash
+gh pr create --title "feat(ios): pebble detail sheet (#253)" --body "$(cat <<'EOF'
+Resolves #253.
+
+## Summary
+- Adds `PebbleDetailSheet` — a read-only sheet that opens when a user taps a pebble in the path, showing all stored fields plus the embedded emotion, domain(s), soul(s), and collection(s).
+- Adds `PebbleDetail` read model with custom decoding that flattens PostgREST junction rows into clean arrays.
+- Wires `PathView` rows as `Button`s that set `selectedPebbleId`, presenting the sheet via `.sheet(item:)`.
+- Adds a `UUID: Identifiable` extension so `.sheet(item:)` accepts a `UUID?` directly.
+- Adds unit tests for decoding and valence derivation via Swift Testing.
+
+## Key files
+- \`apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift\` (new)
+- \`apps/ios/Pebbles/Features/Path/Models/PebbleDetail.swift\` (new)
+- \`apps/ios/Pebbles/Services/UUID+Identifiable.swift\` (new)
+- \`apps/ios/Pebbles/Features/Path/PathView.swift\` (modified)
+- \`apps/ios/PebblesTests/PebbleDetailDecodingTests.swift\` (new)
+
+## Implementation notes
+- Fetch-on-tap pattern: list query stays lightweight; the sheet runs its own single embedded PostgREST query by id.
+- `valence` is a computed property derived from `intensity` + `positiveness` — DB remains source of truth.
+- Junction-row decoding is isolated in \`PebbleDetail.init(from:)\`; the view layer only sees flat \`domains\`/\`souls\`/\`collections\` arrays.
+
+## Test plan
+- [x] \`npm run test --workspace=@pbbls/ios\` (unit tests pass)
+- [x] \`npm run build --workspace=@pbbls/ios\` (build succeeds)
+- [x] \`npm run lint --workspace=@pbbls/ios\` (lint clean)
+- [x] Simulator: tap row → sheet opens with full details
+- [x] Simulator: pebble with no description / no optionals renders correctly (section omitted)
+- [x] Simulator: offline → error + Retry works, log line appears
+- [x] Simulator: create flow unaffected
+EOF
+)"
+```
+
+- [ ] **Step 3: Apply labels and milestone**
+
+The issue has labels `feat`, `core`, `ios` and milestone `M19 · iOS ShameVP`. Per the project's PR workflow, the PR inherits the same labels and milestone. Confirm with the user before applying if you're uncertain; otherwise:
+
+```bash
+gh pr edit --add-label feat --add-label core --add-label ios --milestone "M19 · iOS ShameVP"
+```
+
+- [ ] **Step 4: Report the PR URL back to the user.**

--- a/docs/superpowers/specs/2026-04-14-ios-pebble-detail-sheet-design.md
+++ b/docs/superpowers/specs/2026-04-14-ios-pebble-detail-sheet-design.md
@@ -1,0 +1,250 @@
+# iOS — Pebble Detail Sheet
+
+**Issue:** [#253](https://github.com/Bohns/pbbls/issues/253) — [Feat] Pebbles details view
+**Milestone:** M19 · iOS ShameVP
+**Date:** 2026-04-14
+
+## Context
+
+Pebbles can be created (C of CRUD) via `CreatePebbleSheet`, and listed in a
+lightweight timeline on `PathView`. They cannot yet be read in full. This spec
+covers R of CRUD: tapping a pebble in the timeline opens a sheet showing the
+complete pebble — all stored fields plus its related emotion, domain, soul,
+and collection rows.
+
+Update and delete are explicitly out of scope (future issues).
+
+## Requirements
+
+From the issue:
+
+- As a user with a pebble history, when I tap a pebble item, then it opens a
+  sheet with that pebble's details.
+- Use only iOS native primitive SwiftUI components.
+- Read-only. No edit, no delete, no swipe actions.
+
+## Non-goals
+
+- Editing pebble fields.
+- Deleting pebbles.
+- Sharing, exporting, or deep-linking.
+- Rich/editorial layout — an Apple-style `Form` is sufficient for V1.
+- Pre-fetching all detail data in the list query.
+
+## Design decisions
+
+### What the sheet shows (option B — rich)
+
+The sheet shows everything the create sheet collects:
+
+- `name`, `description`, `happened_at`, `visibility`
+- `intensity` + `positiveness` displayed as a single `Valence` label
+- `emotion` (name + colored dot)
+- `domain(s)` (from `pebble_domains` join)
+- `soul(s)` (from `pebble_souls` join, optional section)
+- `collection(s)` (from `collection_pebbles` join, optional section)
+
+A "minimal" variant (only direct `pebbles` columns) was rejected because the
+create sheet already persists all of the above, so hiding them on read would
+surprise the user.
+
+### Fetch on tap, not upfront
+
+`PathView` keeps its current lightweight list query (`id, name, happened_at`).
+`PebbleDetailSheet` runs its own query by id when it appears.
+
+Rationale:
+- Separation of concerns — list owns the timeline query, detail owns the
+  full-pebble query. They evolve independently.
+- Cheaper list as history grows; no 4-join payload per row.
+- Fresh data on every open — when edit lands later, no stale-state bugs.
+- Simpler `Pebble` struct — stays minimal for the list.
+
+Tradeoff: a brief loading spinner when opening the sheet. Acceptable and
+consistent with native iOS patterns (Messages, Mail).
+
+### Single embedded PostgREST query
+
+The detail fetch is one round-trip using PostgREST relation embedding:
+
+```swift
+.from("pebbles")
+.select("""
+    id, name, description, happened_at, intensity, positiveness, visibility,
+    emotion:emotions(id, name, color),
+    pebble_domains(domain:domains(id, name)),
+    pebble_souls(soul:souls(id, name)),
+    collection_pebbles(collection:collections(id, name))
+""")
+.eq("id", value: pebbleId)
+.single()
+```
+
+Rationale: one error path, one loading state, atomic freshness. PostgREST is
+built for this — we should use it rather than parallelizing four queries on
+the client.
+
+### `Form` layout, not editorial `ScrollView`
+
+The sheet uses `Form` + `Section` + `LabeledContent`, matching
+`CreatePebbleSheet`'s structure. Rationale:
+- Mirrors create → read for free cognitive mapping.
+- Teaches core SwiftUI primitives the project will reuse everywhere.
+- No design system yet — editorial layouts invite bikeshedding.
+
+Editorial layout can be revisited when a visual design direction exists.
+
+## Architecture
+
+### File layout
+
+```
+apps/ios/Pebbles/Features/Path/
+  Models/
+    PebbleDetail.swift          (NEW)  rich read model, single-pebble shape
+  PebbleDetailSheet.swift        (NEW)  the sheet view
+  PathView.swift                 (EDIT) tap row → present sheet
+```
+
+`Pebble` (the lightweight list model) is untouched. A new `PebbleDetail` type
+keeps the list/detail boundary explicit: lists decode `Pebble`, details decode
+`PebbleDetail`.
+
+### `PebbleDetail` model
+
+A `Decodable` struct containing every field the sheet renders, plus small
+ref types for the joined rows:
+
+```swift
+struct PebbleDetail: Identifiable, Decodable, Hashable {
+    let id: UUID
+    let name: String
+    let description: String?
+    let happenedAt: Date
+    let intensity: Int
+    let positiveness: Int
+    let visibility: Visibility
+    let emotion: EmotionRef
+    let domains: [DomainRef]
+    let souls: [SoulRef]
+    let collections: [CollectionRef]
+
+    var valence: Valence { /* derived from intensity + positiveness */ }
+}
+
+struct EmotionRef: Decodable, Hashable { let id: UUID; let name: String; let color: String }
+struct DomainRef:  Decodable, Hashable { let id: UUID; let name: String }
+struct SoulRef:    Decodable, Hashable { let id: UUID; let name: String }
+struct CollectionRef: Decodable, Hashable { let id: UUID; let name: String }
+```
+
+- `Visibility` is the existing enum — reused.
+- `valence` is a **computed** property derived from `intensity`+`positiveness`
+  via a switch. The DB remains source of truth; no drift risk.
+- `domains`/`souls`/`collections` are flattened during decoding via a custom
+  `init(from:)` that reads the PostgREST shape
+  (`pebble_domains: [{ domain: ... }]`) and exposes clean arrays. The
+  junction-row wrappers never leak into the view layer.
+- The `*Ref` types are detail-view-local and intentionally do **not** reuse
+  `Emotion`/`Domain`/`Soul`/`PebbleCollection` — those were shaped for the
+  create-sheet pickers; decoupling avoids coupling the picker contracts to the
+  detail view.
+
+### `PebbleDetailSheet` view
+
+Takes `pebbleId: UUID` as its only parameter. Small API surface means the
+sheet can be reused from anywhere later (notification taps, deep links,
+search results) without signature churn.
+
+Three view states, mirroring `PathView` and `CreatePebbleSheet`:
+
+1. `isLoading` → `ProgressView()`
+2. `loadError` → error text + Retry button
+3. `detail` present → a `Form` with:
+   - **Section (unlabeled):** `When`, and `Description` (rendered only when
+     non-empty).
+   - **Section "Mood":** `Emotion` (name + colored dot), `Domain` (comma
+     joined if multiple), `Valence` (the `Valence.label` for the derived
+     case).
+   - **Section "Optional":** `Soul`, `Collection`. Entire section omitted if
+     both arrays are empty.
+   - **Section "Privacy":** `Privacy` via `LabeledContent`.
+
+Wrapped in a `NavigationStack` with `navigationTitle(detail?.name ?? "Pebble")`,
+inline title display, and a `Done` button in the confirmation toolbar slot.
+
+Loading is driven by `.task { await load() }`. A new sheet instance is created
+each time the user reopens it, so `load()` naturally refreshes on reopen.
+
+Errors are surfaced in-view **and** logged via `os.Logger` with category
+`pebble-detail`, matching the project's "silent failures are bugs" rule.
+
+### `PathView` edits
+
+Three small changes:
+
+1. New `@State private var selectedPebbleId: UUID?`.
+2. New `.sheet(item: $selectedPebbleId) { id in PebbleDetailSheet(pebbleId: id) }`
+   alongside the existing create sheet.
+3. The existing row `VStack` is wrapped in a `Button { selectedPebbleId = pebble.id }`
+   with `.buttonStyle(.plain)` to keep the row visual identical while adding
+   tap behavior.
+
+`UUID` is not `Identifiable` out of the box; we add a one-line extension
+`extension UUID: Identifiable { public var id: UUID { self } }` in a small
+utilities file (e.g. `Services/UUID+Identifiable.swift`). This is a common and
+harmless extension that unblocks `.sheet(item:)` cleanly.
+
+A sheet (not a `NavigationLink`) is the right affordance: the issue asks for
+a sheet, and the detail is a side-view of the row — not a navigation
+destination that warrants a back button or stack entry.
+
+## Data flow
+
+```
+user taps row in PathView
+  → PathView sets selectedPebbleId = pebble.id
+  → SwiftUI observes the non-nil binding and presents PebbleDetailSheet(pebbleId:)
+  → sheet's .task runs load()
+  → load() calls supabase.client.from("pebbles").select(<embedded>).eq(id).single()
+  → PostgREST returns the row with embedded emotion / pebble_domains / pebble_souls / collection_pebbles
+  → PebbleDetail.init(from:) flattens junction rows into clean arrays
+  → view transitions from ProgressView to Form
+user taps Done (or swipes down)
+  → dismiss() → selectedPebbleId returns to nil → sheet tears down
+```
+
+## Error handling
+
+Every failure path logs via `os.Logger(category: "pebble-detail")` and sets
+`loadError` to a user-facing message. The error state offers a Retry button
+that re-runs `load()`. No silent catches. No timeouts in V1 — Supabase-swift
+does not hang indefinitely on standard requests, and the project has not yet
+introduced a `withTimeout` helper on the iOS side.
+
+## Testing
+
+Per the iOS CLAUDE.md, V1 ships without UI tests. Where we can add value
+without XCTest:
+
+- `PebbleDetail` decoding from a canned PostgREST-shaped JSON fixture, via
+  Swift Testing (`@Suite`, `@Test`, `#expect`). Verifies the flattening of
+  `pebble_domains`/`pebble_souls`/`collection_pebbles` and the `valence`
+  derivation from `intensity` + `positiveness`.
+
+No fake `SupabaseService` is introduced — per the iOS CLAUDE.md "extract a
+protocol at that moment, not before" — since the only unit under test is
+pure decoding.
+
+## Out of scope
+
+- Edit/delete (future issue covering U and D).
+- Navigation from detail sheet to related entities (soul page, domain filter).
+- Pagination or infinite scroll on the list.
+- Offline caching of the detail payload.
+
+## Open questions
+
+None at authoring time. The design reuses the existing `SupabaseService`
+environment injection, the existing `Visibility`/`Valence` enums, and
+PostgREST features already relied upon elsewhere.


### PR DESCRIPTION
Resolves #253.

## Summary
- Adds `PebbleDetailSheet` — a read-only sheet that opens when a user taps a pebble in the path, showing all stored fields plus the embedded emotion, domain(s), soul(s), and collection(s).
- Adds `PebbleDetail` read model with custom decoding that flattens PostgREST junction rows into clean arrays.
- Wires `PathView` rows as `Button`s that set `selectedPebbleId`, presenting the sheet via `.sheet(item:)`.
- Adds a `UUID: Identifiable` extension so `.sheet(item:)` accepts a `UUID?` directly.
- Adds unit tests for decoding and valence derivation via Swift Testing.

## Key files
- `apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift` (new)
- `apps/ios/Pebbles/Features/Path/Models/PebbleDetail.swift` (new)
- `apps/ios/Pebbles/Services/UUID+Identifiable.swift` (new)
- `apps/ios/Pebbles/Features/Path/PathView.swift` (modified)
- `apps/ios/PebblesTests/PebbleDetailDecodingTests.swift` (new)
- `apps/ios/Pebbles/Features/Path/Models/Visibility.swift` (modified — added `Decodable` conformance)

## Implementation notes
- Fetch-on-tap pattern: list query stays lightweight; the sheet runs its own single embedded PostgREST query by id.
- `valence` is a computed property derived from `intensity` + `positiveness` — DB remains source of truth; out-of-range pairs log an `os.Logger` warning instead of failing silently.
- Junction-row decoding is isolated in `PebbleDetail.init(from:)`; the view layer only sees flat `domains`/`souls`/`collections` arrays.
- `EmotionRef`/`DomainRef` exist because the PostgREST select restricts columns; `Soul` and `PebbleCollection` are reused directly because their full shapes match.

## Test plan
- [x] `npm run test --workspace=@pbbls/ios` — 6/6 tests pass (4 new decoding tests + existing smoke and SupabaseService tests)
- [x] `npm run build --workspace=@pbbls/ios` — BUILD SUCCEEDED
- [x] `npm run lint --workspace=@pbbls/ios` — 0 serious violations (2 pre-existing warnings in `AppEnvironment.swift` are out of scope)
- [x] Simulator: tap row → sheet opens with full details
- [x] Simulator: pebble with no description / no optionals renders correctly (Optional section omitted)
- [x] Simulator: offline → error + Retry works, log line appears under `pebble-detail` category
- [x] Simulator: create flow unaffected