### PR TITLE
feat(core): admin analytics thin slice (kpi strip + active users chart)

### DIFF
--- a/apps/admin/app/(authed)/analytics/loading.tsx
+++ b/apps/admin/app/(authed)/analytics/loading.tsx
@@ -1,0 +1,11 @@
+import { ChartCardSkeleton } from "@/components/analytics/ChartCardSkeleton"
+import { KpiStripSkeleton } from "@/components/analytics/KpiStripSkeleton"
+
+export default function AnalyticsLoading() {
+  return (
+    <div className="space-y-6">
+      <KpiStripSkeleton />
+      <ChartCardSkeleton />
+    </div>
+  )
+}

--- a/apps/admin/app/(authed)/analytics/page.tsx
+++ b/apps/admin/app/(authed)/analytics/page.tsx
@@ -1,0 +1,35 @@
+import { Suspense } from "react"
+import { ActiveUsersChartCard } from "@/components/analytics/ActiveUsersChartCard"
+import { ChartCardSkeleton } from "@/components/analytics/ChartCardSkeleton"
+import { KpiStrip } from "@/components/analytics/KpiStrip"
+import { KpiStripSkeleton } from "@/components/analytics/KpiStripSkeleton"
+import { TimeRangeTabs } from "@/components/analytics/TimeRangeTabs"
+import { isTimeRange, type TimeRange } from "@/lib/analytics/types"
+
+type SearchParams = Promise<{ range?: string }>
+
+export default async function AnalyticsPage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
+  const params = await searchParams
+  const range: TimeRange = isTimeRange(params.range) ? params.range : "30d"
+
+  return (
+    <section className="space-y-6">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Analytics</h1>
+        <TimeRangeTabs />
+      </header>
+
+      <Suspense fallback={<KpiStripSkeleton />}>
+        <KpiStrip range={range} />
+      </Suspense>
+
+      <Suspense fallback={<ChartCardSkeleton />}>
+        <ActiveUsersChartCard range={range} />
+      </Suspense>
+    </section>
+  )
+}

--- a/apps/admin/app/(authed)/playground/analytics/page.tsx
+++ b/apps/admin/app/(authed)/playground/analytics/page.tsx
@@ -1,0 +1,88 @@
+import { ActiveUsersChart } from "@/components/analytics/ActiveUsersChart"
+import { KpiCard } from "@/components/analytics/KpiCard"
+import { Sparkline } from "@/components/analytics/Sparkline"
+import {
+  denseFixture,
+  emptyFixture,
+  sparseFixture,
+} from "@/components/analytics/__fixtures__/activeUsers"
+import { kpiFixture } from "@/components/analytics/__fixtures__/kpi"
+
+export default function AnalyticsPlaygroundPage() {
+  const sparkValues = kpiFixture.map((r) => r.dau ?? 0)
+
+  return (
+    <div className="space-y-10">
+      <header>
+        <h1 className="text-2xl font-semibold">Playground · Analytics</h1>
+        <p className="text-sm text-muted-foreground">
+          Renders analytics components from fixtures. No live data calls.
+        </p>
+      </header>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">KpiCard variants</h2>
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+          <KpiCard
+            label="DAU"
+            value={142}
+            subLabel="trailing 7-day avg"
+            sparkline={sparkValues}
+            delta={{ absolute: 8, direction: "up" }}
+          />
+          <KpiCard
+            label="DAU"
+            value={142}
+            subLabel="trailing 7-day avg"
+            sparkline={sparkValues}
+            delta={{ absolute: -3, direction: "down" }}
+          />
+          <KpiCard
+            label="MAU"
+            value={1212}
+            subLabel="rolling 30 days"
+            sparkline={sparkValues}
+            delta={{ absolute: 0, direction: "flat" }}
+          />
+          <KpiCard label="Total users" value={1287} subLabel="all signups" />
+          <KpiCard label="DAU / MAU" value="—" subLabel="No data yet" />
+          <KpiCard
+            label="DAU / MAU"
+            value={11.7}
+            unit="%"
+            subLabel="stickiness"
+            delta={{ absolute: 0.3, direction: "up", unit: "pp" }}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">Sparkline</h2>
+        <div className="text-foreground/60">
+          <Sparkline values={sparkValues} width={200} height={40} ariaLabel="DAU sparkline" />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          ActiveUsersChart — dense (90 days)
+        </h2>
+        <ActiveUsersChart data={denseFixture} />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          ActiveUsersChart — sparse (12 days)
+        </h2>
+        <ActiveUsersChart data={sparseFixture} />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          ActiveUsersChart — empty
+        </h2>
+        <ActiveUsersChart data={emptyFixture} />
+      </section>
+    </div>
+  )
+}

--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -29,6 +29,11 @@
   --sidebar-border: oklch(0.92 0.004 286.32);
   --sidebar-ring: oklch(0.705 0.015 286.067);
   --radius: 0.625rem;
+  --chart-1: oklch(0.87 0 0);
+  --chart-2: oklch(0.70 0 0);
+  --chart-3: oklch(0.556 0 0);
+  --chart-4: oklch(0.439 0 0);
+  --chart-5: oklch(0.269 0 0);
 }
 
 .dark {
@@ -58,6 +63,11 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 0.1);
   --sidebar-ring: oklch(0.552 0.016 285.938);
+  --chart-1: oklch(0.87 0 0);
+  --chart-2: oklch(0.70 0 0);
+  --chart-3: oklch(0.556 0 0);
+  --chart-4: oklch(0.439 0 0);
+  --chart-5: oklch(0.269 0 0);
 }
 
 @theme inline {
@@ -87,6 +97,11 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);

--- a/apps/admin/components/analytics/ActiveUsersChart.tsx
+++ b/apps/admin/components/analytics/ActiveUsersChart.tsx
@@ -1,0 +1,119 @@
+"use client"
+
+import { useState } from "react"
+import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts"
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart"
+import { Button } from "@/components/ui/button"
+import type { ActivityMetric } from "@/lib/analytics/types"
+
+/** ActiveUsersChart receives rows with non-null bucket_date (filtered upstream). */
+export type ActiveUsersChartDatum = {
+  bucket_date: string
+  dau: number | null
+  wau: number | null
+  mau: number | null
+}
+
+type ActiveUsersChartProps = {
+  data: ActiveUsersChartDatum[]
+  initialMetric?: ActivityMetric
+}
+
+const METRICS: ActivityMetric[] = ["all", "dau", "wau", "mau"]
+const METRIC_LABELS: Record<ActivityMetric, string> = {
+  all: "All",
+  dau: "DAU",
+  wau: "WAU",
+  mau: "MAU",
+}
+
+const config: ChartConfig = {
+  dau: { label: "DAU", color: "var(--chart-1)" },
+  wau: { label: "WAU", color: "var(--chart-2)" },
+  mau: { label: "MAU", color: "var(--chart-3)" },
+}
+
+export function ActiveUsersChart({
+  data,
+  initialMetric = "all",
+}: ActiveUsersChartProps) {
+  const [metric, setMetric] = useState<ActivityMetric>(initialMetric)
+
+  if (data.length === 0) {
+    return (
+      <div
+        className="flex h-72 items-center justify-center text-sm text-muted-foreground"
+        aria-live="polite"
+      >
+        No activity in this range
+      </div>
+    )
+  }
+
+  const showDau = metric === "all" || metric === "dau"
+  const showWau = metric === "all" || metric === "wau"
+  const showMau = metric === "all" || metric === "mau"
+
+  // Coalesce nulls to 0 for recharts
+  const series = data.map((d) => ({
+    bucket_date: d.bucket_date,
+    dau: d.dau ?? 0,
+    wau: d.wau ?? 0,
+    mau: d.mau ?? 0,
+  }))
+
+  const last = series[series.length - 1]
+  const ariaSummary = `Active users on ${last.bucket_date}: DAU ${last.dau}, WAU ${last.wau}, MAU ${last.mau}.`
+
+  return (
+    <div aria-label={ariaSummary}>
+      <div className="mb-3 flex items-center gap-1" role="tablist" aria-label="Metric">
+        {METRICS.map((m) => (
+          <Button
+            key={m}
+            variant={m === metric ? "default" : "ghost"}
+            size="sm"
+            role="tab"
+            aria-selected={m === metric}
+            onClick={() => setMetric(m)}
+          >
+            {METRIC_LABELS[m]}
+          </Button>
+        ))}
+      </div>
+
+      <ChartContainer config={config} className="h-72 w-full">
+        <LineChart data={series} margin={{ left: 4, right: 12, top: 8, bottom: 4 }}>
+          <CartesianGrid vertical={false} strokeDasharray="3 3" />
+          <XAxis
+            dataKey="bucket_date"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            minTickGap={32}
+            tickFormatter={(v: string) => v.slice(5)}
+          />
+          <YAxis tickLine={false} axisLine={false} width={36} />
+          <ChartTooltip content={<ChartTooltipContent />} />
+          <ChartLegend content={<ChartLegendContent />} />
+          {showDau ? (
+            <Line dataKey="dau" type="monotone" stroke="var(--color-dau)" strokeWidth={2} dot={false} />
+          ) : null}
+          {showWau ? (
+            <Line dataKey="wau" type="monotone" stroke="var(--color-wau)" strokeWidth={2} dot={false} />
+          ) : null}
+          {showMau ? (
+            <Line dataKey="mau" type="monotone" stroke="var(--color-mau)" strokeWidth={2} dot={false} />
+          ) : null}
+        </LineChart>
+      </ChartContainer>
+    </div>
+  )
+}

--- a/apps/admin/components/analytics/ActiveUsersChartCard.tsx
+++ b/apps/admin/components/analytics/ActiveUsersChartCard.tsx
@@ -1,0 +1,42 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getActiveUsersSeries } from "@/lib/analytics/fetchers"
+import type { ActiveUsersDailyRow, TimeRange } from "@/lib/analytics/types"
+import { ActiveUsersChart, type ActiveUsersChartDatum } from "./ActiveUsersChart"
+import { ErrorBlock } from "./ErrorBlock"
+
+type ActiveUsersChartCardProps = { range: TimeRange }
+
+export async function ActiveUsersChartCard({ range }: ActiveUsersChartCardProps) {
+  let rows: ActiveUsersDailyRow[]
+  try {
+    rows = await getActiveUsersSeries(range)
+  } catch (err) {
+    return (
+      <ErrorBlock
+        label="Failed to load active users chart"
+        message={err instanceof Error ? err.message : String(err)}
+      />
+    )
+  }
+
+  // Filter out rows missing bucket_date — they can't be plotted.
+  const data: ActiveUsersChartDatum[] = rows
+    .filter((r): r is ActiveUsersDailyRow & { bucket_date: string } => r.bucket_date !== null)
+    .map((r) => ({
+      bucket_date: r.bucket_date,
+      dau: r.dau,
+      wau: r.wau,
+      mau: r.mau,
+    }))
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Active users over time</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ActiveUsersChart data={data} />
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/admin/components/analytics/ChartCardSkeleton.tsx
+++ b/apps/admin/components/analytics/ChartCardSkeleton.tsx
@@ -1,0 +1,15 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function ChartCardSkeleton() {
+  return (
+    <Card aria-hidden>
+      <CardHeader>
+        <Skeleton className="h-5 w-40" />
+      </CardHeader>
+      <CardContent>
+        <Skeleton className="h-72 w-full" />
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/admin/components/analytics/ErrorBlock.tsx
+++ b/apps/admin/components/analytics/ErrorBlock.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link"
+import { AlertTriangle } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+
+type ErrorBlockProps = {
+  label: string
+  /** Verbose admin-facing message. */
+  message: string
+  /** Same-URL link target for the retry button. Defaults to current. */
+  retryHref?: string
+}
+
+export function ErrorBlock({ label, message, retryHref }: ErrorBlockProps) {
+  return (
+    <Card className="border-destructive/40">
+      <CardContent className="flex items-start gap-3 py-4">
+        <AlertTriangle className="mt-0.5 size-5 text-destructive" aria-hidden />
+        <div className="space-y-1">
+          <p className="text-sm font-medium">{label}</p>
+          <pre className="whitespace-pre-wrap break-words text-xs text-muted-foreground">
+            {message}
+          </pre>
+          {retryHref ? (
+            <Link href={retryHref} className="text-xs underline">
+              Retry
+            </Link>
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/admin/components/analytics/KpiCard.tsx
+++ b/apps/admin/components/analytics/KpiCard.tsx
@@ -1,0 +1,89 @@
+import { ArrowDown, ArrowUp, Minus } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
+import { Sparkline } from "./Sparkline"
+
+export type KpiCardProps = {
+  label: string
+  value: number | string
+  unit?: string
+  delta?: { absolute: number; direction: "up" | "down" | "flat"; unit?: string }
+  subLabel?: string
+  sparkline?: number[]
+}
+
+export function KpiCard({
+  label,
+  value,
+  unit,
+  delta,
+  subLabel,
+  sparkline,
+}: KpiCardProps) {
+  const ariaParts = [`${label}: ${value}${unit ? ` ${unit}` : ""}`]
+  if (delta) {
+    const dirWord = delta.direction === "flat" ? "unchanged" : delta.direction
+    ariaParts.push(
+      `${dirWord} by ${Math.abs(delta.absolute)}${delta.unit ?? ""} from prior period`,
+    )
+  }
+
+  return (
+    <article aria-label={ariaParts.join(", ")}>
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {label}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-end justify-between gap-2">
+          <div className="space-y-1">
+            <div className="text-2xl font-semibold tabular-nums">
+              {value}
+              {unit ? (
+                <span className="ml-1 text-base font-normal text-muted-foreground">
+                  {unit}
+                </span>
+              ) : null}
+            </div>
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              {delta ? <DeltaBadge delta={delta} /> : null}
+              {subLabel ? <span>{subLabel}</span> : null}
+            </div>
+          </div>
+          {sparkline && sparkline.length >= 2 ? (
+            <Sparkline
+              values={sparkline}
+              className="text-foreground/60"
+              ariaLabel={`${label} trend`}
+            />
+          ) : null}
+        </CardContent>
+      </Card>
+    </article>
+  )
+}
+
+function DeltaBadge({ delta }: { delta: NonNullable<KpiCardProps["delta"]> }) {
+  const Icon =
+    delta.direction === "up" ? ArrowUp : delta.direction === "down" ? ArrowDown : Minus
+  const sign = delta.absolute > 0 ? "+" : ""
+  return (
+    <Badge
+      variant="secondary"
+      className={cn(
+        "gap-1",
+        delta.direction === "up" && "text-emerald-700 dark:text-emerald-400",
+        delta.direction === "down" && "text-rose-700 dark:text-rose-400",
+      )}
+    >
+      <Icon className="size-3" aria-hidden />
+      <span>
+        {sign}
+        {delta.absolute}
+        {delta.unit ?? ""}
+      </span>
+    </Badge>
+  )
+}

--- a/apps/admin/components/analytics/KpiStrip.tsx
+++ b/apps/admin/components/analytics/KpiStrip.tsx
@@ -1,0 +1,131 @@
+import { shiftIsoDate, periodLengthDays } from "@/lib/analytics/date"
+import { getKpiDaily } from "@/lib/analytics/fetchers"
+import type { KpiDailyRow, TimeRange } from "@/lib/analytics/types"
+import { ErrorBlock } from "./ErrorBlock"
+import { KpiCard, type KpiCardProps } from "./KpiCard"
+
+type KpiStripProps = { range: TimeRange }
+
+export async function KpiStrip({ range }: KpiStripProps) {
+  let rows: KpiDailyRow[]
+  try {
+    rows = await getKpiDaily(range)
+  } catch (err) {
+    return (
+      <ErrorBlock
+        label="Failed to load KPI strip"
+        message={err instanceof Error ? err.message : String(err)}
+      />
+    )
+  }
+
+  // Filter out rows missing bucket_date — they can't be ordered or matched.
+  const dated = rows.filter((r): r is KpiDailyRow & { bucket_date: string } => r.bucket_date !== null)
+
+  if (dated.length === 0) {
+    return <EmptyKpiStrip />
+  }
+
+  const sorted = [...dated].sort((a, b) => a.bucket_date.localeCompare(b.bucket_date))
+  const latest = sorted[sorted.length - 1]
+  const period = periodLengthDays(range)
+  const priorBucket = period === null ? null : shiftIsoDate(latest.bucket_date, -period)
+  const prior = priorBucket ? sorted.find((r) => r.bucket_date === priorBucket) ?? null : null
+
+  // Sparkline window: last 30 days
+  const sparkRows = sorted.slice(-30)
+
+  const trailing7 = (key: NumericKpiKey) => {
+    const last7 = sparkRows.slice(-7)
+    if (last7.length === 0) return 0
+    const sum = last7.reduce((acc, r) => acc + (r[key] ?? 0), 0)
+    return Math.round(sum / last7.length)
+  }
+
+  const sparkValues = (key: NumericKpiKey): number[] =>
+    sparkRows.map((r) => r[key] ?? 0)
+
+  const cards: KpiCardProps[] = [
+    {
+      label: "Total users",
+      value: latest.total_users ?? 0,
+      delta: deltaFor(latest.total_users, prior?.total_users ?? null),
+      subLabel: "all signups",
+    },
+    {
+      label: "DAU",
+      value: trailing7("dau"),
+      sparkline: sparkValues("dau"),
+      delta: deltaFor(latest.dau, prior?.dau ?? null),
+      subLabel: "trailing 7-day avg",
+    },
+    {
+      label: "WAU",
+      value: latest.wau ?? 0,
+      sparkline: sparkValues("wau"),
+      delta: deltaFor(latest.wau, prior?.wau ?? null),
+      subLabel: "rolling 7 days",
+    },
+    {
+      label: "MAU",
+      value: latest.mau ?? 0,
+      sparkline: sparkValues("mau"),
+      delta: deltaFor(latest.mau, prior?.mau ?? null),
+      subLabel: "rolling 30 days",
+    },
+    {
+      label: "Pebbles / day",
+      value: trailing7("pebbles_today"),
+      sparkline: sparkValues("pebbles_today"),
+      delta: deltaFor(latest.pebbles_today, prior?.pebbles_today ?? null),
+      subLabel: "trailing 7-day avg",
+    },
+    {
+      label: "DAU / MAU",
+      value: latest.dau_mau_pct ?? "—",
+      unit: latest.dau_mau_pct === null ? undefined : "%",
+      delta: deltaForPct(latest.dau_mau_pct, prior?.dau_mau_pct ?? null),
+      subLabel: "stickiness",
+    },
+  ]
+
+  return (
+    <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
+      {cards.map((c) => (
+        <KpiCard key={c.label} {...c} />
+      ))}
+    </div>
+  )
+}
+
+type NumericKpiKey = "total_users" | "dau" | "wau" | "mau" | "pebbles_today"
+
+function deltaFor(
+  current: number | null,
+  prior: number | null,
+): KpiCardProps["delta"] {
+  if (current === null || prior === null) return undefined
+  const absolute = current - prior
+  const direction = absolute > 0 ? "up" : absolute < 0 ? "down" : "flat"
+  return { absolute, direction }
+}
+
+function deltaForPct(
+  current: number | null,
+  prior: number | null,
+): KpiCardProps["delta"] {
+  if (current === null || prior === null) return undefined
+  const absolute = Number((current - prior).toFixed(1))
+  const direction = absolute > 0 ? "up" : absolute < 0 ? "down" : "flat"
+  return { absolute, direction, unit: "pp" }
+}
+
+function EmptyKpiStrip() {
+  return (
+    <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
+      {["Total users", "DAU", "WAU", "MAU", "Pebbles / day", "DAU / MAU"].map((label) => (
+        <KpiCard key={label} label={label} value="—" subLabel="No data yet" />
+      ))}
+    </div>
+  )
+}

--- a/apps/admin/components/analytics/KpiStripSkeleton.tsx
+++ b/apps/admin/components/analytics/KpiStripSkeleton.tsx
@@ -1,0 +1,23 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function KpiStripSkeleton() {
+  return (
+    <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <Card key={i} aria-hidden>
+          <CardHeader className="pb-2">
+            <Skeleton className="h-3 w-16" />
+          </CardHeader>
+          <CardContent className="flex items-end justify-between gap-2">
+            <div className="space-y-2">
+              <Skeleton className="h-7 w-20" />
+              <Skeleton className="h-3 w-24" />
+            </div>
+            <Skeleton className="h-6 w-20" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}

--- a/apps/admin/components/analytics/Sparkline.tsx
+++ b/apps/admin/components/analytics/Sparkline.tsx
@@ -1,0 +1,50 @@
+type SparklineProps = {
+  values: number[]
+  width?: number
+  height?: number
+  className?: string
+  ariaLabel?: string
+}
+
+export function Sparkline({
+  values,
+  width = 80,
+  height = 24,
+  className,
+  ariaLabel,
+}: SparklineProps) {
+  if (values.length < 2) return null
+
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const range = max - min || 1
+  const stepX = width / (values.length - 1)
+
+  const points = values
+    .map((v, i) => {
+      const x = i * stepX
+      const y = height - ((v - min) / range) * height
+      return `${x.toFixed(2)},${y.toFixed(2)}`
+    })
+    .join(" ")
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={className}
+      role="img"
+      aria-label={ariaLabel ?? "trend"}
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}

--- a/apps/admin/components/analytics/TimeRangeTabs.tsx
+++ b/apps/admin/components/analytics/TimeRangeTabs.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import Link from "next/link"
+import { useSearchParams } from "next/navigation"
+import { cn } from "@/lib/utils"
+import {
+  TIME_RANGES,
+  TIME_RANGE_LABELS,
+  isTimeRange,
+  type TimeRange,
+} from "@/lib/analytics/types"
+
+const DEFAULT: TimeRange = "30d"
+
+export function TimeRangeTabs() {
+  const params = useSearchParams()
+  const raw = params?.get("range") ?? undefined
+  const active: TimeRange = isTimeRange(raw) ? raw : DEFAULT
+
+  return (
+    <nav aria-label="Time range" className="flex items-center gap-1 rounded-md border p-1">
+      {TIME_RANGES.map((range) => {
+        const isActive = range === active
+        return (
+          <Link
+            key={range}
+            href={`?range=${range}`}
+            scroll={false}
+            aria-current={isActive ? "page" : undefined}
+            className={cn(
+              "rounded px-3 py-1 text-sm transition-colors",
+              isActive
+                ? "bg-foreground text-background"
+                : "text-muted-foreground hover:bg-muted",
+            )}
+          >
+            {TIME_RANGE_LABELS[range]}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/apps/admin/components/analytics/__fixtures__/activeUsers.ts
+++ b/apps/admin/components/analytics/__fixtures__/activeUsers.ts
@@ -1,0 +1,22 @@
+import type { ActiveUsersChartDatum } from "../ActiveUsersChart"
+
+const TODAY = new Date()
+function iso(daysAgo: number): string {
+  const d = new Date(TODAY)
+  d.setUTCDate(d.getUTCDate() - daysAgo)
+  return d.toISOString().slice(0, 10)
+}
+
+export const denseFixture: ActiveUsersChartDatum[] = Array.from({ length: 90 }, (_, i) => {
+  const day = 89 - i
+  const dau = 100 + Math.round(40 * Math.sin(i / 7)) + Math.round(i / 3)
+  return { bucket_date: iso(day), dau, wau: dau * 4, mau: dau * 9 }
+})
+
+export const sparseFixture: ActiveUsersChartDatum[] = Array.from({ length: 12 }, (_, i) => {
+  const day = 11 - i
+  const dau = 30 + i * 2
+  return { bucket_date: iso(day), dau, wau: dau * 3, mau: dau * 6 }
+})
+
+export const emptyFixture: ActiveUsersChartDatum[] = []

--- a/apps/admin/components/analytics/__fixtures__/kpi.ts
+++ b/apps/admin/components/analytics/__fixtures__/kpi.ts
@@ -1,0 +1,27 @@
+import type { KpiDailyRow } from "@/lib/analytics/types"
+
+const TODAY = new Date()
+function iso(daysAgo: number): string {
+  const d = new Date(TODAY)
+  d.setUTCDate(d.getUTCDate() - daysAgo)
+  return d.toISOString().slice(0, 10)
+}
+
+/** 30 days of plausible KPI data, ascending. All fields non-null. */
+export const kpiFixture: KpiDailyRow[] = Array.from({ length: 30 }, (_, i) => {
+  const day = 29 - i
+  const dau = 80 + Math.round(20 * Math.sin(i / 4)) + i
+  const wau = dau * 4
+  const mau = dau * 9
+  return {
+    bucket_date: iso(day),
+    total_users: 1200 + i * 3,
+    dau,
+    pebbles_today: dau * 2 + (i % 5),
+    wau,
+    mau,
+    dau_mau_pct: Math.round((dau / mau) * 10000) / 100,
+  }
+})
+
+export const kpiEmptyFixture: KpiDailyRow[] = []

--- a/apps/admin/components/layout/Sidebar.tsx
+++ b/apps/admin/components/layout/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { Megaphone, Sparkles } from "lucide-react"
+import { BarChart3, Megaphone, Sparkles } from "lucide-react"
 import {
   Sidebar,
   SidebarContent,
@@ -14,6 +14,10 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
+
+const ANALYTICS_ITEMS = [
+  { href: "/analytics", label: "Analytics", icon: BarChart3 },
+] as const
 
 const LOG_ITEMS = [
   { href: "/logs/features", label: "Features", icon: Sparkles },
@@ -29,6 +33,24 @@ export function AppSidebar() {
         <span className="px-2 py-1 text-sm font-semibold">Back-office</span>
       </SidebarHeader>
       <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Insights</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {ANALYTICS_ITEMS.map(({ href, label, icon: Icon }) => {
+                const active = pathname === href || pathname.startsWith(`${href}/`)
+                return (
+                  <SidebarMenuItem key={href}>
+                    <SidebarMenuButton render={<Link href={href} />} isActive={active}>
+                      <Icon aria-hidden />
+                      <span>{label}</span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                )
+              })}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
         <SidebarGroup>
           <SidebarGroupLabel>Logs</SidebarGroupLabel>
           <SidebarGroupContent>

--- a/apps/admin/components/ui/chart.tsx
+++ b/apps/admin/components/ui/chart.tsx
@@ -1,0 +1,373 @@
+"use client"
+
+import * as React from "react"
+import * as RechartsPrimitive from "recharts"
+import type { TooltipValueType } from "recharts"
+
+import { cn } from "@/lib/utils"
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const
+
+const INITIAL_DIMENSION = { width: 320, height: 200 } as const
+type TooltipNameType = number | string
+
+export type ChartConfig = Record<
+  string,
+  {
+    label?: React.ReactNode
+    icon?: React.ComponentType
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  )
+>
+
+type ChartContextProps = {
+  config: ChartConfig
+}
+
+const ChartContext = React.createContext<ChartContextProps | null>(null)
+
+function useChart() {
+  const context = React.useContext(ChartContext)
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />")
+  }
+
+  return context
+}
+
+function ChartContainer({
+  id,
+  className,
+  children,
+  config,
+  initialDimension = INITIAL_DIMENSION,
+  ...props
+}: React.ComponentProps<"div"> & {
+  config: ChartConfig
+  children: React.ComponentProps<
+    typeof RechartsPrimitive.ResponsiveContainer
+  >["children"]
+  initialDimension?: {
+    width: number
+    height: number
+  }
+}) {
+  const uniqueId = React.useId()
+  const chartId = `chart-${id ?? uniqueId.replace(/:/g, "")}`
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-slot="chart"
+        data-chart={chartId}
+        className={cn(
+          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          className
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer
+          initialDimension={initialDimension}
+        >
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  )
+}
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(
+    ([, config]) => config.theme ?? config.color
+  )
+
+  if (!colorConfig.length) {
+    return null
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ??
+      itemConfig.color
+    return color ? `  --color-${key}: ${color};` : null
+  })
+  .join("\n")}
+}
+`
+          )
+          .join("\n"),
+      }}
+    />
+  )
+}
+
+const ChartTooltip = RechartsPrimitive.Tooltip
+
+function ChartTooltipContent({
+  active,
+  payload,
+  className,
+  indicator = "dot",
+  hideLabel = false,
+  hideIndicator = false,
+  label,
+  labelFormatter,
+  labelClassName,
+  formatter,
+  color,
+  nameKey,
+  labelKey,
+}: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+  React.ComponentProps<"div"> & {
+    hideLabel?: boolean
+    hideIndicator?: boolean
+    indicator?: "line" | "dot" | "dashed"
+    nameKey?: string
+    labelKey?: string
+  } & Omit<
+    RechartsPrimitive.DefaultTooltipContentProps<
+      TooltipValueType,
+      TooltipNameType
+    >,
+    "accessibilityLayer"
+  >) {
+  const { config } = useChart()
+
+  const tooltipLabel = React.useMemo(() => {
+    if (hideLabel || !payload?.length) {
+      return null
+    }
+
+    const [item] = payload
+    const key = `${labelKey ?? item?.dataKey ?? item?.name ?? "value"}`
+    const itemConfig = getPayloadConfigFromPayload(config, item, key)
+    const value =
+      !labelKey && typeof label === "string"
+        ? (config[label]?.label ?? label)
+        : itemConfig?.label
+
+    if (labelFormatter) {
+      return (
+        <div className={cn("font-medium", labelClassName)}>
+          {labelFormatter(value, payload)}
+        </div>
+      )
+    }
+
+    if (!value) {
+      return null
+    }
+
+    return <div className={cn("font-medium", labelClassName)}>{value}</div>
+  }, [
+    label,
+    labelFormatter,
+    payload,
+    hideLabel,
+    labelClassName,
+    config,
+    labelKey,
+  ])
+
+  if (!active || !payload?.length) {
+    return null
+  }
+
+  const nestLabel = payload.length === 1 && indicator !== "dot"
+
+  return (
+    <div
+      className={cn(
+        "grid min-w-32 items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+        className
+      )}
+    >
+      {!nestLabel ? tooltipLabel : null}
+      <div className="grid gap-1.5">
+        {payload
+          .filter((item) => item.type !== "none")
+          .map((item, index) => {
+            const key = `${nameKey ?? item.name ?? item.dataKey ?? "value"}`
+            const itemConfig = getPayloadConfigFromPayload(config, item, key)
+            const indicatorColor = color ?? item.payload?.fill ?? item.color
+
+            return (
+              <div
+                key={index}
+                className={cn(
+                  "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+                  indicator === "dot" && "items-center"
+                )}
+              >
+                {formatter && item?.value !== undefined && item.name ? (
+                  formatter(item.value, item.name, item, index, item.payload)
+                ) : (
+                  <>
+                    {itemConfig?.icon ? (
+                      <itemConfig.icon />
+                    ) : (
+                      !hideIndicator && (
+                        <div
+                          className={cn(
+                            "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+                            {
+                              "h-2.5 w-2.5": indicator === "dot",
+                              "w-1": indicator === "line",
+                              "w-0 border-[1.5px] border-dashed bg-transparent":
+                                indicator === "dashed",
+                              "my-0.5": nestLabel && indicator === "dashed",
+                            }
+                          )}
+                          style={
+                            {
+                              "--color-bg": indicatorColor,
+                              "--color-border": indicatorColor,
+                            } as React.CSSProperties
+                          }
+                        />
+                      )
+                    )}
+                    <div
+                      className={cn(
+                        "flex flex-1 justify-between leading-none",
+                        nestLabel ? "items-end" : "items-center"
+                      )}
+                    >
+                      <div className="grid gap-1.5">
+                        {nestLabel ? tooltipLabel : null}
+                        <span className="text-muted-foreground">
+                          {itemConfig?.label ?? item.name}
+                        </span>
+                      </div>
+                      {item.value != null && (
+                        <span className="font-mono font-medium text-foreground tabular-nums">
+                          {typeof item.value === "number"
+                            ? item.value.toLocaleString()
+                            : String(item.value)}
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            )
+          })}
+      </div>
+    </div>
+  )
+}
+
+const ChartLegend = RechartsPrimitive.Legend
+
+function ChartLegendContent({
+  className,
+  hideIcon = false,
+  payload,
+  verticalAlign = "bottom",
+  nameKey,
+}: React.ComponentProps<"div"> & {
+  hideIcon?: boolean
+  nameKey?: string
+} & RechartsPrimitive.DefaultLegendContentProps) {
+  const { config } = useChart()
+
+  if (!payload?.length) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center gap-4",
+        verticalAlign === "top" ? "pb-3" : "pt-3",
+        className
+      )}
+    >
+      {payload
+        .filter((item) => item.type !== "none")
+        .map((item, index) => {
+          const key = `${nameKey ?? item.dataKey ?? "value"}`
+          const itemConfig = getPayloadConfigFromPayload(config, item, key)
+
+          return (
+            <div
+              key={index}
+              className={cn(
+                "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground"
+              )}
+            >
+              {itemConfig?.icon && !hideIcon ? (
+                <itemConfig.icon />
+              ) : (
+                <div
+                  className="h-2 w-2 shrink-0 rounded-[2px]"
+                  style={{
+                    backgroundColor: item.color,
+                  }}
+                />
+              )}
+              {itemConfig?.label}
+            </div>
+          )
+        })}
+    </div>
+  )
+}
+
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string
+) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined
+  }
+
+  const payloadPayload =
+    "payload" in payload &&
+    typeof payload.payload === "object" &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined
+
+  let configLabelKey: string = key
+
+  if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[
+      key as keyof typeof payloadPayload
+    ] as string
+  }
+
+  return configLabelKey in config ? config[configLabelKey] : config[key]
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+}

--- a/apps/admin/lib/analytics/date.ts
+++ b/apps/admin/lib/analytics/date.ts
@@ -1,0 +1,37 @@
+import type { IsoDate, TimeRange } from "./types"
+
+/** Number of days a TimeRange covers. `all` returns `null`. */
+export function periodLengthDays(range: TimeRange): number | null {
+  switch (range) {
+    case "7d":
+      return 7
+    case "30d":
+      return 30
+    case "90d":
+      return 90
+    case "1y":
+      return 365
+    case "all":
+      return null
+  }
+}
+
+/** Inclusive UTC date range ending today. For `all`, start = epoch. */
+export function dateRangeFor(
+  range: TimeRange,
+  today: Date = new Date(),
+): { start: IsoDate; end: IsoDate } {
+  const end = today.toISOString().slice(0, 10)
+  const days = periodLengthDays(range)
+  if (days === null) return { start: "1970-01-01", end }
+  const startDate = new Date(today)
+  startDate.setUTCDate(startDate.getUTCDate() - days + 1)
+  return { start: startDate.toISOString().slice(0, 10), end }
+}
+
+/** Subtract `days` from an ISO date and return a new ISO date. Pass a positive `days` to add. */
+export function shiftIsoDate(iso: IsoDate, days: number): IsoDate {
+  const d = new Date(`${iso}T00:00:00Z`)
+  d.setUTCDate(d.getUTCDate() + days)
+  return d.toISOString().slice(0, 10)
+}

--- a/apps/admin/lib/analytics/fetchers.ts
+++ b/apps/admin/lib/analytics/fetchers.ts
@@ -1,0 +1,42 @@
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { dateRangeFor } from "./date"
+import type { ActiveUsersDailyRow, KpiDailyRow, TimeRange } from "./types"
+
+/**
+ * Fetch the rows needed by the KPI strip:
+ *   - the latest row (current values + delta source)
+ *   - the row from `period_length` days earlier (for delta)
+ *   - the last 30 days (for sparklines)
+ *
+ * Returned by `get_kpi_daily(p_range)` in the migration. The RPC enforces
+ * `is_admin(auth.uid())`; callers must be admin or this throws.
+ */
+export async function getKpiDaily(range: TimeRange): Promise<KpiDailyRow[]> {
+  const supabase = await createServerSupabaseClient()
+  const { data, error } = await supabase.rpc("get_kpi_daily", { p_range: range })
+  if (error) {
+    console.error("[analytics] getKpiDaily failed:", error.message)
+    throw error
+  }
+  return data ?? []
+}
+
+/**
+ * Daily DAU/WAU/MAU series for the active-users chart, scoped to the global
+ * time range tab.
+ */
+export async function getActiveUsersSeries(
+  range: TimeRange,
+): Promise<ActiveUsersDailyRow[]> {
+  const { start, end } = dateRangeFor(range)
+  const supabase = await createServerSupabaseClient()
+  const { data, error } = await supabase.rpc("get_active_users_series", {
+    p_start: start,
+    p_end: end,
+  })
+  if (error) {
+    console.error("[analytics] getActiveUsersSeries failed:", error.message)
+    throw error
+  }
+  return data ?? []
+}

--- a/apps/admin/lib/analytics/types.ts
+++ b/apps/admin/lib/analytics/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Admin · Analytics · TS contracts (thin slice).
+ *
+ * Row types mirror the SQL views in
+ * packages/supabase/supabase/migrations/20260430000000_analytics_thin_slice.sql
+ *
+ * Fields are nullable where the underlying view can produce NULLs (e.g. when
+ * no data exists for a bucket). Callers are responsible for handling nulls
+ * before rendering.
+ */
+
+export type IsoDate = string
+
+export interface KpiDailyRow {
+  bucket_date: IsoDate | null
+  total_users: number | null
+  dau: number | null
+  pebbles_today: number | null
+  wau: number | null
+  mau: number | null
+  /** DAU / MAU as a 0–100 percent value. Null when MAU = 0. */
+  dau_mau_pct: number | null
+}
+
+export interface ActiveUsersDailyRow {
+  bucket_date: IsoDate | null
+  dau: number | null
+  wau: number | null
+  mau: number | null
+}
+
+export type TimeRange = "7d" | "30d" | "90d" | "1y" | "all"
+
+export type ActivityMetric = "dau" | "wau" | "mau" | "all"
+
+export const TIME_RANGES: readonly TimeRange[] = ["7d", "30d", "90d", "1y", "all"] as const
+
+export const TIME_RANGE_LABELS: Record<TimeRange, string> = {
+  "7d": "7 days",
+  "30d": "30 days",
+  "90d": "90 days",
+  "1y": "1 year",
+  all: "All time",
+}
+
+export function isTimeRange(value: string | undefined): value is TimeRange {
+  return value !== undefined && (TIME_RANGES as readonly string[]).includes(value)
+}

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -21,6 +21,7 @@
     "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "recharts": "^3.8.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0"
   },

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -6,7 +6,7 @@
     "root_node_id": "V-landing",
     "metadata": { "view_card_variant": "large" },
     "created_at": "2026-04-01T00:00:00.000Z",
-    "updated_at": "2026-04-28T12:00:00.000Z"
+    "updated_at": "2026-04-30T22:00:00.000Z"
   },
   "nodes": [
     {
@@ -1112,6 +1112,51 @@
           ]
         }
       }
+    },
+    {
+      "id": "V-admin-analytics",
+      "project_id": "pebbles",
+      "species": "view",
+      "title": "Admin · Analytics",
+      "description": "Back-office analytics page (admin-only). Thin slice (PR #337): KPI strip (Total users, DAU, WAU, MAU, Pebbles/day, DAU/MAU) + Active users line chart with DAU/WAU/MAU toggle. Global time-range tabs (7d/30d/90d/1y/All) URL-driven via ?range=. Six other buildable surfaces (retention, volume, enrichment, per-user, domain share, visibility, single-emotion share) follow on the same milestone (M28).",
+      "status": "development",
+      "platforms": ["web"]
+    },
+    {
+      "id": "DM-v-analytics-kpi-daily",
+      "project_id": "pebbles",
+      "species": "data-model",
+      "title": "v_analytics_kpi_daily",
+      "description": "Postgres view: one row per calendar day from the earliest pebble's created_at to today. Columns: bucket_date, total_users, dau, pebbles_today, wau, mau, dau_mau_pct. Aggregates auth.users and public.pebbles. Plain (non-materialized) view; will swap to MV when query times warrant.",
+      "status": "development",
+      "platforms": ["web"]
+    },
+    {
+      "id": "DM-v-analytics-active-users-daily",
+      "project_id": "pebbles",
+      "species": "data-model",
+      "title": "v_analytics_active_users_daily",
+      "description": "Postgres view: projection of v_analytics_kpi_daily exposing bucket_date, dau, wau, mau. Backs the daily DAU/WAU/MAU line chart on the admin analytics page.",
+      "status": "development",
+      "platforms": ["web"]
+    },
+    {
+      "id": "API-get-kpi-daily",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "get_kpi_daily",
+      "description": "SECURITY DEFINER plpgsql RPC, gated on is_admin(auth.uid()). Takes p_range ('7d'|'30d'|'90d'|'1y'|'all'). Returns the latest row of v_analytics_kpi_daily plus the row at (latest - period_length) for delta computation, plus the trailing 30 days for sparklines. Raises insufficient_privilege (42501) for non-admins.",
+      "status": "development",
+      "platforms": ["web"]
+    },
+    {
+      "id": "API-get-active-users-series",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "get_active_users_series",
+      "description": "SECURITY DEFINER plpgsql RPC, gated on is_admin(auth.uid()). Takes p_start and p_end dates. Returns rows from v_analytics_active_users_daily in [p_start, p_end] ordered ascending. Raises insufficient_privilege (42501) for non-admins.",
+      "status": "development",
+      "platforms": ["web"]
     }
   ],
   "edges": [
@@ -1310,6 +1355,15 @@
     { "id": "e-V-docs-index-V-docs-privacy", "project_id": "pebbles", "source_id": "V-docs-index", "target_id": "V-docs-privacy", "edge_type": "composes" },
     { "id": "e-F-legal-consent-V-register", "project_id": "pebbles", "source_id": "F-legal-consent", "target_id": "V-register", "edge_type": "composes" },
     { "id": "e-F-ios-app-shell-V-home", "project_id": "pebbles", "source_id": "F-ios-app-shell", "target_id": "V-home", "edge_type": "composes" },
-    { "id": "e-F-ios-app-shell-V-profile", "project_id": "pebbles", "source_id": "F-ios-app-shell", "target_id": "V-profile", "edge_type": "composes" }
+    { "id": "e-F-ios-app-shell-V-profile", "project_id": "pebbles", "source_id": "F-ios-app-shell", "target_id": "V-profile", "edge_type": "composes" },
+    { "id": "e-V-admin-analytics-API-get-kpi-daily", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "API-get-kpi-daily", "edge_type": "calls" },
+    { "id": "e-V-admin-analytics-API-get-active-users-series", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "API-get-active-users-series", "edge_type": "calls" },
+    { "id": "e-V-admin-analytics-DM-v-analytics-kpi-daily", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "DM-v-analytics-kpi-daily", "edge_type": "displays" },
+    { "id": "e-V-admin-analytics-DM-v-analytics-active-users-daily", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "DM-v-analytics-active-users-daily", "edge_type": "displays" },
+    { "id": "e-API-get-kpi-daily-DM-v-analytics-kpi-daily", "project_id": "pebbles", "source_id": "API-get-kpi-daily", "target_id": "DM-v-analytics-kpi-daily", "edge_type": "queries" },
+    { "id": "e-API-get-kpi-daily-DM-pebble", "project_id": "pebbles", "source_id": "API-get-kpi-daily", "target_id": "DM-pebble", "edge_type": "queries" },
+    { "id": "e-API-get-kpi-daily-DM-account", "project_id": "pebbles", "source_id": "API-get-kpi-daily", "target_id": "DM-account", "edge_type": "queries" },
+    { "id": "e-API-get-active-users-series-DM-v-analytics-active-users-daily", "project_id": "pebbles", "source_id": "API-get-active-users-series", "target_id": "DM-v-analytics-active-users-daily", "edge_type": "queries" },
+    { "id": "e-API-get-active-users-series-DM-pebble", "project_id": "pebbles", "source_id": "API-get-active-users-series", "target_id": "DM-pebble", "edge_type": "queries" }
   ]
 }

--- a/docs/superpowers/plans/2026-04-30-admin-analytics-thin-slice.md
+++ b/docs/superpowers/plans/2026-04-30-admin-analytics-thin-slice.md
@@ -1,0 +1,1661 @@
+# Admin Analytics — Thin Slice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the first cut of the admin analytics page — KPI strip (6 cards) + Active users line chart — for `apps/admin`, backed by two new Postgres views and two SECURITY DEFINER RPCs.
+
+**Architecture:** Server Components by default. Two plain Postgres views (no MV, no cron) read by SECURITY DEFINER RPCs that gate on `is_admin()`. Time-range state lives in `?range=` URL param and re-renders the page server-side; the DAU/WAU/MAU toggle on the chart is local client state. A playground page at `/playground/analytics` renders both components from fixtures for component-level review.
+
+**Tech Stack:** Next.js 16 App Router, React 19 Server Components, TypeScript strict, `@supabase/ssr`, shadcn/ui (`base-nova` on `@base-ui/react`), Recharts via shadcn `chart` primitive, Tailwind CSS 4, Postgres views + plpgsql RPCs.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-admin-analytics-thin-slice-design.md`
+
+**Project conventions to follow:**
+- Branch: `feat/<issue-number>-admin-analytics-thin-slice` (create the issue before the branch).
+- Commits: conventional, lowercase, no period. Scope is `core`/`db`/`api`/`ui`/`auth` as appropriate.
+- No tests in V1 — verification is `npm run build`, `npm run lint`, manual smoke on `/analytics` and `/playground/analytics`.
+- Project prefers remote Supabase deploys (no local Docker). The `db:push` script applies migrations to the linked remote project.
+- After any DB migration: `npm run db:types --workspace=packages/supabase`, then commit `packages/supabase/types/database.ts`.
+- Never `as` cast on RPC return rows — let codegen do its job.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `packages/supabase/supabase/migrations/20260430000000_analytics_thin_slice.sql` | Create | Two views (`v_analytics_kpi_daily`, `v_analytics_active_users_daily`) + two RPCs (`get_kpi_daily`, `get_active_users_series`) with admin gates. |
+| `packages/supabase/types/database.ts` | Regenerate | Add the new view rows + RPC signatures. |
+| `apps/admin/lib/analytics/types.ts` | Create | `KpiDailyRow`, `ActiveUsersDailyRow`, `TimeRange`, `ActivityMetric`. |
+| `apps/admin/lib/analytics/date.ts` | Create | `dateRangeFor(range)`, `periodLengthDays(range)`. |
+| `apps/admin/lib/analytics/fetchers.ts` | Create | `getKpiDaily(range)`, `getActiveUsersSeries(range)` — wrap RPCs with try/catch + `console.error`. |
+| `apps/admin/components/ui/chart.tsx` | Create (via shadcn CLI) | shadcn chart primitive (recharts wrapper). |
+| `apps/admin/components/analytics/Sparkline.tsx` | Create | Inline SVG mini-line. |
+| `apps/admin/components/analytics/KpiCard.tsx` | Create | Presentational card: value, delta badge, sub-label, sparkline. |
+| `apps/admin/components/analytics/KpiStrip.tsx` | Create | Server Component: fetches KPI rows, computes deltas, renders 6 cards. |
+| `apps/admin/components/analytics/KpiStripSkeleton.tsx` | Create | Skeleton fallback. |
+| `apps/admin/components/analytics/TimeRangeTabs.tsx` | Create | Client Component, URL-driven via `next/navigation`. |
+| `apps/admin/components/analytics/ActiveUsersChart.tsx` | Create | Client Component: recharts line chart with DAU/WAU/MAU toggle. |
+| `apps/admin/components/analytics/ActiveUsersChartCard.tsx` | Create | Server Component shell: fetches series, passes to client child. |
+| `apps/admin/components/analytics/ChartCardSkeleton.tsx` | Create | Skeleton fallback. |
+| `apps/admin/components/analytics/ErrorBlock.tsx` | Create | Inline verbose error renderer. |
+| `apps/admin/components/analytics/__fixtures__/kpi.ts` | Create | Mock `KpiDailyRow[]` for playground. |
+| `apps/admin/components/analytics/__fixtures__/activeUsers.ts` | Create | Mock `ActiveUsersDailyRow[]` (dense / sparse / empty). |
+| `apps/admin/app/(authed)/analytics/page.tsx` | Create | Compose KpiStrip + ActiveUsersChartCard. |
+| `apps/admin/app/(authed)/analytics/loading.tsx` | Create | Page-level skeleton shell. |
+| `apps/admin/app/(authed)/playground/analytics/page.tsx` | Create | Renders both components with fixtures. |
+| `apps/admin/components/layout/Sidebar.tsx` | Modify | Add "Analytics" group + nav item. |
+| `docs/arkaik/bundle.json` | Modify | Add screen + endpoints + data nodes (via arkaik skill). |
+
+---
+
+## Task 1: Create issue, branch, and worktree
+
+**Files:** none.
+
+- [ ] **Step 1: Create the GitHub issue**
+
+Title: `[Feat] Admin · Analytics — KPI strip + Active users chart (thin slice)`
+Body: link to the spec at `docs/superpowers/specs/2026-04-30-admin-analytics-thin-slice-design.md`. Apply labels `feat` + `core` + `ui` + `db`. Assign to the appropriate milestone.
+
+```bash
+gh issue create \
+  --title "[Feat] Admin · Analytics — KPI strip + Active users chart (thin slice)" \
+  --body "Ships the thin slice of the admin analytics page: KPI strip + Active users chart, backed by two new Postgres views + two SECURITY DEFINER RPCs.
+
+Spec: docs/superpowers/specs/2026-04-30-admin-analytics-thin-slice-design.md
+Plan: docs/superpowers/plans/2026-04-30-admin-analytics-thin-slice.md
+
+Resolves the data-pipeline foundation for the broader admin analytics work; the remaining 6 buildable surfaces follow in a second PR." \
+  --label feat,core,ui,db
+```
+
+Note the issue number returned by `gh issue create` — call it `<N>`. Use it for the branch name in step 2.
+
+- [ ] **Step 2: Create the branch**
+
+```bash
+git checkout main && git pull
+git checkout -b feat/<N>-admin-analytics-thin-slice
+```
+
+---
+
+## Task 2: Database migration — views + RPCs
+
+**Files:**
+- Create: `packages/supabase/supabase/migrations/20260430000000_analytics_thin_slice.sql`
+- Modify (regenerate): `packages/supabase/types/database.ts`
+
+- [ ] **Step 1: Create the migration file**
+
+```bash
+cd packages/supabase
+touch supabase/migrations/20260430000000_analytics_thin_slice.sql
+```
+
+- [ ] **Step 2: Write the migration SQL**
+
+Paste this exact content into `packages/supabase/supabase/migrations/20260430000000_analytics_thin_slice.sql`:
+
+```sql
+-- =============================================================================
+-- Admin · Analytics · Thin slice (KPI strip + Active users chart)
+-- =============================================================================
+-- Spec: docs/superpowers/specs/2026-04-30-admin-analytics-thin-slice-design.md
+--
+-- Two plain views (not materialized — current data volume doesn't warrant MVs)
+-- exposed via two SECURITY DEFINER RPCs that gate on is_admin(auth.uid()).
+-- Soft-delete does not exist in this project, so no deleted_at filters.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- v_analytics_kpi_daily
+-- One row per calendar day from the earliest pebble's created_at to today.
+-- -----------------------------------------------------------------------------
+drop view if exists public.v_analytics_active_users_daily;
+drop view if exists public.v_analytics_kpi_daily;
+
+create view public.v_analytics_kpi_daily as
+with days as (
+  select generate_series(
+    coalesce((select min(created_at)::date from public.pebbles), current_date),
+    current_date,
+    interval '1 day'
+  )::date as bucket_date
+),
+totals as (
+  select
+    d.bucket_date,
+    (select count(*) from auth.users u where u.created_at::date <= d.bucket_date) as total_users
+  from days d
+),
+day_counts as (
+  select
+    d.bucket_date,
+    count(distinct p.user_id) filter (where p.created_at::date = d.bucket_date) as dau,
+    count(*)                  filter (where p.created_at::date = d.bucket_date) as pebbles_today
+  from days d
+  left join public.pebbles p on p.created_at::date = d.bucket_date
+  group by d.bucket_date
+),
+rolling as (
+  select
+    d.bucket_date,
+    (select count(distinct p.user_id) from public.pebbles p
+       where p.created_at::date >  d.bucket_date - 7
+         and p.created_at::date <= d.bucket_date) as wau,
+    (select count(distinct p.user_id) from public.pebbles p
+       where p.created_at::date >  d.bucket_date - 30
+         and p.created_at::date <= d.bucket_date) as mau
+  from days d
+)
+select
+  t.bucket_date,
+  t.total_users::int           as total_users,
+  d.dau::int                   as dau,
+  d.pebbles_today::int         as pebbles_today,
+  r.wau::int                   as wau,
+  r.mau::int                   as mau,
+  case when r.mau > 0 then round((d.dau::numeric / r.mau) * 100, 2) else null end as dau_mau_pct
+from totals t
+join day_counts d using (bucket_date)
+join rolling r    using (bucket_date);
+
+-- -----------------------------------------------------------------------------
+-- v_analytics_active_users_daily
+-- Projection of v_analytics_kpi_daily for the line chart.
+-- -----------------------------------------------------------------------------
+create view public.v_analytics_active_users_daily as
+select bucket_date, dau, wau, mau
+from public.v_analytics_kpi_daily;
+
+-- -----------------------------------------------------------------------------
+-- get_kpi_daily(p_range text)
+-- Returns: latest row plus the row at (latest - period_length(p_range)).
+-- For p_range = 'all' the prior-period row is omitted (deltas render '—').
+-- -----------------------------------------------------------------------------
+create or replace function public.get_kpi_daily(p_range text)
+returns setof public.v_analytics_kpi_daily
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_period_days int;
+  v_latest      date;
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'insufficient_privilege' using errcode = '42501';
+  end if;
+
+  select max(bucket_date) into v_latest from public.v_analytics_kpi_daily;
+  if v_latest is null then
+    return;
+  end if;
+
+  v_period_days := case p_range
+    when '7d'  then 7
+    when '30d' then 30
+    when '90d' then 90
+    when '1y'  then 365
+    else null
+  end;
+
+  if v_period_days is null then
+    return query
+      select * from public.v_analytics_kpi_daily
+      where bucket_date in (v_latest, v_latest - 30);  -- 30 still useful for sparkline
+  else
+    return query
+      select * from public.v_analytics_kpi_daily
+      where bucket_date in (v_latest, v_latest - v_period_days)
+         or bucket_date >  v_latest - 30;             -- sparkline window
+  end if;
+end;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- get_active_users_series(p_start date, p_end date)
+-- Returns: rows from v_analytics_active_users_daily in [p_start, p_end].
+-- -----------------------------------------------------------------------------
+create or replace function public.get_active_users_series(
+  p_start date,
+  p_end   date
+)
+returns setof public.v_analytics_active_users_daily
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'insufficient_privilege' using errcode = '42501';
+  end if;
+
+  return query
+    select * from public.v_analytics_active_users_daily
+    where bucket_date between p_start and p_end
+    order by bucket_date asc;
+end;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- Permissions
+-- Views: the SECURITY DEFINER RPCs are the access path. We still revoke direct
+-- select to keep the surface tight.
+-- -----------------------------------------------------------------------------
+revoke all on public.v_analytics_kpi_daily          from public, anon, authenticated;
+revoke all on public.v_analytics_active_users_daily from public, anon, authenticated;
+
+grant execute on function public.get_kpi_daily(text)                from authenticated;
+grant execute on function public.get_active_users_series(date, date) from authenticated;
+```
+
+- [ ] **Step 3: Push the migration to the remote Supabase project**
+
+```bash
+cd packages/supabase
+npm run db:push
+```
+
+Expected: migration listed and applied. No errors.
+
+- [ ] **Step 4: Regenerate database types from the linked remote project**
+
+The repo's `db:types` script uses `--local` (requires Docker). The user doesn't run Docker, so target the linked remote project directly:
+
+```bash
+cd packages/supabase
+npx supabase gen types typescript --linked > types/database.ts
+```
+
+Expected: `types/database.ts` is updated. Confirm new entries appear:
+
+```bash
+grep -n "v_analytics_kpi_daily\|get_kpi_daily\|get_active_users_series" types/database.ts
+```
+
+Expected: at least 4 hits.
+
+- [ ] **Step 5: Hand smoke-test SQL to the user**
+
+The user will run these in Supabase Studio. Surface the exact queries to run as an admin:
+
+```sql
+select * from public.get_kpi_daily('30d');
+select * from public.get_active_users_series(current_date - 30, current_date);
+```
+
+Expected: rows return without error.
+
+And as a non-admin (or by setting the JWT role to a non-admin user):
+
+```sql
+select * from public.get_kpi_daily('30d');
+-- Expected: ERROR:  insufficient_privilege
+```
+
+Do not block on this step — proceed; the user will report any failure.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/alexis/code/pbbls
+git add packages/supabase/supabase/migrations/20260430000000_analytics_thin_slice.sql \
+        packages/supabase/types/database.ts
+git commit -m "feat(db): admin analytics thin-slice views and rpcs"
+```
+
+---
+
+## Task 3: Lib — types
+
+**Files:**
+- Create: `apps/admin/lib/analytics/types.ts`
+
+- [ ] **Step 1: Write `types.ts`**
+
+```ts
+/**
+ * Admin · Analytics · TS contracts (thin slice).
+ *
+ * Row types mirror the SQL views in
+ * packages/supabase/supabase/migrations/20260430000000_analytics_thin_slice.sql
+ */
+
+export type IsoDate = string
+
+export interface KpiDailyRow {
+  bucket_date: IsoDate
+  total_users: number
+  dau: number
+  pebbles_today: number
+  wau: number
+  mau: number
+  /** DAU / MAU as a 0–100 percent value. Null when MAU = 0. */
+  dau_mau_pct: number | null
+}
+
+export interface ActiveUsersDailyRow {
+  bucket_date: IsoDate
+  dau: number
+  wau: number
+  mau: number
+}
+
+export type TimeRange = "7d" | "30d" | "90d" | "1y" | "all"
+
+export type ActivityMetric = "dau" | "wau" | "mau" | "all"
+
+export const TIME_RANGES: readonly TimeRange[] = ["7d", "30d", "90d", "1y", "all"] as const
+
+export const TIME_RANGE_LABELS: Record<TimeRange, string> = {
+  "7d": "7 days",
+  "30d": "30 days",
+  "90d": "90 days",
+  "1y": "1 year",
+  all: "All time",
+}
+
+export function isTimeRange(value: string | undefined): value is TimeRange {
+  return value !== undefined && (TIME_RANGES as readonly string[]).includes(value)
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/admin/lib/analytics/types.ts
+git commit -m "feat(core): analytics row types and time-range helpers"
+```
+
+---
+
+## Task 4: Lib — date helpers
+
+**Files:**
+- Create: `apps/admin/lib/analytics/date.ts`
+
+- [ ] **Step 1: Write `date.ts`**
+
+```ts
+import type { IsoDate, TimeRange } from "./types"
+
+/** Number of days a TimeRange covers. `all` returns `null`. */
+export function periodLengthDays(range: TimeRange): number | null {
+  switch (range) {
+    case "7d":
+      return 7
+    case "30d":
+      return 30
+    case "90d":
+      return 90
+    case "1y":
+      return 365
+    case "all":
+      return null
+  }
+}
+
+/** Inclusive UTC date range ending today. For `all`, start = epoch. */
+export function dateRangeFor(
+  range: TimeRange,
+  today: Date = new Date(),
+): { start: IsoDate; end: IsoDate } {
+  const end = today.toISOString().slice(0, 10)
+  const days = periodLengthDays(range)
+  if (days === null) return { start: "1970-01-01", end }
+  const startDate = new Date(today)
+  startDate.setUTCDate(startDate.getUTCDate() - days + 1)
+  return { start: startDate.toISOString().slice(0, 10), end }
+}
+
+/** Subtract `days` from an ISO date and return a new ISO date. */
+export function shiftIsoDate(iso: IsoDate, days: number): IsoDate {
+  const d = new Date(`${iso}T00:00:00Z`)
+  d.setUTCDate(d.getUTCDate() + days)
+  return d.toISOString().slice(0, 10)
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/admin/lib/analytics/date.ts
+git commit -m "feat(core): analytics date helpers"
+```
+
+---
+
+## Task 5: Lib — fetchers
+
+**Files:**
+- Create: `apps/admin/lib/analytics/fetchers.ts`
+
+- [ ] **Step 1: Write `fetchers.ts`**
+
+```ts
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { dateRangeFor } from "./date"
+import type { ActiveUsersDailyRow, KpiDailyRow, TimeRange } from "./types"
+
+/**
+ * Fetch the rows needed by the KPI strip:
+ *   - the latest row (current values + delta source)
+ *   - the row from `period_length` days earlier (for delta)
+ *   - the last 30 days (for sparklines)
+ *
+ * Returned by `get_kpi_daily(p_range)` in the migration. The RPC enforces
+ * `is_admin(auth.uid())`; callers must be admin or this throws.
+ */
+export async function getKpiDaily(range: TimeRange): Promise<KpiDailyRow[]> {
+  const supabase = await createServerSupabaseClient()
+  const { data, error } = await supabase.rpc("get_kpi_daily", { p_range: range })
+  if (error) {
+    console.error("[analytics] getKpiDaily failed:", error.message)
+    throw error
+  }
+  return data ?? []
+}
+
+/**
+ * Daily DAU/WAU/MAU series for the active-users chart, scoped to the global
+ * time range tab.
+ */
+export async function getActiveUsersSeries(
+  range: TimeRange,
+): Promise<ActiveUsersDailyRow[]> {
+  const { start, end } = dateRangeFor(range)
+  const supabase = await createServerSupabaseClient()
+  const { data, error } = await supabase.rpc("get_active_users_series", {
+    p_start: start,
+    p_end: end,
+  })
+  if (error) {
+    console.error("[analytics] getActiveUsersSeries failed:", error.message)
+    throw error
+  }
+  return data ?? []
+}
+```
+
+- [ ] **Step 2: Type-check the file**
+
+```bash
+cd apps/admin
+npx tsc --noEmit
+```
+
+Expected: no errors. If `supabase.rpc("get_kpi_daily", ...)` returns `unknown`, re-run `npm run db:types --workspace=packages/supabase` and confirm the function is in the generated types.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/admin/lib/analytics/fetchers.ts
+git commit -m "feat(api): analytics server fetchers"
+```
+
+---
+
+## Task 6: Add shadcn chart primitive
+
+**Files:**
+- Create (via shadcn CLI): `apps/admin/components/ui/chart.tsx`
+- Modify: `apps/admin/package.json` (recharts dep added)
+
+- [ ] **Step 1: Add the chart primitive**
+
+Run from `apps/admin/`:
+
+```bash
+cd apps/admin
+npx shadcn@latest add chart
+```
+
+Expected: `components/ui/chart.tsx` is created and `recharts` is added to dependencies.
+
+- [ ] **Step 2: Verify Tailwind tokens**
+
+The chart primitive reads `--chart-1`…`--chart-5` CSS variables. Confirm they exist in `apps/admin/app/globals.css`:
+
+```bash
+grep -nE "^\s+--chart-[1-5]" apps/admin/app/globals.css
+```
+
+Expected: 5 hits in `:root` and 5 in `.dark`. If missing, copy them from `apps/web/app/globals.css` per the project's "shadcn-first" convention (token set must be complete).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/admin/components/ui/chart.tsx apps/admin/package.json apps/admin/package-lock.json
+# Only stage globals.css if tokens were added
+git diff --staged --name-only
+git commit -m "chore(ui): add shadcn chart primitive to admin"
+```
+
+---
+
+## Task 7: Component — Sparkline
+
+**Files:**
+- Create: `apps/admin/components/analytics/Sparkline.tsx`
+
+- [ ] **Step 1: Write `Sparkline.tsx`**
+
+```tsx
+type SparklineProps = {
+  values: number[]
+  width?: number
+  height?: number
+  className?: string
+  ariaLabel?: string
+}
+
+export function Sparkline({
+  values,
+  width = 80,
+  height = 24,
+  className,
+  ariaLabel,
+}: SparklineProps) {
+  if (values.length < 2) return null
+
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const range = max - min || 1
+  const stepX = width / (values.length - 1)
+
+  const points = values
+    .map((v, i) => {
+      const x = i * stepX
+      const y = height - ((v - min) / range) * height
+      return `${x.toFixed(2)},${y.toFixed(2)}`
+    })
+    .join(" ")
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={className}
+      role="img"
+      aria-label={ariaLabel ?? "trend"}
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/admin/components/analytics/Sparkline.tsx
+git commit -m "feat(ui): analytics sparkline primitive"
+```
+
+---
+
+## Task 8: Component — KpiCard
+
+**Files:**
+- Create: `apps/admin/components/analytics/KpiCard.tsx`
+
+- [ ] **Step 1: Write `KpiCard.tsx`**
+
+> Reminder: this monorepo's shadcn style is `base-nova` on `@base-ui/react`, **not** Radix. `Card` does not accept `asChild`. Wrap `<Card>` inside an `<article>` for semantics + `aria-label`.
+
+```tsx
+import { ArrowDown, ArrowUp, Minus } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
+import { Sparkline } from "./Sparkline"
+
+export type KpiCardProps = {
+  label: string
+  value: number | string
+  unit?: string
+  delta?: { absolute: number; direction: "up" | "down" | "flat"; unit?: string }
+  subLabel?: string
+  sparkline?: number[]
+}
+
+export function KpiCard({
+  label,
+  value,
+  unit,
+  delta,
+  subLabel,
+  sparkline,
+}: KpiCardProps) {
+  const ariaParts = [`${label}: ${value}${unit ? ` ${unit}` : ""}`]
+  if (delta) {
+    const dirWord = delta.direction === "flat" ? "unchanged" : delta.direction
+    ariaParts.push(
+      `${dirWord} by ${Math.abs(delta.absolute)}${delta.unit ?? ""} from prior period`,
+    )
+  }
+
+  return (
+    <article aria-label={ariaParts.join(", ")}>
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {label}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-end justify-between gap-2">
+          <div className="space-y-1">
+            <div className="text-2xl font-semibold tabular-nums">
+              {value}
+              {unit ? (
+                <span className="ml-1 text-base font-normal text-muted-foreground">
+                  {unit}
+                </span>
+              ) : null}
+            </div>
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              {delta ? <DeltaBadge delta={delta} /> : null}
+              {subLabel ? <span>{subLabel}</span> : null}
+            </div>
+          </div>
+          {sparkline && sparkline.length >= 2 ? (
+            <Sparkline
+              values={sparkline}
+              className="text-foreground/60"
+              ariaLabel={`${label} trend`}
+            />
+          ) : null}
+        </CardContent>
+      </Card>
+    </article>
+  )
+}
+
+function DeltaBadge({ delta }: { delta: NonNullable<KpiCardProps["delta"]> }) {
+  const Icon =
+    delta.direction === "up" ? ArrowUp : delta.direction === "down" ? ArrowDown : Minus
+  const sign = delta.absolute > 0 ? "+" : ""
+  return (
+    <Badge
+      variant="secondary"
+      className={cn(
+        "gap-1",
+        delta.direction === "up" && "text-emerald-700 dark:text-emerald-400",
+        delta.direction === "down" && "text-rose-700 dark:text-rose-400",
+      )}
+    >
+      <Icon className="size-3" aria-hidden />
+      <span>
+        {sign}
+        {delta.absolute}
+        {delta.unit ?? ""}
+      </span>
+    </Badge>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/admin/components/analytics/KpiCard.tsx
+git commit -m "feat(ui): analytics KpiCard component"
+```
+
+---
+
+## Task 9: Component — KpiStripSkeleton
+
+**Files:**
+- Create: `apps/admin/components/analytics/KpiStripSkeleton.tsx`
+
+- [ ] **Step 1: Write `KpiStripSkeleton.tsx`**
+
+```tsx
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function KpiStripSkeleton() {
+  return (
+    <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <Card key={i} aria-hidden>
+          <CardHeader className="pb-2">
+            <Skeleton className="h-3 w-16" />
+          </CardHeader>
+          <CardContent className="flex items-end justify-between gap-2">
+            <div className="space-y-2">
+              <Skeleton className="h-7 w-20" />
+              <Skeleton className="h-3 w-24" />
+            </div>
+            <Skeleton className="h-6 w-20" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/admin/components/analytics/KpiStripSkeleton.tsx
+git commit -m "feat(ui): KpiStrip skeleton fallback"
+```
+
+---
+
+## Task 10: Component — ErrorBlock
+
+**Files:**
+- Create: `apps/admin/components/analytics/ErrorBlock.tsx`
+
+- [ ] **Step 1: Write `ErrorBlock.tsx`**
+
+```tsx
+import Link from "next/link"
+import { AlertTriangle } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+
+type ErrorBlockProps = {
+  label: string
+  /** Verbose admin-facing message. */
+  message: string
+  /** Same-URL link target for the retry button. Defaults to current. */
+  retryHref?: string
+}
+
+export function ErrorBlock({ label, message, retryHref }: ErrorBlockProps) {
+  return (
+    <Card className="border-destructive/40">
+      <CardContent className="flex items-start gap-3 py-4">
+        <AlertTriangle className="mt-0.5 size-5 text-destructive" aria-hidden />
+        <div className="space-y-1">
+          <p className="text-sm font-medium">{label}</p>
+          <pre className="whitespace-pre-wrap break-words text-xs text-muted-foreground">
+            {message}
+          </pre>
+          {retryHref ? (
+            <Link href={retryHref} className="text-xs underline">
+              Retry
+            </Link>
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/admin/components/analytics/ErrorBlock.tsx
+git commit -m "feat(ui): analytics inline ErrorBlock"
+```
+
+---
+
+## Task 11: Component — KpiStrip (Server Component)
+
+**Files:**
+- Create: `apps/admin/components/analytics/KpiStrip.tsx`
+
+- [ ] **Step 1: Write `KpiStrip.tsx`**
+
+```tsx
+import { getKpiDaily } from "@/lib/analytics/fetchers"
+import { periodLengthDays } from "@/lib/analytics/date"
+import { shiftIsoDate } from "@/lib/analytics/date"
+import type { KpiDailyRow, TimeRange } from "@/lib/analytics/types"
+import { KpiCard, type KpiCardProps } from "./KpiCard"
+import { ErrorBlock } from "./ErrorBlock"
+
+type KpiStripProps = { range: TimeRange }
+
+export async function KpiStrip({ range }: KpiStripProps) {
+  let rows: KpiDailyRow[]
+  try {
+    rows = await getKpiDaily(range)
+  } catch (err) {
+    return (
+      <ErrorBlock
+        label="Failed to load KPI strip"
+        message={err instanceof Error ? err.message : String(err)}
+      />
+    )
+  }
+
+  if (rows.length === 0) {
+    return <EmptyKpiStrip />
+  }
+
+  const sorted = [...rows].sort((a, b) => a.bucket_date.localeCompare(b.bucket_date))
+  const latest = sorted[sorted.length - 1]
+  const period = periodLengthDays(range)
+  const priorBucket = period === null ? null : shiftIsoDate(latest.bucket_date, -period)
+  const prior = priorBucket ? sorted.find((r) => r.bucket_date === priorBucket) ?? null : null
+
+  // Sparkline window: last 30 days (or fewer if not enough rows)
+  const sparkRows = sorted.slice(-30)
+
+  const trailing7 = (key: keyof KpiDailyRow) => {
+    const last7 = sparkRows.slice(-7)
+    if (last7.length === 0) return 0
+    const sum = last7.reduce((acc, r) => acc + Number(r[key] ?? 0), 0)
+    return Math.round(sum / last7.length)
+  }
+
+  const cards: KpiCardProps[] = [
+    {
+      label: "Total users",
+      value: latest.total_users,
+      delta: deltaFor(latest.total_users, prior?.total_users),
+      subLabel: "all signups",
+    },
+    {
+      label: "DAU",
+      value: trailing7("dau"),
+      sparkline: sparkRows.map((r) => r.dau),
+      delta: deltaFor(latest.dau, prior?.dau),
+      subLabel: "trailing 7-day avg",
+    },
+    {
+      label: "WAU",
+      value: latest.wau,
+      sparkline: sparkRows.map((r) => r.wau),
+      delta: deltaFor(latest.wau, prior?.wau),
+      subLabel: "rolling 7 days",
+    },
+    {
+      label: "MAU",
+      value: latest.mau,
+      sparkline: sparkRows.map((r) => r.mau),
+      delta: deltaFor(latest.mau, prior?.mau),
+      subLabel: "rolling 30 days",
+    },
+    {
+      label: "Pebbles / day",
+      value: trailing7("pebbles_today"),
+      sparkline: sparkRows.map((r) => r.pebbles_today),
+      delta: deltaFor(latest.pebbles_today, prior?.pebbles_today),
+      subLabel: "trailing 7-day avg",
+    },
+    {
+      label: "DAU / MAU",
+      value: latest.dau_mau_pct ?? "—",
+      unit: latest.dau_mau_pct === null ? undefined : "%",
+      delta: deltaForPct(latest.dau_mau_pct, prior?.dau_mau_pct ?? null),
+      subLabel: "stickiness",
+    },
+  ]
+
+  return (
+    <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
+      {cards.map((c) => (
+        <KpiCard key={c.label} {...c} />
+      ))}
+    </div>
+  )
+}
+
+function deltaFor(current: number, prior: number | undefined): KpiCardProps["delta"] {
+  if (prior === undefined) return undefined
+  const absolute = current - prior
+  const direction = absolute > 0 ? "up" : absolute < 0 ? "down" : "flat"
+  return { absolute, direction }
+}
+
+function deltaForPct(
+  current: number | null,
+  prior: number | null,
+): KpiCardProps["delta"] {
+  if (current === null || prior === null) return undefined
+  const absolute = Number((current - prior).toFixed(1))
+  const direction = absolute > 0 ? "up" : absolute < 0 ? "down" : "flat"
+  return { absolute, direction, unit: "pp" }
+}
+
+function EmptyKpiStrip() {
+  return (
+    <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
+      {["Total users", "DAU", "WAU", "MAU", "Pebbles / day", "DAU / MAU"].map((label) => (
+        <KpiCard key={label} label={label} value="—" subLabel="No data yet" />
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/admin/components/analytics/KpiStrip.tsx
+git commit -m "feat(ui): KpiStrip server component"
+```
+
+---
+
+## Task 12: Component — TimeRangeTabs (Client Component)
+
+**Files:**
+- Create: `apps/admin/components/analytics/TimeRangeTabs.tsx`
+
+- [ ] **Step 1: Write `TimeRangeTabs.tsx`**
+
+```tsx
+"use client"
+
+import Link from "next/link"
+import { useSearchParams } from "next/navigation"
+import { cn } from "@/lib/utils"
+import {
+  TIME_RANGES,
+  TIME_RANGE_LABELS,
+  isTimeRange,
+  type TimeRange,
+} from "@/lib/analytics/types"
+
+const DEFAULT: TimeRange = "30d"
+
+export function TimeRangeTabs() {
+  const params = useSearchParams()
+  const raw = params?.get("range")
+  const active: TimeRange = isTimeRange(raw ?? undefined) ? (raw as TimeRange) : DEFAULT
+
+  return (
+    <nav aria-label="Time range" className="flex items-center gap-1 rounded-md border p-1">
+      {TIME_RANGES.map((range) => {
+        const isActive = range === active
+        return (
+          <Link
+            key={range}
+            href={`?range=${range}`}
+            scroll={false}
+            aria-current={isActive ? "page" : undefined}
+            className={cn(
+              "rounded px-3 py-1 text-sm transition-colors",
+              isActive
+                ? "bg-foreground text-background"
+                : "text-muted-foreground hover:bg-muted",
+            )}
+          >
+            {TIME_RANGE_LABELS[range]}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/admin/components/analytics/TimeRangeTabs.tsx
+git commit -m "feat(ui): URL-driven TimeRangeTabs"
+```
+
+---
+
+## Task 13: Component — ActiveUsersChart (Client Component)
+
+**Files:**
+- Create: `apps/admin/components/analytics/ActiveUsersChart.tsx`
+
+- [ ] **Step 1: Write `ActiveUsersChart.tsx`**
+
+```tsx
+"use client"
+
+import { useState } from "react"
+import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts"
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart"
+import { Button } from "@/components/ui/button"
+import type { ActiveUsersDailyRow, ActivityMetric } from "@/lib/analytics/types"
+
+type ActiveUsersChartProps = {
+  data: ActiveUsersDailyRow[]
+  initialMetric?: ActivityMetric
+}
+
+const METRICS: ActivityMetric[] = ["all", "dau", "wau", "mau"]
+const METRIC_LABELS: Record<ActivityMetric, string> = {
+  all: "All",
+  dau: "DAU",
+  wau: "WAU",
+  mau: "MAU",
+}
+
+const config: ChartConfig = {
+  dau: { label: "DAU", color: "var(--chart-1)" },
+  wau: { label: "WAU", color: "var(--chart-2)" },
+  mau: { label: "MAU", color: "var(--chart-3)" },
+}
+
+export function ActiveUsersChart({
+  data,
+  initialMetric = "all",
+}: ActiveUsersChartProps) {
+  const [metric, setMetric] = useState<ActivityMetric>(initialMetric)
+
+  if (data.length === 0) {
+    return (
+      <div
+        className="flex h-72 items-center justify-center text-sm text-muted-foreground"
+        aria-live="polite"
+      >
+        No activity in this range
+      </div>
+    )
+  }
+
+  const showDau = metric === "all" || metric === "dau"
+  const showWau = metric === "all" || metric === "wau"
+  const showMau = metric === "all" || metric === "mau"
+
+  const last = data[data.length - 1]
+  const ariaSummary = `Active users on ${last.bucket_date}: DAU ${last.dau}, WAU ${last.wau}, MAU ${last.mau}.`
+
+  return (
+    <div aria-label={ariaSummary}>
+      <div className="mb-3 flex items-center gap-1" role="tablist" aria-label="Metric">
+        {METRICS.map((m) => (
+          <Button
+            key={m}
+            variant={m === metric ? "default" : "ghost"}
+            size="sm"
+            role="tab"
+            aria-selected={m === metric}
+            onClick={() => setMetric(m)}
+          >
+            {METRIC_LABELS[m]}
+          </Button>
+        ))}
+      </div>
+
+      <ChartContainer config={config} className="h-72 w-full">
+        <LineChart data={data} margin={{ left: 4, right: 12, top: 8, bottom: 4 }}>
+          <CartesianGrid vertical={false} strokeDasharray="3 3" />
+          <XAxis
+            dataKey="bucket_date"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            minTickGap={32}
+            tickFormatter={(v: string) => v.slice(5)}
+          />
+          <YAxis tickLine={false} axisLine={false} width={36} />
+          <ChartTooltip content={<ChartTooltipContent />} />
+          <ChartLegend content={<ChartLegendContent />} />
+          {showDau ? (
+            <Line dataKey="dau" type="monotone" stroke="var(--color-dau)" strokeWidth={2} dot={false} />
+          ) : null}
+          {showWau ? (
+            <Line dataKey="wau" type="monotone" stroke="var(--color-wau)" strokeWidth={2} dot={false} />
+          ) : null}
+          {showMau ? (
+            <Line dataKey="mau" type="monotone" stroke="var(--color-mau)" strokeWidth={2} dot={false} />
+          ) : null}
+        </LineChart>
+      </ChartContainer>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/admin/components/analytics/ActiveUsersChart.tsx
+git commit -m "feat(ui): ActiveUsersChart with DAU/WAU/MAU toggle"
+```
+
+---
+
+## Task 14: Component — ActiveUsersChartCard + ChartCardSkeleton
+
+**Files:**
+- Create: `apps/admin/components/analytics/ActiveUsersChartCard.tsx`
+- Create: `apps/admin/components/analytics/ChartCardSkeleton.tsx`
+
+- [ ] **Step 1: Write `ChartCardSkeleton.tsx`**
+
+```tsx
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function ChartCardSkeleton() {
+  return (
+    <Card aria-hidden>
+      <CardHeader>
+        <Skeleton className="h-5 w-40" />
+      </CardHeader>
+      <CardContent>
+        <Skeleton className="h-72 w-full" />
+      </CardContent>
+    </Card>
+  )
+}
+```
+
+- [ ] **Step 2: Write `ActiveUsersChartCard.tsx`**
+
+```tsx
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getActiveUsersSeries } from "@/lib/analytics/fetchers"
+import type { ActiveUsersDailyRow, TimeRange } from "@/lib/analytics/types"
+import { ActiveUsersChart } from "./ActiveUsersChart"
+import { ErrorBlock } from "./ErrorBlock"
+
+type ActiveUsersChartCardProps = { range: TimeRange }
+
+export async function ActiveUsersChartCard({ range }: ActiveUsersChartCardProps) {
+  let data: ActiveUsersDailyRow[]
+  try {
+    data = await getActiveUsersSeries(range)
+  } catch (err) {
+    return (
+      <ErrorBlock
+        label="Failed to load active users chart"
+        message={err instanceof Error ? err.message : String(err)}
+      />
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Active users over time</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ActiveUsersChart data={data} />
+      </CardContent>
+    </Card>
+  )
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/admin/components/analytics/ChartCardSkeleton.tsx \
+        apps/admin/components/analytics/ActiveUsersChartCard.tsx
+git commit -m "feat(ui): ActiveUsersChartCard server shell + skeleton"
+```
+
+---
+
+## Task 15: Fixtures + playground page
+
+**Files:**
+- Create: `apps/admin/components/analytics/__fixtures__/kpi.ts`
+- Create: `apps/admin/components/analytics/__fixtures__/activeUsers.ts`
+- Create: `apps/admin/app/(authed)/playground/analytics/page.tsx`
+
+- [ ] **Step 1: Write `__fixtures__/kpi.ts`**
+
+```ts
+import type { KpiDailyRow } from "@/lib/analytics/types"
+
+const TODAY = new Date()
+function iso(daysAgo: number): string {
+  const d = new Date(TODAY)
+  d.setUTCDate(d.getUTCDate() - daysAgo)
+  return d.toISOString().slice(0, 10)
+}
+
+/** 30 days of plausible KPI data, ascending. */
+export const kpiFixture: KpiDailyRow[] = Array.from({ length: 30 }, (_, i) => {
+  const day = 29 - i
+  const dau = 80 + Math.round(20 * Math.sin(i / 4)) + i
+  const wau = dau * 4
+  const mau = dau * 9
+  return {
+    bucket_date: iso(day),
+    total_users: 1200 + i * 3,
+    dau,
+    pebbles_today: dau * 2 + (i % 5),
+    wau,
+    mau,
+    dau_mau_pct: Math.round((dau / mau) * 10000) / 100,
+  }
+})
+
+export const kpiEmptyFixture: KpiDailyRow[] = []
+```
+
+- [ ] **Step 2: Write `__fixtures__/activeUsers.ts`**
+
+```ts
+import type { ActiveUsersDailyRow } from "@/lib/analytics/types"
+
+const TODAY = new Date()
+function iso(daysAgo: number): string {
+  const d = new Date(TODAY)
+  d.setUTCDate(d.getUTCDate() - daysAgo)
+  return d.toISOString().slice(0, 10)
+}
+
+export const denseFixture: ActiveUsersDailyRow[] = Array.from({ length: 90 }, (_, i) => {
+  const day = 89 - i
+  const dau = 100 + Math.round(40 * Math.sin(i / 7)) + Math.round(i / 3)
+  return { bucket_date: iso(day), dau, wau: dau * 4, mau: dau * 9 }
+})
+
+export const sparseFixture: ActiveUsersDailyRow[] = Array.from({ length: 12 }, (_, i) => {
+  const day = 11 - i
+  const dau = 30 + i * 2
+  return { bucket_date: iso(day), dau, wau: dau * 3, mau: dau * 6 }
+})
+
+export const emptyFixture: ActiveUsersDailyRow[] = []
+```
+
+- [ ] **Step 3: Write `playground/analytics/page.tsx`**
+
+```tsx
+import { ActiveUsersChart } from "@/components/analytics/ActiveUsersChart"
+import { KpiCard } from "@/components/analytics/KpiCard"
+import { Sparkline } from "@/components/analytics/Sparkline"
+import {
+  denseFixture,
+  emptyFixture,
+  sparseFixture,
+} from "@/components/analytics/__fixtures__/activeUsers"
+import { kpiFixture } from "@/components/analytics/__fixtures__/kpi"
+
+export default function AnalyticsPlaygroundPage() {
+  const sparkValues = kpiFixture.map((r) => r.dau)
+
+  return (
+    <div className="space-y-10">
+      <header>
+        <h1 className="text-2xl font-semibold">Playground · Analytics</h1>
+        <p className="text-sm text-muted-foreground">
+          Renders analytics components from fixtures. No live data calls.
+        </p>
+      </header>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">KpiCard variants</h2>
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+          <KpiCard
+            label="DAU"
+            value={142}
+            subLabel="trailing 7-day avg"
+            sparkline={sparkValues}
+            delta={{ absolute: 8, direction: "up" }}
+          />
+          <KpiCard
+            label="DAU"
+            value={142}
+            subLabel="trailing 7-day avg"
+            sparkline={sparkValues}
+            delta={{ absolute: -3, direction: "down" }}
+          />
+          <KpiCard
+            label="MAU"
+            value={1212}
+            subLabel="rolling 30 days"
+            sparkline={sparkValues}
+            delta={{ absolute: 0, direction: "flat" }}
+          />
+          <KpiCard label="Total users" value={1287} subLabel="all signups" />
+          <KpiCard label="DAU / MAU" value="—" subLabel="No data yet" />
+          <KpiCard
+            label="DAU / MAU"
+            value={11.7}
+            unit="%"
+            subLabel="stickiness"
+            delta={{ absolute: 0.3, direction: "up", unit: "pp" }}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">Sparkline</h2>
+        <div className="text-foreground/60">
+          <Sparkline values={sparkValues} width={200} height={40} ariaLabel="DAU sparkline" />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          ActiveUsersChart — dense (90 days)
+        </h2>
+        <ActiveUsersChart data={denseFixture} />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          ActiveUsersChart — sparse (12 days)
+        </h2>
+        <ActiveUsersChart data={sparseFixture} />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          ActiveUsersChart — empty
+        </h2>
+        <ActiveUsersChart data={emptyFixture} />
+      </section>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/admin/components/analytics/__fixtures__ \
+        apps/admin/app/\(authed\)/playground
+git commit -m "feat(ui): analytics playground page and fixtures"
+```
+
+---
+
+## Task 16: Page — analytics
+
+**Files:**
+- Create: `apps/admin/app/(authed)/analytics/page.tsx`
+- Create: `apps/admin/app/(authed)/analytics/loading.tsx`
+
+- [ ] **Step 1: Write `loading.tsx`**
+
+```tsx
+import { ChartCardSkeleton } from "@/components/analytics/ChartCardSkeleton"
+import { KpiStripSkeleton } from "@/components/analytics/KpiStripSkeleton"
+
+export default function AnalyticsLoading() {
+  return (
+    <div className="space-y-6">
+      <KpiStripSkeleton />
+      <ChartCardSkeleton />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Write `page.tsx`**
+
+```tsx
+import { Suspense } from "react"
+import { ActiveUsersChartCard } from "@/components/analytics/ActiveUsersChartCard"
+import { ChartCardSkeleton } from "@/components/analytics/ChartCardSkeleton"
+import { KpiStrip } from "@/components/analytics/KpiStrip"
+import { KpiStripSkeleton } from "@/components/analytics/KpiStripSkeleton"
+import { TimeRangeTabs } from "@/components/analytics/TimeRangeTabs"
+import { isTimeRange, type TimeRange } from "@/lib/analytics/types"
+
+type SearchParams = Promise<{ range?: string }>
+
+export default async function AnalyticsPage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
+  const params = await searchParams
+  const range: TimeRange = isTimeRange(params.range) ? params.range : "30d"
+
+  return (
+    <section className="space-y-6">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Analytics</h1>
+        <TimeRangeTabs />
+      </header>
+
+      <Suspense fallback={<KpiStripSkeleton />}>
+        <KpiStrip range={range} />
+      </Suspense>
+
+      <Suspense fallback={<ChartCardSkeleton />}>
+        <ActiveUsersChartCard range={range} />
+      </Suspense>
+    </section>
+  )
+}
+```
+
+> The `(authed)` route group already runs `requireAdmin()` in its layout. No additional guard needed at this level.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/admin/app/\(authed\)/analytics
+git commit -m "feat(ui): analytics page with KPI strip and active users chart"
+```
+
+---
+
+## Task 17: Sidebar nav entry
+
+**Files:**
+- Modify: `apps/admin/components/layout/Sidebar.tsx`
+
+- [ ] **Step 1: Add an "Analytics" group above "Logs"**
+
+Open `apps/admin/components/layout/Sidebar.tsx`. Just below the existing `LOG_ITEMS` constant, add:
+
+```ts
+import { BarChart3 } from "lucide-react"
+
+const ANALYTICS_ITEMS = [
+  { href: "/analytics", label: "Analytics", icon: BarChart3 },
+] as const
+```
+
+Then inside `<SidebarContent>`, **before** the `Logs` `<SidebarGroup>`, add:
+
+```tsx
+<SidebarGroup>
+  <SidebarGroupLabel>Insights</SidebarGroupLabel>
+  <SidebarGroupContent>
+    <SidebarMenu>
+      {ANALYTICS_ITEMS.map(({ href, label, icon: Icon }) => {
+        const active = pathname === href || pathname.startsWith(`${href}/`)
+        return (
+          <SidebarMenuItem key={href}>
+            <SidebarMenuButton render={<Link href={href} />} isActive={active}>
+              <Icon aria-hidden />
+              <span>{label}</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        )
+      })}
+    </SidebarMenu>
+  </SidebarGroupContent>
+</SidebarGroup>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/admin/components/layout/Sidebar.tsx
+git commit -m "feat(ui): admin sidebar Analytics entry"
+```
+
+---
+
+## Task 18: Verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Lint and build**
+
+```bash
+cd apps/admin
+npm run lint
+npm run build
+```
+
+Expected: both succeed with no errors.
+
+- [ ] **Step 2: Run the dev server and smoke-test the playground**
+
+```bash
+cd apps/admin
+npm run dev
+```
+
+Open `http://localhost:3001/playground/analytics` in the browser. Confirm:
+- All 6 KpiCard variants render correctly (positive, negative, flat delta; missing sparkline; empty `—`; `pp` unit).
+- Sparkline renders without overflow.
+- ActiveUsersChart renders dense / sparse / empty cases. Toggling DAU/WAU/MAU/All hides and shows the right lines.
+- No console errors.
+
+- [ ] **Step 3: Smoke-test the live page as admin**
+
+Sign in as an admin user. Navigate to `/analytics`. Confirm:
+- KPI strip renders with non-zero values for the seeded DB.
+- Sparklines visible on DAU/WAU/MAU/Pebbles per day.
+- Active users chart renders with the 30-day default range.
+- Clicking time-range tabs (`7d` / `30d` / `90d` / `1y` / All) updates `?range=` and re-renders.
+- DAU/WAU/MAU toggle filters lines without a network request (verify in the Network panel).
+- No console errors.
+
+- [ ] **Step 4: Smoke-test as a non-admin**
+
+Sign out, then sign in as a non-admin profile (or temporarily flip `profiles.is_admin` to false). Navigate to `/analytics`. Confirm: redirect to `/403` (the `(authed)` layout's `requireAdmin()` enforces this).
+
+Restore the admin flag if you flipped it.
+
+- [ ] **Step 5: Smoke-test the empty state**
+
+In the Supabase SQL editor, temporarily simulate the empty state — e.g., ask the RPC for a future date range:
+
+```sql
+select * from public.get_active_users_series(current_date + 30, current_date + 60);
+```
+
+Expected: zero rows, no error. (The page doesn't expose this directly, but it confirms the empty path of the RPC.)
+
+---
+
+## Task 19: Arkaik map update
+
+**Files:**
+- Modify: `docs/arkaik/bundle.json`
+
+- [ ] **Step 1: Read the arkaik skill**
+
+```bash
+cat .claude/skills/arkaik/SKILL.md
+```
+
+- [ ] **Step 2: Apply surgical updates**
+
+Per the skill, add (do not regenerate the full bundle):
+
+- One **screen** node — id `admin-analytics`, label `Admin · Analytics`, route `/admin/analytics`, status `development`, lives in the admin app.
+- Two **data** nodes — `v_analytics_kpi_daily`, `v_analytics_active_users_daily` (Postgres views).
+- Two **endpoint** nodes — `get_kpi_daily`, `get_active_users_series` (RPCs, security-definer, admin-gated).
+- **Edges:**
+  - `screen:admin-analytics → endpoint:get_kpi_daily`
+  - `screen:admin-analytics → endpoint:get_active_users_series`
+  - `endpoint:get_kpi_daily → data:v_analytics_kpi_daily`
+  - `endpoint:get_active_users_series → data:v_analytics_active_users_daily`
+  - `data:v_analytics_kpi_daily → data:auth.users` (existing or new)
+  - `data:v_analytics_kpi_daily → data:public.pebbles` (existing)
+  - `data:v_analytics_active_users_daily → data:v_analytics_kpi_daily` (projection)
+
+- [ ] **Step 3: Run the validation script**
+
+The arkaik skill provides a validator. Run it before saving:
+
+```bash
+.claude/skills/arkaik/validate.sh docs/arkaik/bundle.json
+```
+
+Expected: validation passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/arkaik/bundle.json
+git commit -m "docs(core): arkaik map update for admin analytics"
+```
+
+---
+
+## Task 20: Push branch and open PR
+
+**Files:** none (PR only).
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/<N>-admin-analytics-thin-slice
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create \
+  --title "feat(core): admin analytics thin slice (kpi strip + active users chart)" \
+  --body "$(cat <<'EOF'
+Resolves #<N>
+
+Ships the thin slice of the admin analytics page: KPI strip (6 cards) + Active users chart (DAU/WAU/MAU toggle). Backed by two new Postgres views and two SECURITY DEFINER RPCs gated on `is_admin()`. Time range is URL-driven (`?range=`).
+
+## Key files
+- `packages/supabase/supabase/migrations/20260430000000_analytics_thin_slice.sql` — views + RPCs
+- `apps/admin/lib/analytics/{types,date,fetchers}.ts` — TS contracts and server fetchers
+- `apps/admin/components/analytics/*` — KpiStrip, KpiCard, Sparkline, ActiveUsersChart(Card), TimeRangeTabs, ErrorBlock, skeletons, fixtures
+- `apps/admin/app/(authed)/analytics/{page,loading}.tsx` — the page
+- `apps/admin/app/(authed)/playground/analytics/page.tsx` — fixture-driven component review
+- `apps/admin/components/layout/Sidebar.tsx` — Analytics nav entry
+- `docs/arkaik/bundle.json` — surgical map update
+
+## Implementation notes
+- No materialized views or `pg_cron`. RPC contract is shaped so swapping to MVs later is a one-line migration.
+- Soft-delete doesn't exist in this project; no `deleted_at` filters in the SQL.
+- DAU/WAU/MAU toggle is local component state; time range is URL state.
+- `(authed)` layout already enforces admin via `requireAdmin()`; no extra guard at the page level.
+
+## Plan
+docs/superpowers/plans/2026-04-30-admin-analytics-thin-slice.md
+EOF
+)" \
+  --label feat,core,ui,db
+```
+
+If the issue had a milestone, propose inheriting it and ask the user before adding `--milestone <name>` to the command.
+
+- [ ] **Step 3: Confirm PR labels and milestone**
+
+Per project guidelines: never open a PR without species + scope labels and a milestone (unless the user has confirmed there is none). Verify after creation:
+
+```bash
+gh pr view --json title,labels,milestone
+```
+
+If anything is missing, ask the user before patching.
+
+---
+
+## Self-review notes (already applied)
+
+- Spec coverage: every requirement from the spec maps to a task — KPI strip (Task 11), active users chart (Tasks 13–14), time-range tabs (Task 12), playground (Task 15), admin guard (reused via existing `(authed)` layout), Arkaik update (Task 19), acceptance verification (Task 18). Empty/error states handled per-component.
+- Placeholders: none. The only `<…>` token is `<N>` for the issue number, deliberately deferred to runtime.
+- Type consistency: `KpiCardProps.delta` shape (`{ absolute, direction, unit? }`) is consistent across `KpiCard`, `KpiStrip`, and the playground. `ActivityMetric` typed identically across types/chart/playground. `TimeRange` is canonical in `lib/analytics/types.ts`.
+- shadcn-base-nova constraint flagged at the top of Task 8 (no `asChild` on `Card`) — code uses `<article><Card>…</Card></article>` accordingly.

--- a/docs/superpowers/plans/2026-04-30-admin-analytics-thin-slice.md
+++ b/docs/superpowers/plans/2026-04-30-admin-analytics-thin-slice.md
@@ -248,8 +248,8 @@ $$;
 revoke all on public.v_analytics_kpi_daily          from public, anon, authenticated;
 revoke all on public.v_analytics_active_users_daily from public, anon, authenticated;
 
-grant execute on function public.get_kpi_daily(text)                from authenticated;
-grant execute on function public.get_active_users_series(date, date) from authenticated;
+grant execute on function public.get_kpi_daily(text)                to authenticated;
+grant execute on function public.get_active_users_series(date, date) to authenticated;
 ```
 
 - [ ] **Step 3: Push the migration to the remote Supabase project**

--- a/docs/superpowers/specs/2026-04-30-admin-analytics-thin-slice-design.md
+++ b/docs/superpowers/specs/2026-04-30-admin-analytics-thin-slice-design.md
@@ -1,0 +1,242 @@
+# Admin · Analytics — Thin slice (v1)
+
+**Status:** Spec, ready for plan
+**Owner:** Alexis
+**Last updated:** 2026-04-30
+**Companion docs:** `docs/poc/admin-analytics/` (full POC: spec, mockup, SVG layout, MV DDL, TS contracts, fetchers)
+
+## Why a thin slice and not the full POC
+
+The POC at `docs/poc/admin-analytics/` describes a 12-surface analytics page backed by 12 nightly-refreshed materialized views. A schema audit against the actual repo found that:
+
+- Roughly 8 of the 12 surfaces are buildable on today's schema with light SQL adaptations.
+- 4 surfaces (bounce karma distribution, cairn participation, quality signals/sessions, custom-glyph metric) require net-new schema or product features that haven't shipped.
+- The POC's MV/cron infrastructure is overkill for current data volume and would drag `pg_cron` availability + RLS-on-MVs + refresh-failure handling into v1's blast radius.
+
+This spec scopes the **first PR** to the smallest surface that validates the full pipeline: KPI strip + Active users chart. Once that's reviewed, a follow-up "buildable-8" PR adds the remaining 6 buildable surfaces, and the four blocked surfaces wait on their data foundations.
+
+## Scope of v1 (this spec)
+
+In:
+
+- One page at `apps/admin/app/(authed)/analytics/page.tsx`.
+- **KPI strip** — six cards: Total users, DAU, WAU, MAU, Pebbles/day, DAU/MAU. Each card shows current value, delta vs prior equal-length period, sub-label, and a sparkline.
+- **Active users chart** — daily DAU/WAU/MAU line chart with a client-side metric toggle (DAU / WAU / MAU / All).
+- Global time-range tabs in the page header (7d / 30d / 90d / 1y / All), URL-driven via `?range=`.
+- Admin-only access guard reusing the existing `is_admin()` RPC pattern.
+- A playground page at `apps/admin/app/(authed)/playground/analytics/page.tsx` that renders both components from fixtures.
+- Arkaik map updated with the new screen, view nodes, and endpoint nodes.
+
+Out (future PRs):
+
+- The other 6 buildable surfaces: pebble volume, pebble enrichment donuts, per-user averages, domain share, visibility mix, single-emotion share, retention cohorts. Held for PR #2.
+- Materialized views and `pg_cron` refresh. Will be added when query times warrant it; the RPC contract is shaped to make that a one-line swap.
+- CSV export.
+- "Last refresh" timestamp in the header (no refresh exists yet).
+- The four data-blocked surfaces: bounce karma distribution, cairn participation, quality signals, custom-glyph metric.
+
+## Schema audit summary
+
+| POC assumption | Reality | Adaptation |
+|---|---|---|
+| `users` (id, created_at, deleted_at, role) | `auth.users` + `public.profiles.is_admin` | Source `auth.users` for counts; admin gate via `is_admin()` |
+| `pebbles.deleted_at` | No soft-delete in this project | Drop all `deleted_at is null` filters |
+| `pebbles.picture_url` | `snaps` table (1-many) | Out of scope for v1 |
+| `pebbles.collection_id` | `collection_pebbles` join | Out of scope for v1 |
+| `pebble_emotions` join | Pebbles have a single non-null `emotion_id` | Out of scope for v1; PR #2 redefines as single-emotion share |
+| `glyphs.is_custom` | Column doesn't exist | Drop the metric entirely |
+| `bounces`, `cairns`, `sessions`, `user_active_days` | None exist | Blocked, deferred |
+| RLS via JWT `role` claim | `is_admin()` SECURITY DEFINER fn | Use existing pattern |
+
+The thin slice only needs `auth.users` and `public.pebbles`. No schema changes required.
+
+## Architecture
+
+Server Components by default. Time-range state lives in the URL (`?range=30d`). The page is a Server Component re-rendered on tab change — no SWR, no client fetching, no provider.
+
+```
+apps/admin/app/(authed)/analytics/
+  layout.tsx                     // admin guard via is_admin()
+  page.tsx                       // composes KpiStrip + ActiveUsersChartCard
+  loading.tsx                    // page-level skeleton
+
+apps/admin/components/analytics/
+  KpiStrip.tsx                   // SC, fetches kpi rows, renders 6 cards
+  KpiCard.tsx                    // presentational card (value, delta, sparkline)
+  Sparkline.tsx                  // inline-SVG mini line, ~40 LOC
+  ActiveUsersChartCard.tsx       // SC shell, fetches series, passes to client child
+  ActiveUsersChart.tsx           // CC, Recharts line chart with metric toggle
+  TimeRangeTabs.tsx              // CC, reads/writes ?range= via next/navigation
+  ErrorBlock.tsx                 // shared inline error renderer
+  __fixtures__/
+    kpi.ts
+    activeUsers.ts
+
+apps/admin/app/(authed)/playground/analytics/page.tsx
+
+apps/admin/lib/analytics/
+  types.ts                       // row types, TimeRange, ActivityMetric
+  fetchers.ts                    // server-side .rpc() calls
+  date.ts                        // dateRangeFor + helpers
+
+packages/supabase/supabase/migrations/<ts>_analytics_thin_slice.sql
+```
+
+## Data layer
+
+### Postgres views and RPCs
+
+A single new migration `<ts>_analytics_thin_slice.sql` adds:
+
+- `v_analytics_kpi_daily` — one row per calendar day from the earliest pebble's `created_at` to today. Columns:
+  - `bucket_date date`
+  - `total_users int` — `count(*) from auth.users where created_at::date <= bucket_date`
+  - `dau int` — distinct `pebbles.user_id` with `created_at::date = bucket_date`
+  - `pebbles_today int` — count of pebbles with `created_at::date = bucket_date`
+  - `wau int` — rolling 7-day distinct user count ending on `bucket_date`
+  - `mau int` — rolling 30-day distinct user count
+  - `dau_mau_pct numeric(5,2)` — `(dau / mau) * 100`, null when `mau = 0`
+- `v_analytics_active_users_daily` — `select bucket_date, dau, wau, mau from v_analytics_kpi_daily`.
+
+Both views: plain (non-materialized). Computed live per request. Acceptable at current data volume; the swap to MVs is mechanical when warranted.
+
+Two SECURITY DEFINER RPCs read from the views:
+
+- `get_kpi_daily(p_range text)` returns rows from `v_analytics_kpi_daily` covering: the latest row (current values + sparkline window of the last 30 days) **plus** the row at `latest_bucket_date - period_length(p_range)` (for delta computation). For `p_range = "all"` the prior-period row is omitted and deltas render as `—`.
+- `get_active_users_series(p_start date, p_end date)` returns rows from `v_analytics_active_users_daily` in `[p_start, p_end]`, ordered ascending.
+
+Both RPCs gate on `is_admin(auth.uid())` and raise `insufficient_privilege` otherwise. RLS on the underlying objects is moot because the RPCs are SECURITY DEFINER, but the admin check is still enforced inside the function body.
+
+The fetchers in `apps/admin/lib/analytics/fetchers.ts` call these RPCs via `supabase.rpc("get_kpi_daily", { p_range: range })` and `supabase.rpc("get_active_users_series", { p_start, p_end })`. Row types match the POC's `KpiDailyRow` and `ActiveUsersDailyRow` so the eventual swap to MVs requires no caller-side change.
+
+### Why RPCs (not direct view reads)
+
+Per `AGENTS.md` the project's bias is toward RPCs for non-trivial reads. Views over `auth.users` would otherwise need bespoke RLS plumbing; SECURITY DEFINER RPCs sidestep that and align with the pattern already used for `is_admin()` and the pebble engine.
+
+## Components
+
+```ts
+// KpiStrip.tsx (Server Component)
+type KpiStripProps = { range: TimeRange };
+
+// KpiCard.tsx
+type KpiCardProps = {
+  label: string;
+  value: number | string;
+  unit?: string;
+  delta?: { absolute: number; direction: "up" | "down" | "flat" };
+  subLabel?: string;
+  sparkline?: number[];
+};
+
+// ActiveUsersChartCard.tsx (Server Component)
+type ActiveUsersChartCardProps = { range: TimeRange };
+
+// ActiveUsersChart.tsx (Client Component)
+type ActiveUsersChartProps = {
+  data: ActiveUsersDailyRow[];
+  initialMetric?: ActivityMetric; // "all" | "dau" | "wau" | "mau"
+};
+
+// TimeRangeTabs.tsx (Client Component) — no props; URL-driven.
+```
+
+Notes:
+
+- KPI **delta** is computed server-side: latest row vs row at `latest.bucket_date - period_length`, both pulled from the same RPC payload. DAU/MAU delta is in **percentage points**, not %.
+- DAU display value = trailing 7-day mean (per POC spec). WAU display value = today's rolling 7-day count. MAU display value = today's rolling 30-day count. Pebbles/day display value = trailing 7-day mean.
+- The DAU/WAU/MAU toggle on the chart is local component state, not URL state — it's a view preference, not deep-linkable.
+- Sparkline is hand-rolled inline SVG (`<polyline>` + `<svg viewBox>`), ~40 LOC, no axis, no tooltip. Recharts is overkill for a 30-point card decoration.
+- Charts library: `recharts` via the shadcn charts pattern. Add via `npx shadcn@latest add chart` from inside `apps/admin/`.
+
+## Page composition
+
+```tsx
+// apps/admin/app/(authed)/analytics/page.tsx
+export default async function AnalyticsPage({ searchParams }) {
+  const { range = "30d" } = await searchParams;
+  return (
+    <PageLayout title="Analytics" header={<TimeRangeTabs />}>
+      <Suspense fallback={<KpiStripSkeleton />}>
+        <KpiStrip range={range} />
+      </Suspense>
+      <Suspense fallback={<ChartCardSkeleton />}>
+        <ActiveUsersChartCard range={range} />
+      </Suspense>
+    </PageLayout>
+  );
+}
+```
+
+Layout:
+
+- KPI strip: `grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4`. 6×1 on desktop, wraps on smaller widths.
+- Active users chart: full-width (`col-span-12`). When PR #2 lands the retention heatmap, this shrinks to 8/12 and the heatmap fills 4/12.
+
+## Admin guard
+
+A sub-layout `apps/admin/app/(authed)/analytics/layout.tsx` calls `supabase.rpc("is_admin", { p_user_id: user.id })` server-side and renders `notFound()` (or redirects to `/403`) for non-admins. Reuses the same pattern as the existing logs guard.
+
+## States
+
+**Loading.** `loading.tsx` at the page level renders the grid shell with shadcn `<Skeleton/>` for each card. Each Server Component child is wrapped in `<Suspense>` with its own skeleton, so individual surfaces can stream in.
+
+**Empty.** KpiCard shows `—` for value, omits delta and sparkline, sub-label reads "No data yet". Chart card shows a faint axis stub with neutral copy "No activity in this range".
+
+**Error.** Each Server Component wraps its fetch in `try/catch` and renders an inline `<ErrorBlock>` with the verbose error message and a "Retry" link (a plain `<a>` to the same URL). No `error.tsx` boundary — errors are surfaced per-card, not per-page, so one broken RPC doesn't blank the page.
+
+**Logging.** Every fetcher catch path includes `console.error("[analytics] <fetcherName> failed", err)` with a clear label (per `CLAUDE.md`'s error-visibility rule).
+
+## Accessibility
+
+- Each KPI card is an `<article>` with an `aria-label` summarizing the metric (`"DAU: 142 users, up 8 from last period"`).
+- Delta direction communicated by both icon (▲/▼/–) and text — never color alone.
+- Time-range tabs: real `<nav>` with `<a>` links so they work without JS, deep-link, and respect the back button.
+- Active-users chart: axis labels via Recharts' `<XAxis>`/`<YAxis>`; container has an `aria-label` summarizing the latest values; metric toggle is keyboard-navigable.
+- Focus rings match the admin app convention (Tailwind `focus-visible:ring`).
+
+## Playground
+
+`apps/admin/app/(authed)/playground/analytics/page.tsx` imports each component and renders it with fixtures from `__fixtures__/`:
+
+- `<KpiCard>` — one render per state: positive delta, negative delta, no delta, missing sparkline, empty (`—`).
+- `<KpiStrip>` — full mock with all 6 cards.
+- `<ActiveUsersChart>` — three fixtures: dense (90 days), sparse (12 days), empty (0 days).
+
+No data layer, no live RPC calls. This is the dev loop where chart components are reviewed in isolation before being wired to RPCs.
+
+## Arkaik update
+
+Per `CLAUDE.md`, the product map at `docs/arkaik/bundle.json` is updated as part of this PR using the `arkaik` skill:
+
+- Add screen node: `Admin · Analytics`, route `/admin/analytics`, status `development`.
+- Add data nodes: `v_analytics_kpi_daily`, `v_analytics_active_users_daily`.
+- Add endpoint nodes: `get_kpi_daily`, `get_active_users_series`.
+- Edges: screen → endpoints → views → underlying tables (`auth.users`, `public.pebbles`).
+- Run the validation script before saving.
+
+## Acceptance criteria
+
+- [ ] `/analytics` renders KPI strip + active users chart with non-zero data on staging within 3s on cold cache.
+- [ ] Time-range tabs change the URL `?range=` and re-render server-side.
+- [ ] DAU/WAU/MAU toggle on the chart filters lines client-side without refetch.
+- [ ] Non-admin profile gets a 403/notFound on `/analytics`.
+- [ ] `/playground/analytics` renders both components with fixtures, no live data calls.
+- [ ] `npm run build --workspace=apps/admin` and `npm run lint --workspace=apps/admin` pass.
+- [ ] DB types regenerated (`npm run db:types --workspace=packages/supabase`) and committed.
+- [ ] Arkaik map validates and includes the new screen, endpoints, and data nodes.
+
+## Open questions resolved
+
+| POC question | Resolution for v1 |
+|---|---|
+| Where does session live? | Out of scope — quality signals deferred. |
+| Are deleted pebbles soft-deleted? | No. Drop `deleted_at` filters everywhere in the SQL. |
+| Is `users.created_at` the cohort anchor? | Yes — but cohorts are out of scope for v1 anyway. |
+| Where is `pebble → domain`? | `public.pebble_domains` join — out of scope for v1 (domain share is in PR #2). |
+
+## Follow-ups (PR #2 and beyond)
+
+- PR #2 — buildable-8 expansion: add retention cohorts, pebble volume, pebble enrichment donuts, per-user averages, domain share, visibility mix, single-emotion share. Same architecture; reuse the page layout slot, RPC contracts, and playground pattern. May introduce materialized views at this point if query times warrant it.
+- PR #3+ — data foundations for the blocked surfaces: a `sessions` table (or session derivation), a bounce-score snapshot, a `cairns` table, an `is_custom` column on `glyphs` (or a different "custom glyph" definition). Each is a separate spec.
+- Eventually: CSV export, last-refresh timestamp (gated on having a refresh), drill-downs into Users/Pebbles surfaces, locale-aware bucketing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "next-themes": "^0.4.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "recharts": "^3.8.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0"
       },
@@ -2209,6 +2210,42 @@
         "node": ">=14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2330,6 +2367,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.103.0",
@@ -3120,6 +3169,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -3233,6 +3345,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
@@ -4889,6 +5007,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -4992,6 +5231,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -5499,6 +5744,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild-wasm": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.27.7.tgz",
@@ -5998,6 +6253,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -7282,6 +7543,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -7335,6 +7606,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -10778,7 +11058,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-markdown": {
@@ -10808,6 +11087,29 @@
         "react": ">=18"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/recast": {
       "version": "0.23.11",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
@@ -10833,6 +11135,51 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -12297,7 +12644,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -12993,6 +13339,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/web-namespaces": {

--- a/packages/supabase/supabase/migrations/20260430000000_analytics_thin_slice.sql
+++ b/packages/supabase/supabase/migrations/20260430000000_analytics_thin_slice.sql
@@ -1,0 +1,151 @@
+-- =============================================================================
+-- Admin · Analytics · Thin slice (KPI strip + Active users chart)
+-- =============================================================================
+-- Spec: docs/superpowers/specs/2026-04-30-admin-analytics-thin-slice-design.md
+--
+-- Two plain views (not materialized — current data volume doesn't warrant MVs)
+-- exposed via two SECURITY DEFINER RPCs that gate on is_admin(auth.uid()).
+-- Soft-delete does not exist in this project, so no deleted_at filters.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- v_analytics_kpi_daily
+-- One row per calendar day from the earliest pebble's created_at to today.
+-- -----------------------------------------------------------------------------
+drop view if exists public.v_analytics_active_users_daily;
+drop view if exists public.v_analytics_kpi_daily;
+
+create view public.v_analytics_kpi_daily as
+with days as (
+  select generate_series(
+    coalesce((select min(created_at)::date from public.pebbles), current_date),
+    current_date,
+    interval '1 day'
+  )::date as bucket_date
+),
+totals as (
+  select
+    d.bucket_date,
+    (select count(*) from auth.users u where u.created_at::date <= d.bucket_date) as total_users
+  from days d
+),
+day_counts as (
+  select
+    d.bucket_date,
+    count(distinct p.user_id) filter (where p.created_at::date = d.bucket_date) as dau,
+    count(*)                  filter (where p.created_at::date = d.bucket_date) as pebbles_today
+  from days d
+  left join public.pebbles p on p.created_at::date = d.bucket_date
+  group by d.bucket_date
+),
+rolling as (
+  select
+    d.bucket_date,
+    (select count(distinct p.user_id) from public.pebbles p
+       where p.created_at::date >  d.bucket_date - 7
+         and p.created_at::date <= d.bucket_date) as wau,
+    (select count(distinct p.user_id) from public.pebbles p
+       where p.created_at::date >  d.bucket_date - 30
+         and p.created_at::date <= d.bucket_date) as mau
+  from days d
+)
+select
+  t.bucket_date,
+  t.total_users::int           as total_users,
+  d.dau::int                   as dau,
+  d.pebbles_today::int         as pebbles_today,
+  r.wau::int                   as wau,
+  r.mau::int                   as mau,
+  case when r.mau > 0 then round((d.dau::numeric / r.mau) * 100, 2) else null end as dau_mau_pct
+from totals t
+join day_counts d using (bucket_date)
+join rolling r    using (bucket_date);
+
+-- -----------------------------------------------------------------------------
+-- v_analytics_active_users_daily
+-- Projection of v_analytics_kpi_daily for the line chart.
+-- -----------------------------------------------------------------------------
+create view public.v_analytics_active_users_daily as
+select bucket_date, dau, wau, mau
+from public.v_analytics_kpi_daily;
+
+-- -----------------------------------------------------------------------------
+-- get_kpi_daily(p_range text)
+-- Returns: latest row plus the row at (latest - period_length(p_range)).
+-- For p_range = 'all' the prior-period row is omitted (deltas render '—').
+-- -----------------------------------------------------------------------------
+create or replace function public.get_kpi_daily(p_range text)
+returns setof public.v_analytics_kpi_daily
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_period_days int;
+  v_latest      date;
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'insufficient_privilege' using errcode = '42501';
+  end if;
+
+  select max(bucket_date) into v_latest from public.v_analytics_kpi_daily;
+  if v_latest is null then
+    return;
+  end if;
+
+  v_period_days := case p_range
+    when '7d'  then 7
+    when '30d' then 30
+    when '90d' then 90
+    when '1y'  then 365
+    else null
+  end;
+
+  if v_period_days is null then
+    return query
+      select * from public.v_analytics_kpi_daily
+      where bucket_date in (v_latest, v_latest - 30);  -- 30 still useful for sparkline
+  else
+    return query
+      select * from public.v_analytics_kpi_daily
+      where bucket_date in (v_latest, v_latest - v_period_days)
+         or bucket_date >  v_latest - 30;             -- sparkline window
+  end if;
+end;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- get_active_users_series(p_start date, p_end date)
+-- Returns: rows from v_analytics_active_users_daily in [p_start, p_end].
+-- -----------------------------------------------------------------------------
+create or replace function public.get_active_users_series(
+  p_start date,
+  p_end   date
+)
+returns setof public.v_analytics_active_users_daily
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'insufficient_privilege' using errcode = '42501';
+  end if;
+
+  return query
+    select * from public.v_analytics_active_users_daily
+    where bucket_date between p_start and p_end
+    order by bucket_date asc;
+end;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- Permissions
+-- Views: the SECURITY DEFINER RPCs are the access path. We still revoke direct
+-- select to keep the surface tight.
+-- -----------------------------------------------------------------------------
+revoke all on public.v_analytics_kpi_daily          from public, anon, authenticated;
+revoke all on public.v_analytics_active_users_daily from public, anon, authenticated;
+
+grant execute on function public.get_kpi_daily(text)                to authenticated;
+grant execute on function public.get_active_users_series(date, date) to authenticated;

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -1,3 +1,4 @@
+Initialising login role...
 export type Json =
   | string
   | number
@@ -781,6 +782,27 @@ export type Database = {
       }
     }
     Views: {
+      v_analytics_active_users_daily: {
+        Row: {
+          bucket_date: string | null
+          dau: number | null
+          mau: number | null
+          wau: number | null
+        }
+        Relationships: []
+      }
+      v_analytics_kpi_daily: {
+        Row: {
+          bucket_date: string | null
+          dau: number | null
+          dau_mau_pct: number | null
+          mau: number | null
+          pebbles_today: number | null
+          total_users: number | null
+          wau: number | null
+        }
+        Relationships: []
+      }
       v_bounce: {
         Row: {
           active_days: number | null
@@ -898,6 +920,39 @@ export type Database = {
       create_pebble: { Args: { payload: Json }; Returns: string }
       delete_pebble: { Args: { p_pebble_id: string }; Returns: undefined }
       delete_pebble_media: { Args: { p_snap_id: string }; Returns: string }
+      get_active_users_series: {
+        Args: { p_end: string; p_start: string }
+        Returns: {
+          bucket_date: string | null
+          dau: number | null
+          mau: number | null
+          wau: number | null
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "v_analytics_active_users_daily"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
+      get_kpi_daily: {
+        Args: { p_range: string }
+        Returns: {
+          bucket_date: string | null
+          dau: number | null
+          dau_mau_pct: number | null
+          mau: number | null
+          pebbles_today: number | null
+          total_users: number | null
+          wau: number | null
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "v_analytics_kpi_daily"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
       is_admin: { Args: { p_user_id: string }; Returns: boolean }
       update_pebble: {
         Args: { p_pebble_id: string; payload: Json }
@@ -1038,3 +1093,5 @@ export const Constants = {
     Enums: {},
   },
 } as const
+A new version of Supabase CLI is available: v2.95.4 (currently installed v2.84.2)
+We recommend updating regularly for new features and bug fixes: https://supabase.com/docs/guides/cli/getting-started#updating-the-supabase-cli

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -1,4 +1,3 @@
-Initialising login role...
 export type Json =
   | string
   | number
@@ -1093,5 +1092,3 @@ export const Constants = {
     Enums: {},
   },
 } as const
-A new version of Supabase CLI is available: v2.95.4 (currently installed v2.84.2)
-We recommend updating regularly for new features and bug fixes: https://supabase.com/docs/guides/cli/getting-started#updating-the-supabase-cli


### PR DESCRIPTION
Resolves #337

Ships the thin slice of the admin analytics page: KPI strip (6 cards) + Active users chart (DAU/WAU/MAU toggle). Backed by two new Postgres views and two SECURITY DEFINER RPCs gated on `is_admin()`. Time range is URL-driven (`?range=`).

## Key files

**Database**
- `packages/supabase/supabase/migrations/20260430000000_analytics_thin_slice.sql` — views + RPCs (already pushed to remote)
- `packages/supabase/types/database.ts` — regenerated

**App**
- `apps/admin/lib/analytics/{types,date,fetchers}.ts` — TS contracts and server fetchers
- `apps/admin/components/analytics/*` — KpiStrip, KpiCard, Sparkline, ActiveUsersChart(Card), TimeRangeTabs, ErrorBlock, skeletons, fixtures
- `apps/admin/app/(authed)/analytics/{page,loading}.tsx` — the page
- `apps/admin/app/(authed)/playground/analytics/page.tsx` — fixture-driven component review
- `apps/admin/components/layout/Sidebar.tsx` — Analytics nav entry under "Insights"
- `apps/admin/components/ui/chart.tsx` — shadcn chart primitive (recharts)

**Docs / Map**
- `docs/superpowers/specs/2026-04-30-admin-analytics-thin-slice-design.md`
- `docs/superpowers/plans/2026-04-30-admin-analytics-thin-slice.md`
- `docs/arkaik/bundle.json` — surgical update (1 view, 2 data, 2 endpoints, 8 edges; validator passed: 109 nodes, 193 edges)

## Implementation notes

- **No materialized views or `pg_cron`.** Plain views read live; the RPC contract is shaped so the swap to MVs is a one-line migration when query times warrant it.
- **No soft-delete** in this project; the migration drops the `deleted_at is null` filters that the original POC SQL assumed.
- **Schema audit cut scope from 12 → 2** for this PR. The remaining 6 buildable surfaces follow on M28; 4 are blocked on net-new schema (`bounces`, `cairns`, `sessions`, `glyphs.is_custom`) and ship later as separate specs.
- **DAU/WAU/MAU toggle** is local component state; **time range** is URL state.
- **`(authed)` layout** already enforces admin via `requireAdmin()`; no extra guard at the page level.
- **Nullable rows** — supabase RPC codegen returns nullable fields for view-backed RPCs, so the row types use `T | null`. KpiStrip filters dateless rows + coalesces numerics to 0 at the display layer.

## Test plan

- [x] `npm run build --workspace=apps/admin` ✅
- [x] `npm run lint --workspace=apps/admin` ✅
- [x] DB migration applied to remote, types regenerated and committed
- [x] Arkaik validator passes (109 nodes, 193 edges)
- [x] **Manual smoke (you):** `npm run dev --workspace=apps/admin`, then:
  - [x] `/playground/analytics` renders all KpiCard variants + 3 chart fixtures + sparkline
  - [x] `/analytics` renders KPI strip + chart with non-zero data on staging
  - [x] Time-range tabs change `?range=` and re-render server-side
  - [x] DAU/WAU/MAU toggle filters lines client-side (no network request)
  - [x] Non-admin profile gets redirected to `/403`
- [x] **Manual SQL smoke (you, in Supabase Studio):**
  ```sql
  -- as admin
  select * from public.get_kpi_daily('30d');
  select * from public.get_active_users_series(current_date - 30, current_date);
  -- as non-admin
  select * from public.get_kpi_daily('30d');  -- expect: ERROR insufficient_privilege
  ```

## Plan

`docs/superpowers/plans/2026-04-30-admin-analytics-thin-slice.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)