### PR TITLE
feat(ios): attribute a glyph to souls (#298)

### DIFF
--- a/apps/ios/Pebbles/Features/Glyph/Utils/SystemGlyph.swift
+++ b/apps/ios/Pebbles/Features/Glyph/Utils/SystemGlyph.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// UUIDs for the system glyphs seeded server-side (migration
+/// `20260415000001_remote_pebble_engine.sql` and re-asserted by
+/// `20260426000000_add_glyph_to_souls.sql`).
+///
+/// `default` is the canonical fallback used when a soul or domain has no
+/// user-carved glyph attached. iOS uses it to seed `SoulDraft.glyphId`
+/// when creating a new soul, and the migration uses it as the column default.
+enum SystemGlyph {
+    static let `default` = UUID(uuidString: "4759c37c-68a6-46a6-b4fc-046bd0316752")!
+}

--- a/apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
@@ -87,7 +87,7 @@ struct CreatePebbleSheet: View {
                 .value
             async let soulsQuery: [Soul] = supabase.client
                 .from("souls")
-                .select("id, name")
+                .select("id, name, glyph_id")
                 .order("name")
                 .execute()
                 .value

--- a/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
@@ -99,7 +99,7 @@ struct EditPebbleSheet: View {
                     render_svg, render_version, glyph_id,
                     emotion:emotions(id, slug, name, color),
                     pebble_domains(domain:domains(id, slug, name)),
-                    pebble_souls(soul:souls(id, name)),
+                    pebble_souls(soul:souls(id, name, glyph_id)),
                     collection_pebbles(collection:collections(id, name))
                 """)
                 .eq("id", value: pebbleId)

--- a/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
@@ -121,7 +121,7 @@ struct EditPebbleSheet: View {
                 .value
             async let soulsQuery: [Soul] = supabase.client
                 .from("souls")
-                .select("id, name")
+                .select("id, name, glyph_id")
                 .order("name")
                 .execute()
                 .value

--- a/apps/ios/Pebbles/Features/Path/Models/Soul.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/Soul.swift
@@ -3,4 +3,11 @@ import Foundation
 struct Soul: Identifiable, Decodable, Hashable {
     let id: UUID
     let name: String
+    let glyphId: UUID
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case glyphId = "glyph_id"
+    }
 }

--- a/apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift
@@ -89,7 +89,7 @@ struct PebbleDetailSheet: View {
                     render_svg, render_version,
                     emotion:emotions(id, slug, name, color),
                     pebble_domains(domain:domains(id, slug, name)),
-                    pebble_souls(soul:souls(id, name)),
+                    pebble_souls(soul:souls(id, name, glyph_id)),
                     collection_pebbles(collection:collections(id, name))
                 """)
                 .eq("id", value: pebbleId)

--- a/apps/ios/Pebbles/Features/Profile/Lists/SoulGridCell.swift
+++ b/apps/ios/Pebbles/Features/Profile/Lists/SoulGridCell.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// One cell in the Souls 3-column grid. Square glyph thumbnail above a
+/// single-line truncating name. Tap target wraps the entire cell — tap
+/// behaviour is owned by the parent `NavigationLink`, this view is purely
+/// visual.
+struct SoulGridCell: View {
+    let soul: SoulWithGlyph
+
+    var body: some View {
+        VStack(spacing: 8) {
+            GlyphThumbnail(strokes: soul.glyph.strokes, side: 96)
+                .accessibilityHidden(true)
+            Text(soul.name)
+                .font(.callout)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(soul.name)
+    }
+}
+
+#Preview {
+    SoulGridCell(
+        soul: SoulWithGlyph(
+            id: UUID(),
+            name: "Preview Soul",
+            glyphId: SystemGlyph.default,
+            glyph: Glyph(
+                id: SystemGlyph.default,
+                name: nil,
+                strokes: [GlyphStroke(d: "M30,30 L170,170", width: 6)],
+                viewBox: "0 0 200 200"
+            )
+        )
+    )
+    .padding()
+}

--- a/apps/ios/Pebbles/Features/Profile/Lists/SoulsListView.swift
+++ b/apps/ios/Pebbles/Features/Profile/Lists/SoulsListView.swift
@@ -3,14 +3,16 @@ import os
 
 struct SoulsListView: View {
     @Environment(SupabaseService.self) private var supabase
-    @State private var items: [Soul] = []
+    @State private var items: [SoulWithGlyph] = []
     @State private var isLoading = true
     @State private var loadError: String?
     @State private var isPresentingCreate = false
-    @State private var pendingDeletion: Soul?
+    @State private var pendingDeletion: SoulWithGlyph?
     @State private var deleteError: String?
 
     private let logger = Logger(subsystem: "app.pbbls.ios", category: "profile.souls")
+
+    private let columns = [GridItem(.adaptive(minimum: 96), spacing: 16)]
 
     var body: some View {
         content
@@ -83,24 +85,27 @@ struct SoulsListView: View {
                 description: Text("People and beings you tag on your pebbles will appear here.")
             )
         } else {
-            List {
-                ForEach(items) { soul in
-                    NavigationLink {
-                        SoulDetailView(soul: soul, onChanged: {
-                            Task { await load() }
-                        })
-                    } label: {
-                        Text(soul.name)
-                    }
-                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                        Button(role: .destructive) {
-                            pendingDeletion = soul
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 16) {
+                    ForEach(items) { item in
+                        NavigationLink {
+                            SoulDetailView(initial: item, onChanged: {
+                                Task { await load() }
+                            })
                         } label: {
-                            Label("Delete", systemImage: "trash")
+                            SoulGridCell(soul: item)
+                        }
+                        .buttonStyle(.plain)
+                        .contextMenu {
+                            Button(role: .destructive) {
+                                pendingDeletion = item
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
                         }
                     }
-                    .listRowBackground(Color.pebblesListRow)
                 }
+                .padding()
             }
         }
     }
@@ -109,10 +114,10 @@ struct SoulsListView: View {
         isLoading = true
         loadError = nil
         do {
-            let result: [Soul] = try await supabase.client
+            let result: [SoulWithGlyph] = try await supabase.client
                 .from("souls")
-                .select("id, name")
-                .order("name")
+                .select("id, name, glyph_id, glyphs(id, name, strokes, view_box)")
+                .order("name", ascending: true)
                 .execute()
                 .value
             self.items = result
@@ -123,7 +128,7 @@ struct SoulsListView: View {
         self.isLoading = false
     }
 
-    private func delete(_ soul: Soul) async {
+    private func delete(_ soul: SoulWithGlyph) async {
         pendingDeletion = nil
         do {
             try await supabase.client

--- a/apps/ios/Pebbles/Features/Profile/Models/SoulDraft.swift
+++ b/apps/ios/Pebbles/Features/Profile/Models/SoulDraft.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// In-progress form state for the create/edit-soul sheets.
+/// A value type held in `@State`. `currentGlyph` is the in-memory cache
+/// so the form's thumbnail row renders without a glyph-by-id refetch
+/// after the picker returns a selection.
+struct SoulDraft {
+    var name: String = ""
+    var glyphId: UUID = SystemGlyph.default
+    var currentGlyph: Glyph?
+
+    /// True when every mandatory field is set.
+    var isValid: Bool {
+        !name.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+}
+
+extension SoulDraft {
+    /// Build a prefilled draft from a fetched `SoulWithGlyph`.
+    /// Used by `EditSoulSheet` to populate the form with current values.
+    init(from soulWithGlyph: SoulWithGlyph) {
+        self.name = soulWithGlyph.name
+        self.glyphId = soulWithGlyph.glyphId
+        self.currentGlyph = soulWithGlyph.glyph
+    }
+}

--- a/apps/ios/Pebbles/Features/Profile/Models/SoulPayloads.swift
+++ b/apps/ios/Pebbles/Features/Profile/Models/SoulPayloads.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Body for `INSERT INTO public.souls`. RLS requires `user_id` to match
+/// `auth.uid()`, so the sheet supplies it from the active session.
+struct SoulInsertPayload: Encodable {
+    let userId: UUID
+    let name: String
+    let glyphId: UUID
+
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case name
+        case glyphId = "glyph_id"
+    }
+}
+
+/// Body for `UPDATE public.souls SET ... WHERE id = ?`. Owned by the
+/// caller — `id` is supplied via the `.eq("id", value:)` filter, not in the body.
+struct SoulUpdatePayload: Encodable {
+    let name: String
+    let glyphId: UUID
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case glyphId = "glyph_id"
+    }
+}

--- a/apps/ios/Pebbles/Features/Profile/Models/SoulWithGlyph.swift
+++ b/apps/ios/Pebbles/Features/Profile/Models/SoulWithGlyph.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// A soul together with its joined glyph, decoded from a single PostgREST
+/// request:
+///
+///     supabase.from("souls")
+///         .select("id, name, glyph_id, glyphs(id, strokes, view_box)")
+///
+/// PostgREST nests the joined row under the relation name (`glyphs`).
+struct SoulWithGlyph: Identifiable, Decodable, Hashable {
+    let id: UUID
+    let name: String
+    let glyphId: UUID
+    let glyph: Glyph
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case glyphId = "glyph_id"
+        case glyph = "glyphs"
+    }
+
+    /// Convenience for code paths that already hold a `Soul` and need to
+    /// drop the joined glyph (e.g. passing into `EditSoulSheet` which only
+    /// needs the `Soul` shape).
+    var soul: Soul {
+        Soul(id: id, name: name, glyphId: glyphId)
+    }
+}

--- a/apps/ios/Pebbles/Features/Profile/Sheets/CreateSoulSheet.swift
+++ b/apps/ios/Pebbles/Features/Profile/Sheets/CreateSoulSheet.swift
@@ -81,19 +81,6 @@ struct CreateSoulSheet: View {
     }
 }
 
-/// Matches the `souls` row shape required for insert.
-/// `user_id` is explicit because the RLS policy still requires it in the row
-/// (the policy's `with check` compares it to `auth.uid()`).
-private struct SoulInsertPayload: Encodable {
-    let userId: UUID
-    let name: String
-
-    enum CodingKeys: String, CodingKey {
-        case userId = "user_id"
-        case name
-    }
-}
-
 #Preview {
     CreateSoulSheet(onCreated: {})
         .environment(SupabaseService())

--- a/apps/ios/Pebbles/Features/Profile/Sheets/CreateSoulSheet.swift
+++ b/apps/ios/Pebbles/Features/Profile/Sheets/CreateSoulSheet.swift
@@ -1,31 +1,36 @@
 import SwiftUI
 import os
 
-/// Sheet for creating a new soul. One text field, save/cancel toolbar.
+/// Sheet for creating a new soul. Name + glyph row, save/cancel toolbar.
 /// INSERT goes directly to `public.souls` — RLS scopes to the current user.
+/// `glyph_id` is initialised to the system default; the user can swap it
+/// via `GlyphPickerSheet` (which itself can carve a fresh glyph).
 struct CreateSoulSheet: View {
     let onCreated: () -> Void
 
     @Environment(SupabaseService.self) private var supabase
     @Environment(\.dismiss) private var dismiss
 
-    @State private var name: String = ""
+    @State private var draft = SoulDraft()
     @State private var isSaving = false
     @State private var saveError: String?
+    @State private var isPresentingPicker = false
 
     private let logger = Logger(subsystem: "app.pbbls.ios", category: "profile.souls")
-
-    private var trimmedName: String {
-        name.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
 
     var body: some View {
         NavigationStack {
             Form {
                 Section {
-                    TextField("Name", text: $name)
+                    TextField("Name", text: $draft.name)
                         .textInputAutocapitalization(.words)
                         .autocorrectionDisabled(false)
+                }
+                Section("Glyph") {
+                    GlyphRow(
+                        glyph: draft.currentGlyph,
+                        onTap: { isPresentingPicker = true }
+                    )
                 }
                 if let saveError {
                     Section {
@@ -48,16 +53,55 @@ struct CreateSoulSheet: View {
                         Button("Save") {
                             Task { await save() }
                         }
-                        .disabled(trimmedName.isEmpty)
+                        .disabled(!draft.isValid)
                     }
                 }
             }
             .pebblesScreen()
+            .task { await loadDefaultGlyph() }
+            .sheet(isPresented: $isPresentingPicker) {
+                GlyphPickerSheet(
+                    currentGlyphId: draft.glyphId,
+                    onSelected: { selected in
+                        // Picker returns the chosen glyph's id. Update draft
+                        // and refetch the glyph so the row's thumbnail
+                        // re-renders without waiting for a list reload.
+                        if let selected {
+                            draft.glyphId = selected
+                            Task { await loadGlyph(id: selected) }
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    private func loadDefaultGlyph() async {
+        // Idempotent: only fetch if we still hold the system default and
+        // haven't already loaded its strokes.
+        guard draft.glyphId == SystemGlyph.default,
+              draft.currentGlyph?.id != SystemGlyph.default else { return }
+        await loadGlyph(id: SystemGlyph.default)
+    }
+
+    private func loadGlyph(id: UUID) async {
+        do {
+            let fetched: Glyph = try await supabase.client
+                .from("glyphs")
+                .select("id, name, strokes, view_box")
+                .eq("id", value: id)
+                .single()
+                .execute()
+                .value
+            draft.currentGlyph = fetched
+        } catch {
+            logger.error("create soul: load glyph failed: \(error.localizedDescription, privacy: .private)")
+            // Leave currentGlyph as-is; the empty thumbnail still works as a tap target.
         }
     }
 
     private func save() async {
-        guard !trimmedName.isEmpty else { return }
+        guard draft.isValid else { return }
         guard let userId = supabase.session?.user.id else {
             logger.error("create soul: no session")
             saveError = "You're signed out. Please sign in again."
@@ -66,7 +110,11 @@ struct CreateSoulSheet: View {
         isSaving = true
         saveError = nil
         do {
-            let payload = SoulInsertPayload(userId: userId, name: trimmedName)
+            let payload = SoulInsertPayload(
+                userId: userId,
+                name: draft.name.trimmingCharacters(in: .whitespacesAndNewlines),
+                glyphId: draft.glyphId
+            )
             try await supabase.client
                 .from("souls")
                 .insert(payload)
@@ -78,6 +126,36 @@ struct CreateSoulSheet: View {
             saveError = "Couldn't save the soul. Please try again."
             isSaving = false
         }
+    }
+}
+
+/// Row used by both create and edit soul sheets. Shows the current glyph
+/// thumbnail (or a dashed placeholder when not yet loaded) + label + chevron.
+private struct GlyphRow: View {
+    let glyph: Glyph?
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 12) {
+                if let glyph {
+                    GlyphThumbnail(strokes: glyph.strokes, side: 32)
+                        .accessibilityHidden(true)
+                } else {
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(style: StrokeStyle(lineWidth: 1, dash: [3]))
+                        .frame(width: 32, height: 32)
+                        .foregroundStyle(.secondary)
+                }
+                Text("Tap to choose")
+                    .foregroundStyle(.primary)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/apps/ios/Pebbles/Features/Profile/Sheets/EditSoulSheet.swift
+++ b/apps/ios/Pebbles/Features/Profile/Sheets/EditSoulSheet.swift
@@ -93,6 +93,6 @@ private struct SoulUpdatePayload: Encodable {
 }
 
 #Preview {
-    EditSoulSheet(soul: Soul(id: UUID(), name: "Preview"), onSaved: {})
+    EditSoulSheet(soul: Soul(id: UUID(), name: "Preview", glyphId: UUID()), onSaved: {})
         .environment(SupabaseService())
 }

--- a/apps/ios/Pebbles/Features/Profile/Sheets/EditSoulSheet.swift
+++ b/apps/ios/Pebbles/Features/Profile/Sheets/EditSoulSheet.swift
@@ -88,10 +88,6 @@ struct EditSoulSheet: View {
     }
 }
 
-private struct SoulUpdatePayload: Encodable {
-    let name: String
-}
-
 #Preview {
     EditSoulSheet(soul: Soul(id: UUID(), name: "Preview", glyphId: UUID()), onSaved: {})
         .environment(SupabaseService())

--- a/apps/ios/Pebbles/Features/Profile/Sheets/EditSoulSheet.swift
+++ b/apps/ios/Pebbles/Features/Profile/Sheets/EditSoulSheet.swift
@@ -1,42 +1,49 @@
 import SwiftUI
 import os
 
-/// Sheet for renaming an existing soul. One text field, save/cancel toolbar.
+/// Sheet for editing a soul. Name + glyph row, save/cancel toolbar.
 /// UPDATE goes directly to `public.souls` — RLS scopes to the owner.
 struct EditSoulSheet: View {
-    let soul: Soul
+    let original: SoulWithGlyph
     let onSaved: () -> Void
 
     @Environment(SupabaseService.self) private var supabase
     @Environment(\.dismiss) private var dismiss
 
-    @State private var name: String
+    @State private var draft: SoulDraft
     @State private var isSaving = false
     @State private var saveError: String?
+    @State private var isPresentingPicker = false
 
     private let logger = Logger(subsystem: "app.pbbls.ios", category: "profile.souls")
 
-    init(soul: Soul, onSaved: @escaping () -> Void) {
-        self.soul = soul
+    init(original: SoulWithGlyph, onSaved: @escaping () -> Void) {
+        self.original = original
         self.onSaved = onSaved
-        self._name = State(initialValue: soul.name)
-    }
-
-    private var trimmedName: String {
-        name.trimmingCharacters(in: .whitespacesAndNewlines)
+        self._draft = State(initialValue: SoulDraft(from: original))
     }
 
     private var canSave: Bool {
-        !trimmedName.isEmpty && trimmedName != soul.name
+        guard draft.isValid else { return false }
+        let trimmed = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let nameChanged = trimmed != original.name
+        let glyphChanged = draft.glyphId != original.glyphId
+        return nameChanged || glyphChanged
     }
 
     var body: some View {
         NavigationStack {
             Form {
                 Section {
-                    TextField("Name", text: $name)
+                    TextField("Name", text: $draft.name)
                         .textInputAutocapitalization(.words)
                         .autocorrectionDisabled(false)
+                }
+                Section("Glyph") {
+                    GlyphRow(
+                        glyph: draft.currentGlyph,
+                        onTap: { isPresentingPicker = true }
+                    )
                 }
                 if let saveError {
                     Section {
@@ -64,6 +71,32 @@ struct EditSoulSheet: View {
                 }
             }
             .pebblesScreen()
+            .sheet(isPresented: $isPresentingPicker) {
+                GlyphPickerSheet(
+                    currentGlyphId: draft.glyphId,
+                    onSelected: { selected in
+                        if let selected {
+                            draft.glyphId = selected
+                            Task { await loadGlyph(id: selected) }
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    private func loadGlyph(id: UUID) async {
+        do {
+            let fetched: Glyph = try await supabase.client
+                .from("glyphs")
+                .select("id, name, strokes, view_box")
+                .eq("id", value: id)
+                .single()
+                .execute()
+                .value
+            draft.currentGlyph = fetched
+        } catch {
+            logger.error("edit soul: load glyph failed: \(error.localizedDescription, privacy: .private)")
         }
     }
 
@@ -72,11 +105,14 @@ struct EditSoulSheet: View {
         isSaving = true
         saveError = nil
         do {
-            let payload = SoulUpdatePayload(name: trimmedName)
+            let payload = SoulUpdatePayload(
+                name: draft.name.trimmingCharacters(in: .whitespacesAndNewlines),
+                glyphId: draft.glyphId
+            )
             try await supabase.client
                 .from("souls")
                 .update(payload)
-                .eq("id", value: soul.id)
+                .eq("id", value: original.id)
                 .execute()
             onSaved()
             dismiss()
@@ -88,7 +124,50 @@ struct EditSoulSheet: View {
     }
 }
 
+/// Row shared with `CreateSoulSheet`. Kept duplicated as `private` here because
+/// only two callers exist; lift to `Profile/Components/` if a third appears.
+private struct GlyphRow: View {
+    let glyph: Glyph?
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 12) {
+                if let glyph {
+                    GlyphThumbnail(strokes: glyph.strokes, side: 32)
+                        .accessibilityHidden(true)
+                } else {
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(style: StrokeStyle(lineWidth: 1, dash: [3]))
+                        .frame(width: 32, height: 32)
+                        .foregroundStyle(.secondary)
+                }
+                Text("Tap to choose")
+                    .foregroundStyle(.primary)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
 #Preview {
-    EditSoulSheet(soul: Soul(id: UUID(), name: "Preview", glyphId: UUID()), onSaved: {})
-        .environment(SupabaseService())
+    EditSoulSheet(
+        original: SoulWithGlyph(
+            id: UUID(),
+            name: "Preview",
+            glyphId: SystemGlyph.default,
+            glyph: Glyph(
+                id: SystemGlyph.default,
+                name: nil,
+                strokes: [],
+                viewBox: "0 0 200 200"
+            )
+        ),
+        onSaved: {}
+    )
+    .environment(SupabaseService())
 }

--- a/apps/ios/Pebbles/Features/Profile/Views/SoulDetailView.swift
+++ b/apps/ios/Pebbles/Features/Profile/Views/SoulDetailView.swift
@@ -3,16 +3,18 @@ import os
 
 /// Pushed detail view for a single soul.
 ///
-/// - Shows the pebbles linked to this soul (filtered via `pebble_souls` inner join).
-/// - Header = `.navigationTitle(soul.name)`; header stays in sync with `soul` local state
-///   so renames reflect without popping the stack (local state is updated in Task 3).
-/// - Tapping a pebble opens the existing `EditPebbleSheet`, matching `PathView` UX.
+/// - Compact header: 56pt glyph thumbnail + name + pebble count.
+/// - Below the header: pebbles tagged with this soul (filtered via
+///   `pebble_souls` inner join).
+/// - Edit toolbar action presents `EditSoulSheet`. The sheet receives the
+///   already-fetched `SoulWithGlyph` so its glyph row renders immediately
+///   without a second fetch.
 struct SoulDetailView: View {
     let onChanged: () -> Void
 
     @Environment(SupabaseService.self) private var supabase
 
-    @State private var soul: Soul
+    @State private var soulWithGlyph: SoulWithGlyph
     @State private var pebbles: [Pebble] = []
     @State private var isLoading = true
     @State private var loadError: String?
@@ -21,14 +23,14 @@ struct SoulDetailView: View {
 
     private let logger = Logger(subsystem: "app.pbbls.ios", category: "profile.soul.detail")
 
-    init(soul: Soul, onChanged: @escaping () -> Void) {
+    init(initial: SoulWithGlyph, onChanged: @escaping () -> Void) {
         self.onChanged = onChanged
-        self._soul = State(initialValue: soul)
+        self._soulWithGlyph = State(initialValue: initial)
     }
 
     var body: some View {
         content
-            .navigationTitle(soul.name)
+            .navigationTitle(soulWithGlyph.name)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
@@ -39,9 +41,7 @@ struct SoulDetailView: View {
             }
             .task { await load() }
             .sheet(isPresented: $isPresentingEdit) {
-                EditSoulSheet(soul: soul, onSaved: {
-                    // Refresh this view's header and the parent list independently;
-                    // neither blocks the other.
+                EditSoulSheet(original: soulWithGlyph, onSaved: {
                     Task { await reloadSoul() }
                     onChanged()
                 })
@@ -52,6 +52,23 @@ struct SoulDetailView: View {
                 })
             }
             .pebblesScreen()
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            GlyphThumbnail(strokes: soulWithGlyph.glyph.strokes, side: 56)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(soulWithGlyph.name)
+                    .font(.headline)
+                Text("^[\(pebbles.count) pebbles](inflect: true)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
     }
 
     @ViewBuilder
@@ -65,39 +82,45 @@ struct SoulDetailView: View {
                 systemImage: "exclamationmark.triangle",
                 description: Text(loadError)
             )
-        } else if pebbles.isEmpty {
-            ContentUnavailableView(
-                "No pebbles yet",
-                systemImage: "circle.grid.2x1",
-                description: Text("Pebbles you tag with this soul will appear here.")
-            )
         } else {
-            List(pebbles) { pebble in
-                Button {
-                    selectedPebbleId = pebble.id
-                } label: {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(pebble.name).font(.body)
-                        Text(pebble.happenedAt, style: .date)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+            VStack(spacing: 0) {
+                header
+                if pebbles.isEmpty {
+                    ContentUnavailableView(
+                        "No pebbles yet",
+                        systemImage: "circle.grid.2x1",
+                        description: Text("Pebbles you tag with this soul will appear here.")
+                    )
+                    .frame(maxHeight: .infinity)
+                } else {
+                    List(pebbles) { pebble in
+                        Button {
+                            selectedPebbleId = pebble.id
+                        } label: {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(pebble.name).font(.body)
+                                Text(pebble.happenedAt, style: .date)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .buttonStyle(.plain)
                     }
                 }
-                .buttonStyle(.plain)
             }
         }
     }
 
     private func reloadSoul() async {
         do {
-            let refreshed: Soul = try await supabase.client
+            let refreshed: SoulWithGlyph = try await supabase.client
                 .from("souls")
-                .select("id, name")
-                .eq("id", value: soul.id)
+                .select("id, name, glyph_id, glyphs(id, name, strokes, view_box)")
+                .eq("id", value: soulWithGlyph.id)
                 .single()
                 .execute()
                 .value
-            self.soul = refreshed
+            self.soulWithGlyph = refreshed
         } catch {
             logger.error("soul reload failed: \(error.localizedDescription, privacy: .private)")
             // Leave stale state; next navigation will refresh.
@@ -108,13 +131,10 @@ struct SoulDetailView: View {
         isLoading = true
         loadError = nil
         do {
-            // `pebble_souls!inner(soul_id)` forces an inner join so the `.eq`
-            // on the join column filters the parent rows. The extra column is
-            // tolerated by `Pebble`'s default `Decodable` (extra keys ignored).
             let result: [Pebble] = try await supabase.client
                 .from("pebbles")
                 .select("id, name, happened_at, pebble_souls!inner(soul_id)")
-                .eq("pebble_souls.soul_id", value: soul.id)
+                .eq("pebble_souls.soul_id", value: soulWithGlyph.id)
                 .order("happened_at", ascending: false)
                 .execute()
                 .value
@@ -129,7 +149,20 @@ struct SoulDetailView: View {
 
 #Preview {
     NavigationStack {
-        SoulDetailView(soul: Soul(id: UUID(), name: "Preview Soul", glyphId: UUID()), onChanged: {})
-            .environment(SupabaseService())
+        SoulDetailView(
+            initial: SoulWithGlyph(
+                id: UUID(),
+                name: "Preview Soul",
+                glyphId: SystemGlyph.default,
+                glyph: Glyph(
+                    id: SystemGlyph.default,
+                    name: nil,
+                    strokes: [],
+                    viewBox: "0 0 200 200"
+                )
+            ),
+            onChanged: {}
+        )
+        .environment(SupabaseService())
     }
 }

--- a/apps/ios/Pebbles/Features/Profile/Views/SoulDetailView.swift
+++ b/apps/ios/Pebbles/Features/Profile/Views/SoulDetailView.swift
@@ -129,7 +129,7 @@ struct SoulDetailView: View {
 
 #Preview {
     NavigationStack {
-        SoulDetailView(soul: Soul(id: UUID(), name: "Preview Soul"), onChanged: {})
+        SoulDetailView(soul: Soul(id: UUID(), name: "Preview Soul", glyphId: UUID()), onChanged: {})
             .environment(SupabaseService())
     }
 }

--- a/apps/ios/Pebbles/Resources/Localizable.xcstrings
+++ b/apps/ios/Pebbles/Resources/Localizable.xcstrings
@@ -70,6 +70,23 @@
         }
       }
     },
+    "^[%lld pebbles](inflect: true)" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[%lld pebbles](inflect: true)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "^[%lld galets](inflect: true)"
+          }
+        }
+      }
+    },
     "A coffee with a friend. A concert that gave you chills. A tough conversation. Record it in seconds — no blank page, no pressure, no audience." : {
       "extractionState" : "manual",
       "localizations" : {
@@ -3077,6 +3094,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Appuyer sur + pour graver mon premier glyphe."
+          }
+        }
+      }
+    },
+    "Tap to choose" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to choose"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toucher pour choisir"
           }
         }
       }

--- a/apps/ios/PebblesTests/PebbleDetailDecodingTests.swift
+++ b/apps/ios/PebblesTests/PebbleDetailDecodingTests.swift
@@ -42,7 +42,7 @@ struct PebbleDetailDecodingTests {
         { "domain": { "id": "33333333-3333-3333-3333-333333333333", "slug": "zoe", "name": "Work" } }
       ],
       "pebble_souls": [
-        { "soul": { "id": "44444444-4444-4444-4444-444444444444", "name": "Alex" } }
+        { "soul": { "id": "44444444-4444-4444-4444-444444444444", "name": "Alex", "glyph_id": "4759c37c-68a6-46a6-b4fc-046bd0316752" } }
       ],
       "collection_pebbles": [
         { "collection": { "id": "55555555-5555-5555-5555-555555555555", "name": "Wins" } }

--- a/apps/ios/PebblesTests/PebbleDetailDecodingTests.swift
+++ b/apps/ios/PebblesTests/PebbleDetailDecodingTests.swift
@@ -42,7 +42,13 @@ struct PebbleDetailDecodingTests {
         { "domain": { "id": "33333333-3333-3333-3333-333333333333", "slug": "zoe", "name": "Work" } }
       ],
       "pebble_souls": [
-        { "soul": { "id": "44444444-4444-4444-4444-444444444444", "name": "Alex", "glyph_id": "4759c37c-68a6-46a6-b4fc-046bd0316752" } }
+        {
+          "soul": {
+            "id": "44444444-4444-4444-4444-444444444444",
+            "name": "Alex",
+            "glyph_id": "4759c37c-68a6-46a6-b4fc-046bd0316752"
+          }
+        }
       ],
       "collection_pebbles": [
         { "collection": { "id": "55555555-5555-5555-5555-555555555555", "name": "Wins" } }

--- a/apps/ios/PebblesTests/PebbleDraftFromDetailTests.swift
+++ b/apps/ios/PebblesTests/PebbleDraftFromDetailTests.swift
@@ -72,7 +72,7 @@ struct PebbleDraftFromDetailTests {
             visibility: .public,
             emotionId: emotionId,
             domains: [DomainRef(id: domainId, slug: "zoe", name: "Work")],
-            souls: [Soul(id: soulId, name: "Me")],
+            souls: [Soul(id: soulId, name: "Me", glyphId: UUID())],
             collections: [PebbleCollection(id: collectionId, name: "Wins")]
         )
 

--- a/apps/ios/PebblesTests/PebbleDraftFromDetailTests.swift
+++ b/apps/ios/PebblesTests/PebbleDraftFromDetailTests.swift
@@ -25,7 +25,13 @@ struct PebbleDraftFromDetailTests {
             "color": "#FFD166"
         ]
         let domainsJSON = domains.map { domain in ["domain": ["id": domain.id.uuidString, "slug": domain.slug, "name": domain.name]] }
-        let soulsJSON = souls.map { soul in ["soul": ["id": soul.id.uuidString, "name": soul.name, "glyph_id": soul.glyphId.uuidString]] }
+        let soulsJSON = souls.map { soul -> [String: [String: String]] in
+            ["soul": [
+                "id": soul.id.uuidString,
+                "name": soul.name,
+                "glyph_id": soul.glyphId.uuidString
+            ]]
+        }
         let collectionsJSON = collections.map { coll in ["collection": ["id": coll.id.uuidString, "name": coll.name]] }
 
         var root: [String: Any] = [

--- a/apps/ios/PebblesTests/PebbleDraftFromDetailTests.swift
+++ b/apps/ios/PebblesTests/PebbleDraftFromDetailTests.swift
@@ -25,7 +25,7 @@ struct PebbleDraftFromDetailTests {
             "color": "#FFD166"
         ]
         let domainsJSON = domains.map { domain in ["domain": ["id": domain.id.uuidString, "slug": domain.slug, "name": domain.name]] }
-        let soulsJSON = souls.map { soul in ["soul": ["id": soul.id.uuidString, "name": soul.name]] }
+        let soulsJSON = souls.map { soul in ["soul": ["id": soul.id.uuidString, "name": soul.name, "glyph_id": soul.glyphId.uuidString]] }
         let collectionsJSON = collections.map { coll in ["collection": ["id": coll.id.uuidString, "name": coll.name]] }
 
         var root: [String: Any] = [

--- a/apps/ios/PebblesTests/SoulInsertPayloadEncodingTests.swift
+++ b/apps/ios/PebblesTests/SoulInsertPayloadEncodingTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+@testable import Pebbles
+
+@Suite("SoulInsertPayload encoding")
+struct SoulInsertPayloadEncodingTests {
+
+    private let userId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+    private let glyphId = UUID(uuidString: "4759c37c-68a6-46a6-b4fc-046bd0316752")!
+
+    private func encode(_ payload: SoulInsertPayload) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(payload)
+        let object = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+        return try #require(object as? [String: Any])
+    }
+
+    @Test("encodes user_id, name, glyph_id with snake_case keys")
+    func snakeCaseKeys() throws {
+        let payload = SoulInsertPayload(userId: userId, name: "Alex", glyphId: glyphId)
+        let json = try encode(payload)
+        #expect(json["user_id"] as? String == userId.uuidString)
+        #expect(json["name"] as? String == "Alex")
+        #expect(json["glyph_id"] as? String == glyphId.uuidString)
+    }
+
+    @Test("does not emit a top-level id field")
+    func noIdField() throws {
+        let payload = SoulInsertPayload(userId: userId, name: "Alex", glyphId: glyphId)
+        let json = try encode(payload)
+        #expect(json["id"] == nil)
+    }
+}

--- a/apps/ios/PebblesTests/SoulUpdatePayloadEncodingTests.swift
+++ b/apps/ios/PebblesTests/SoulUpdatePayloadEncodingTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Testing
+@testable import Pebbles
+
+@Suite("SoulUpdatePayload encoding")
+struct SoulUpdatePayloadEncodingTests {
+
+    private let glyphId = UUID(uuidString: "4759c37c-68a6-46a6-b4fc-046bd0316752")!
+
+    private func encode(_ payload: SoulUpdatePayload) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(payload)
+        let object = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+        return try #require(object as? [String: Any])
+    }
+
+    @Test("encodes name and glyph_id with snake_case keys")
+    func snakeCaseKeys() throws {
+        let payload = SoulUpdatePayload(name: "Alex", glyphId: glyphId)
+        let json = try encode(payload)
+        #expect(json["name"] as? String == "Alex")
+        #expect(json["glyph_id"] as? String == glyphId.uuidString)
+    }
+}

--- a/apps/ios/PebblesTests/SoulWithGlyphDecodingTests.swift
+++ b/apps/ios/PebblesTests/SoulWithGlyphDecodingTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+@testable import Pebbles
+
+@Suite("SoulWithGlyph decoding")
+struct SoulWithGlyphDecodingTests {
+
+    private let soulId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+    private let glyphId = UUID(uuidString: "4759c37c-68a6-46a6-b4fc-046bd0316752")!
+
+    @Test("decodes the joined PostgREST payload for the system default glyph")
+    func decodesSystemDefault() throws {
+        let json = """
+        {
+          "id": "\(soulId.uuidString)",
+          "name": "Alex",
+          "glyph_id": "\(glyphId.uuidString)",
+          "glyphs": {
+            "id": "\(glyphId.uuidString)",
+            "name": null,
+            "strokes": [],
+            "view_box": "0 0 200 200"
+          }
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(SoulWithGlyph.self, from: json)
+        #expect(decoded.id == soulId)
+        #expect(decoded.name == "Alex")
+        #expect(decoded.glyphId == glyphId)
+        #expect(decoded.glyph.id == glyphId)
+        #expect(decoded.glyph.viewBox == "0 0 200 200")
+        #expect(decoded.glyph.strokes.isEmpty)
+    }
+
+    @Test("decodes a soul with a user-carved glyph that has strokes")
+    func decodesUserGlyph() throws {
+        let userGlyphId = UUID()
+        let json = """
+        {
+          "id": "\(soulId.uuidString)",
+          "name": "Sam",
+          "glyph_id": "\(userGlyphId.uuidString)",
+          "glyphs": {
+            "id": "\(userGlyphId.uuidString)",
+            "name": "wave",
+            "strokes": [{"d": "M0,0 L10,10", "width": 6}],
+            "view_box": "0 0 200 200"
+          }
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(SoulWithGlyph.self, from: json)
+        #expect(decoded.glyph.name == "wave")
+        #expect(decoded.glyph.strokes.count == 1)
+        #expect(decoded.glyph.strokes.first?.d == "M0,0 L10,10")
+    }
+
+    @Test("soul accessor strips the joined glyph")
+    func soulAccessor() throws {
+        let json = """
+        {
+          "id": "\(soulId.uuidString)",
+          "name": "Alex",
+          "glyph_id": "\(glyphId.uuidString)",
+          "glyphs": { "id": "\(glyphId.uuidString)", "name": null, "strokes": [], "view_box": "0 0 200 200" }
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(SoulWithGlyph.self, from: json)
+        #expect(decoded.soul.id == soulId)
+        #expect(decoded.soul.name == "Alex")
+        #expect(decoded.soul.glyphId == glyphId)
+    }
+}

--- a/apps/ios/PebblesTests/SoulWithGlyphDecodingTests.swift
+++ b/apps/ios/PebblesTests/SoulWithGlyphDecodingTests.swift
@@ -10,7 +10,7 @@ struct SoulWithGlyphDecodingTests {
 
     @Test("decodes the joined PostgREST payload for the system default glyph")
     func decodesSystemDefault() throws {
-        let json = """
+        let json = Data("""
         {
           "id": "\(soulId.uuidString)",
           "name": "Alex",
@@ -22,7 +22,7 @@ struct SoulWithGlyphDecodingTests {
             "view_box": "0 0 200 200"
           }
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         let decoded = try JSONDecoder().decode(SoulWithGlyph.self, from: json)
         #expect(decoded.id == soulId)
@@ -36,7 +36,7 @@ struct SoulWithGlyphDecodingTests {
     @Test("decodes a soul with a user-carved glyph that has strokes")
     func decodesUserGlyph() throws {
         let userGlyphId = UUID()
-        let json = """
+        let json = Data("""
         {
           "id": "\(soulId.uuidString)",
           "name": "Sam",
@@ -48,7 +48,7 @@ struct SoulWithGlyphDecodingTests {
             "view_box": "0 0 200 200"
           }
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         let decoded = try JSONDecoder().decode(SoulWithGlyph.self, from: json)
         #expect(decoded.glyph.name == "wave")
@@ -58,14 +58,14 @@ struct SoulWithGlyphDecodingTests {
 
     @Test("soul accessor strips the joined glyph")
     func soulAccessor() throws {
-        let json = """
+        let json = Data("""
         {
           "id": "\(soulId.uuidString)",
           "name": "Alex",
           "glyph_id": "\(glyphId.uuidString)",
           "glyphs": { "id": "\(glyphId.uuidString)", "name": null, "strokes": [], "view_box": "0 0 200 200" }
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         let decoded = try JSONDecoder().decode(SoulWithGlyph.self, from: json)
         #expect(decoded.soul.id == soulId)

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -203,7 +203,7 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Souls Directory",
-      "description": "Browse and manage all souls (people in your life).",
+      "description": "Browse and manage all souls (people in your life) as a 3-column glyph grid.",
       "status": "live",
       "platforms": ["web", "ios", "android"]
     },
@@ -655,7 +655,7 @@
       "project_id": "pebbles",
       "species": "data-model",
       "title": "Soul",
-      "description": "A person linked to pebbles, representing someone in the user's life.",
+      "description": "A person linked to pebbles, representing someone in the user's life. Each soul carries a glyph for visual identity.",
       "status": "idea",
       "platforms": ["web", "ios", "android"]
     },

--- a/docs/superpowers/plans/2026-04-26-ios-soul-glyph-design.md
+++ b/docs/superpowers/plans/2026-04-26-ios-soul-glyph-design.md
@@ -1,0 +1,1630 @@
+# iOS — Soul Glyph Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Attribute a glyph to every soul, surface it in a 3-column grid on the Souls list, in the soul detail header, and inside create/edit sheets — backed by a new `souls.glyph_id` column.
+
+**Architecture:** A nullable→backfill→tighten migration adds `souls.glyph_id` with the system default glyph as the FK target. iOS reads souls with a nested PostgREST select that joins `glyphs(id, strokes, view_box)` in one round-trip and decodes into a new `SoulWithGlyph` value. Create/edit sheets reuse the existing `GlyphPickerSheet` + `GlyphCarveSheet` flow; `SoulDraft` mirrors `PebbleDraft` and carries an in-memory `currentGlyph` cache so the form thumbnail renders without a refetch. Saves stay direct single-table INSERT / UPDATE per `AGENTS.md` (no RPC).
+
+**Tech Stack:** SwiftUI (iOS 17+, `@Observable`), Supabase Swift SDK, PostgREST. Postgres migration via `packages/supabase/supabase/migrations/`. Swift Testing for unit tests. Strings in `Localizable.xcstrings` (en + fr).
+
+**Spec:** `docs/superpowers/specs/2026-04-25-ios-soul-glyph-design.md` (issue #298).
+
+---
+
+## File Structure
+
+**Created:**
+- `packages/supabase/supabase/migrations/20260426000000_add_glyph_to_souls.sql` — adds nullable `glyph_id`, seeds default glyph, backfills, sets NOT NULL + default.
+- `apps/ios/Pebbles/Features/Profile/Models/SoulDraft.swift` — value-type form state (mirrors `PebbleDraft`).
+- `apps/ios/Pebbles/Features/Profile/Models/SoulWithGlyph.swift` — decoded shape for the joined select used by list and detail views.
+- `apps/ios/Pebbles/Features/Profile/Lists/SoulGridCell.swift` — pure presentational cell: glyph thumbnail above the soul's name.
+- `apps/ios/Pebbles/Features/Glyph/Utils/SystemGlyph.swift` — single source of truth for the default glyph UUID (avoids stringly-typed UUIDs across files).
+- `apps/ios/PebblesTests/SoulWithGlyphDecodingTests.swift` — verifies the joined payload decodes correctly.
+- `apps/ios/PebblesTests/SoulInsertPayloadEncodingTests.swift` — verifies create payload emits `glyph_id` snake-cased.
+- `apps/ios/PebblesTests/SoulUpdatePayloadEncodingTests.swift` — verifies update payload emits `name` and `glyph_id` snake-cased.
+
+**Modified:**
+- `packages/supabase/types/database.ts` — regenerated via `npm run db:types --workspace=packages/supabase`.
+- `apps/ios/Pebbles/Features/Path/Models/Soul.swift` — adds `glyphId: UUID` (non-optional).
+- `apps/ios/Pebbles/Features/Profile/Lists/SoulsListView.swift` — replaces `List` with a 3-column `LazyVGrid` of `SoulGridCell`; switches the fetch to the joined select; refactors local state to `[SoulWithGlyph]`.
+- `apps/ios/Pebbles/Features/Profile/Views/SoulDetailView.swift` — adds compact glyph header, switches the soul fetch to include the joined glyph, passes `currentGlyph` to `EditSoulSheet`.
+- `apps/ios/Pebbles/Features/Profile/Sheets/CreateSoulSheet.swift` — adds Glyph row, picker presentation, default-glyph fetch on `.task`, `glyph_id` on save.
+- `apps/ios/Pebbles/Features/Profile/Sheets/EditSoulSheet.swift` — adds Glyph row pre-filled from the parent's `currentGlyph`, picker presentation, `glyph_id` on save.
+- `apps/ios/Pebbles/Resources/Localizable.xcstrings` — adds new strings: "Glyph", "Tap to choose", and a pluralised `%lld pebbles` (en/fr).
+- `docs/arkaik/bundle.json` — `DM-soul` description gets a one-line note that souls now carry a glyph; `V-souls-list` description switches "flat list" → "3-column grid".
+
+**No changes needed to:**
+- `GlyphPickerSheet.swift` / `GlyphCarveSheet.swift` / `GlyphThumbnail.swift` — already accept the right props and behave as required.
+- `apps/ios/project.yml` — xcodegen auto-discovers under `Pebbles/` and `PebblesTests/`. New files require `xcodegen generate` (or `npm run generate --workspace=@pbbls/ios`) before the next Xcode build.
+
+---
+
+## Task 1: Database migration — add `souls.glyph_id`
+
+**Files:**
+- Create: `packages/supabase/supabase/migrations/20260426000000_add_glyph_to_souls.sql`
+- Modify: `packages/supabase/types/database.ts` (regenerated, not hand-edited)
+
+The migration inserts the system default glyph if missing, adds the column nullable, backfills, then tightens to NOT NULL with a default. `ON DELETE RESTRICT` prevents a soul from being silently stranded if the default glyph were ever deleted.
+
+The default glyph UUID `4759c37c-68a6-46a6-b4fc-046bd0316752` already exists in the remote DB as one of the 18 system glyphs seeded by `20260415000001_remote_pebble_engine.sql`. The `INSERT … ON CONFLICT DO NOTHING` here is purely defensive in case a fresh local environment runs migrations before the seed.
+
+- [ ] **Step 1: Create the migration file**
+
+Create `packages/supabase/supabase/migrations/20260426000000_add_glyph_to_souls.sql` with:
+
+```sql
+-- Migration: Add glyph_id to souls (issue #298)
+--
+-- Souls today carry only a name. This migration adds an FK to glyphs so each
+-- soul has a visual identity (rendered in the iOS Souls grid + detail header).
+--
+-- Strategy:
+--   1. Defensively guarantee the system default glyph exists.
+--   2. Add column nullable (so existing rows don't violate the constraint).
+--   3. Backfill all rows to the system default.
+--   4. Tighten: NOT NULL + default = system default glyph.
+--
+-- ON DELETE RESTRICT: glyphs aren't user-deletable today, but if that changes
+-- the constraint stops a deletion from silently stranding a soul.
+-- The default glyph itself must never be deletable while any soul references it.
+
+-- 1. Defensively ensure the system default glyph row exists.
+--    The remote DB already has it (seeded by 20260415000001), but a fresh local
+--    DB might not have run that seed yet. ON CONFLICT keeps it idempotent.
+insert into public.glyphs (id, user_id, shape_id, strokes, view_box)
+values (
+  '4759c37c-68a6-46a6-b4fc-046bd0316752',
+  null,
+  null,
+  '[]'::jsonb,
+  '0 0 200 200'
+)
+on conflict (id) do nothing;
+
+-- 2. Add column nullable, FK to glyphs.
+alter table public.souls
+  add column glyph_id uuid references public.glyphs(id) on delete restrict;
+
+-- 3. Backfill existing rows to the system default.
+update public.souls
+set glyph_id = '4759c37c-68a6-46a6-b4fc-046bd0316752'
+where glyph_id is null;
+
+-- 4. Tighten: NOT NULL + default.
+alter table public.souls
+  alter column glyph_id set not null,
+  alter column glyph_id set default '4759c37c-68a6-46a6-b4fc-046bd0316752';
+```
+
+- [ ] **Step 2: Apply the migration to the remote DB**
+
+This project deploys to remote Supabase rather than running a local container (per the user's avoid-Docker preference noted in MEMORY.md / `feedback_avoid_docker.md`). Apply via the workspace's existing migration push command — confirm with the user before running if uncertain. Typical command:
+
+```bash
+npm run db:push --workspace=packages/supabase
+```
+
+Expected: migration applies cleanly with no errors. If `db:push` is named differently in this workspace, run `npm run -w packages/supabase --silent run-script ls 2>/dev/null` or read `packages/supabase/package.json` to find the right script.
+
+- [ ] **Step 3: Regenerate TypeScript types**
+
+Run from the repo root:
+
+```bash
+npm run db:types --workspace=packages/supabase
+```
+
+Expected: `packages/supabase/types/database.ts` now lists `glyph_id: string` (not `string | null`) under `souls.Row` and `souls.Insert` (with default). Verify by grepping:
+
+```bash
+grep -A 12 'souls: {' packages/supabase/types/database.ts | head -40
+```
+
+- [ ] **Step 4: Commit migration + regenerated types**
+
+```bash
+git add packages/supabase/supabase/migrations/20260426000000_add_glyph_to_souls.sql packages/supabase/types/database.ts
+git commit -m "feat(db): add glyph_id to souls (#298)"
+```
+
+---
+
+## Task 2: Add `glyphId` to the iOS `Soul` model
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/Models/Soul.swift`
+
+The `Soul` value type used today decodes only `id, name`. Selectors that don't request `glyph_id` would now break decoding because `glyphId` is non-optional. Every `select(...)` on `souls` is updated in later tasks; this task lands the model change in lockstep.
+
+- [ ] **Step 1: Update `Soul.swift`**
+
+Replace contents with:
+
+```swift
+import Foundation
+
+struct Soul: Identifiable, Decodable, Hashable {
+    let id: UUID
+    let name: String
+    let glyphId: UUID
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case glyphId = "glyph_id"
+    }
+}
+```
+
+- [ ] **Step 2: Build the iOS target to surface every call site that breaks**
+
+```bash
+xcodebuild -workspace apps/ios/Pebbles.xcworkspace -scheme Pebbles -destination 'generic/platform=iOS Simulator' -quiet build 2>&1 | head -40
+```
+
+Expected: the build fails with errors at every site that constructs `Soul(...)` without `glyphId` and at every `.from("souls").select("id, name")` call site (decoding-time errors only show up at runtime; compile errors come from constructor sites and SwiftUI previews). Note each error site — they're all addressed in subsequent tasks.
+
+If the workspace name is different (e.g. `Pebbles.xcodeproj`), discover via:
+
+```bash
+ls apps/ios/*.xcworkspace apps/ios/*.xcodeproj 2>/dev/null
+```
+
+- [ ] **Step 3: Update `Soul(...)` constructor sites in previews and tests**
+
+Search for every constructor:
+
+```bash
+grep -rn "Soul(id:" apps/ios/Pebbles apps/ios/PebblesTests
+```
+
+For each match, add `glyphId: UUID()` (or a fixed UUID like `UUID(uuidString: "4759c37c-68a6-46a6-b4fc-046bd0316752")!` for previews). At the time of writing the known sites are the `#Preview` blocks in `SoulsListView.swift`, `SoulDetailView.swift`, `EditSoulSheet.swift` — verify with the grep above.
+
+Example fix for `EditSoulSheet.swift` preview:
+
+```swift
+#Preview {
+    EditSoulSheet(
+        soul: Soul(id: UUID(), name: "Preview", glyphId: UUID()),
+        onSaved: {}
+    )
+    .environment(SupabaseService())
+}
+```
+
+- [ ] **Step 4: Re-run the build**
+
+```bash
+xcodebuild -workspace apps/ios/Pebbles.xcworkspace -scheme Pebbles -destination 'generic/platform=iOS Simulator' -quiet build 2>&1 | tail -20
+```
+
+Expected: build succeeds. (Runtime decode errors will appear in the next tasks until the `select(...)` strings are widened to include `glyph_id`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Path/Models/Soul.swift apps/ios/Pebbles/Features/Profile/
+git commit -m "feat(ios): add glyphId to Soul model"
+```
+
+---
+
+## Task 3: Add `SystemGlyph` constant + `SoulWithGlyph` decode model
+
+**Files:**
+- Create: `apps/ios/Pebbles/Features/Glyph/Utils/SystemGlyph.swift`
+- Create: `apps/ios/Pebbles/Features/Profile/Models/SoulWithGlyph.swift`
+- Create: `apps/ios/PebblesTests/SoulWithGlyphDecodingTests.swift`
+
+Centralise the default glyph UUID so the iOS code never duplicates the literal. `SoulWithGlyph` decodes the joined PostgREST payload (`select("id, name, glyph_id, glyphs(id, strokes, view_box)")`) into one value used by the list and detail views.
+
+PostgREST returns the joined relation as a nested object keyed by the relation name (`glyphs`). The decoder needs a custom `init(from:)` because `Glyph.CodingKeys` doesn't include the parent's `name`/`id` fields — the nested `glyphs` JSON object decodes via `Glyph`'s own `Decodable` synthesis.
+
+- [ ] **Step 1: Create the `SystemGlyph` constant**
+
+Create `apps/ios/Pebbles/Features/Glyph/Utils/SystemGlyph.swift`:
+
+```swift
+import Foundation
+
+/// UUIDs for the system glyphs seeded server-side (migration
+/// `20260415000001_remote_pebble_engine.sql` and re-asserted by
+/// `20260426000000_add_glyph_to_souls.sql`).
+///
+/// `default` is the canonical fallback used when a soul or domain has no
+/// user-carved glyph attached. iOS uses it to seed `SoulDraft.glyphId`
+/// when creating a new soul, and the migration uses it as the column default.
+enum SystemGlyph {
+    static let `default` = UUID(uuidString: "4759c37c-68a6-46a6-b4fc-046bd0316752")!
+}
+```
+
+- [ ] **Step 2: Create the `SoulWithGlyph` value**
+
+Create `apps/ios/Pebbles/Features/Profile/Models/SoulWithGlyph.swift`:
+
+```swift
+import Foundation
+
+/// A soul together with its joined glyph, decoded from a single PostgREST
+/// request:
+///
+///     supabase.from("souls")
+///         .select("id, name, glyph_id, glyphs(id, strokes, view_box)")
+///
+/// PostgREST nests the joined row under the relation name (`glyphs`).
+struct SoulWithGlyph: Identifiable, Decodable, Hashable {
+    let id: UUID
+    let name: String
+    let glyphId: UUID
+    let glyph: Glyph
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case glyphId = "glyph_id"
+        case glyph = "glyphs"
+    }
+
+    /// Convenience for code paths that already hold a `Soul` and need to
+    /// drop the joined glyph (e.g. passing into `EditSoulSheet` which only
+    /// needs the `Soul` shape).
+    var soul: Soul {
+        Soul(id: id, name: name, glyphId: glyphId)
+    }
+}
+```
+
+- [ ] **Step 3: Write the decoding test (failing first)**
+
+Create `apps/ios/PebblesTests/SoulWithGlyphDecodingTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import Pebbles
+
+@Suite("SoulWithGlyph decoding")
+struct SoulWithGlyphDecodingTests {
+
+    private let soulId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+    private let glyphId = UUID(uuidString: "4759c37c-68a6-46a6-b4fc-046bd0316752")!
+
+    @Test("decodes the joined PostgREST payload for the system default glyph")
+    func decodesSystemDefault() throws {
+        let json = """
+        {
+          "id": "\(soulId.uuidString)",
+          "name": "Alex",
+          "glyph_id": "\(glyphId.uuidString)",
+          "glyphs": {
+            "id": "\(glyphId.uuidString)",
+            "name": null,
+            "strokes": [],
+            "view_box": "0 0 200 200"
+          }
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(SoulWithGlyph.self, from: json)
+        #expect(decoded.id == soulId)
+        #expect(decoded.name == "Alex")
+        #expect(decoded.glyphId == glyphId)
+        #expect(decoded.glyph.id == glyphId)
+        #expect(decoded.glyph.viewBox == "0 0 200 200")
+        #expect(decoded.glyph.strokes.isEmpty)
+    }
+
+    @Test("decodes a soul with a user-carved glyph that has strokes")
+    func decodesUserGlyph() throws {
+        let userGlyphId = UUID()
+        let json = """
+        {
+          "id": "\(soulId.uuidString)",
+          "name": "Sam",
+          "glyph_id": "\(userGlyphId.uuidString)",
+          "glyphs": {
+            "id": "\(userGlyphId.uuidString)",
+            "name": "wave",
+            "strokes": [{"d": "M0,0 L10,10", "width": 6}],
+            "view_box": "0 0 200 200"
+          }
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(SoulWithGlyph.self, from: json)
+        #expect(decoded.glyph.name == "wave")
+        #expect(decoded.glyph.strokes.count == 1)
+        #expect(decoded.glyph.strokes.first?.d == "M0,0 L10,10")
+    }
+
+    @Test("soul accessor strips the joined glyph")
+    func soulAccessor() throws {
+        let json = """
+        {
+          "id": "\(soulId.uuidString)",
+          "name": "Alex",
+          "glyph_id": "\(glyphId.uuidString)",
+          "glyphs": { "id": "\(glyphId.uuidString)", "name": null, "strokes": [], "view_box": "0 0 200 200" }
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(SoulWithGlyph.self, from: json)
+        #expect(decoded.soul.id == soulId)
+        #expect(decoded.soul.name == "Alex")
+        #expect(decoded.soul.glyphId == glyphId)
+    }
+}
+```
+
+- [ ] **Step 4: Regenerate the Xcode project so new files are included**
+
+```bash
+npm run generate --workspace=@pbbls/ios
+```
+
+Expected: `xcodegen generate` runs and refreshes the pbxproj.
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+xcodebuild -workspace apps/ios/Pebbles.xcworkspace -scheme Pebbles -destination 'platform=iOS Simulator,name=iPhone 16' test -only-testing:PebblesTests/SoulWithGlyphDecodingTests 2>&1 | tail -30
+```
+
+Expected: all three tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Glyph/Utils/SystemGlyph.swift apps/ios/Pebbles/Features/Profile/Models/SoulWithGlyph.swift apps/ios/PebblesTests/SoulWithGlyphDecodingTests.swift apps/ios/Pebbles.xcodeproj
+git commit -m "feat(ios): add SystemGlyph constant and SoulWithGlyph decode model"
+```
+
+---
+
+## Task 4: `SoulDraft` form-state value
+
+**Files:**
+- Create: `apps/ios/Pebbles/Features/Profile/Models/SoulDraft.swift`
+
+A small value type held by `@State` in the create/edit sheets. Mirrors `PebbleDraft` so the patterns match.
+
+- [ ] **Step 1: Create `SoulDraft.swift`**
+
+```swift
+import Foundation
+
+/// In-progress form state for the create/edit-soul sheets.
+/// A value type held in `@State`. `currentGlyph` is the in-memory cache
+/// so the form's thumbnail row renders without a glyph-by-id refetch
+/// after the picker returns a selection.
+struct SoulDraft {
+    var name: String = ""
+    var glyphId: UUID = SystemGlyph.default
+    var currentGlyph: Glyph?
+
+    /// True when every mandatory field is set.
+    var isValid: Bool {
+        !name.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+}
+
+extension SoulDraft {
+    /// Build a prefilled draft from a fetched `SoulWithGlyph`.
+    /// Used by `EditSoulSheet` to populate the form with current values.
+    init(from soulWithGlyph: SoulWithGlyph) {
+        self.name = soulWithGlyph.name
+        self.glyphId = soulWithGlyph.glyphId
+        self.currentGlyph = soulWithGlyph.glyph
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate the Xcode project**
+
+```bash
+npm run generate --workspace=@pbbls/ios
+```
+
+- [ ] **Step 3: Build to confirm it compiles**
+
+```bash
+xcodebuild -workspace apps/ios/Pebbles.xcworkspace -scheme Pebbles -destination 'generic/platform=iOS Simulator' -quiet build 2>&1 | tail -10
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Profile/Models/SoulDraft.swift apps/ios/Pebbles.xcodeproj
+git commit -m "feat(ios): add SoulDraft form-state value"
+```
+
+---
+
+## Task 5: Insert/update payload encoding tests
+
+**Files:**
+- Create: `apps/ios/PebblesTests/SoulInsertPayloadEncodingTests.swift`
+- Create: `apps/ios/PebblesTests/SoulUpdatePayloadEncodingTests.swift`
+
+Lock down the wire format before changing the sheet code so the round-trip is provably correct. The payload types themselves are private inside the sheets today; the tests force us to lift them into a shared file in Task 6.
+
+- [ ] **Step 1: Write the failing insert encoding test**
+
+Create `apps/ios/PebblesTests/SoulInsertPayloadEncodingTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import Pebbles
+
+@Suite("SoulInsertPayload encoding")
+struct SoulInsertPayloadEncodingTests {
+
+    private let userId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+    private let glyphId = UUID(uuidString: "4759c37c-68a6-46a6-b4fc-046bd0316752")!
+
+    private func encode(_ payload: SoulInsertPayload) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(payload)
+        let object = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+        return try #require(object as? [String: Any])
+    }
+
+    @Test("encodes user_id, name, glyph_id with snake_case keys")
+    func snakeCaseKeys() throws {
+        let payload = SoulInsertPayload(userId: userId, name: "Alex", glyphId: glyphId)
+        let json = try encode(payload)
+        #expect(json["user_id"] as? String == userId.uuidString)
+        #expect(json["name"] as? String == "Alex")
+        #expect(json["glyph_id"] as? String == glyphId.uuidString)
+    }
+
+    @Test("does not emit a top-level id field")
+    func noIdField() throws {
+        let payload = SoulInsertPayload(userId: userId, name: "Alex", glyphId: glyphId)
+        let json = try encode(payload)
+        #expect(json["id"] == nil)
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing update encoding test**
+
+Create `apps/ios/PebblesTests/SoulUpdatePayloadEncodingTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import Pebbles
+
+@Suite("SoulUpdatePayload encoding")
+struct SoulUpdatePayloadEncodingTests {
+
+    private let glyphId = UUID(uuidString: "4759c37c-68a6-46a6-b4fc-046bd0316752")!
+
+    private func encode(_ payload: SoulUpdatePayload) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(payload)
+        let object = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+        return try #require(object as? [String: Any])
+    }
+
+    @Test("encodes name and glyph_id with snake_case keys")
+    func snakeCaseKeys() throws {
+        let payload = SoulUpdatePayload(name: "Alex", glyphId: glyphId)
+        let json = try encode(payload)
+        #expect(json["name"] as? String == "Alex")
+        #expect(json["glyph_id"] as? String == glyphId.uuidString)
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail (types not yet declared)**
+
+```bash
+xcodebuild -workspace apps/ios/Pebbles.xcworkspace -scheme Pebbles -destination 'platform=iOS Simulator,name=iPhone 16' test -only-testing:PebblesTests/SoulInsertPayloadEncodingTests -only-testing:PebblesTests/SoulUpdatePayloadEncodingTests 2>&1 | tail -10
+```
+
+Expected: build failure with "Cannot find 'SoulInsertPayload' / 'SoulUpdatePayload' in scope". This is intentional — Task 6 promotes them into a shared file.
+
+---
+
+## Task 6: Promote `SoulInsertPayload` / `SoulUpdatePayload` to shared file
+
+**Files:**
+- Create: `apps/ios/Pebbles/Features/Profile/Models/SoulPayloads.swift`
+- Modify: `apps/ios/Pebbles/Features/Profile/Sheets/CreateSoulSheet.swift` (remove the private struct)
+- Modify: `apps/ios/Pebbles/Features/Profile/Sheets/EditSoulSheet.swift` (remove the private struct)
+
+Today both payload types live as `private` siblings of the sheets, which the unit tests can't reach. Lift both into a shared file under Profile/Models. This also makes them symmetric — both carry `glyph_id`.
+
+- [ ] **Step 1: Create `SoulPayloads.swift`**
+
+```swift
+import Foundation
+
+/// Body for `INSERT INTO public.souls`. RLS requires `user_id` to match
+/// `auth.uid()`, so the sheet supplies it from the active session.
+struct SoulInsertPayload: Encodable {
+    let userId: UUID
+    let name: String
+    let glyphId: UUID
+
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case name
+        case glyphId = "glyph_id"
+    }
+}
+
+/// Body for `UPDATE public.souls SET ... WHERE id = ?`. Owned by the
+/// caller — `id` is supplied via the `.eq("id", value:)` filter, not in the body.
+struct SoulUpdatePayload: Encodable {
+    let name: String
+    let glyphId: UUID
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case glyphId = "glyph_id"
+    }
+}
+```
+
+- [ ] **Step 2: Remove the private payload struct from `CreateSoulSheet.swift`**
+
+Open `apps/ios/Pebbles/Features/Profile/Sheets/CreateSoulSheet.swift`. Delete this block (currently lines 87–95):
+
+```swift
+private struct SoulInsertPayload: Encodable {
+    let userId: UUID
+    let name: String
+
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case name
+    }
+}
+```
+
+(This file gets a more substantial rewrite in Task 8 — for now we just delete the duplicate struct so the build picks up the new shared one. The existing call to `SoulInsertPayload(userId:, name:)` will fail to compile because the new shared struct now requires `glyphId`. That call site is rewritten in Task 8.)
+
+- [ ] **Step 3: Remove the private payload struct from `EditSoulSheet.swift`**
+
+Open `apps/ios/Pebbles/Features/Profile/Sheets/EditSoulSheet.swift`. Delete this block (currently lines 91–93):
+
+```swift
+private struct SoulUpdatePayload: Encodable {
+    let name: String
+}
+```
+
+The existing call to `SoulUpdatePayload(name:)` will fail to compile — that call site is rewritten in Task 9.
+
+- [ ] **Step 4: Regenerate Xcode project + run tests**
+
+```bash
+npm run generate --workspace=@pbbls/ios
+xcodebuild -workspace apps/ios/Pebbles.xcworkspace -scheme Pebbles -destination 'platform=iOS Simulator,name=iPhone 16' test -only-testing:PebblesTests/SoulInsertPayloadEncodingTests -only-testing:PebblesTests/SoulUpdatePayloadEncodingTests 2>&1 | tail -15
+```
+
+Expected: tests pass. The full app build will still fail at the call sites in `CreateSoulSheet`/`EditSoulSheet` — that's resolved in Tasks 8 + 9.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Profile/Models/SoulPayloads.swift apps/ios/Pebbles/Features/Profile/Sheets/CreateSoulSheet.swift apps/ios/Pebbles/Features/Profile/Sheets/EditSoulSheet.swift apps/ios/PebblesTests/SoulInsertPayloadEncodingTests.swift apps/ios/PebblesTests/SoulUpdatePayloadEncodingTests.swift apps/ios/Pebbles.xcodeproj
+git commit -m "test(ios): cover SoulInsertPayload and SoulUpdatePayload encoding"
+```
+
+---
+
+## Task 7: `SoulGridCell` view
+
+**Files:**
+- Create: `apps/ios/Pebbles/Features/Profile/Lists/SoulGridCell.swift`
+
+Pure presentational cell used by `SoulsListView`. Square `GlyphThumbnail` above a single-line truncating name.
+
+- [ ] **Step 1: Create the cell**
+
+```swift
+import SwiftUI
+
+/// One cell in the Souls 3-column grid. Square glyph thumbnail above a
+/// single-line truncating name. Tap target wraps the entire cell — tap
+/// behaviour is owned by the parent `NavigationLink`, this view is purely
+/// visual.
+struct SoulGridCell: View {
+    let soul: SoulWithGlyph
+
+    var body: some View {
+        VStack(spacing: 8) {
+            GlyphThumbnail(strokes: soul.glyph.strokes, side: 96)
+                .accessibilityHidden(true)
+            Text(soul.name)
+                .font(.callout)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(soul.name)
+    }
+}
+
+#Preview {
+    SoulGridCell(
+        soul: SoulWithGlyph(
+            id: UUID(),
+            name: "Preview Soul",
+            glyphId: SystemGlyph.default,
+            glyph: Glyph(
+                id: SystemGlyph.default,
+                name: nil,
+                strokes: [GlyphStroke(d: "M30,30 L170,170", width: 6)],
+                viewBox: "0 0 200 200"
+            )
+        )
+    )
+    .padding()
+}
+```
+
+- [ ] **Step 2: Regenerate Xcode project + build**
+
+```bash
+npm run generate --workspace=@pbbls/ios
+xcodebuild -workspace apps/ios/Pebbles.xcworkspace -scheme Pebbles -destination 'generic/platform=iOS Simulator' -quiet build 2>&1 | tail -10
+```
+
+Expected: still failing at the `CreateSoulSheet` / `EditSoulSheet` call sites from Task 6, but no new errors from this file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Profile/Lists/SoulGridCell.swift apps/ios/Pebbles.xcodeproj
+git commit -m "feat(ios): add SoulGridCell view"
+```
+
+---
+
+## Task 8: Rewrite `CreateSoulSheet` with glyph row
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Profile/Sheets/CreateSoulSheet.swift`
+
+Switch `@State` from `name: String` to a `SoulDraft`. Add a "Glyph" `Section` with a button that opens `GlyphPickerSheet`. Eagerly fetch the system default glyph on `.task` so the row renders the correct thumbnail before the user taps anything. On save, send the new shared `SoulInsertPayload` with `glyphId`.
+
+- [ ] **Step 1: Replace the file body**
+
+Replace contents of `apps/ios/Pebbles/Features/Profile/Sheets/CreateSoulSheet.swift` with:
+
+```swift
+import SwiftUI
+import os
+
+/// Sheet for creating a new soul. Name + glyph row, save/cancel toolbar.
+/// INSERT goes directly to `public.souls` — RLS scopes to the current user.
+/// `glyph_id` is initialised to the system default; the user can swap it
+/// via `GlyphPickerSheet` (which itself can carve a fresh glyph).
+struct CreateSoulSheet: View {
+    let onCreated: () -> Void
+
+    @Environment(SupabaseService.self) private var supabase
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var draft = SoulDraft()
+    @State private var isSaving = false
+    @State private var saveError: String?
+    @State private var isPresentingPicker = false
+
+    private let logger = Logger(subsystem: "app.pbbls.ios", category: "profile.souls")
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Name", text: $draft.name)
+                        .textInputAutocapitalization(.words)
+                        .autocorrectionDisabled(false)
+                }
+                Section("Glyph") {
+                    GlyphRow(
+                        glyph: draft.currentGlyph,
+                        onTap: { isPresentingPicker = true }
+                    )
+                }
+                if let saveError {
+                    Section {
+                        Text(saveError)
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("New soul")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if isSaving {
+                        ProgressView()
+                    } else {
+                        Button("Save") {
+                            Task { await save() }
+                        }
+                        .disabled(!draft.isValid)
+                    }
+                }
+            }
+            .pebblesScreen()
+            .task { await loadDefaultGlyph() }
+            .sheet(isPresented: $isPresentingPicker) {
+                GlyphPickerSheet(
+                    currentGlyphId: draft.glyphId,
+                    onSelected: { selected in
+                        // Picker returns the chosen glyph's id. Update draft
+                        // and refetch the glyph so the row's thumbnail
+                        // re-renders without waiting for a list reload.
+                        if let selected {
+                            draft.glyphId = selected
+                            Task { await loadGlyph(id: selected) }
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    private func loadDefaultGlyph() async {
+        // Idempotent: only fetch if we still hold the system default and
+        // haven't already loaded its strokes.
+        guard draft.glyphId == SystemGlyph.default,
+              draft.currentGlyph?.id != SystemGlyph.default else { return }
+        await loadGlyph(id: SystemGlyph.default)
+    }
+
+    private func loadGlyph(id: UUID) async {
+        do {
+            let fetched: Glyph = try await supabase.client
+                .from("glyphs")
+                .select("id, name, strokes, view_box")
+                .eq("id", value: id)
+                .single()
+                .execute()
+                .value
+            draft.currentGlyph = fetched
+        } catch {
+            logger.error("create soul: load glyph failed: \(error.localizedDescription, privacy: .private)")
+            // Leave currentGlyph as-is; the empty thumbnail still works as a tap target.
+        }
+    }
+
+    private func save() async {
+        guard draft.isValid else { return }
+        guard let userId = supabase.session?.user.id else {
+            logger.error("create soul: no session")
+            saveError = "You're signed out. Please sign in again."
+            return
+        }
+        isSaving = true
+        saveError = nil
+        do {
+            let payload = SoulInsertPayload(
+                userId: userId,
+                name: draft.name.trimmingCharacters(in: .whitespacesAndNewlines),
+                glyphId: draft.glyphId
+            )
+            try await supabase.client
+                .from("souls")
+                .insert(payload)
+                .execute()
+            onCreated()
+            dismiss()
+        } catch {
+            logger.error("create soul failed: \(error.localizedDescription, privacy: .private)")
+            saveError = "Couldn't save the soul. Please try again."
+            isSaving = false
+        }
+    }
+}
+
+/// Row used by both create and edit soul sheets. Shows the current glyph
+/// thumbnail (or a dashed placeholder when not yet loaded) + label + chevron.
+private struct GlyphRow: View {
+    let glyph: Glyph?
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 12) {
+                if let glyph {
+                    GlyphThumbnail(strokes: glyph.strokes, side: 32)
+                        .accessibilityHidden(true)
+                } else {
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(style: StrokeStyle(lineWidth: 1, dash: [3]))
+                        .frame(width: 32, height: 32)
+                        .foregroundStyle(.secondary)
+                }
+                Text("Tap to choose")
+                    .foregroundStyle(.primary)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    CreateSoulSheet(onCreated: {})
+        .environment(SupabaseService())
+}
+```
+
+- [ ] **Step 2: Build to confirm `CreateSoulSheet` compiles**
+
+```bash
+xcodebuild -workspace apps/ios/Pebbles.xcworkspace -scheme Pebbles -destination 'generic/platform=iOS Simulator' -quiet build 2>&1 | tail -10
+```
+
+Expected: still failing only at the `EditSoulSheet` save site (resolved in Task 9).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Profile/Sheets/CreateSoulSheet.swift
+git commit -m "feat(ios): add glyph row to create-soul sheet (#298)"
+```
+
+---
+
+## Task 9: Rewrite `EditSoulSheet` with glyph row
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Profile/Sheets/EditSoulSheet.swift`
+
+Same pattern as `CreateSoulSheet`. Init now takes a `SoulWithGlyph` so the picker row can render immediately from the parent's already-fetched glyph (no second fetch). The `GlyphRow` view is duplicated as a private struct here for now; if a third caller appears, lift it into `Profile/Components/`.
+
+- [ ] **Step 1: Replace the file body**
+
+Replace contents of `apps/ios/Pebbles/Features/Profile/Sheets/EditSoulSheet.swift` with:
+
+```swift
+import SwiftUI
+import os
+
+/// Sheet for editing a soul. Name + glyph row, save/cancel toolbar.
+/// UPDATE goes directly to `public.souls` — RLS scopes to the owner.
+struct EditSoulSheet: View {
+    let original: SoulWithGlyph
+    let onSaved: () -> Void
+
+    @Environment(SupabaseService.self) private var supabase
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var draft: SoulDraft
+    @State private var isSaving = false
+    @State private var saveError: String?
+    @State private var isPresentingPicker = false
+
+    private let logger = Logger(subsystem: "app.pbbls.ios", category: "profile.souls")
+
+    init(original: SoulWithGlyph, onSaved: @escaping () -> Void) {
+        self.original = original
+        self.onSaved = onSaved
+        self._draft = State(initialValue: SoulDraft(from: original))
+    }
+
+    private var canSave: Bool {
+        guard draft.isValid else { return false }
+        let trimmed = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let nameChanged = trimmed != original.name
+        let glyphChanged = draft.glyphId != original.glyphId
+        return nameChanged || glyphChanged
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Name", text: $draft.name)
+                        .textInputAutocapitalization(.words)
+                        .autocorrectionDisabled(false)
+                }
+                Section("Glyph") {
+                    GlyphRow(
+                        glyph: draft.currentGlyph,
+                        onTap: { isPresentingPicker = true }
+                    )
+                }
+                if let saveError {
+                    Section {
+                        Text(saveError)
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("Edit soul")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if isSaving {
+                        ProgressView()
+                    } else {
+                        Button("Save") {
+                            Task { await save() }
+                        }
+                        .disabled(!canSave)
+                    }
+                }
+            }
+            .pebblesScreen()
+            .sheet(isPresented: $isPresentingPicker) {
+                GlyphPickerSheet(
+                    currentGlyphId: draft.glyphId,
+                    onSelected: { selected in
+                        if let selected {
+                            draft.glyphId = selected
+                            Task { await loadGlyph(id: selected) }
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    private func loadGlyph(id: UUID) async {
+        do {
+            let fetched: Glyph = try await supabase.client
+                .from("glyphs")
+                .select("id, name, strokes, view_box")
+                .eq("id", value: id)
+                .single()
+                .execute()
+                .value
+            draft.currentGlyph = fetched
+        } catch {
+            logger.error("edit soul: load glyph failed: \(error.localizedDescription, privacy: .private)")
+        }
+    }
+
+    private func save() async {
+        guard canSave else { return }
+        isSaving = true
+        saveError = nil
+        do {
+            let payload = SoulUpdatePayload(
+                name: draft.name.trimmingCharacters(in: .whitespacesAndNewlines),
+                glyphId: draft.glyphId
+            )
+            try await supabase.client
+                .from("souls")
+                .update(payload)
+                .eq("id", value: original.id)
+                .execute()
+            onSaved()
+            dismiss()
+        } catch {
+            logger.error("update soul failed: \(error.localizedDescription, privacy: .private)")
+            saveError = "Couldn't save your changes. Please try again."
+            isSaving = false
+        }
+    }
+}
+
+/// Row shared with `CreateSoulSheet`. Kept duplicated as `private` here because
+/// only two callers exist; lift to `Profile/Components/` if a third appears.
+private struct GlyphRow: View {
+    let glyph: Glyph?
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 12) {
+                if let glyph {
+                    GlyphThumbnail(strokes: glyph.strokes, side: 32)
+                        .accessibilityHidden(true)
+                } else {
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(style: StrokeStyle(lineWidth: 1, dash: [3]))
+                        .frame(width: 32, height: 32)
+                        .foregroundStyle(.secondary)
+                }
+                Text("Tap to choose")
+                    .foregroundStyle(.primary)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    EditSoulSheet(
+        original: SoulWithGlyph(
+            id: UUID(),
+            name: "Preview",
+            glyphId: SystemGlyph.default,
+            glyph: Glyph(
+                id: SystemGlyph.default,
+                name: nil,
+                strokes: [],
+                viewBox: "0 0 200 200"
+            )
+        ),
+        onSaved: {}
+    )
+    .environment(SupabaseService())
+}
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+xcodebuild -workspace apps/ios/Pebbles.xcworkspace -scheme Pebbles -destination 'generic/platform=iOS Simulator' -quiet build 2>&1 | tail -10
+```
+
+Expected: still fails at the `EditSoulSheet(soul:)` call site inside `SoulDetailView` (its signature changed from `soul:` to `original:` and now takes a `SoulWithGlyph`). That site is rewritten in Task 11.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Profile/Sheets/EditSoulSheet.swift
+git commit -m "feat(ios): add glyph row to edit-soul sheet (#298)"
+```
+
+---
+
+## Task 10: Rebuild `SoulsListView` as a 3-column grid
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Profile/Lists/SoulsListView.swift`
+
+Swap `[Soul]` for `[SoulWithGlyph]`. Replace the `List` with a `LazyVGrid` of 3 adaptive columns, each cell wrapped in a `NavigationLink`. Toolbar `+` button stays. Delete via long-press context menu (replaces the current swipe action — `LazyVGrid` cells don't support `.swipeActions`).
+
+- [ ] **Step 1: Replace the file body**
+
+Replace contents of `apps/ios/Pebbles/Features/Profile/Lists/SoulsListView.swift` with:
+
+```swift
+import SwiftUI
+import os
+
+struct SoulsListView: View {
+    @Environment(SupabaseService.self) private var supabase
+    @State private var items: [SoulWithGlyph] = []
+    @State private var isLoading = true
+    @State private var loadError: String?
+    @State private var isPresentingCreate = false
+    @State private var pendingDeletion: SoulWithGlyph?
+    @State private var deleteError: String?
+
+    private let logger = Logger(subsystem: "app.pbbls.ios", category: "profile.souls")
+
+    private let columns = [GridItem(.adaptive(minimum: 96), spacing: 16)]
+
+    var body: some View {
+        content
+            .navigationTitle("Souls")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        isPresentingCreate = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                    .accessibilityLabel("Add soul")
+                }
+            }
+            .task { await load() }
+            .sheet(isPresented: $isPresentingCreate) {
+                CreateSoulSheet(onCreated: {
+                    Task { await load() }
+                })
+            }
+            .confirmationDialog(
+                pendingDeletion.map { "Delete \($0.name)?" } ?? "",
+                isPresented: Binding(
+                    get: { pendingDeletion != nil },
+                    set: { if !$0 { pendingDeletion = nil } }
+                ),
+                titleVisibility: .visible,
+                presenting: pendingDeletion
+            ) { soul in
+                Button("Delete", role: .destructive) {
+                    Task { await delete(soul) }
+                }
+                Button("Cancel", role: .cancel) {
+                    pendingDeletion = nil
+                }
+            } message: { _ in
+                Text("Linked pebbles stay; only the soul and its links are removed.")
+            }
+            .alert(
+                "Couldn't delete",
+                isPresented: Binding(
+                    get: { deleteError != nil },
+                    set: { if !$0 { deleteError = nil } }
+                ),
+                presenting: deleteError
+            ) { _ in
+                Button("OK", role: .cancel) { deleteError = nil }
+            } message: { message in
+                Text(message)
+            }
+            .pebblesScreen()
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isLoading {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let loadError {
+            ContentUnavailableView(
+                "Couldn't load souls",
+                systemImage: "exclamationmark.triangle",
+                description: Text(loadError)
+            )
+        } else if items.isEmpty {
+            ContentUnavailableView(
+                "No souls yet",
+                systemImage: "person.2",
+                description: Text("People and beings you tag on your pebbles will appear here.")
+            )
+        } else {
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 16) {
+                    ForEach(items) { item in
+                        NavigationLink {
+                            SoulDetailView(initial: item, onChanged: {
+                                Task { await load() }
+                            })
+                        } label: {
+                            SoulGridCell(soul: item)
+                        }
+                        .buttonStyle(.plain)
+                        .contextMenu {
+                            Button(role: .destructive) {
+                                pendingDeletion = item
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                    }
+                }
+                .padding()
+            }
+        }
+    }
+
+    private func load() async {
+        isLoading = true
+        loadError = nil
+        do {
+            let result: [SoulWithGlyph] = try await supabase.client
+                .from("souls")
+                .select("id, name, glyph_id, glyphs(id, name, strokes, view_box)")
+                .order("name", ascending: true)
+                .execute()
+                .value
+            self.items = result
+        } catch {
+            logger.error("souls fetch failed: \(error.localizedDescription, privacy: .private)")
+            self.loadError = "Something went wrong. Please try again."
+        }
+        self.isLoading = false
+    }
+
+    private func delete(_ soul: SoulWithGlyph) async {
+        pendingDeletion = nil
+        do {
+            try await supabase.client
+                .from("souls")
+                .delete()
+                .eq("id", value: soul.id)
+                .execute()
+            await load()
+        } catch {
+            logger.error("delete soul failed: \(error.localizedDescription, privacy: .private)")
+            deleteError = "Something went wrong. Please try again."
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SoulsListView()
+            .environment(SupabaseService())
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Build will fail because `SoulDetailView(initial:onChanged:)` doesn't yet exist (current init takes `soul:`). That's resolved in Task 11.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Profile/Lists/SoulsListView.swift
+git commit -m "feat(ios): render Souls as 3-column glyph grid (#298)"
+```
+
+---
+
+## Task 11: Add compact glyph header to `SoulDetailView`
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Profile/Views/SoulDetailView.swift`
+
+The view receives a `SoulWithGlyph` from the list (renamed init param `initial:`). Switch the `reloadSoul()` fetch to also pull the joined glyph. Build a compact header above the existing pebble list: 56pt thumbnail on the left, name + "<n> pebbles" on the right. Pass `original: soulWithGlyph` to `EditSoulSheet`.
+
+The pluralised string `"<n> pebbles"` uses `LocalizedStringResource` with a stringsdict-style plural — added to `Localizable.xcstrings` in Task 12.
+
+- [ ] **Step 1: Replace the file body**
+
+Replace contents of `apps/ios/Pebbles/Features/Profile/Views/SoulDetailView.swift` with:
+
+```swift
+import SwiftUI
+import os
+
+/// Pushed detail view for a single soul.
+///
+/// - Compact header: 56pt glyph thumbnail + name + pebble count.
+/// - Below the header: pebbles tagged with this soul (filtered via
+///   `pebble_souls` inner join).
+/// - Edit toolbar action presents `EditSoulSheet`. The sheet receives the
+///   already-fetched `SoulWithGlyph` so its glyph row renders immediately
+///   without a second fetch.
+struct SoulDetailView: View {
+    let onChanged: () -> Void
+
+    @Environment(SupabaseService.self) private var supabase
+
+    @State private var soulWithGlyph: SoulWithGlyph
+    @State private var pebbles: [Pebble] = []
+    @State private var isLoading = true
+    @State private var loadError: String?
+    @State private var selectedPebbleId: UUID?
+    @State private var isPresentingEdit = false
+
+    private let logger = Logger(subsystem: "app.pbbls.ios", category: "profile.soul.detail")
+
+    init(initial: SoulWithGlyph, onChanged: @escaping () -> Void) {
+        self.onChanged = onChanged
+        self._soulWithGlyph = State(initialValue: initial)
+    }
+
+    var body: some View {
+        content
+            .navigationTitle(soulWithGlyph.name)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button("Edit") {
+                        isPresentingEdit = true
+                    }
+                }
+            }
+            .task { await load() }
+            .sheet(isPresented: $isPresentingEdit) {
+                EditSoulSheet(original: soulWithGlyph, onSaved: {
+                    Task { await reloadSoul() }
+                    onChanged()
+                })
+            }
+            .sheet(item: $selectedPebbleId) { id in
+                EditPebbleSheet(pebbleId: id, onSaved: {
+                    Task { await load() }
+                })
+            }
+            .pebblesScreen()
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            GlyphThumbnail(strokes: soulWithGlyph.glyph.strokes, side: 56)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(soulWithGlyph.name)
+                    .font(.headline)
+                Text("^[\(pebbles.count) pebbles](inflect: true)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isLoading {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let loadError {
+            ContentUnavailableView(
+                "Couldn't load pebbles",
+                systemImage: "exclamationmark.triangle",
+                description: Text(loadError)
+            )
+        } else {
+            VStack(spacing: 0) {
+                header
+                if pebbles.isEmpty {
+                    ContentUnavailableView(
+                        "No pebbles yet",
+                        systemImage: "circle.grid.2x1",
+                        description: Text("Pebbles you tag with this soul will appear here.")
+                    )
+                    .frame(maxHeight: .infinity)
+                } else {
+                    List(pebbles) { pebble in
+                        Button {
+                            selectedPebbleId = pebble.id
+                        } label: {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(pebble.name).font(.body)
+                                Text(pebble.happenedAt, style: .date)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+    }
+
+    private func reloadSoul() async {
+        do {
+            let refreshed: SoulWithGlyph = try await supabase.client
+                .from("souls")
+                .select("id, name, glyph_id, glyphs(id, name, strokes, view_box)")
+                .eq("id", value: soulWithGlyph.id)
+                .single()
+                .execute()
+                .value
+            self.soulWithGlyph = refreshed
+        } catch {
+            logger.error("soul reload failed: \(error.localizedDescription, privacy: .private)")
+            // Leave stale state; next navigation will refresh.
+        }
+    }
+
+    private func load() async {
+        isLoading = true
+        loadError = nil
+        do {
+            let result: [Pebble] = try await supabase.client
+                .from("pebbles")
+                .select("id, name, happened_at, pebble_souls!inner(soul_id)")
+                .eq("pebble_souls.soul_id", value: soulWithGlyph.id)
+                .order("happened_at", ascending: false)
+                .execute()
+                .value
+            self.pebbles = result
+        } catch {
+            logger.error("soul pebbles fetch failed: \(error.localizedDescription, privacy: .private)")
+            self.loadError = "Something went wrong. Please try again."
+        }
+        self.isLoading = false
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SoulDetailView(
+            initial: SoulWithGlyph(
+                id: UUID(),
+                name: "Preview Soul",
+                glyphId: SystemGlyph.default,
+                glyph: Glyph(
+                    id: SystemGlyph.default,
+                    name: nil,
+                    strokes: [],
+                    viewBox: "0 0 200 200"
+                )
+            ),
+            onChanged: {}
+        )
+        .environment(SupabaseService())
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+xcodebuild -workspace apps/ios/Pebbles.xcworkspace -scheme Pebbles -destination 'generic/platform=iOS Simulator' -quiet build 2>&1 | tail -10
+```
+
+Expected: build succeeds. The `^[count pebbles](inflect: true)` automatic-grammar string requires a matching variation in `Localizable.xcstrings`, which Task 12 adds — at runtime without that entry, SwiftUI falls back to `"<n> pebbles"` literally, which is fine until Task 12 lands (no compile error).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Profile/Views/SoulDetailView.swift
+git commit -m "feat(ios): add glyph header to soul detail (#298)"
+```
+
+---
+
+## Task 12: Localised strings (en + fr)
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Resources/Localizable.xcstrings`
+
+Three new entries:
+
+| Key                             | English          | French            |
+|---------------------------------|------------------|-------------------|
+| `Glyph`                         | Glyph            | Glyphe            |
+| `Tap to choose`                 | Tap to choose    | Toucher pour choisir |
+| `^[%lld pebbles](inflect: true)` | one: 1 pebble / other: %lld pebbles | one: 1 pebble / other: %lld pebbles (FR plural per SwiftUI inflection) |
+
+The pluralised entry uses Apple's automatic-grammar markup (`inflect: true`) — SwiftUI handles `1 pebble` / `2 pebbles` for English. For French, mirror the same plural shape (`1 pebble` / `%lld pebbles` until a French translation is finalised — log this as an open follow-up if not yet translated).
+
+- [ ] **Step 1: Open the catalog in Xcode**
+
+```bash
+open apps/ios/Pebbles/Resources/Localizable.xcstrings
+```
+
+- [ ] **Step 2: Confirm Xcode auto-extracted the new keys**
+
+Build the iOS target once so `SWIFT_EMIT_LOC_STRINGS=YES` extracts the literals from Steps in Tasks 8/9/11. After building, re-open the catalog. Expect new entries in `New` state for: `Glyph`, `Tap to choose`, `%lld pebbles` (in inflected form).
+
+```bash
+xcodebuild -workspace apps/ios/Pebbles.xcworkspace -scheme Pebbles -destination 'generic/platform=iOS Simulator' -quiet build 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Add `en` + `fr` translations for each new key**
+
+In Xcode's catalog UI, for each row in `New` state:
+- Set English value (matches the source literal).
+- Set French value:
+  - `Glyph` → `Glyphe`
+  - `Tap to choose` → `Toucher pour choisir`
+  - `%lld pebbles` (inflected) → variations: `one: %lld caillou`, `other: %lld cailloux`
+
+For the inflected plural, set both English and French variations explicitly:
+- English: `one: %lld pebble`, `other: %lld pebbles`
+- French: `one: %lld caillou`, `other: %lld cailloux`
+
+Mark each row as `Translated` (Xcode does this automatically once both columns have values).
+
+- [ ] **Step 4: Verify no `New` / `Stale` rows remain**
+
+Spot-check the catalog: every row that touches the Soul* views must be `Translated` for both `en` and `fr`. If any row is `Stale`, review and re-translate.
+
+- [ ] **Step 5: Build + manually verify French locale**
+
+```bash
+xcodebuild -workspace apps/ios/Pebbles.xcworkspace -scheme Pebbles -destination 'generic/platform=iOS Simulator' -quiet build 2>&1 | tail -5
+```
+
+Then run the simulator with `-AppleLanguages '(fr-FR)' -AppleLocale fr_FR` (Xcode → Edit Scheme → Run → App Language: French) and confirm the Souls list, detail header ("X cailloux"), and create/edit sheets render in French.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/ios/Pebbles/Resources/Localizable.xcstrings
+git commit -m "feat(ios): localise soul glyph strings (en + fr)"
+```
+
+---
+
+## Task 13: Update Arkaik product map
+
+**Files:**
+- Modify: `docs/arkaik/bundle.json`
+
+Use the `arkaik` skill (`.claude/skills/arkaik/`) — it explains the schema and provides a validation script. Two surgical edits:
+
+- [ ] **Step 1: Invoke the arkaik skill**
+
+Read `.claude/skills/arkaik/SKILL.md` (via the Skill tool). Follow its update pattern.
+
+- [ ] **Step 2: Update `DM-soul` description**
+
+Find the node `DM-soul` (around line 656 in `docs/arkaik/bundle.json`). Append " Each soul carries a glyph for visual identity." to its `description`. Keep all other fields untouched.
+
+- [ ] **Step 3: Update `V-souls-list` description**
+
+Find the node `V-souls-list` (around line 202). Update `description` from "Browse and manage all souls (people in your life)." to "Browse and manage all souls (people in your life) as a 3-column glyph grid."
+
+- [ ] **Step 4: Run the arkaik validation script**
+
+```bash
+node .claude/skills/arkaik/validate.mjs docs/arkaik/bundle.json
+```
+
+(Use the exact script path the skill specifies — verify by reading the skill's instructions.) Expected: validation passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/arkaik/bundle.json
+git commit -m "docs(arkaik): note soul glyph in souls list and DM-soul"
+```
+
+---
+
+## Task 14: Final verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+xcodebuild -workspace apps/ios/Pebbles.xcworkspace -scheme Pebbles -destination 'platform=iOS Simulator,name=iPhone 16' test 2>&1 | tail -30
+```
+
+Expected: every test passes — including the 3 new ones added in Tasks 3, 5, 6.
+
+- [ ] **Step 2: Run the workspace lint**
+
+```bash
+npm run lint
+```
+
+Expected: clean exit (no warnings, no errors).
+
+- [ ] **Step 3: Manual smoke on simulator**
+
+Boot the simulator and verify each scenario from the spec:
+1. Existing pre-migration soul shows the system default glyph in the grid and detail header.
+2. Create a soul without tapping the glyph row → soul saved, default glyph appears in the grid.
+3. Create a soul, open picker, carve a fresh glyph → soul saved with the new glyph; grid reflects it.
+4. Edit an existing soul, change the glyph via picker → grid updates after dismissal.
+5. Switch simulator to French → every Soul* string renders in French.
+
+If any scenario fails, return to the relevant task and fix before proceeding.
+
+- [ ] **Step 4: Confirm no stale strings**
+
+Re-open `Localizable.xcstrings` in Xcode. Confirm no `New` or `Stale` rows for any Soul-related keys.
+
+- [ ] **Step 5: Push branch + open PR**
+
+The branch should already match `feat/298-ios-soul-glyph-design` (per memory & repo conventions). Push and open the PR with the exact issue/labels/milestone inheritance flow from `CLAUDE.md`:
+
+```bash
+git push -u origin feat/298-ios-soul-glyph-design
+```
+
+Then propose to the user: "PR will resolve #298, inheriting labels (`feat`, `ios`, `core`) and milestone (`M25 · Improved core UX`) from the issue. Confirm?"
+
+After confirmation, create the PR with `gh pr create` per the project's PR Workflow Checklist (title in conventional commits format, body starting with `Resolves #298`, key files listed).
+
+---
+
+## Notes for the implementer
+
+- **No RPC.** Both writes are single-table single-statement (per `AGENTS.md`). Don't be tempted to wrap them in a function.
+- **No `await` inside `onAuthStateChange`.** Not a concern in any of these files, but worth keeping in mind if you touch session code by accident.
+- **Picker `onSelected` signature.** Today `GlyphPickerSheet.onSelected: (UUID?) -> Void` — tolerant of nil so the picker can pass through a "cleared" selection. We treat `nil` here as "no change" (the spec says: picker dismissed without selection → keep prior value), so the `if let selected` guard inside the create/edit sheets is intentional. Don't refactor the picker's signature in this PR.
+- **`GlyphRow` duplication between sheets.** Two callers, kept private. If a third caller shows up later, lift to `apps/ios/Pebbles/Features/Profile/Components/GlyphRow.swift`.
+- **`xcodegen generate` after every new file.** The pbxproj is regenerated; commit it together with the new source file (don't gitignore changes there during this work).

--- a/docs/superpowers/specs/2026-04-25-ios-soul-glyph-design.md
+++ b/docs/superpowers/specs/2026-04-25-ios-soul-glyph-design.md
@@ -1,0 +1,172 @@
+# iOS — Soul Glyph (issue #298)
+
+**Date:** 2026-04-25
+**Issue:** #298 — Attribute a glyph to souls
+**Milestone:** M25 · Improved core UX
+**Labels:** `feat`, `ios`, `core`
+
+## Goal
+
+Souls today carry only a name and are listed as a flat text list on Profile → Souls. We want each soul to also carry a glyph — a small drawn mark — so it has a visual identity in the grid, on its detail page, and (later) anywhere else souls surface.
+
+## Scope
+
+**In scope**
+- A `glyph_id` column on `souls`, FK to `glyphs`, defaulted to the existing system default glyph (`4759c37c-68a6-46a6-b4fc-046bd0316752`).
+- Souls list rendered as a 3-column grid with a glyph thumbnail + name per cell, ordered alphabetically by name.
+- Soul detail page gets a compact header: small glyph thumbnail beside the name + pebble count, then the existing pebbles list.
+- Create-soul and edit-soul sheets get a "Glyph" row that opens the existing `GlyphPickerSheet`. Picker reuses today's behaviour: pick an existing glyph, or carve a new one via `GlyphCarveSheet`.
+
+**Out of scope (deferred)**
+- Reworking the soul selector inside the pebble record flow. The native dropdown stays as-is for this issue. Tracked separately.
+- Sorting souls by most-recent-pebble. Likely needs a denormalised column or a join with `MAX(pebbles.created_at)`. Defer.
+- Web-side soul→glyph linkage. iOS goes first; web mirrors later.
+
+## Non-goals
+
+- No new RPCs. Soul writes stay direct INSERT/UPDATE on the table — single-statement, single-table, per AGENTS.md.
+- No `inline new_glyph` payload on a soul write. The carve flow inside `GlyphPickerSheet` already inserts the glyph client-side and returns it; the soul write only needs the resulting `glyph_id`.
+
+## Data model
+
+**Migration** — `packages/supabase/supabase/migrations/<ts>_add_glyph_to_souls.sql`:
+
+1. Insert the system default glyph if it isn't already present:
+   ```sql
+   insert into public.glyphs (id, user_id, ...)
+   values ('4759c37c-68a6-46a6-b4fc-046bd0316752', null, ...)
+   on conflict (id) do nothing;
+   ```
+   This guarantees the FK target exists before the backfill, even if the seed has drifted between environments.
+2. Add the column nullable, FK to glyphs:
+   ```sql
+   alter table public.souls
+     add column glyph_id uuid references public.glyphs(id) on delete restrict;
+   ```
+3. Backfill existing rows:
+   ```sql
+   update public.souls
+   set glyph_id = '4759c37c-68a6-46a6-b4fc-046bd0316752'
+   where glyph_id is null;
+   ```
+4. Tighten:
+   ```sql
+   alter table public.souls
+     alter column glyph_id set not null,
+     alter column glyph_id set default '4759c37c-68a6-46a6-b4fc-046bd0316752';
+   ```
+
+`ON DELETE RESTRICT` — the default glyph must never be deletable while a soul references it; user-carved glyphs being deleted shouldn't silently strand a soul. Glyphs aren't user-deletable today; this future-proofs.
+
+**RLS** — no change. `souls` already restricts by `user_id`. The join to `glyphs` succeeds because the existing `glyphs` SELECT policy already allows the user's own glyphs and system glyphs (`user_id IS NULL`).
+
+**Type regeneration** — after applying the migration:
+```
+npm run db:types --workspace=packages/supabase
+git add packages/supabase/types/database.ts
+```
+
+## iOS model
+
+`apps/ios/Pebbles/Features/Path/Models/Soul.swift`
+- Add `let glyphId: UUID` (non-optional). `CodingKeys.glyphId = "glyph_id"`.
+
+`apps/ios/Pebbles/Features/Profile/Models/SoulDraft.swift` (new, mirrors `PebbleDraft`)
+- `var name: String`
+- `var glyphId: UUID` — defaults to the system default at construction.
+- `var currentGlyph: Glyph?` — in-memory cache so the form's thumbnail can render without a glyph-by-id fetch.
+
+`Profile/Models/SoulWithGlyph.swift` (new) — value used by the list/detail views. `Soul` + the joined `Glyph`, decoded from the PostgREST nested select.
+
+## Components
+
+**Reused unchanged**
+- `Features/Glyph/Views/GlyphPickerSheet.swift` — already takes `currentGlyphId: UUID?` + `onSelected: (UUID) -> Void`.
+- `Features/Glyph/Views/GlyphCarveSheet.swift` — opened from inside the picker, persists the new glyph, returns it.
+- `Features/Glyph/Views/GlyphThumbnail.swift` — square stroke renderer used in the grid cell, the detail header, and the form row.
+
+**Modified**
+
+`Profile/Lists/SoulsListView.swift`
+- Replace the text list with a `LazyVGrid` of three adaptive columns.
+- Extract a small `SoulGridCell` view: a rounded-square `GlyphThumbnail` (~96 pt) above the soul's name (one-line, truncating).
+- Order: `name` ascending.
+- "+" stays in the toolbar, not in the grid — keeps cell layout uniform.
+- Tap → push existing `SoulDetailView`.
+
+`Profile/Views/SoulDetailView.swift`
+- New compact header above the existing pebbles section: 56 pt `GlyphThumbnail` on the left, name + "<n> pebbles" on the right.
+- "Edit" toolbar action stays.
+
+`Profile/Sheets/CreateSoulSheet.swift`
+- New "Glyph" row in the form. Shows the current `GlyphThumbnail` + label + chevron. Tap presents `GlyphPickerSheet`.
+- On creation, `draft.glyphId` is initialised to the system default. On `.task`, the sheet eagerly fetches the default glyph (`select id, strokes, view_box from glyphs where id = $default`) and stores it in `draft.currentGlyph` so the row renders the correct thumbnail immediately. If the fetch fails, log via `os.Logger` and fall back to an empty thumbnail; the user can still tap to pick.
+- Save: direct `INSERT INTO souls (name, glyph_id)` via the existing service path, plus `glyph_id` field.
+
+`Profile/Sheets/EditSoulSheet.swift`
+- Same "Glyph" row pattern, pre-filled with the soul's current `glyph_id` and the already-fetched glyph passed in from `SoulDetailView`.
+- Save: direct `UPDATE souls SET name=$1, glyph_id=$2 WHERE id=$3`.
+
+**New**
+- `Profile/Lists/SoulGridCell.swift` — pure presentational, ~30 LoC.
+- `Profile/Models/SoulDraft.swift` — described above.
+
+## Data flow
+
+**Souls list load**
+```
+supabase.from("souls")
+  .select("id, name, glyph_id, glyphs(id, strokes, view_box)")
+  .order("name", ascending: true)
+```
+One round-trip. Decode into `[SoulWithGlyph]`. Render via `SoulGridCell`.
+
+**Soul detail load**
+The existing soul + pebbles fetch gets `glyph_id, glyphs(id, strokes, view_box)` appended to the soul select. Pebble count for the header subtitle comes from the already-loaded pebbles array — no extra query.
+
+**Create / edit flow**
+1. Sheet opens with `draft.glyphId` populated (system default for create, current value for edit) and `draft.currentGlyph` populated where possible (passed in from the detail view on edit).
+2. User taps the Glyph row → `GlyphPickerSheet` presents with `currentGlyphId: draft.glyphId`.
+3. User picks an existing glyph (or carves one inside `GlyphCarveSheet`, which inserts the row in `glyphs` and returns the persisted `Glyph`).
+4. `onSelected(glyph)` updates `draft.glyphId` AND `draft.currentGlyph` so the form thumbnail re-renders without a re-fetch.
+5. Save: direct INSERT or UPDATE on `souls`. Single-statement, single-table.
+6. On dismissal, the parent view (`SoulsListView` or `SoulDetailView`) refetches via the existing `.task(id:)` refresh-token pattern.
+
+## Error handling & logging
+
+- `SoulsListView` and `SoulDetailView` log + surface errors today; the only change is the joined select. The same error path catches join failures.
+- `CreateSoulSheet` / `EditSoulSheet` save: log via `os.Logger` with a label (`"create soul"`, `"update soul"`) on `catch`, present the existing inline error state. No timeout wrapper — the call is button-driven, not render-blocking.
+- The migration's `INSERT … ON CONFLICT DO NOTHING` of the system default glyph guards against a missing FK target before backfill.
+- Picker dismissed without selection: `draft.glyphId` stays at its prior value. No error case.
+- Carve failure inside the picker: handled by existing `GlyphService` paths. Unchanged.
+
+## Localization
+
+Strings touched:
+- "Souls" (page title) — already exists.
+- "Glyph" (form row label) — new key.
+- "Tap to choose" (form row hint) — new key, or reuse an existing equivalent if there is one in the pebble form.
+- "<n> pebbles" / "<n> pebble" — pluralised. Use `LocalizedStringResource` with a stringsdict-style plural in `Localizable.xcstrings`.
+
+Add `en` and `fr` values for any new key. Open `Localizable.xcstrings` in Xcode before opening the PR and confirm no row is in `New` / `Stale` state.
+
+## Testing
+
+Swift Testing where it earns its keep:
+- Decoding test: the joined `souls + glyphs(...)` payload decodes into `SoulWithGlyph` correctly, including a row pointing at the system default.
+- `SoulDraft` payload encoding: emits `glyph_id` snake-cased, both for create (no `id`) and update (with `id`).
+
+Manual verification before opening the PR:
+- Build + run on iPhone simulator.
+- Existing soul (pre-migration) shows the default glyph in the grid and detail.
+- Create a soul without tapping the glyph row → soul saved with default `glyph_id`.
+- Create a soul, open picker, carve a fresh glyph → soul saved with the new `glyph_id`.
+- Edit a soul, change the glyph → grid reflects the change after dismissal.
+- Run with French locale: every new string renders in French.
+- `npm run lint` and a clean iOS build.
+
+## Open follow-ups (not part of this issue)
+
+- Pebble record flow soul selector: replace the native dropdown with a valence-style picker showing each soul's name + glyph. Mentioned in the issue's "Intention" but explicitly out of scope here. Track in a new issue.
+- Sort souls by most-recent-pebble.
+- Web-side soul→glyph rendering parity.

--- a/packages/supabase/supabase/migrations/20260426000000_add_glyph_to_souls.sql
+++ b/packages/supabase/supabase/migrations/20260426000000_add_glyph_to_souls.sql
@@ -1,0 +1,41 @@
+-- Migration: Add glyph_id to souls (issue #298)
+--
+-- Souls today carry only a name. This migration adds an FK to glyphs so each
+-- soul has a visual identity (rendered in the iOS Souls grid + detail header).
+--
+-- Strategy:
+--   1. Defensively guarantee the system default glyph exists.
+--   2. Add column nullable (so existing rows don't violate the constraint).
+--   3. Backfill all rows to the system default.
+--   4. Tighten: NOT NULL + default = system default glyph.
+--
+-- ON DELETE RESTRICT: glyphs aren't user-deletable today, but if that changes
+-- the constraint stops a deletion from silently stranding a soul.
+-- The default glyph itself must never be deletable while any soul references it.
+
+-- 1. Defensively ensure the system default glyph row exists.
+--    The remote DB already has it (seeded by 20260415000001), but a fresh local
+--    DB might not have run that seed yet. ON CONFLICT keeps it idempotent.
+insert into public.glyphs (id, user_id, shape_id, strokes, view_box)
+values (
+  '4759c37c-68a6-46a6-b4fc-046bd0316752',
+  null,
+  null,
+  '[]'::jsonb,
+  '0 0 200 200'
+)
+on conflict (id) do nothing;
+
+-- 2. Add column nullable, FK to glyphs.
+alter table public.souls
+  add column glyph_id uuid references public.glyphs(id) on delete restrict;
+
+-- 3. Backfill existing rows to the system default.
+update public.souls
+set glyph_id = '4759c37c-68a6-46a6-b4fc-046bd0316752'
+where glyph_id is null;
+
+-- 4. Tighten: NOT NULL + default.
+alter table public.souls
+  alter column glyph_id set not null,
+  alter column glyph_id set default '4759c37c-68a6-46a6-b4fc-046bd0316752';

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -733,6 +733,7 @@ export type Database = {
       souls: {
         Row: {
           created_at: string
+          glyph_id: string
           id: string
           name: string
           updated_at: string
@@ -740,6 +741,7 @@ export type Database = {
         }
         Insert: {
           created_at?: string
+          glyph_id?: string
           id?: string
           name: string
           updated_at?: string
@@ -747,12 +749,20 @@ export type Database = {
         }
         Update: {
           created_at?: string
+          glyph_id?: string
           id?: string
           name?: string
           updated_at?: string
           user_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "souls_glyph_id_fkey"
+            columns: ["glyph_id"]
+            isOneToOne: false
+            referencedRelation: "glyphs"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "souls_user_id_fkey"
             columns: ["user_id"]


### PR DESCRIPTION
Resolves #298.

## Summary

Souls now carry a glyph alongside their name. The Souls list switches from a flat text list to a 3-column grid of glyph thumbnails, the soul detail page gains a compact glyph header with pebble count, and the create / edit sheets get a Glyph row that reuses the existing `GlyphPickerSheet` (pick existing or carve new).

## Database

Migration `20260426000000_add_glyph_to_souls.sql`:

1. Defensively `INSERT … ON CONFLICT DO NOTHING` for the system default glyph (`4759c37c-…-046bd0316752`).
2. Add `souls.glyph_id` nullable, FK to `glyphs(id)` with `ON DELETE RESTRICT`.
3. Backfill existing rows to the system default.
4. Tighten: `NOT NULL` + default = system default glyph.

`packages/supabase/types/database.ts` regenerated against the linked remote project.

## iOS — model layer

- `Soul` widened with `glyphId: UUID` (snake-cased CodingKey).
- `SystemGlyph.default` constant for the canonical fallback UUID.
- `SoulWithGlyph` decodes the joined PostgREST payload `souls + glyphs(...)` in one round-trip; exposes `.soul` accessor for callers that want the bare `Soul` shape.
- `SoulDraft` form-state value (mirrors `PebbleDraft`); seeded with `SystemGlyph.default`, holds `currentGlyph: Glyph?` so the form thumbnail renders without a refetch after the picker returns.
- `SoulInsertPayload` / `SoulUpdatePayload` lifted out of the private scope of the sheets into a shared `SoulPayloads.swift` so both the sheets and the encoding tests reach them.

## iOS — views

- `SoulsListView` — `LazyVGrid` of three adaptive 96 pt columns of `SoulGridCell` (glyph thumbnail above truncating name); single round-trip joined select; swipe-to-delete replaced with long-press context menu.
- `SoulDetailView` — compact header (56 pt thumbnail + name + pluralised pebble count) above the existing pebbles list; init now takes `initial: SoulWithGlyph` and passes the already-fetched glyph through to the edit sheet.
- `CreateSoulSheet` — adds a Glyph row that opens `GlyphPickerSheet`; eagerly fetches the system default glyph so the row's thumbnail renders correctly before the user taps; saves direct INSERT with `glyph_id`.
- `EditSoulSheet` — same Glyph row pattern, prefilled from the parent's `SoulWithGlyph`; saves direct UPDATE with `name` + `glyph_id`.

`GlyphRow` is intentionally duplicated as a private struct in both create and edit sheets — two callers warrants duplication; lift to `Profile/Components/` if a third appears.

## Localization

Two new keys added to `Localizable.xcstrings` with en + fr:

- `Tap to choose` / `Toucher pour choisir`
- `^[%lld pebbles](inflect: true)` / `^[%lld galets](inflect: true)`

The 11 pre-existing Lab catalog gaps (`Lab`, `Changelog`, `Announcements`, etc.) remain on `main` and are out of scope.

## Tests

- New: `SoulWithGlyphDecodingTests` (3 tests covering joined payload decode, user-carved glyphs, `.soul` accessor).
- New: `SoulInsertPayloadEncodingTests`, `SoulUpdatePayloadEncodingTests` (3 tests verifying snake_case keys + no top-level `id`).
- Patched: `PebbleDetailDecodingTests`, `PebbleDraftFromDetailTests` — soul JSON fixtures widened to include `glyph_id`.

Total iOS test outcome: 112 tests, 11 failures — all pre-existing localization-catalog gaps from the Lab feature, present on `main`.

## Things touched outside the issue scope (followed the runtime-correctness chain)

- `PebbleDetailSheet` and `EditPebbleSheet` joined selects widened from `souls(id, name)` → `souls(id, name, glyph_id)` so the inner `Soul` decode wouldn't crash at runtime.
- `EditPebbleSheet` and `CreatePebbleSheet` standalone soul dropdown queries widened the same way (caught during simulator testing — without this, opening / creating any pebble against a real account threw "The data couldn't be read because it is missing.").

## Map

`docs/arkaik/bundle.json`:
- `DM-soul.description` — appended "Each soul carries a glyph for visual identity."
- `V-souls-list.description` — switched "flat list" → "3-column glyph grid".

Validated via `node .claude/skills/arkaik/scripts/validate-bundle.js docs/arkaik/bundle.json`.

## Test plan

- [x] Migration applied to remote Supabase via Studio SQL editor.
- [x] Existing pre-migration soul shows the system default glyph in the grid and detail.
- [x] Create a soul without tapping the glyph row → soul saved with default `glyph_id`.
- [x] Create a soul, open picker, carve a fresh glyph → soul saved with new `glyph_id`.
- [x] Edit a soul, change the glyph → grid reflects the change after dismissal.
- [x] Open an existing pebble (post-fix) — edit sheet loads cleanly.
- [x] Create a new pebble — soul dropdown loads cleanly.
- [x] Build green, lint clean (4 warnings, all pre-existing on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)