### PR TITLE
feat(ui): display pebble render in path

### DIFF
--- a/apps/ios/Pebbles/Features/Path/Models/Pebble.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/Pebble.swift
@@ -4,10 +4,23 @@ struct Pebble: Identifiable, Decodable, Hashable {
     let id: UUID
     let name: String
     let happenedAt: Date
+    let renderSvg: String?
+    let emotion: EmotionRef?
 
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case id
         case name
         case happenedAt = "happened_at"
+        case renderSvg = "render_svg"
+        case emotion
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.happenedAt = try container.decode(Date.self, forKey: .happenedAt)
+        self.renderSvg = try container.decodeIfPresent(String.self, forKey: .renderSvg)
+        self.emotion = try container.decodeIfPresent(EmotionRef.self, forKey: .emotion)
     }
 }

--- a/apps/ios/Pebbles/Features/Path/Models/Pebble.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/Pebble.swift
@@ -14,13 +14,4 @@ struct Pebble: Identifiable, Decodable, Hashable {
         case renderSvg = "render_svg"
         case emotion
     }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.id = try container.decode(UUID.self, forKey: .id)
-        self.name = try container.decode(String.self, forKey: .name)
-        self.happenedAt = try container.decode(Date.self, forKey: .happenedAt)
-        self.renderSvg = try container.decodeIfPresent(String.self, forKey: .renderSvg)
-        self.emotion = try container.decodeIfPresent(EmotionRef.self, forKey: .emotion)
-    }
 }

--- a/apps/ios/Pebbles/Features/Path/PathView.swift
+++ b/apps/ios/Pebbles/Features/Path/PathView.swift
@@ -57,11 +57,14 @@ struct PathView: View {
                         Button {
                             selectedPebbleId = pebble.id
                         } label: {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(pebble.name).font(.body)
-                                Text(pebble.happenedAt, style: .date)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+                            HStack(spacing: 12) {
+                                pebbleThumbnail(for: pebble)
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(pebble.name).font(.body)
+                                    Text(pebble.happenedAt, style: .date)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
                             }
                         }
                         .buttonStyle(.plain)
@@ -71,11 +74,23 @@ struct PathView: View {
         }
     }
 
+    @ViewBuilder
+    private func pebbleThumbnail(for pebble: Pebble) -> some View {
+        if let svg = pebble.renderSvg {
+            PebbleRenderView(svg: svg, strokeColor: pebble.emotion?.color)
+                .frame(width: 40, height: 40)
+        } else {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color.secondary.opacity(0.15))
+                .frame(width: 40, height: 40)
+        }
+    }
+
     private func load() async {
         do {
             let result: [Pebble] = try await supabase.client
                 .from("pebbles")
-                .select("id, name, happened_at")
+                .select("id, name, happened_at, render_svg, emotion:emotions(id, name, color)")
                 .order("happened_at", ascending: false)
                 .execute()
                 .value

--- a/docs/superpowers/plans/2026-04-17-ios-path-pebble-render.md
+++ b/docs/superpowers/plans/2026-04-17-ios-path-pebble-render.md
@@ -1,0 +1,231 @@
+# Display Pebble Render in Path — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show each pebble's server-composed SVG visual, colored by the pebble's emotion, as a 40×40 leading thumbnail in every row of the Path list. Edited pebbles refresh automatically when returning to Path.
+
+**Architecture:** Extend the `Pebble` model with `renderSvg: String?` and `emotion: EmotionRef?` and update `PathView`'s PostgREST select to pull them. Replace the row's `VStack` with an `HStack` that leads with `PebbleRenderView` (or a placeholder `RoundedRectangle` when the SVG is missing). Existing refresh-after-sheet-dismiss wiring covers the edit-refresh acceptance criterion.
+
+**Tech Stack:** SwiftUI, iOS 17+, SVGView (exyte), Supabase Swift client (PostgREST)
+
+**Spec:** `docs/superpowers/specs/2026-04-17-ios-path-pebble-render-design.md`
+
+**Branch:** `feat/276-path-pebble-render`
+
+---
+
+### File Map
+
+- **Modify:** `apps/ios/Pebbles/Features/Path/Models/Pebble.swift` — add `renderSvg` + `emotion` fields with nested-emotion decoding
+- **Modify:** `apps/ios/Pebbles/Features/Path/PathView.swift` — extend select; replace row `VStack` with `HStack` containing leading visual
+
+---
+
+### Task 1: Extend `Pebble` model
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/Models/Pebble.swift`
+
+- [ ] **Step 1: Add fields and custom decoder**
+
+The existing struct uses synthesized `Decodable`. We need to decode a nested `emotion:emotions(...)` relation, which requires a custom `init(from:)` that pulls the color from the nested object. Reuse the established `EmotionRef` type already defined in `PebbleDetail.swift` (id/name/color) — consistent with how `EditPebbleSheet` / `PebbleDetailSheet` handle nested emotion.
+
+Replace the file contents with:
+
+```swift
+import Foundation
+
+struct Pebble: Identifiable, Decodable, Hashable {
+    let id: UUID
+    let name: String
+    let happenedAt: Date
+    let renderSvg: String?
+    let emotion: EmotionRef?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case happenedAt = "happened_at"
+        case renderSvg = "render_svg"
+        case emotion
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.happenedAt = try container.decode(Date.self, forKey: .happenedAt)
+        self.renderSvg = try container.decodeIfPresent(String.self, forKey: .renderSvg)
+        self.emotion = try container.decodeIfPresent(EmotionRef.self, forKey: .emotion)
+    }
+}
+```
+
+Both `renderSvg` and `emotion` are optional: `render_svg` can be `NULL` when the `compose-pebble` edge function fails (soft-success path), and we want Path to survive that rather than crash the list.
+
+---
+
+### Task 2: Update Path query to fetch SVG + emotion color
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/PathView.swift` (lines 74-89)
+
+- [ ] **Step 1: Change the PostgREST select**
+
+Replace the current `load()` implementation:
+
+```swift
+private func load() async {
+    do {
+        let result: [Pebble] = try await supabase.client
+            .from("pebbles")
+            .select("id, name, happened_at, render_svg, emotion:emotions(id, name, color)")
+            .order("happened_at", ascending: false)
+            .execute()
+            .value
+        self.pebbles = result
+        self.isLoading = false
+    } catch {
+        logger.error("path fetch failed: \(error.localizedDescription, privacy: .private)")
+        self.loadError = "Couldn't load your pebbles."
+        self.isLoading = false
+    }
+}
+```
+
+The new select fields (`render_svg`, nested `emotion`) come back as part of the same round-trip. Error handling is unchanged.
+
+- [ ] **Step 2: Build to verify decoding compiles**
+
+Run: `npm run build --workspace=@pbbls/ios 2>&1 | tail -30`
+
+Expected: BUILD SUCCEEDED. (The row body still uses only `pebble.name` and `pebble.happenedAt`, so no call-site errors yet — we're verifying the model + query compile cleanly before touching the UI.)
+
+---
+
+### Task 3: Replace row `VStack` with `HStack` + leading visual
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/PathView.swift` (lines 55-69)
+
+- [ ] **Step 1: Refactor the row body**
+
+Replace the `Section("Path") { ... }` block with:
+
+```swift
+Section("Path") {
+    ForEach(pebbles) { pebble in
+        Button {
+            selectedPebbleId = pebble.id
+        } label: {
+            HStack(spacing: 12) {
+                pebbleThumbnail(for: pebble)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(pebble.name).font(.body)
+                    Text(pebble.happenedAt, style: .date)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+```
+
+- [ ] **Step 2: Add the thumbnail helper**
+
+Add this `@ViewBuilder` method inside `PathView`, next to the existing `content` computed property:
+
+```swift
+@ViewBuilder
+private func pebbleThumbnail(for pebble: Pebble) -> some View {
+    if let svg = pebble.renderSvg {
+        PebbleRenderView(svg: svg, strokeColor: pebble.emotion?.color)
+            .frame(width: 40, height: 40)
+    } else {
+        RoundedRectangle(cornerRadius: 6)
+            .fill(Color.secondary.opacity(0.15))
+            .frame(width: 40, height: 40)
+    }
+}
+```
+
+`PebbleRenderView` already handles `strokeColor: nil` by skipping the `currentColor` replacement, so passing `pebble.emotion?.color` directly is safe even when emotion is missing. The placeholder branch keeps row height stable for the soft-success case.
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build --workspace=@pbbls/ios 2>&1 | tail -30`
+
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 4: Lint**
+
+Run: `npm run lint --workspace=@pbbls/ios 2>&1 | tail -20`
+
+Expected: no new violations introduced by the change. (Pre-existing warnings elsewhere in the package may remain — only regressions in the files you touched are blockers.)
+
+---
+
+### Task 4: Manual QA in the iOS simulator
+
+Required before shipping — the build tells us the code compiles, not that it looks right.
+
+- [ ] **Step 1: Run the app on the iPhone 17 simulator**
+
+Open the generated `.xcodeproj` in Xcode and run, or use the CLI:
+
+```bash
+cd apps/ios && xcodebuild -scheme Pebbles -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug build
+```
+
+Then launch the resulting `.app` in Simulator.app, or run directly from Xcode with ⌘R.
+
+- [ ] **Step 2: Verify the golden path**
+
+Sign in and navigate to Path. Confirm:
+- Every row shows a 40×40 pebble visual on the leading edge.
+- Each visual is stroked in the emotion's color (should differ per pebble based on the emotion assigned).
+- Name and date remain legible and aligned with the visual's vertical center.
+- Tapping a row still opens the edit sheet.
+
+- [ ] **Step 3: Verify the refresh-on-edit flow**
+
+- Tap a pebble → edit sheet opens.
+- Change the name (keeping the same emotion) → save.
+- Confirm the path row's text updates. The visual should remain unchanged (same `render_svg` on the server).
+- Open the same pebble again and change the emotion → save.
+- Confirm the path row's text and color refresh. (If color does not refresh, it means the server did not re-stroke on edit — this is expected per the spec's "non-goals"; recomposition on edit is out of scope for #276.)
+
+- [ ] **Step 4: Verify the soft-success fallback**
+
+If you have (or can create) a pebble where `render_svg` is `NULL` in the DB, confirm the row renders a subtle empty rounded-rect placeholder instead of crashing or collapsing the row height. If no such pebble exists, skip this step and note it in the PR body.
+
+---
+
+### Task 5: Commit
+
+- [ ] **Step 1: Stage and commit both files**
+
+```bash
+git add apps/ios/Pebbles/Features/Path/Models/Pebble.swift apps/ios/Pebbles/Features/Path/PathView.swift
+git commit -m "feat(ui): display pebble render in path (#276)"
+```
+
+- [ ] **Step 2: Push and open PR**
+
+```bash
+git push -u origin feat/276-path-pebble-render
+```
+
+Follow the project's PR workflow (title `feat(ui): display pebble render in path`, body starts with `Resolves #276`, inherit labels `feat` + `ios` + `ui` and milestone `M23 · TestFlight V1` from the issue — confirm with user before opening).
+
+---
+
+## Out of scope reminders (do NOT implement here)
+
+- Server-side recomposition when editing a pebble's emotion or valence.
+- Animation of the pebble visual.
+- Changes to `PebbleRenderView` itself (it's already frame-agnostic).
+- Any redesign of Path rows beyond adding the leading visual.
+- Pagination / prefetch / caching of SVG strings.

--- a/docs/superpowers/specs/2026-04-17-ios-path-pebble-render-design.md
+++ b/docs/superpowers/specs/2026-04-17-ios-path-pebble-render-design.md
@@ -21,7 +21,7 @@ Show each pebble's visual (the server-composed SVG, colored by the pebble's emot
 ## Current state (reference)
 
 - `apps/ios/Pebbles/Features/Path/PathView.swift` — Path list. Each row is a `Button` wrapping `VStack(name, date)`. Query selects `id, name, happened_at` only. `load()` is invoked from `.task` and after create/edit sheets dismiss.
-- `apps/ios/Pebbles/Features/Path/PebbleRenderView.swift` — SwiftUI view that takes `svg: String` + `strokeColor: String?`, replaces `currentColor` tokens, and renders via `SVGView` at a hardcoded `.frame(width: 260, height: 260)`.
+- `apps/ios/Pebbles/Features/Path/PebbleRenderView.swift` — SwiftUI view that takes `svg: String` + `strokeColor: String?`, replaces `currentColor` tokens, and renders via `SVGView` with `.aspectRatio(contentMode: .fit)`. The view does not set its own frame; call sites size it via `.frame(width:height:)`.
 - Emotion color is stored on `emotions.color` (hex string). It is not on `pebbles`; the Path query does not currently join emotions.
 - `pebbles.render_svg` is populated by the `compose-pebble` edge function on create. It can be `NULL` when compose failed (soft-success path).
 
@@ -70,19 +70,9 @@ Replace the current `VStack(name, date)` with an `HStack`:
 
 40pt matches the combined height of `.body` + `.caption` text, keeping rows compact (per option A confirmed during brainstorming).
 
-### 3. `PebbleRenderView` size parameter
+### 3. Sizing
 
-`PebbleRenderView` currently hardcodes `.frame(width: 260, height: 260)`. Add a `size: CGFloat` parameter with a default of `260` so existing call sites (Create/Edit/Detail sheets) remain unchanged. Path passes `size: 40`.
-
-```swift
-struct PebbleRenderView: View {
-    let svg: String
-    var strokeColor: String?
-    var size: CGFloat = 260
-    // ...
-    .frame(width: size, height: size)
-}
-```
+`PebbleRenderView` is already frame-agnostic — callers apply `.frame()`. Path applies `.frame(width: 40, height: 40)` at the call site. No change to `PebbleRenderView` itself.
 
 ### 4. Fallbacks
 
@@ -96,7 +86,6 @@ No new plumbing required. `PathView` already calls `load()` when the create and 
 ## Files to change
 
 - `apps/ios/Pebbles/Features/Path/PathView.swift` — update query, extend `Pebble` struct, refactor row to `HStack` with leading `PebbleRenderView`, handle fallbacks.
-- `apps/ios/Pebbles/Features/Path/PebbleRenderView.swift` — add `size: CGFloat = 260` parameter.
 
 ## Risks / open items
 

--- a/docs/superpowers/specs/2026-04-17-ios-path-pebble-render-design.md
+++ b/docs/superpowers/specs/2026-04-17-ios-path-pebble-render-design.md
@@ -33,22 +33,23 @@ Extend the Path query to pull SVG + emotion color in a single round-trip:
 
 ```swift
 .from("pebbles")
-.select("id, name, happened_at, render_svg, emotion:emotions(color)")
+.select("id, name, happened_at, render_svg, emotion:emotions(id, name, color)")
 .order("happened_at", ascending: false)
 ```
 
-The `Pebble` struct used by `PathView` gains two optional fields:
+The `Pebble` struct used by `PathView` gains two optional fields and a custom decoder for the nested emotion relation:
 
 ```swift
 struct Pebble: Identifiable, Decodable, Hashable {
     let id: UUID
     let name: String
     let happenedAt: Date
-    let renderSvg: String?      // nil when compose-pebble failed
-    let emotionColor: String?   // nil if the emotion row has no color
-    // nested decoding helper for `emotion:emotions(color)` → emotionColor
+    let renderSvg: String?   // nil when compose-pebble failed (soft-success)
+    let emotion: EmotionRef? // nil if the pebble's emotion_id is null
 }
 ```
+
+`EmotionRef` is already defined in `PebbleDetail.swift` (id, name, color) for the detail sheet's restricted select. Reusing it here keeps the two screens consistent and avoids a parallel single-field struct. The select mirrors `EditPebbleSheet`'s `emotion:emotions(id, name, color)` exactly.
 
 Rationale: one round-trip beats lazy per-row loading. The list is short (pre-pagination), and rendering rows piecemeal as SVG strings stream in would feel janky.
 

--- a/docs/superpowers/specs/2026-04-17-ios-path-pebble-render-design.md
+++ b/docs/superpowers/specs/2026-04-17-ios-path-pebble-render-design.md
@@ -1,0 +1,104 @@
+# iOS — Display pebble render in Path list
+
+**Issue:** [#276](https://github.com/bohns/pbbls/issues/276) · `ios` · `ui` · M23
+
+## Goal
+
+Show each pebble's visual (the server-composed SVG, colored by the pebble's emotion) as a small leading thumbnail inside every row of the Path list. When a pebble is edited and the user returns to Path, the refreshed visual must reflect any changes.
+
+## Acceptance
+
+- As a user with pebbles, when I'm on the Path, I see the pebble visual for each item.
+- As a user edits an existing pebble, when I return to the Path, the edited pebble's visual is refreshed.
+
+## Non-goals
+
+- Server-side recomposition when an edit changes emotion or valence. This issue renders whatever `render_svg` the server currently stores; triggering `compose-pebble` on edit is tracked separately.
+- Animation of the pebble visual (slice 1 — static render only).
+- Any redesign of Path rows beyond adding the leading visual.
+- Pagination, prefetching, or caching of SVG strings.
+
+## Current state (reference)
+
+- `apps/ios/Pebbles/Features/Path/PathView.swift` — Path list. Each row is a `Button` wrapping `VStack(name, date)`. Query selects `id, name, happened_at` only. `load()` is invoked from `.task` and after create/edit sheets dismiss.
+- `apps/ios/Pebbles/Features/Path/PebbleRenderView.swift` — SwiftUI view that takes `svg: String` + `strokeColor: String?`, replaces `currentColor` tokens, and renders via `SVGView` at a hardcoded `.frame(width: 260, height: 260)`.
+- Emotion color is stored on `emotions.color` (hex string). It is not on `pebbles`; the Path query does not currently join emotions.
+- `pebbles.render_svg` is populated by the `compose-pebble` edge function on create. It can be `NULL` when compose failed (soft-success path).
+
+## Design
+
+### 1. Data layer
+
+Extend the Path query to pull SVG + emotion color in a single round-trip:
+
+```swift
+.from("pebbles")
+.select("id, name, happened_at, render_svg, emotion:emotions(color)")
+.order("happened_at", ascending: false)
+```
+
+The `Pebble` struct used by `PathView` gains two optional fields:
+
+```swift
+struct Pebble: Identifiable, Decodable, Hashable {
+    let id: UUID
+    let name: String
+    let happenedAt: Date
+    let renderSvg: String?      // nil when compose-pebble failed
+    let emotionColor: String?   // nil if the emotion row has no color
+    // nested decoding helper for `emotion:emotions(color)` → emotionColor
+}
+```
+
+Rationale: one round-trip beats lazy per-row loading. The list is short (pre-pagination), and rendering rows piecemeal as SVG strings stream in would feel janky.
+
+### 2. Row layout
+
+Replace the current `VStack(name, date)` with an `HStack`:
+
+- Leading: `PebbleRenderView` sized 40×40.
+- Spacing: 12pt.
+- Trailing: existing `VStack(alignment: .leading) { name; date }`.
+- Outer `Button { selectedPebbleId = pebble.id }` wraps the whole row, `buttonStyle(.plain)` preserved.
+
+```
+┌─────────────────────────────────────────┐
+│  [▣]   Pebble name                      │
+│  40pt  Apr 17, 2026                     │
+└─────────────────────────────────────────┘
+```
+
+40pt matches the combined height of `.body` + `.caption` text, keeping rows compact (per option A confirmed during brainstorming).
+
+### 3. `PebbleRenderView` size parameter
+
+`PebbleRenderView` currently hardcodes `.frame(width: 260, height: 260)`. Add a `size: CGFloat` parameter with a default of `260` so existing call sites (Create/Edit/Detail sheets) remain unchanged. Path passes `size: 40`.
+
+```swift
+struct PebbleRenderView: View {
+    let svg: String
+    var strokeColor: String?
+    var size: CGFloat = 260
+    // ...
+    .frame(width: size, height: size)
+}
+```
+
+### 4. Fallbacks
+
+- **`renderSvg == nil`:** render a 40×40 `RoundedRectangle` filled with a subtle surface color (no icon, no text) inline in the row via an `if let` branch. Keeps row height stable without drawing attention to the missing visual and avoids spawning a single-use placeholder view.
+- **`emotionColor == nil`:** pass `strokeColor: nil` to `PebbleRenderView`. The existing implementation already handles this by skipping the `currentColor` replacement.
+
+### 5. Refresh on edit
+
+No new plumbing required. `PathView` already calls `load()` when the create and edit sheets dismiss. Since the same query now pulls `render_svg` and emotion color, the refreshed array naturally includes any server-stored updates. Acceptance criterion 2 is satisfied by the existing pattern.
+
+## Files to change
+
+- `apps/ios/Pebbles/Features/Path/PathView.swift` — update query, extend `Pebble` struct, refactor row to `HStack` with leading `PebbleRenderView`, handle fallbacks.
+- `apps/ios/Pebbles/Features/Path/PebbleRenderView.swift` — add `size: CGFloat = 260` parameter.
+
+## Risks / open items
+
+- SVG rendering performance at 40pt across a list of N rows: untested at list density. If scroll performance degrades with many pebbles, revisit (cache rendered images, or switch to `Image`-backed raster rendering). Not a blocker for shipping this issue; flag if observed during testing.
+- The soft-success case (pebble exists without `render_svg`) will now be visually apparent as a blank placeholder in Path — previously invisible. Expected behavior.


### PR DESCRIPTION
Resolves #276

## Summary
- Show each pebble's server-composed SVG visual, colored by the pebble's emotion, as a 40×40 leading thumbnail in every row of the Path list.
- Extend the `Pebble` model with `renderSvg: String?` and `emotion: EmotionRef?`; extend Path's PostgREST select to pull both in a single round-trip.
- Replace the row `VStack` with an `HStack` + `pebbleThumbnail(for:)` helper. Fall back to a subtle rounded-rect placeholder when `render_svg` is null (soft-success case).

## Files changed
- `apps/ios/Pebbles/Features/Path/Models/Pebble.swift` — new optional `renderSvg` + `emotion` fields (reuses `EmotionRef` from `PebbleDetail.swift`).
- `apps/ios/Pebbles/Features/Path/PathView.swift` — extended select, row refactored to `HStack`, new `pebbleThumbnail(for:)` `@ViewBuilder`.

## Implementation notes
- `PebbleRenderView` is already frame-agnostic; the 40×40 sizing is applied at the call site, no changes to the view itself.
- Refresh-on-edit falls out of the existing `load()`-after-sheet-dismiss wiring — the same query now pulls the refreshed `render_svg` + emotion color, no new plumbing.
- Server-side recomposition when an edit changes emotion or valence is explicitly out of scope (tracked separately).

## Test plan
- [x] `npm run build --workspace=@pbbls/ios` passes
- [x] `npm run lint --workspace=@pbbls/ios` — 0 violations
- [x] Manual QA in iPhone 17 simulator: thumbnails render per row, emotion color applied, tap opens edit sheet, edits refresh row on return, null-`render_svg` rows show placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)