### PR TITLE
feat(ui): render pebble artwork in edit sheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ public/sw.js.map
 
 certificates
 deno.lock
+
+# supabase local state
+.branches/

--- a/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
@@ -22,6 +22,7 @@ struct EditPebbleSheet: View {
     @State private var domains: [Domain] = []
     @State private var souls: [Soul] = []
     @State private var collections: [PebbleCollection] = []
+    @State private var renderSvg: String?
 
     @State private var isLoading = true
     @State private var loadError: String?
@@ -73,7 +74,8 @@ struct EditPebbleSheet: View {
                 domains: domains,
                 souls: souls,
                 collections: collections,
-                saveError: saveError
+                saveError: saveError,
+                renderSvg: renderSvg
             )
         }
     }
@@ -132,6 +134,7 @@ struct EditPebbleSheet: View {
             self.souls = loadedSouls
             self.collections = loadedCollections
             self.draft = PebbleDraft(from: detail)
+            self.renderSvg = detail.renderSvg
             self.isLoading = false
         } catch {
             logger.error("edit pebble load failed: \(error.localizedDescription, privacy: .private)")

--- a/apps/ios/Pebbles/Features/Path/PebbleFormView.swift
+++ b/apps/ios/Pebbles/Features/Path/PebbleFormView.swift
@@ -13,9 +13,20 @@ struct PebbleFormView: View {
     let souls: [Soul]
     let collections: [PebbleCollection]
     let saveError: String?
+    var renderSvg: String? = nil
 
     var body: some View {
         Form {
+            if let svg = renderSvg {
+                PebbleRenderView(svg: svg)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 260)
+                    .padding(.vertical)
+                    // Form rows add insets and a card background; strip both so the artwork spans edge-to-edge.
+                    .listRowInsets(EdgeInsets())
+                    .listRowBackground(Color.clear)
+            }
+
             Section {
                 DatePicker(
                     "When",

--- a/docs/superpowers/plans/2026-04-16-pebble-detail-render.md
+++ b/docs/superpowers/plans/2026-04-16-pebble-detail-render.md
@@ -1,0 +1,132 @@
+# Pebble Detail Render in Edit Sheet — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Display the server-composed pebble artwork at the top of `EditPebbleSheet` when opening an existing pebble.
+
+**Architecture:** Add an optional `renderSvg` parameter to `PebbleFormView`. When non-nil, render `PebbleRenderView` as a header row at the top of the `Form`. `EditPebbleSheet` passes the value from `PebbleDetail`; `CreatePebbleSheet` passes `nil`.
+
+**Tech Stack:** SwiftUI, iOS 17+, SVGView (exyte)
+
+---
+
+### File Map
+
+- **Modify:** `apps/ios/Pebbles/Features/Path/PebbleFormView.swift` — add optional `renderSvg` param, render artwork header
+- **Modify:** `apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift` — store `renderSvg` from loaded detail, pass to form
+- **Modify:** `apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift` — pass `renderSvg: nil` to form
+
+---
+
+### Task 1: Add `renderSvg` parameter to `PebbleFormView`
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/PebbleFormView.swift`
+
+- [ ] **Step 1: Add the property and render the artwork**
+
+Add `let renderSvg: String?` to `PebbleFormView`. At the top of the `Form` body, before the first `Section`, conditionally render the artwork:
+
+```swift
+struct PebbleFormView: View {
+    @Binding var draft: PebbleDraft
+    let emotions: [Emotion]
+    let domains: [Domain]
+    let souls: [Soul]
+    let collections: [PebbleCollection]
+    let saveError: String?
+    let renderSvg: String?
+
+    var body: some View {
+        Form {
+            if let svg = renderSvg {
+                PebbleRenderView(svg: svg)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 260)
+                    .padding(.vertical)
+                    .listRowInsets(EdgeInsets())
+                    .listRowBackground(Color.clear)
+            }
+
+            Section {
+                // ... existing fields unchanged
+```
+
+The `.listRowInsets(EdgeInsets())` removes default Form padding so the artwork spans full width. `.listRowBackground(Color.clear)` removes the row's card background.
+
+- [ ] **Step 2: Verify it compiles (will fail — callers don't pass the new param yet)**
+
+Run: `cd apps/ios && xcodegen generate && xcodebuild -scheme Pebbles -destination 'platform=iOS Simulator,name=iPhone 16' build 2>&1 | tail -20`
+
+Expected: compile errors in `CreatePebbleSheet.swift` and `EditPebbleSheet.swift` — missing argument `renderSvg`.
+
+---
+
+### Task 2: Pass `renderSvg` from `EditPebbleSheet`
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift`
+
+- [ ] **Step 1: Add state and wire it up**
+
+Add a `@State` property and populate it in `load()`:
+
+```swift
+@State private var renderSvg: String?
+```
+
+In `load()`, after `self.draft = PebbleDraft(from: detail)` (line 134), add:
+
+```swift
+self.renderSvg = detail.renderSvg
+```
+
+In the `content` builder, update the `PebbleFormView` call to pass the new parameter:
+
+```swift
+PebbleFormView(
+    draft: $draft,
+    emotions: emotions,
+    domains: domains,
+    souls: souls,
+    collections: collections,
+    saveError: saveError,
+    renderSvg: renderSvg
+)
+```
+
+---
+
+### Task 3: Pass `nil` from `CreatePebbleSheet`
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift`
+
+- [ ] **Step 1: Add `renderSvg: nil` to the `PebbleFormView` call**
+
+Update the call site (line 60-67):
+
+```swift
+PebbleFormView(
+    draft: $draft,
+    emotions: emotions,
+    domains: domains,
+    souls: souls,
+    collections: collections,
+    saveError: saveError,
+    renderSvg: nil
+)
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd apps/ios && xcodebuild -scheme Pebbles -destination 'platform=iOS Simulator,name=iPhone 16' build 2>&1 | tail -20`
+
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Path/PebbleFormView.swift apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
+git commit -m "feat(ui): render pebble artwork in edit sheet (#263)"
+```

--- a/docs/superpowers/specs/2026-04-16-pebble-detail-render-design.md
+++ b/docs/superpowers/specs/2026-04-16-pebble-detail-render-design.md
@@ -1,0 +1,46 @@
+# Pebble Detail Render in Edit Sheet
+
+**Issue:** #263 — Render the Pebble in detail view
+**Date:** 2026-04-16
+
+## Summary
+
+Display the server-composed pebble artwork when opening an existing pebble's edit sheet. The artwork already exists in the DB (`render_svg` column) and is already fetched by `EditPebbleSheet`'s `load()` via `PebbleDetail`. The change surfaces it visually.
+
+## Design
+
+### Approach
+
+Add an optional `renderSvg: String?` parameter to `PebbleFormView`. When non-nil, render `PebbleRenderView` as a header row at the top of the `Form`, before the first `Section`. This keeps a single scroll container and avoids nesting scrollable views.
+
+### Changes
+
+**`PebbleFormView.swift`**
+- Add `let renderSvg: String?` property
+- At the top of the `Form` body (before the first `Section`), conditionally render `PebbleRenderView(svg:)` with the same sizing as `PebbleDetailSheet`: 260pt height, full width, vertical padding
+
+**`EditPebbleSheet.swift`**
+- Add `@State private var renderSvg: String?`
+- In `load()`, assign `self.renderSvg = detail.renderSvg` alongside the draft prefill
+- Pass `renderSvg` to `PebbleFormView`
+
+**`CreatePebbleSheet.swift`**
+- Pass `renderSvg: nil` to `PebbleFormView` (no artwork exists pre-save)
+
+### What doesn't change
+
+- `PebbleDetailSheet` (post-create reveal) — untouched
+- `PebbleRenderView` — reused as-is
+- Backend / edge functions — no changes needed
+- Data fetching — `EditPebbleSheet` already fetches `render_svg` via `PebbleDetail`
+
+### Edge cases
+
+- **Legacy pebbles without a render:** `renderSvg` is nil, artwork section simply doesn't appear. Form renders exactly as before.
+- **Soft-success pebbles (render failed on create):** Same as above — nil svg, no artwork shown.
+
+## Acceptance criteria
+
+- Opening an existing pebble with a render shows the artwork above the form fields
+- Opening an existing pebble without a render shows the form as before (no empty space)
+- Creating a new pebble still works identically (no artwork in create flow)


### PR DESCRIPTION
Resolves #263

## Summary
- Add optional `renderSvg` parameter to `PebbleFormView` with a default of `nil`
- `EditPebbleSheet` passes the loaded `PebbleDetail.renderSvg` to the form, rendering `PebbleRenderView` as a full-width header above the form fields
- `CreatePebbleSheet` omits the parameter (no artwork exists pre-save)

## Key files
- `apps/ios/Pebbles/Features/Path/PebbleFormView.swift` — new `renderSvg` property + conditional artwork render
- `apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift` — stores and passes `renderSvg` from loaded detail

## Test plan
- [ ] Open an existing pebble that has a render → artwork displays above the form
- [ ] Open an existing pebble without a render (legacy) → form displays as before, no empty space
- [ ] Create a new pebble → form has no artwork header, flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)