### PR TITLE
feat(core): wire webapp to compose-pebble edge function

### DIFF
--- a/apps/web/components/pebble/PebbleVisual.tsx
+++ b/apps/web/components/pebble/PebbleVisual.tsx
@@ -13,17 +13,49 @@ type PebbleVisualProps = {
   className?: string
 }
 
-export function PebbleVisual({
+// Split into two variants so the local engine (usePebbleVisual) only runs for
+// pebbles without a server render — React hooks can't be called conditionally,
+// so we branch at the component level instead of inside the hook.
+export function PebbleVisual(props: PebbleVisualProps) {
+  return props.pebble.render_svg
+    ? <ServerRenderedVisual {...props} renderSvg={props.pebble.render_svg} />
+    : <LocalRenderedVisual {...props} />
+}
+
+function ServerRenderedVisual({
+  pebble,
+  className,
+  renderSvg,
+}: PebbleVisualProps & { renderSvg: string }) {
+  const emotion = EMOTIONS.find((e) => e.id === pebble.emotion_id)
+  const svg = emotion?.color
+    ? renderSvg.replaceAll("currentColor", emotion.color)
+    : renderSvg
+  return <SvgHost pebble={pebble} emotionName={emotion?.name} className={className} svg={svg} />
+}
+
+function LocalRenderedVisual({
   pebble,
   mark = null,
   tier = "thumbnail",
   className,
 }: PebbleVisualProps) {
   const { svg } = usePebbleVisual(pebble, mark, tier)
+  const emotion = EMOTIONS.find((e) => e.id === pebble.emotion_id)
+  return <SvgHost pebble={pebble} emotionName={emotion?.name} className={className} svg={svg} />
+}
 
-  const emotionName =
-    EMOTIONS.find((e) => e.id === pebble.emotion_id)?.name ?? "Unknown"
-
+function SvgHost({
+  pebble,
+  emotionName = "Unknown",
+  className,
+  svg,
+}: {
+  pebble: Pebble
+  emotionName?: string
+  className?: string
+  svg: string
+}) {
   return (
     <div
       data-slot="pebble-visual"

--- a/apps/web/lib/data/supabase-provider.ts
+++ b/apps/web/lib/data/supabase-provider.ts
@@ -18,6 +18,23 @@ import type {
   Collection,
   Mark,
 } from "@/lib/types"
+import { withTimeout } from "@/lib/utils/with-timeout"
+
+// Edge-function response shared by compose-pebble and recompose-pebble. On
+// compose failure the server still returns pebble_id (soft-success), so we
+// accept the render fields as optional and fall back to the local engine in
+// PebbleVisual when they're missing.
+type ComposeResponse = {
+  pebble_id?: string
+  render_svg?: string
+  render_manifest?: unknown
+  render_version?: string
+  error?: string
+}
+
+type ComposeRequest =
+  | { payload: Record<string, unknown> }
+  | { pebble_id: string }
 
 export class SupabaseProvider implements DataProvider {
   private store: Store
@@ -91,6 +108,9 @@ export class SupabaseProvider implements DataProvider {
         species_id: c.species_id,
         value: c.value,
       })),
+      render_svg: (row.render_svg as string) ?? undefined,
+      render_manifest: row.render_manifest ?? undefined,
+      render_version: (row.render_version as string) ?? undefined,
       created_at: row.created_at as string,
       updated_at: row.updated_at as string,
     }))
@@ -176,27 +196,37 @@ export class SupabaseProvider implements DataProvider {
   // ---------------------------------------------------------------------------
 
   async createPebble(input: CreatePebbleInput): Promise<Pebble> {
-    const result = await this.supabase.rpc("create_pebble", {
-      payload: {
-        name: input.name,
-        description: input.description ?? null,
-        happened_at: input.happened_at,
-        intensity: input.intensity,
-        positiveness: input.positiveness,
-        visibility: input.visibility,
-        emotion_id: input.emotion_id,
-        soul_ids: input.soul_ids,
-        domain_ids: input.domain_ids,
-        cards: input.cards.map((c, i) => ({
-          species_id: c.species_id,
-          value: c.value,
-          sort_order: i,
-        })),
-      },
-    })
-    const pebbleId = this.unwrap(result) as string
+    // Invoke the compose-pebble edge function instead of calling create_pebble
+    // directly. The edge function forwards the same payload into the RPC and
+    // then runs the shared compose engine, writing render_svg / render_manifest
+    // / render_version back to the row. Mirrors the iOS CreatePebbleSheet flow,
+    // including the soft-success path where compose failed but the pebble row
+    // was created.
+    const payload = {
+      name: input.name,
+      description: input.description ?? null,
+      happened_at: input.happened_at,
+      intensity: input.intensity,
+      positiveness: input.positiveness,
+      visibility: input.visibility,
+      emotion_id: input.emotion_id,
+      soul_ids: input.soul_ids,
+      domain_ids: input.domain_ids,
+      cards: input.cards.map((c, i) => ({
+        species_id: c.species_id,
+        value: c.value,
+        sort_order: i,
+      })),
+    }
+
+    const { pebbleId, softError } = await this.invokeCompose("compose-pebble", { payload })
+    if (!pebbleId) throw new Error(softError ?? "compose-pebble failed")
+    if (softError) console.warn("[compose-pebble] soft-success:", softError)
+
     await this.loadFromSupabase()
-    return this.store.pebbles.find((p) => p.id === pebbleId)!
+    const created = this.store.pebbles.find((p) => p.id === pebbleId)
+    if (!created) throw new Error(`Pebble not found after create: ${pebbleId}`)
+    return created
   }
 
   async updatePebble(id: string, input: UpdatePebbleInput): Promise<Pebble> {
@@ -222,10 +252,73 @@ export class SupabaseProvider implements DataProvider {
       },
     })
     this.unwrap(result)
+
+    // Re-compose so the saved render_svg stays in sync with visual-affecting
+    // edits (intensity, valence, emotion, glyph). The update already landed,
+    // so compose failures are logged and swallowed — PebbleVisual's local
+    // engine fallback handles display until the next successful compose.
+    try {
+      const { softError } = await this.invokeCompose("recompose-pebble", { pebble_id: id })
+      if (softError) console.warn("[recompose-pebble] soft-success:", softError)
+    } catch (err) {
+      console.warn("[recompose-pebble] failed:", err)
+    }
+
     await this.loadFromSupabase()
     const updated = this.store.pebbles.find((p) => p.id === id)
     if (!updated) throw new Error(`Pebble not found after update: ${id}`)
     return updated
+  }
+
+  // ---------------------------------------------------------------------------
+  // Edge function invocation shared by create + update paths
+  // ---------------------------------------------------------------------------
+  //
+  // The compose edge functions use a "soft-success" pattern: on compose
+  // failure after the pebble was created/updated, they respond with a 5xx
+  // whose body still includes pebble_id. supabase-js wraps non-2xx responses
+  // in a FunctionsHttpError whose body is consumed lazily via context.response;
+  // we clone + parse it to recover that pebble_id so callers can distinguish
+  // "nothing happened" (hard failure) from "pebble exists, render didn't"
+  // (soft failure).
+
+  private async invokeCompose(
+    fn: "compose-pebble" | "recompose-pebble",
+    body: ComposeRequest,
+  ): Promise<{ pebbleId: string | null; softError: string | null }> {
+    const invocation = this.supabase.functions.invoke<ComposeResponse>(fn, { body })
+    const { data, error } = await withTimeout(invocation, 10_000, fn)
+
+    if (!error && data?.pebble_id) {
+      return { pebbleId: data.pebble_id, softError: null }
+    }
+
+    const softPebbleId = await this.extractSoftPebbleId(error)
+    if (softPebbleId) {
+      const softError =
+        (data?.error as string | undefined) ??
+        (error instanceof Error ? error.message : `${fn} returned non-2xx`)
+      return { pebbleId: softPebbleId, softError }
+    }
+
+    const message =
+      (data?.error as string | undefined) ??
+      (error instanceof Error ? error.message : `${fn} failed`)
+    throw new Error(message)
+  }
+
+  private async extractSoftPebbleId(error: unknown): Promise<string | null> {
+    if (!error || typeof error !== "object") return null
+    const ctx = (error as { context?: { response?: Response } }).context
+    const response = ctx?.response
+    if (!response) return null
+    try {
+      const body = (await response.clone().json()) as ComposeResponse
+      return body.pebble_id ?? null
+    } catch (err) {
+      console.warn("extractSoftPebbleId: failed to parse error body:", err)
+      return null
+    }
   }
 
   async deletePebble(id: string): Promise<void> {

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -27,6 +27,13 @@ export type Pebble = {
   mark_id?: string
   instants: string[]
   cards: PebbleCard[]
+  // Server-composed render — produced by the compose-pebble / recompose-pebble
+  // edge functions. Absent for legacy pebbles or when the compose step failed
+  // (soft-success path); in that case the webapp falls back to the local
+  // engine render in PebbleVisual.
+  render_svg?: string
+  render_manifest?: unknown
+  render_version?: string
   created_at: string
   updated_at: string
 }

--- a/packages/supabase/supabase/functions/compose-pebble/index.ts
+++ b/packages/supabase/supabase/functions/compose-pebble/index.ts
@@ -24,7 +24,7 @@ interface RequestBody {
 
 const CORS = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, content-type",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
 };
 

--- a/packages/supabase/supabase/functions/recompose-pebble/index.ts
+++ b/packages/supabase/supabase/functions/recompose-pebble/index.ts
@@ -31,7 +31,7 @@ interface RequestBody {
 
 const CORS = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, content-type",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
 };
 

--- a/packages/supabase/supabase/functions/recompose-pebble/index.ts
+++ b/packages/supabase/supabase/functions/recompose-pebble/index.ts
@@ -1,0 +1,99 @@
+/**
+ * Edge function: recompose-pebble
+ *
+ * Client-facing. Takes { pebble_id } and re-runs the compose engine against
+ * an existing pebble owned by the caller. Intended for use after an
+ * update_pebble RPC on the web client, to keep the saved render_svg fresh
+ * when the user edits intensity / valence / emotion / glyph.
+ *
+ * Auth model mirrors compose-pebble:
+ *   1. Auth-forwards the caller's JWT to verify they own the pebble (via RLS
+ *      on the pebbles table — a SELECT returning 0 rows means "not yours").
+ *   2. Uses an admin client only to run compose-and-write (which bypasses
+ *      RLS for the single UPDATE to the render columns).
+ *
+ * This is the auth-forwarded counterpart of backfill-pebble-render (which
+ * requires the service-role bearer token and is ops-only).
+ *
+ * Response: { pebble_id, render_svg, render_manifest, render_version }.
+ * On compose failure: 500 with pebble_id so clients can fall back to the
+ * local engine render for display.
+ */
+
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+
+import { createAuthForwardedClient, createAdminClient } from "../_shared/supabase-client.ts";
+import { composeAndWriteRender } from "../_shared/compose-and-write.ts";
+
+interface RequestBody {
+  pebble_id: string;
+}
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: CORS });
+  }
+  if (req.method !== "POST") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  let body: RequestBody;
+  try {
+    body = await req.json();
+  } catch (err) {
+    console.error("recompose-pebble: body parse failed:", err);
+    return json({ error: "invalid body: not JSON" }, 400);
+  }
+  if (!body || typeof body.pebble_id !== "string") {
+    console.error("recompose-pebble: invalid pebble_id");
+    return json({ error: "invalid pebble_id" }, 400);
+  }
+
+  // Ownership check via RLS: selecting the pebble with the caller's JWT
+  // returns 0 rows if they don't own it (or if it doesn't exist).
+  const authClient = createAuthForwardedClient(req);
+  const { data: ownedPebble, error: ownError } = await authClient
+    .from("pebbles")
+    .select("id")
+    .eq("id", body.pebble_id)
+    .maybeSingle();
+
+  if (ownError) {
+    console.error("recompose-pebble: ownership check failed:", ownError);
+    return json({ error: ownError.message }, 400);
+  }
+  if (!ownedPebble) {
+    return json({ error: "pebble not found" }, 404);
+  }
+
+  const admin = createAdminClient();
+  try {
+    const rendered = await composeAndWriteRender(admin, body.pebble_id);
+    return json({ pebble_id: body.pebble_id, ...rendered }, 200);
+  } catch (err) {
+    console.error("recompose-pebble: compose failed:", err);
+    // Soft-success: pebble exists, compose failed. Return 500 with pebble_id
+    // so the client can fall back to the local engine render for display.
+    return json(
+      {
+        error: `compose failed: ${err instanceof Error ? err.message : String(err)}`,
+        pebble_id: body.pebble_id,
+      },
+      500,
+    );
+  }
+});
+
+// deno-lint-ignore no-explicit-any
+function json(body: any, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...CORS },
+  });
+}

--- a/packages/supabase/supabase/migrations/20260416000000_v_pebbles_full_render_columns.sql
+++ b/packages/supabase/supabase/migrations/20260416000000_v_pebbles_full_render_columns.sql
@@ -1,0 +1,127 @@
+-- Migration: Expose render columns on v_pebbles_full
+--
+-- Migration 20260415000001 added render_svg, render_manifest, render_version
+-- to the pebbles table, but v_pebbles_full (defined in 20260411000002_views.sql)
+-- was never updated to project them. The web client loads pebbles through this
+-- view, so without this change the edge-function-produced render is invisible
+-- to the webapp.
+--
+-- We must DROP + CREATE (not CREATE OR REPLACE) because Postgres refuses to
+-- add new columns to a view via CREATE OR REPLACE.
+
+drop view if exists public.v_pebbles_full;
+
+create view public.v_pebbles_full as
+select
+  p.id,
+  p.user_id,
+  p.name,
+  p.description,
+  p.happened_at,
+  p.intensity,
+  p.positiveness,
+  p.visibility,
+  p.emotion_id,
+  p.glyph_id,
+  p.render_svg,
+  p.render_manifest,
+  p.render_version,
+  p.created_at,
+  p.updated_at,
+
+  -- emotion (1:1, always present)
+  jsonb_build_object(
+    'id',    e.id,
+    'slug',  e.slug,
+    'name',  e.name,
+    'color', e.color
+  ) as emotion,
+
+  -- glyph (1:1, optional)
+  case when g.id is not null then
+    jsonb_build_object(
+      'id',       g.id,
+      'name',     g.name,
+      'shape_id', g.shape_id,
+      'strokes',  g.strokes,
+      'view_box', g.view_box
+    )
+  else null end as glyph,
+
+  -- cards (1:N)
+  coalesce(
+    (select jsonb_agg(
+      jsonb_build_object(
+        'id',         pc.id,
+        'species_id', pc.species_id,
+        'value',      pc.value,
+        'sort_order', pc.sort_order
+      ) order by pc.sort_order
+    )
+    from public.pebble_cards pc
+    where pc.pebble_id = p.id),
+    '[]'::jsonb
+  ) as cards,
+
+  -- souls (N:N)
+  coalesce(
+    (select jsonb_agg(
+      jsonb_build_object(
+        'id',   s.id,
+        'name', s.name
+      ) order by s.name
+    )
+    from public.pebble_souls ps
+    join public.souls s on s.id = ps.soul_id
+    where ps.pebble_id = p.id),
+    '[]'::jsonb
+  ) as souls,
+
+  -- domains (N:N)
+  coalesce(
+    (select jsonb_agg(
+      jsonb_build_object(
+        'id',    d.id,
+        'slug',  d.slug,
+        'name',  d.name,
+        'label', d.label
+      ) order by d.slug
+    )
+    from public.pebble_domains pd
+    join public.domains d on d.id = pd.domain_id
+    where pd.pebble_id = p.id),
+    '[]'::jsonb
+  ) as domains,
+
+  -- snaps (1:N)
+  coalesce(
+    (select jsonb_agg(
+      jsonb_build_object(
+        'id',           sn.id,
+        'storage_path', sn.storage_path,
+        'sort_order',   sn.sort_order
+      ) order by sn.sort_order
+    )
+    from public.snaps sn
+    where sn.pebble_id = p.id),
+    '[]'::jsonb
+  ) as snaps,
+
+  -- collections (N:N)
+  coalesce(
+    (select jsonb_agg(
+      jsonb_build_object(
+        'id',   c.id,
+        'name', c.name,
+        'mode', c.mode
+      ) order by c.name
+    )
+    from public.collection_pebbles cp
+    join public.collections c on c.id = cp.collection_id
+    where cp.pebble_id = p.id),
+    '[]'::jsonb
+  ) as collections
+
+from public.pebbles p
+join public.emotions e on e.id = p.emotion_id
+left join public.glyphs g on g.id = p.glyph_id;


### PR DESCRIPTION
Adapts iOS slice 1 of the remote pebble engine to the Next.js webapp so newly recorded and edited pebbles are composed server-side via the `compose-pebble` edge function and displayed on the path timeline and the detail view — byte-identical to what iOS produces.

Unlike iOS slice 1 (create-only), the webapp also re-composes on update via a new `recompose-pebble` edge function, to keep the saved render fresh when the user edits intensity / valence / emotion / glyph.

## Key files

- **New migration** `packages/supabase/supabase/migrations/20260416000000_v_pebbles_full_render_columns.sql` — DROP + CREATE `v_pebbles_full` to expose `render_svg`, `render_manifest`, `render_version` (needed because Postgres won't add view columns via `CREATE OR REPLACE`).
- **New edge function** `packages/supabase/supabase/functions/recompose-pebble/index.ts` — auth-forwarded counterpart of `backfill-pebble-render`; verifies caller owns the pebble via RLS, then runs the shared `composeAndWriteRender`.
- `apps/web/lib/types.ts` — `Pebble` gets optional `render_svg` / `render_manifest` / `render_version`.
- `apps/web/lib/data/supabase-provider.ts` — `createPebble` now invokes `compose-pebble`; `updatePebble` now re-invokes `recompose-pebble` after the RPC. Both wrapped with `withTimeout(10s)` and handle the soft-success pattern (5xx with `pebble_id`).
- `apps/web/components/pebble/PebbleVisual.tsx` — prefers `pebble.render_svg`, substituting `currentColor` with the emotion hex (matches iOS `PebbleRenderView.swift`). Split into server + local sub-components so `usePebbleVisual` (local engine) is skipped when a server render exists.

## Implementation notes

- Soft-success handling: supabase-js wraps non-2xx responses in a `FunctionsHttpError`; we clone `error.context.response` to recover the `pebble_id` from the 5xx body and fall back to the local engine render in `PebbleVisual`.
- `packages/supabase/types/database.ts` was **not** regenerated in this change — the Supabase CLI isn't available in the environment this was written in. Run `npm run db:types --workspace=packages/supabase` locally after applying the new migration and commit the regenerated file.

## Test plan

- [ ] `npm run db:reset --workspace=packages/supabase` applies the new migration cleanly
- [ ] Recording a pebble on `/record` POSTs to `…/functions/v1/compose-pebble` and returns `render_svg`
- [ ] The new pebble appears on `/path` with the server-composed SVG, tinted with the emotion color
- [ ] Opening the detail view (`/pebble/[id]` or `PebblePeek`) shows the same SVG at detail tier
- [ ] Editing intensity / valence / emotion / glyph on an existing pebble POSTs to `…/functions/v1/recompose-pebble` and updates the DB render columns
- [ ] Soft-success sanity: forcing a compose error leaves the pebble visible via the local engine fallback
- [ ] `npm run lint` and `npm run build` pass

Not included (deferred): `render_manifest` animation playback, SSR of pebble SVG, storage of `snaps`/instants via the edge function.
