### PR TITLE
feat(ios): color pebble render with emotion color (#264)

### DIFF
--- a/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
@@ -23,6 +23,7 @@ struct EditPebbleSheet: View {
     @State private var souls: [Soul] = []
     @State private var collections: [PebbleCollection] = []
     @State private var renderSvg: String?
+    @State private var strokeColor: String?
 
     @State private var isLoading = true
     @State private var loadError: String?
@@ -75,7 +76,8 @@ struct EditPebbleSheet: View {
                 souls: souls,
                 collections: collections,
                 saveError: saveError,
-                renderSvg: renderSvg
+                renderSvg: renderSvg,
+                strokeColor: strokeColor
             )
         }
     }
@@ -135,6 +137,7 @@ struct EditPebbleSheet: View {
             self.collections = loadedCollections
             self.draft = PebbleDraft(from: detail)
             self.renderSvg = detail.renderSvg
+            self.strokeColor = detail.emotion.color
             self.isLoading = false
         } catch {
             logger.error("edit pebble load failed: \(error.localizedDescription, privacy: .private)")

--- a/apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift
@@ -50,7 +50,7 @@ struct PebbleDetailSheet: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
                     if let svg = detail.renderSvg {
-                        PebbleRenderView(svg: svg)
+                        PebbleRenderView(svg: svg, strokeColor: detail.emotion.color)
                             .frame(maxWidth: .infinity)
                             .frame(height: 260)
                             .padding(.vertical)

--- a/apps/ios/Pebbles/Features/Path/PebbleFormView.swift
+++ b/apps/ios/Pebbles/Features/Path/PebbleFormView.swift
@@ -13,8 +13,8 @@ struct PebbleFormView: View {
     let souls: [Soul]
     let collections: [PebbleCollection]
     let saveError: String?
-    var renderSvg: String? = nil
-    var strokeColor: String? = nil
+    var renderSvg: String?
+    var strokeColor: String?
 
     var body: some View {
         Form {

--- a/apps/ios/Pebbles/Features/Path/PebbleFormView.swift
+++ b/apps/ios/Pebbles/Features/Path/PebbleFormView.swift
@@ -14,11 +14,12 @@ struct PebbleFormView: View {
     let collections: [PebbleCollection]
     let saveError: String?
     var renderSvg: String? = nil
+    var strokeColor: String? = nil
 
     var body: some View {
         Form {
             if let svg = renderSvg {
-                PebbleRenderView(svg: svg)
+                PebbleRenderView(svg: svg, strokeColor: strokeColor)
                     .frame(maxWidth: .infinity)
                     .frame(height: 260)
                     .padding(.vertical)

--- a/apps/ios/Pebbles/Features/Path/PebbleRenderView.swift
+++ b/apps/ios/Pebbles/Features/Path/PebbleRenderView.swift
@@ -7,7 +7,7 @@ import SVGView
 /// later slice. Fills width and scales to fit; aspect ratio is preserved.
 struct PebbleRenderView: View {
     let svg: String
-    var strokeColor: String? = nil
+    var strokeColor: String?
 
     private var coloredSvg: String {
         guard let color = strokeColor else { return svg }

--- a/apps/ios/Pebbles/Features/Path/PebbleRenderView.swift
+++ b/apps/ios/Pebbles/Features/Path/PebbleRenderView.swift
@@ -7,19 +7,28 @@ import SVGView
 /// later slice. Fills width and scales to fit; aspect ratio is preserved.
 struct PebbleRenderView: View {
     let svg: String
+    var strokeColor: String? = nil
+
+    private var coloredSvg: String {
+        guard let color = strokeColor else { return svg }
+        return svg.replacingOccurrences(of: "currentColor", with: color)
+    }
 
     var body: some View {
-        SVGView(string: svg)
+        SVGView(string: coloredSvg)
             .aspectRatio(contentMode: .fit)
             .accessibilityHidden(true)
     }
 }
 
 #Preview {
-    PebbleRenderView(svg: """
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-          <circle cx="50" cy="50" r="40" fill="none" stroke="black" stroke-width="2"/>
-        </svg>
-        """)
+    PebbleRenderView(
+        svg: """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+              <circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" stroke-width="2"/>
+            </svg>
+            """,
+        strokeColor: "#EF4444"
+    )
     .frame(width: 260, height: 260)
 }

--- a/docs/superpowers/plans/2026-04-16-color-pebble-render.md
+++ b/docs/superpowers/plans/2026-04-16-color-pebble-render.md
@@ -1,0 +1,227 @@
+# Color Pebble Render Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Color the pebble's SVG strokes with the emotion's hex color on iOS.
+
+**Architecture:** Client-side string replacement — swap `currentColor` with the emotion hex in the SVG string before passing to SVGView. Mirrors the web's `recolor()` pattern. Server SVGs stay monochrome.
+
+**Tech Stack:** SwiftUI, exyte/SVGView
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `apps/ios/Pebbles/Features/Path/PebbleRenderView.swift` | Modify | Accept optional `strokeColor`, apply to SVG |
+| `apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift` | Modify | Pass emotion color to render view |
+| `apps/ios/Pebbles/Features/Path/PebbleFormView.swift` | Modify | Accept and forward `strokeColor` |
+| `apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift` | Modify | Pass emotion color to form view |
+
+---
+
+### Task 1: Add strokeColor to PebbleRenderView
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/PebbleRenderView.swift:1-26`
+
+- [ ] **Step 1: Add strokeColor parameter and coloredSvg computed property**
+
+Replace the full struct body with:
+
+```swift
+struct PebbleRenderView: View {
+    let svg: String
+    var strokeColor: String? = nil
+
+    private var coloredSvg: String {
+        guard let color = strokeColor else { return svg }
+        return svg.replacingOccurrences(of: "currentColor", with: color)
+    }
+
+    var body: some View {
+        SVGView(string: coloredSvg)
+            .aspectRatio(contentMode: .fit)
+            .accessibilityHidden(true)
+    }
+}
+```
+
+The default `nil` keeps the preview and any future call sites without an emotion working unchanged.
+
+- [ ] **Step 2: Update preview to exercise coloring**
+
+Replace the `#Preview` block with:
+
+```swift
+#Preview {
+    PebbleRenderView(
+        svg: """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+              <circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" stroke-width="2"/>
+            </svg>
+            """,
+        strokeColor: "#EF4444"
+    )
+    .frame(width: 260, height: 260)
+}
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run: `npm run build --workspace=@pbbls/ios` (or `xcodebuild build` for the Pebbles scheme)
+Expected: builds with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Path/PebbleRenderView.swift
+git commit -m "feat(ios): add strokeColor param to PebbleRenderView"
+```
+
+---
+
+### Task 2: Pass emotion color in PebbleDetailSheet
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift:52-54`
+
+- [ ] **Step 1: Pass strokeColor to PebbleRenderView**
+
+Replace line 53:
+
+```swift
+                        PebbleRenderView(svg: svg)
+```
+
+with:
+
+```swift
+                        PebbleRenderView(svg: svg, strokeColor: detail.emotion.color)
+```
+
+`detail.emotion` is an `EmotionRef` with a `color: String` field (hex like `"#EF4444"`), already loaded by the query on line 89.
+
+- [ ] **Step 2: Build to verify**
+
+Run: `npm run build --workspace=@pbbls/ios`
+Expected: builds with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift
+git commit -m "feat(ios): color pebble render in detail sheet"
+```
+
+---
+
+### Task 3: Add strokeColor to PebbleFormView and wire EditPebbleSheet
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/PebbleFormView.swift:9-28`
+- Modify: `apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift:70-79`
+
+- [ ] **Step 1: Add strokeColor parameter to PebbleFormView**
+
+In `PebbleFormView.swift`, after line 16 (`var renderSvg: String? = nil`), add:
+
+```swift
+    var strokeColor: String? = nil
+```
+
+- [ ] **Step 2: Pass strokeColor to PebbleRenderView inside PebbleFormView**
+
+Replace line 21:
+
+```swift
+                PebbleRenderView(svg: svg)
+```
+
+with:
+
+```swift
+                PebbleRenderView(svg: svg, strokeColor: strokeColor)
+```
+
+- [ ] **Step 3: Pass strokeColor from EditPebbleSheet**
+
+In `EditPebbleSheet.swift`, replace the `PebbleFormView` call (lines 71-79):
+
+```swift
+            PebbleFormView(
+                draft: $draft,
+                emotions: emotions,
+                domains: domains,
+                souls: souls,
+                collections: collections,
+                saveError: saveError,
+                renderSvg: renderSvg
+            )
+```
+
+with:
+
+```swift
+            PebbleFormView(
+                draft: $draft,
+                emotions: emotions,
+                domains: domains,
+                souls: souls,
+                collections: collections,
+                saveError: saveError,
+                renderSvg: renderSvg,
+                strokeColor: strokeColor
+            )
+```
+
+`EditPebbleSheet` needs a `strokeColor` state property. After line 26 (`@State private var renderSvg: String?`), add:
+
+```swift
+    @State private var strokeColor: String?
+```
+
+And in the `load()` function, after line 137 (`self.renderSvg = detail.renderSvg`), add:
+
+```swift
+            self.strokeColor = detail.emotion.color
+```
+
+- [ ] **Step 4: Build to verify**
+
+Run: `npm run build --workspace=@pbbls/ios`
+Expected: builds with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Path/PebbleFormView.swift apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
+git commit -m "feat(ios): color pebble render in edit sheet"
+```
+
+---
+
+### Task 4: Final verification and lint
+
+- [ ] **Step 1: Run full build and lint**
+
+```bash
+npm run build --workspace=@pbbls/ios
+npm run lint
+```
+
+Expected: both pass with no errors.
+
+- [ ] **Step 2: Verify no regressions**
+
+Confirm `CreatePebbleSheet` still compiles without changes — it doesn't pass `renderSvg` or `strokeColor` to `PebbleFormView`, and both default to `nil`, so the existing call site is unaffected.
+
+- [ ] **Step 3: Commit (if lint required changes)**
+
+Only if lint/build surfaced fixable issues:
+
+```bash
+git add -A
+git commit -m "quality(ios): lint fixes for pebble color render"
+```

--- a/docs/superpowers/specs/2026-04-16-color-pebble-render-design.md
+++ b/docs/superpowers/specs/2026-04-16-color-pebble-render-design.md
@@ -1,0 +1,80 @@
+# Color pebble strokes with emotion color (iOS)
+
+**Issue:** #264
+**Date:** 2026-04-16
+
+## Context
+
+The pebble engine composes monochrome SVGs with `stroke="currentColor"` and `fill="none"`. This design keeps the server output theme-agnostic and animation-friendly — the client resolves color at render time.
+
+On the web, `render.ts` already does this via string replacement (`recolor()`). On iOS, slice 1 shipped `PebbleRenderView` without applying any color — strokes render in the SVGView default (black).
+
+## Decision
+
+Apply the emotion's hex color to the SVG via client-side string replacement on iOS, mirroring the web pattern. The monochrome `currentColor` SVGs stay untouched server-side.
+
+**Why string replacement over SwiftUI `foregroundStyle`:** The exyte/SVGView library parses SVG independently of SwiftUI's color inheritance. There's no documented guarantee that `foregroundStyle` propagates to `currentColor` inside the parsed SVG tree. String replacement is deterministic and proven on the web side.
+
+**Why not server-side baking:** Baking the hex into the SVG would break light/dark mode adaptation and complicate the animation consumer (which will need per-layer color control via the manifest).
+
+## Design
+
+### PebbleRenderView
+
+Add an optional `strokeColor: String?` parameter. When provided, replace all occurrences of `currentColor` with the hex value in the SVG string before passing it to `SVGView`.
+
+```swift
+struct PebbleRenderView: View {
+    let svg: String
+    var strokeColor: String? = nil
+
+    private var coloredSvg: String {
+        guard let color = strokeColor else { return svg }
+        return svg.replacingOccurrences(of: "currentColor", with: color)
+    }
+
+    var body: some View {
+        SVGView(string: coloredSvg)
+            .aspectRatio(contentMode: .fit)
+            .accessibilityHidden(true)
+    }
+}
+```
+
+Default is `nil` so existing call sites (previews, future contexts without an emotion) continue to work.
+
+### PebbleDetailSheet
+
+Pass the loaded emotion color to `PebbleRenderView`:
+
+```swift
+PebbleRenderView(svg: svg, strokeColor: detail.emotion.color)
+```
+
+The emotion color is already fetched in the detail query (`emotion:emotions(id, name, color)`).
+
+### PebbleFormView + EditPebbleSheet
+
+`PebbleFormView` already accepts an optional `renderSvg`. Add a sibling `strokeColor: String?` parameter and pass it through to `PebbleRenderView`.
+
+`EditPebbleSheet` passes `detail.emotion.color` alongside `detail.renderSvg`.
+
+### CreatePebbleSheet
+
+No changes needed. `CreatePebbleSheet` doesn't render the pebble — it calls `onCreated(pebbleId)` and dismisses. `PebbleDetailSheet` handles the post-create render and loads the emotion color itself.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `PebbleRenderView.swift` | Add `strokeColor` param, `coloredSvg` computed property |
+| `PebbleDetailSheet.swift` | Pass `detail.emotion.color` to `PebbleRenderView` |
+| `PebbleFormView.swift` | Add `strokeColor` param, pass to `PebbleRenderView` |
+| `EditPebbleSheet.swift` | Pass `detail.emotion.color` to `PebbleFormView` |
+
+## Acceptance criteria
+
+- Opening a pebble with "angry" emotion from the path shows strokes in `#EF4444`.
+- Recording a pebble with "surprise" emotion (mapped to amazed/excited category) shows strokes in `#F97316`.
+- Edit sheet displays the pebble with the correct emotion color.
+- Pebbles without a render SVG still show the text fallback (no regression).


### PR DESCRIPTION
Resolves #264

## Summary

- Add `strokeColor` parameter to `PebbleRenderView` — replaces `currentColor` in the SVG string with the emotion's hex color before passing to SVGView
- Wire emotion color through `PebbleDetailSheet` (post-create reveal) and `EditPebbleSheet` → `PebbleFormView` (edit flow)
- Server SVGs stay monochrome (`currentColor`); coloring is client-side, mirroring the web's `recolor()` pattern

## Key files

- `PebbleRenderView.swift` — `strokeColor` param + `coloredSvg` computed property
- `PebbleDetailSheet.swift` — passes `detail.emotion.color`
- `PebbleFormView.swift` — accepts and forwards `strokeColor`
- `EditPebbleSheet.swift` — loads and passes emotion color

## Design decisions

- **Client-side string replacement over SwiftUI `foregroundStyle`:** SVGView parses SVG independently; no guarantee `foregroundStyle` propagates to `currentColor`
- **Not server-side baking:** Keeps light/dark mode adaptation possible and won't complicate the future animation consumer

## Test plan

- [x] Open a pebble with "angry" emotion from the path → strokes render in red (#EF4444)
- [x] Record a pebble with "surprise" emotion → strokes render in orange (#F97316)
- [x] Open edit sheet for a pebble → render displays with correct emotion color
- [x] Create a pebble (no render SVG yet) → no regression, form displays normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)