### PR TITLE
docs(core): admin analytics roadmap and POC handoff

### DIFF
--- a/docs/admin-analytics/ROADMAP.md
+++ b/docs/admin-analytics/ROADMAP.md
@@ -1,0 +1,87 @@
+# Admin · Analytics — Roadmap
+
+**Milestone:** [M28 · Admin Analytics](https://github.com/alexisbohns/pbbls/milestone/28)
+**Last updated:** 2026-04-30
+
+This file is the single source of truth for the analytics work on the back-office. It indexes the spec, the original POC handoff, the shipped slice, and the open follow-up issues.
+
+## Source material
+
+| Path | What it is |
+|---|---|
+| [`docs/superpowers/specs/2026-04-30-admin-analytics-thin-slice-design.md`](../superpowers/specs/2026-04-30-admin-analytics-thin-slice-design.md) | Brainstorming-derived spec for the thin slice (KPI strip + Active users chart). Includes the schema audit table that drove the scope cut. |
+| [`docs/superpowers/plans/2026-04-30-admin-analytics-thin-slice.md`](../superpowers/plans/2026-04-30-admin-analytics-thin-slice.md) | The 20-task implementation plan that produced PR #338. |
+| [`docs/poc/admin-analytics/`](../poc/admin-analytics/) | The original POC handoff from Claude Cowork: HTML mockup, SVG layout, MV DDL, TS contracts, server fetchers, and the implementation kickoff prompt. **Reference material — not all of it is buildable on the current schema.** |
+
+The POC and the thin-slice spec sometimes disagree. **The spec wins for what we actually ship.** The POC is the visual + product reference.
+
+## Status: shipped
+
+| PR | Issue | What |
+|---|---|---|
+| [#338](https://github.com/alexisbohns/pbbls/pull/338) | [#337](https://github.com/alexisbohns/pbbls/issues/337) | Thin slice — KPI strip (6 cards) + Active users line chart, 2 Postgres views + 2 SECURITY DEFINER RPCs, playground page, Arkaik update. |
+
+Architecture from the thin slice (RPC contract, URL-driven time range, server-component fetch, client toggle for chart-local state, fixture-driven playground, no MVs/cron yet) is the **template** for every follow-up issue below.
+
+## Status: open — buildable on today's schema
+
+These five issues are mechanical extensions of the thin slice. Each adds a new view + RPC + card following the exact same pattern.
+
+| Issue | Surface(s) | Layout slot | Notes |
+|---|---|---|---|
+| [#339](https://github.com/alexisbohns/pbbls/issues/339) | Retention cohort heatmap | engagement row, 4/12 (Active Users shrinks to 8/12) | Cohorts via `auth.users.created_at`, activity via `pebbles`. |
+| [#340](https://github.com/alexisbohns/pbbls/issues/340) | Pebble volume + enrichment ratios | volume row, 8+4 | Two views, one issue (shared source). Picture via `snaps`, collection via `collection_pebbles`. **Custom-glyph metric dropped** — blocked on [#347](https://github.com/alexisbohns/pbbls/issues/347). **% with emotion dropped** — `pebbles.emotion_id` is NOT NULL so it's always 100%. |
+| [#341](https://github.com/alexisbohns/pbbls/issues/341) | Per-user weekly averages | per-user row, 7/12 (paired with bounce, blocked) | Glyphs / souls / collections per active user, last 12 weeks. |
+| [#342](https://github.com/alexisbohns/pbbls/issues/342) | Meaning: emotion + domain share | meaning row, 6+6 | **Single-emotion model** — pebble has one `emotion_id`, so emotion shares sum to 100% per week (vs the POC's "may not sum to 100%"). |
+| [#343](https://github.com/alexisbohns/pbbls/issues/343) | Visibility mix | cairns/visibility row, 3/12 | Trivial — `pebbles.visibility` already exists. |
+
+## Status: open — blocked on data foundations
+
+These four issues are **product features first, analytics second**. Each requires schema work (and in two cases significant product design) before the analytics card can be built. Each should run through `superpowers:brainstorming` before scoping.
+
+| Issue | Foundation | Unlocks | Size |
+|---|---|---|---|
+| [#344](https://github.com/alexisbohns/pbbls/issues/344) | `bounces` snapshot table + writer (or derive from `karma_events`) | Bounce karma distribution chart | Medium — schema design + backfill, then mechanical chart. |
+| [#345](https://github.com/alexisbohns/pbbls/issues/345) | `cairns` table + lifecycle (creation, completion check) + at least one client surface that creates them | Cairn participation chart | **Large — full product feature.** |
+| [#346](https://github.com/alexisbohns/pbbls/issues/346) | `sessions` + analytics-event log + (probably) `pebble_views` | Quality signals table (8 metrics) | **Largest** — explicit phasing recommended (D-retention first, sessions second, view-events third). |
+| [#347](https://github.com/alexisbohns/pbbls/issues/347) | `glyphs.is_custom` column + definition of "custom" + writer | Custom-glyph overlay on volume + enrichment cards | Small — one column + a definition decision. |
+
+## Status: deferred (non-goals for M28)
+
+- CSV export from any chart.
+- "Last refresh" timestamp in the page header (no MV refresh exists).
+- Materialized views + `pg_cron` nightly refresh — adopt when query times warrant; the RPC contract is shaped to make the swap a one-line migration.
+- Drill-down from any chart into Users / Pebbles surfaces.
+- Real-time data, predictive metrics, geo / device / app-version breakdowns, funnel analysis (per the POC's stated non-goals).
+- Locale-aware bucketing (admin aggregates to UTC).
+- Multi-emotion model — would widen the emotion share view but isn't required for analytics.
+
+## Architecture invariants (apply to every follow-up issue)
+
+If you're picking up any issue above, follow these without re-litigation:
+
+- **One Postgres view + one SECURITY DEFINER RPC per surface.** RPC body checks `is_admin(auth.uid())` and raises `insufficient_privilege` (42501) for non-admins.
+- **Plain views, not materialized views.** Until query times demand otherwise.
+- **Soft-delete doesn't exist** in this project — no `deleted_at is null` filters anywhere.
+- **Server fetchers in `apps/admin/lib/analytics/fetchers.ts`** — one thin async function per RPC, with a `console.error("[analytics] <name> failed", err)` in the catch path.
+- **Time range is URL state** (`?range=`); chart-local toggles are component state.
+- **Server Component shells fetch + render** + Client Component children only when the DOM is needed (Recharts, interactive toggles).
+- **Each new card has a playground fixture** at `apps/admin/components/analytics/__fixtures__/<name>.ts` and a render in `app/(authed)/playground/analytics/page.tsx`.
+- **Each new card has loading + empty + error states** matching the existing pattern (skeletons, "No data yet", inline `<ErrorBlock>`).
+- **Arkaik map updated surgically** — add a data node per view, an endpoint node per RPC, edges screen→endpoint and endpoint→view (and endpoint→underlying tables where the join is meaningful). Run the validator.
+- **`apps/admin` build + lint must pass** before opening a PR.
+
+## Why some POC bits don't apply
+
+The POC was written against an aspirational schema. The real schema is shipped and stable. Concretely:
+
+- POC's `users` table → reality is `auth.users` + `public.profiles` (with `is_admin` boolean).
+- POC's `pebbles.deleted_at` → soft-delete doesn't exist; pebbles use hard delete via `delete_pebble` RPC.
+- POC's `pebbles.picture_url` → `snaps` (1-many).
+- POC's `pebbles.collection_id` → `collection_pebbles` (m2m).
+- POC's `pebble_emotions` join → `pebbles.emotion_id` is a single non-null FK (one emotion per pebble).
+- POC's `glyphs.is_custom` → doesn't exist (#347).
+- POC's `bounces` table → doesn't exist (#344); event log is `karma_events`.
+- POC's `cairns`, `sessions`, `user_active_days` → don't exist (#345, #346).
+
+When in doubt, prefer the spec and the live schema over the POC. The POC stays as visual + naming reference.

--- a/docs/poc/admin-analytics/20260430_analytics_mvs.sql
+++ b/docs/poc/admin-analytics/20260430_analytics_mvs.sql
@@ -1,0 +1,567 @@
+-- =============================================================================
+-- Admin · Analytics · Materialized Views
+-- =============================================================================
+-- Source of truth: docs/specs/admin-analytics.md
+--
+-- Conventions:
+--   * One MV per surface on the analytics page. No cross-MV joins at query time.
+--   * Every MV exposes a `bucket_date` (or `bucket_week`) column. The Next.js
+--     fetchers read `where bucket_date = (select max(bucket_date) from <mv>)`
+--     for "current" values and a date range for time series.
+--   * UTC throughout. Locale-aware bucketing is a v2 concern (see spec).
+--   * "Active user" = user who created ≥1 pebble in the period.
+--   * Soft-deleted pebbles (`deleted_at is not null`) are excluded everywhere.
+--   * Indexes are defined per MV; we use UNIQUE indexes where possible so we
+--     can `REFRESH MATERIALIZED VIEW CONCURRENTLY`.
+--
+-- Schema assumptions (verify against the actual schema before merging):
+--   users           (id, created_at, deleted_at, role)
+--   pebbles         (id, user_id, created_at, deleted_at, picture_url,
+--                    glyph_id, collection_id, intensity, visibility, thought)
+--   glyphs          (id, user_id, is_custom)
+--   souls           (id, user_id, created_at)
+--   collections     (id, user_id, created_at)
+--   emotions        (id, name, color, primary_domain_id)
+--   pebble_emotions (pebble_id, emotion_id, intensity)
+--   domains         (id, name, level)
+--   pebble_domains  (pebble_id, domain_id)
+--   pebble_souls    (pebble_id, soul_id)
+--   bounces         (user_id, score, updated_at)
+--   user_active_days(user_id, active_date)            -- daily activity ledger
+--   cairns          (id, user_id, period, period_start, status, completed_at)
+--   sessions        (id, user_id, started_at, ended_at)  -- TBC, see spec Q1
+-- =============================================================================
+
+-- Drop in reverse-dependency order so this migration is idempotent in dev.
+drop materialized view if exists mv_quality_signals_daily       cascade;
+drop materialized view if exists mv_visibility_mix_daily        cascade;
+drop materialized view if exists mv_cairn_participation_weekly  cascade;
+drop materialized view if exists mv_domain_share_weekly         cascade;
+drop materialized view if exists mv_emotion_share_weekly        cascade;
+drop materialized view if exists mv_bounce_distribution_daily   cascade;
+drop materialized view if exists mv_user_averages_weekly        cascade;
+drop materialized view if exists mv_pebble_enrichment_daily     cascade;
+drop materialized view if exists mv_pebble_volume_daily         cascade;
+drop materialized view if exists mv_retention_cohorts_weekly    cascade;
+drop materialized view if exists mv_active_users_daily          cascade;
+drop materialized view if exists mv_kpi_daily                   cascade;
+
+-- =============================================================================
+-- mv_kpi_daily
+-- One row per day. Powers the KPI strip.
+-- =============================================================================
+create materialized view mv_kpi_daily as
+with days as (
+  select generate_series(
+    (select min(created_at)::date from pebbles),
+    current_date,
+    interval '1 day'
+  )::date as bucket_date
+),
+total as (
+  select bucket_date,
+    (select count(*) from users u where u.created_at::date <= d.bucket_date and u.deleted_at is null) as total_users
+  from days d
+),
+dau as (
+  select d.bucket_date,
+    count(distinct p.user_id) filter (where p.created_at::date = d.bucket_date) as dau,
+    count(*)                  filter (where p.created_at::date = d.bucket_date) as pebbles_today
+  from days d
+  left join pebbles p on p.created_at::date = d.bucket_date and p.deleted_at is null
+  group by d.bucket_date
+),
+wau as (
+  select d.bucket_date,
+    (select count(distinct p.user_id) from pebbles p
+       where p.deleted_at is null
+         and p.created_at::date >  d.bucket_date - 7
+         and p.created_at::date <= d.bucket_date) as wau
+  from days d
+),
+mau as (
+  select d.bucket_date,
+    (select count(distinct p.user_id) from pebbles p
+       where p.deleted_at is null
+         and p.created_at::date >  d.bucket_date - 30
+         and p.created_at::date <= d.bucket_date) as mau
+  from days d
+)
+select
+  t.bucket_date,
+  t.total_users,
+  d.dau,
+  d.pebbles_today,
+  w.wau,
+  m.mau,
+  case when m.mau > 0 then round((d.dau::numeric / m.mau) * 100, 2) else null end as dau_mau_pct
+from total t
+join dau d using (bucket_date)
+join wau w using (bucket_date)
+join mau m using (bucket_date);
+
+create unique index on mv_kpi_daily (bucket_date);
+
+-- =============================================================================
+-- mv_active_users_daily
+-- Daily DAU/WAU/MAU series for the line chart. Same numbers as mv_kpi_daily
+-- but split into its own MV so the chart query is small and fast.
+-- =============================================================================
+create materialized view mv_active_users_daily as
+select bucket_date, dau, wau, mau
+from mv_kpi_daily;
+
+create unique index on mv_active_users_daily (bucket_date);
+
+-- =============================================================================
+-- mv_retention_cohorts_weekly
+-- One row per (cohort_week, week_offset). cohort_week is the Monday of the
+-- user's signup week. week_offset = 0 is the signup week itself.
+-- =============================================================================
+create materialized view mv_retention_cohorts_weekly as
+with cohorts as (
+  select
+    date_trunc('week', u.created_at)::date as cohort_week,
+    u.id as user_id
+  from users u
+  where u.deleted_at is null
+),
+cohort_size as (
+  select cohort_week, count(*) as size
+  from cohorts
+  group by cohort_week
+),
+activity as (
+  select
+    c.cohort_week,
+    floor(extract(epoch from (date_trunc('week', p.created_at) - c.cohort_week)) / 604800)::int as week_offset,
+    c.user_id
+  from cohorts c
+  join pebbles p on p.user_id = c.user_id and p.deleted_at is null
+  where p.created_at >= c.cohort_week
+)
+select
+  a.cohort_week,
+  a.week_offset,
+  cs.size as cohort_size,
+  count(distinct a.user_id) as active_users,
+  round((count(distinct a.user_id)::numeric / cs.size) * 100, 1) as retention_pct
+from activity a
+join cohort_size cs using (cohort_week)
+group by a.cohort_week, a.week_offset, cs.size;
+
+create unique index on mv_retention_cohorts_weekly (cohort_week, week_offset);
+
+-- =============================================================================
+-- mv_pebble_volume_daily
+-- Pebble volume + enrichment overlay counts per day.
+-- =============================================================================
+create materialized view mv_pebble_volume_daily as
+select
+  p.created_at::date as bucket_date,
+  count(*)                                                     as pebbles,
+  count(*) filter (where p.picture_url is not null)            as pebbles_with_picture,
+  count(*) filter (where g.is_custom)                          as pebbles_with_custom_glyph,
+  count(*) filter (where p.collection_id is not null)          as pebbles_in_collection,
+  count(distinct p.user_id)                                    as active_users
+from pebbles p
+left join glyphs g on g.id = p.glyph_id
+where p.deleted_at is null
+group by p.created_at::date;
+
+create unique index on mv_pebble_volume_daily (bucket_date);
+
+-- =============================================================================
+-- mv_pebble_enrichment_daily
+-- Same source as mv_pebble_volume_daily but pre-computes the share fields
+-- the donuts and secondary ratios need. Kept separate so the donut card
+-- doesn't need to do arithmetic in the page.
+-- =============================================================================
+create materialized view mv_pebble_enrichment_daily as
+with base as (
+  select
+    p.created_at::date as bucket_date,
+    p.id,
+    p.picture_url,
+    p.collection_id,
+    p.thought,
+    p.intensity,
+    g.is_custom as glyph_is_custom,
+    exists (select 1 from pebble_emotions pe where pe.pebble_id = p.id) as has_emotion,
+    exists (select 1 from pebble_souls    ps where ps.pebble_id = p.id) as has_soul
+  from pebbles p
+  left join glyphs g on g.id = p.glyph_id
+  where p.deleted_at is null
+)
+select
+  bucket_date,
+  count(*) as total_pebbles,
+  round(100.0 * count(*) filter (where picture_url is not null) / nullif(count(*), 0), 1) as pct_with_picture,
+  round(100.0 * count(*) filter (where glyph_is_custom)         / nullif(count(*), 0), 1) as pct_with_custom_glyph,
+  round(100.0 * count(*) filter (where collection_id is not null) / nullif(count(*), 0), 1) as pct_in_collection,
+  round(100.0 * count(*) filter (where has_emotion)             / nullif(count(*), 0), 1) as pct_with_emotion,
+  round(100.0 * count(*) filter (where has_soul)                / nullif(count(*), 0), 1) as pct_with_soul,
+  round(100.0 * count(*) filter (where thought is not null and length(thought) > 0) / nullif(count(*), 0), 1) as pct_with_thought,
+  round(100.0 * count(*) filter (where intensity is not null)   / nullif(count(*), 0), 1) as pct_with_intensity
+from base
+group by bucket_date;
+
+create unique index on mv_pebble_enrichment_daily (bucket_date);
+
+-- =============================================================================
+-- mv_user_averages_weekly
+-- Per-user averages of glyphs/souls/collections, computed weekly.
+-- Denominator = active users that week (≥1 pebble in week).
+-- =============================================================================
+create materialized view mv_user_averages_weekly as
+with weeks as (
+  select date_trunc('week', d)::date as bucket_week
+  from generate_series(
+    date_trunc('week', (select min(created_at) from pebbles))::date,
+    date_trunc('week', current_date)::date,
+    interval '1 week'
+  ) d
+),
+active_users_in_week as (
+  select date_trunc('week', p.created_at)::date as bucket_week,
+         count(distinct p.user_id) as active_users
+  from pebbles p
+  where p.deleted_at is null
+  group by 1
+),
+glyph_totals as (
+  select w.bucket_week,
+         (select count(*) from glyphs gg
+            where gg.user_id in (select distinct p.user_id from pebbles p
+                                  where p.deleted_at is null
+                                    and date_trunc('week', p.created_at)::date = w.bucket_week)
+         ) as glyph_count
+  from weeks w
+),
+soul_totals as (
+  select w.bucket_week,
+         (select count(*) from souls ss
+            where ss.user_id in (select distinct p.user_id from pebbles p
+                                  where p.deleted_at is null
+                                    and date_trunc('week', p.created_at)::date = w.bucket_week)
+         ) as soul_count
+  from weeks w
+),
+collection_totals as (
+  select w.bucket_week,
+         (select count(*) from collections cc
+            where cc.user_id in (select distinct p.user_id from pebbles p
+                                  where p.deleted_at is null
+                                    and date_trunc('week', p.created_at)::date = w.bucket_week)
+         ) as collection_count
+  from weeks w
+)
+select
+  w.bucket_week,
+  coalesce(au.active_users, 0) as active_users,
+  case when au.active_users > 0 then round(gt.glyph_count::numeric      / au.active_users, 2) else 0 end as avg_glyphs,
+  case when au.active_users > 0 then round(st.soul_count::numeric       / au.active_users, 2) else 0 end as avg_souls,
+  case when au.active_users > 0 then round(ct.collection_count::numeric / au.active_users, 2) else 0 end as avg_collections
+from weeks w
+left join active_users_in_week au on au.bucket_week = w.bucket_week
+left join glyph_totals gt        on gt.bucket_week = w.bucket_week
+left join soul_totals st         on st.bucket_week = w.bucket_week
+left join collection_totals ct   on ct.bucket_week = w.bucket_week;
+
+create unique index on mv_user_averages_weekly (bucket_week);
+
+-- =============================================================================
+-- mv_bounce_distribution_daily
+-- Histogram of users by current bounce score, plus summary stats.
+-- One row per (bucket_date, bucket_label).
+-- =============================================================================
+create materialized view mv_bounce_distribution_daily as
+with today as (
+  select current_date as bucket_date
+),
+binned as (
+  select
+    t.bucket_date,
+    case
+      when b.score = 0                     then '0'
+      when b.score between 1   and 10      then '1-10'
+      when b.score between 11  and 25      then '11-25'
+      when b.score between 26  and 50      then '26-50'
+      when b.score between 51  and 100     then '51-100'
+      else                                      '100+'
+    end as bucket_label,
+    case
+      when b.score = 0                     then 0
+      when b.score between 1   and 10      then 1
+      when b.score between 11  and 25      then 2
+      when b.score between 26  and 50      then 3
+      when b.score between 51  and 100     then 4
+      else                                      5
+    end as bucket_order,
+    b.score
+  from today t
+  cross join bounces b
+)
+select
+  bucket_date,
+  bucket_order,
+  bucket_label,
+  count(*)               as users,
+  -- summary stats are repeated on every row to keep the page query simple
+  (select percentile_cont(0.5) within group (order by score)::int from binned) as median_score,
+  (select round(100.0 * count(*) filter (where score >= coalesce(
+        (select score from bounces b2 where b2.user_id = b.user_id and b2.updated_at < current_date - 7
+          order by b2.updated_at desc limit 1), 0))
+     / nullif(count(*), 0), 1)
+   from bounces b)                                                              as pct_maintaining,
+  (select round(avg(active_days), 2) from (
+      select count(distinct active_date) as active_days
+      from user_active_days
+      where active_date > current_date - 7
+      group by user_id
+    ) x)                                                                        as avg_active_days_per_week
+from binned
+group by bucket_date, bucket_order, bucket_label;
+
+create unique index on mv_bounce_distribution_daily (bucket_date, bucket_order);
+
+-- =============================================================================
+-- mv_emotion_share_weekly
+-- Share of pebbles tagged with each emotion, per week.
+-- A pebble can have multiple pearls; shares do NOT need to sum to 100%.
+-- =============================================================================
+create materialized view mv_emotion_share_weekly as
+with weekly_pebbles as (
+  select date_trunc('week', p.created_at)::date as bucket_week, p.id
+  from pebbles p
+  where p.deleted_at is null
+),
+totals as (
+  select bucket_week, count(*) as total_pebbles
+  from weekly_pebbles
+  group by bucket_week
+)
+select
+  wp.bucket_week,
+  e.id   as emotion_id,
+  e.name as emotion_name,
+  e.color,
+  count(distinct wp.id) as pebbles_with_emotion,
+  t.total_pebbles,
+  round(100.0 * count(distinct wp.id) / nullif(t.total_pebbles, 0), 2) as share_pct
+from weekly_pebbles wp
+join pebble_emotions pe on pe.pebble_id = wp.id
+join emotions e         on e.id = pe.emotion_id
+join totals t           on t.bucket_week = wp.bucket_week
+group by wp.bucket_week, e.id, e.name, e.color, t.total_pebbles;
+
+create unique index on mv_emotion_share_weekly (bucket_week, emotion_id);
+
+-- =============================================================================
+-- mv_domain_share_weekly
+-- Share of pebbles linked to each Maslow domain, per week.
+-- =============================================================================
+create materialized view mv_domain_share_weekly as
+with weekly_pebbles as (
+  select date_trunc('week', p.created_at)::date as bucket_week, p.id
+  from pebbles p
+  where p.deleted_at is null
+),
+totals as (
+  select bucket_week, count(*) as total_pebbles
+  from weekly_pebbles
+  group by bucket_week
+)
+select
+  wp.bucket_week,
+  d.id    as domain_id,
+  d.name  as domain_name,
+  d.level as domain_level,
+  count(distinct wp.id) as pebbles_in_domain,
+  t.total_pebbles,
+  round(100.0 * count(distinct wp.id) / nullif(t.total_pebbles, 0), 2) as share_pct
+from weekly_pebbles wp
+join pebble_domains pd on pd.pebble_id = wp.id
+join domains d         on d.id = pd.domain_id
+join totals t          on t.bucket_week = wp.bucket_week
+group by wp.bucket_week, d.id, d.name, d.level, t.total_pebbles;
+
+create unique index on mv_domain_share_weekly (bucket_week, domain_id);
+
+-- =============================================================================
+-- mv_cairn_participation_weekly
+-- Participation rates for weekly and monthly cairns over the last 12 periods.
+-- =============================================================================
+create materialized view mv_cairn_participation_weekly as
+select
+  c.period,                   -- 'weekly' | 'monthly'
+  c.period_start,
+  count(*) filter (where c.status = 'completed') as completed,
+  count(*) filter (where c.status = 'partial')   as partial,
+  count(*) filter (where c.status = 'missed')    as missed,
+  count(*)                                       as total,
+  round(100.0 * count(*) filter (where c.status = 'completed') / nullif(count(*), 0), 1) as completed_pct,
+  round(100.0 * count(*) filter (where c.status = 'partial')   / nullif(count(*), 0), 1) as partial_pct,
+  round(100.0 * count(*) filter (where c.status = 'missed')    / nullif(count(*), 0), 1) as missed_pct
+from cairns c
+where c.period_start >= current_date - interval '12 weeks'
+group by c.period, c.period_start;
+
+create unique index on mv_cairn_participation_weekly (period, period_start);
+
+-- =============================================================================
+-- mv_visibility_mix_daily
+-- Pebble counts by visibility per day. The page sums the trailing window.
+-- =============================================================================
+create materialized view mv_visibility_mix_daily as
+select
+  p.created_at::date as bucket_date,
+  p.visibility,
+  count(*) as pebbles
+from pebbles p
+where p.deleted_at is null
+group by p.created_at::date, p.visibility;
+
+create unique index on mv_visibility_mix_daily (bucket_date, visibility);
+
+-- =============================================================================
+-- mv_quality_signals_daily
+-- One row per day with the eight habit-health metrics.
+-- NOTE: depends on `sessions` table — see spec open question Q1.
+-- =============================================================================
+create materialized view mv_quality_signals_daily as
+with today as (select current_date as bucket_date),
+session_metrics as (
+  select t.bucket_date,
+    percentile_cont(0.5) within group (
+      order by extract(epoch from (s.ended_at - s.started_at))
+    )::int as median_session_seconds,
+    round((select count(*) from sessions s2
+             where s2.started_at > current_date - 7)::numeric
+          / nullif((select count(distinct user_id) from pebbles p
+                      where p.deleted_at is null
+                        and p.created_at > current_date - 7), 0), 2) as sessions_per_wau
+  from today t
+  left join sessions s on s.started_at > current_date - 7
+  group by t.bucket_date
+),
+pebbles_per_wau as (
+  select t.bucket_date,
+    round(
+      (select count(*) from pebbles p
+         where p.deleted_at is null and p.created_at > current_date - 7)::numeric
+      / nullif((select count(distinct user_id) from pebbles p
+                  where p.deleted_at is null and p.created_at > current_date - 7), 0), 2)
+      as pebbles_per_wau
+  from today t
+),
+retention as (
+  select t.bucket_date,
+    round(100.0 *
+      (select count(distinct u.id) from users u
+         join pebbles p on p.user_id = u.id and p.deleted_at is null
+         where u.created_at::date = current_date - 1
+           and p.created_at::date = current_date)
+      / nullif((select count(*) from users u where u.created_at::date = current_date - 1), 0), 1)
+      as d1_retention,
+    round(100.0 *
+      (select count(distinct u.id) from users u
+         join pebbles p on p.user_id = u.id and p.deleted_at is null
+         where u.created_at::date = current_date - 7
+           and p.created_at::date between current_date - 7 and current_date)
+      / nullif((select count(*) from users u where u.created_at::date = current_date - 7), 0), 1)
+      as d7_retention,
+    round(100.0 *
+      (select count(distinct u.id) from users u
+         join pebbles p on p.user_id = u.id and p.deleted_at is null
+         where u.created_at::date = current_date - 30
+           and p.created_at::date between current_date - 30 and current_date)
+      / nullif((select count(*) from users u where u.created_at::date = current_date - 30), 0), 1)
+      as d30_retention
+  from today t
+)
+select
+  t.bucket_date,
+  sm.median_session_seconds,
+  sm.sessions_per_wau,
+  pw.pebbles_per_wau,
+  -- TODO: % revisits to past pebbles needs a `pebble_views` table; placeholder.
+  null::numeric                  as pct_revisits_to_past_pebbles,
+  r.d1_retention,
+  r.d7_retention,
+  r.d30_retention,
+  -- TODO: friction events / session needs a normalized analytics events table.
+  null::numeric                  as friction_events_per_session
+from today t
+left join session_metrics sm on sm.bucket_date = t.bucket_date
+left join pebbles_per_wau pw on pw.bucket_date = t.bucket_date
+left join retention r        on r.bucket_date  = t.bucket_date;
+
+create unique index on mv_quality_signals_daily (bucket_date);
+
+-- =============================================================================
+-- Refresh function + nightly cron
+-- =============================================================================
+create or replace function refresh_analytics_mvs()
+returns void
+language plpgsql
+security definer
+as $$
+begin
+  refresh materialized view concurrently mv_kpi_daily;
+  refresh materialized view concurrently mv_active_users_daily;
+  refresh materialized view concurrently mv_retention_cohorts_weekly;
+  refresh materialized view concurrently mv_pebble_volume_daily;
+  refresh materialized view concurrently mv_pebble_enrichment_daily;
+  refresh materialized view concurrently mv_user_averages_weekly;
+  refresh materialized view concurrently mv_bounce_distribution_daily;
+  refresh materialized view concurrently mv_emotion_share_weekly;
+  refresh materialized view concurrently mv_domain_share_weekly;
+  refresh materialized view concurrently mv_cairn_participation_weekly;
+  refresh materialized view concurrently mv_visibility_mix_daily;
+  refresh materialized view concurrently mv_quality_signals_daily;
+end;
+$$;
+
+-- pg_cron job: nightly at 03:00 UTC
+-- Requires the pg_cron extension to be enabled in the Supabase project.
+select cron.schedule(
+  'refresh_analytics_mvs_nightly',
+  '0 3 * * *',
+  $$select refresh_analytics_mvs();$$
+);
+
+-- =============================================================================
+-- RLS: admin-only access on every MV
+-- =============================================================================
+-- Supabase exposes MVs via PostgREST. We secure them with a policy that checks
+-- the JWT for the admin role. Adjust the role claim path to match the actual
+-- claim shape used in the app's JWT.
+
+do $$
+declare mv_name text;
+begin
+  for mv_name in
+    select unnest(array[
+      'mv_kpi_daily',
+      'mv_active_users_daily',
+      'mv_retention_cohorts_weekly',
+      'mv_pebble_volume_daily',
+      'mv_pebble_enrichment_daily',
+      'mv_user_averages_weekly',
+      'mv_bounce_distribution_daily',
+      'mv_emotion_share_weekly',
+      'mv_domain_share_weekly',
+      'mv_cairn_participation_weekly',
+      'mv_visibility_mix_daily',
+      'mv_quality_signals_daily'
+    ])
+  loop
+    execute format('alter materialized view %I owner to postgres;', mv_name);
+    execute format('grant select on %I to authenticated;',           mv_name);
+    execute format(
+      'create policy %I_admin_only on %I for select using (
+         (auth.jwt() ->> ''role'') = ''admin''
+       );', mv_name, mv_name);
+  end loop;
+end $$;

--- a/docs/poc/admin-analytics/CLAUDE-PROMPT.md
+++ b/docs/poc/admin-analytics/CLAUDE-PROMPT.md
@@ -1,0 +1,92 @@
+# Implementation kickoff — Admin · Analytics
+
+Paste this into a fresh Claude Code session in the `pbbls` repo.
+
+---
+
+## Briefing
+
+You are implementing the Admin · Analytics page in the pbbls Next.js admin app.
+
+**Read these first, in this order:**
+
+1. `docs/specs/admin-analytics.md` — the spec, including exact metric definitions and acceptance criteria.
+2. `analytics-mockup.html` — open it in your browser. This is the canonical visual reference. Open the network panel to confirm vendor JS loaded from `docs/specs/admin-analytics/vendor/`.
+3. `docs/specs/admin-analytics/screenshots/layout-overview.svg` — labeled layout map. Use it for spatial reference.
+4. `supabase/migrations/20260430_analytics_mvs.sql` — the materialized views you'll be reading from.
+5. `apps/admin/src/lib/analytics/types.ts` and `apps/admin/src/lib/analytics/fetchers.ts` — the data contracts and server-side fetchers. **The MV row types are the source of truth — do not invent new fields.**
+6. `docs/arkaik/pebbles-arkaik.json` and `.claude/skills/arkaik/SKILL.md` — the product architecture map, which you will surgically update as part of this work.
+
+## What you are building
+
+The analytics page at `apps/admin/src/app/(admin)/analytics/page.tsx` and the chart components under `apps/admin/src/components/analytics/`.
+
+12 surfaces in total. The spec lists them and defines every metric. Don't invent definitions — if a definition isn't in the spec, stop and ask.
+
+## Stack & conventions
+
+- Next.js App Router, Server Components by default. Data fetching happens server-side via the fetchers in `lib/analytics/fetchers.ts`. Don't fetch from the client.
+- shadcn/ui for primitives (Card, Tabs, Badge, Table). shadcn charts (Recharts under the hood) for everything visual.
+- Tailwind for layout. The mockup uses a 12-column grid; stick to it.
+- TypeScript strict mode. No `any`, no `as` casts on MV rows.
+- Loading states: `<Skeleton/>` from shadcn. Empty states: short copy, neutral tone.
+- Error states: surface the error to the admin (this is an internal tool — verbose is fine).
+
+## Way of working
+
+1. **Set up the playground first.** Add `apps/admin/src/app/(admin)/playground/analytics/page.tsx` that imports each chart component and renders it with mock data fixtures (write the fixtures alongside the components in `__fixtures__/`). This is your dev loop — Alexis will review chart components in isolation here before they're wired to live MVs.
+2. **Build one surface end-to-end first.** Pick `mv_active_users_daily` → `getActiveUsersSeries` → `<ActiveUsersChart/>`. Get it perfect: types, loading, empty, error, dark mode if applicable, accessibility (axis labels, focus states). Get review on it before parallelizing.
+3. **Then parallelize.** Once the pattern is approved, build the remaining 11 surfaces in the same shape.
+4. **Wire the page.** Compose the page top-down following the layout in the spec. Time-range selector lives in the page and threads down via props.
+5. **Update the Arkaik map** as you go (see below). Don't batch this for the end.
+
+## Arkaik map updates (mandatory)
+
+Per `CLAUDE.md`, the Arkaik map at `docs/arkaik/pebbles-arkaik.json` is the source of truth for the product architecture, and you must update it surgically alongside your code changes. Specifically:
+
+- Add a screen node for `Admin · Analytics` with the route `/admin/analytics`.
+- Add data nodes for each materialized view.
+- Add endpoint nodes for each fetcher in `lib/analytics/fetchers.ts`.
+- Wire edges: screen → fetcher → MV → underlying tables (the schema assumptions in the SQL header).
+
+Use the Arkaik skill at `.claude/skills/arkaik/SKILL.md` — read it first. Run the validation script before saving.
+
+## Acceptance — what "done" means
+
+The list in `docs/specs/admin-analytics.md` under "Acceptance criteria" is the bar. In particular:
+
+- The page loads with non-zero data on staging within 5s on a warm cache.
+- Lighthouse performance score ≥ 90.
+- A non-admin user gets 403 on every fetcher (test it).
+- The Arkaik map validates and reflects the new screen, data nodes, and endpoints.
+- `/playground/analytics` renders every chart with fixtures.
+
+## Open questions to resolve before starting
+
+These are listed at the bottom of `admin-analytics.md`. Don't begin coding `mv_quality_signals_daily` consumption until you have answers:
+
+1. Where does session live — `events` table, derived from pebble gaps, or a separate `sessions` table?
+2. Are deleted pebbles soft-deleted? (Affects every count.)
+3. Is `users.created_at` the cohort anchor, or is there a `signed_up_at`?
+4. Where is the canonical `pebble → domain` link?
+
+Ask Alexis on Slack/Notion before assuming.
+
+## What NOT to do
+
+- Don't refactor unrelated admin code. Keep the diff scoped to analytics.
+- Don't change the Pebbles repo on GitHub without explicit allowance (per project guidelines).
+- Don't fetch from the client. Server Components only.
+- Don't invent metrics or rename MV columns. The contracts are fixed.
+- Don't regenerate the full Arkaik map. Surgical updates only.
+- Don't add real-time data, drill-downs, or any of the spec's stated non-goals — those are v2.
+
+## First message to send back
+
+After you've read the spec, mockup, SQL, and TS, reply with:
+
+1. The four open-question answers (or "still need answers from Alexis on Q1/Q2/...").
+2. A 5-bullet plan for the first surface end-to-end.
+3. Anything in the spec or mockup that looks wrong, ambiguous, or technically risky.
+
+Then wait for confirmation before writing code.

--- a/docs/poc/admin-analytics/admin-analytics.md
+++ b/docs/poc/admin-analytics/admin-analytics.md
@@ -1,0 +1,228 @@
+# Admin · Analytics
+
+**Status:** Draft v0.1 · POC mockup approved, pending implementation
+**Owner:** Alexis
+**Last updated:** 2026-04-30
+
+## Why
+
+Pebbles is a daily ritual product — its long-term success depends on whether
+people come back, whether they're collecting meaningful pebbles (not just
+text-only one-liners), and whether the product gives them back the mirror it
+promises (emotional shape, who matters, what domains of their life are full or
+starved). The admin Analytics surface answers four questions on one page:
+
+1. **Are people coming back?** (retention, engagement)
+2. **Are they collecting?** (usage volume by period, with picture/glyph/collection)
+3. **What does an average user look like?** (per-user averages of glyphs, souls, collections — and how those evolve)
+4. **What's emerging?** (emotion and domain prevalence, and how those shift)
+
+This is for us, not for users — operating instrument, not consumer dashboard.
+
+## Goals
+
+- One page, no drill-downs in v1.
+- All charts driven by Supabase materialized views, refreshed once per day at night.
+- All metrics show **both** an absolute current value **and** a delta vs. the previous period (or a time series).
+- Built with `shadcn/ui` and shadcn charts (Recharts under the hood).
+- Loadable end-to-end in under 1.5s on a warm cache.
+
+## Non-goals (v1)
+
+- Per-user drill-down. Use the Users surface for that.
+- Cohort comparison beyond weekly retention table.
+- Real-time data. Nightly refresh is enough.
+- Predictive metrics (churn risk, propensity). Defer.
+- Geo, device, app-version breakdowns. Defer.
+- Funnel analysis (signup → first pebble → first cairn). Defer to a separate "Funnels" surface.
+- Export beyond CSV.
+
+## Visual reference
+
+- Live interactive mockup: `analytics-mockup.html` (project root). Open in any browser; deps are bundled locally under `docs/specs/admin-analytics/vendor/`.
+- Layout map: `docs/specs/admin-analytics/screenshots/layout-overview.svg`.
+
+If anything in this spec is ambiguous, the **live mockup wins** for visual decisions and **this doc wins** for metric definitions.
+
+## Layout
+
+The page is a 12-column grid. Reading top-to-bottom:
+
+| Row | Width split | Contents |
+|---|---|---|
+| Header | 12 | Title, breadcrumb, time-range tabs (7d / 30d / 90d / 1y / All), last-refresh timestamp, Export CSV. |
+| KPI strip | 6 × 2 | Total users · DAU · WAU · MAU · Pebbles/day · DAU/MAU. Each card has value, delta badge, contextual sub-label, sparkline. |
+| Engagement | 8 + 4 | Active users line chart (DAU/WAU/MAU toggle) · Retention cohort heatmap (weekly). |
+| Volume | 8 + 4 | Pebbles collected (bar volume + enrichment overlay lines, with Day/Week/Month/Year toggle) · Pebble enrichment donuts + secondary ratios. |
+| Per-user & habit | 7 + 5 | Per-user averages over time (glyphs, souls, collections) · Bounce karma distribution + habit summary. |
+| Meaning | 6 + 6 | Emotion pearls prevalence (snapshot bar + over-time stacked area) · Maslow domains prevalence + biggest movers. |
+| Cairns & visibility | 6 + 3 + 3 | Cairn participation · Visibility mix · Quality signals table. |
+
+Time range selector applies globally to every chart. The toggles within charts (DAU/WAU/MAU, Day/Week/Month/Year) only change which series is visible, not the underlying time window.
+
+## Metric definitions
+
+> **Active user** throughout this spec means a user who created **at least one pebble** in the period. Sessions don't count — passive opens don't make you active in Pebbles' terms.
+
+> **Period buckets** are anchored to UTC. We make this explicit because cairns and bounces are user-locale-aware in the product but admin analytics aggregate to UTC for consistency.
+
+### KPI strip
+
+- **Total users** — `count(distinct user_id)` from `users` where `deleted_at is null`. Delta vs. prior period of equal length.
+- **DAU** — distinct users with ≥1 pebble created in the past 24h. Sparkline shows the last 30d. Display value = trailing 7-day average.
+- **WAU** — distinct users with ≥1 pebble created in the past 7d, rolling. Display value = today's rolling 7d count.
+- **MAU** — distinct users with ≥1 pebble created in the past 30d, rolling.
+- **Pebbles / day** — count of pebbles created in the past 24h. Display value = trailing 7-day average.
+- **DAU / MAU** — stickiness ratio. `dau_today / mau_today`. Delta in **percentage points** (pp), not %.
+
+### Active users over time
+
+- Daily series of DAU, WAU, and MAU as defined above.
+- Toggle: DAU / WAU / MAU / All.
+- Time window respects the global range tab.
+
+### Retention cohort heatmap
+
+- Cohort = users grouped by **signup week** (Mon–Sun, UTC).
+- Cell `[cohort, week_n]` = `% of cohort users who created ≥1 pebble in week_n` where `week_n` is weeks elapsed since signup.
+- W0 is always 100% by definition (signup week, signup ≥1 pebble in onboarding). If we ever decouple signup from first pebble, change W0 to "% with ≥1 pebble in W0".
+- Last 8 cohorts shown, oldest on top.
+- Color scale: light → stone, with 8 buckets (10% steps).
+
+### Pebbles collected
+
+- Total bars: count of pebbles created per bucket (Day/Week/Month/Year). Y-axis switches accordingly.
+- Overlay lines (counts, not %, on the same axis):
+  - **With picture** — pebbles where `picture_url is not null`.
+  - **Custom glyph** — pebbles where `glyph_id` references a glyph with `is_custom = true`.
+  - **In collection** — pebbles where `collection_id is not null`.
+- Display the absolute count, not the share. The donuts handle share.
+
+### Pebble enrichment (donuts + ratios)
+
+Three donuts showing the **current period** share:
+- % of pebbles with picture
+- % of pebbles with custom glyph
+- % of pebbles in a collection
+
+Then four secondary ratios listed below:
+- % with ≥1 emotion pearl
+- % linked to ≥1 soul
+- % with thought attached
+- % with intensity set (should approach 100% — useful as a sanity check)
+
+### Per-user averages over time
+
+For each of the last 12 weeks (week ending Sunday):
+- **Avg glyphs / user** — total glyphs owned divided by users who were active that week. (Not all users, only active.)
+- **Avg souls / user** — total souls created divided by active users.
+- **Avg collections / user** — total collections divided by active users.
+
+Display the latest week's value as a number with delta vs. prior week. Chart shows the 12-week trend.
+
+### Bounce karma distribution
+
+- **Buckets:** 0, 1–10, 11–25, 26–50, 51–100, 100+.
+- Y-axis = count of users currently in each bucket.
+- Three summary stats:
+  - **Median bounce** — median of all users' current bounce.
+  - **% maintaining** — share of users whose bounce **did not decrease** vs. 7 days ago.
+  - **Avg active days / week** — across all MAU, average distinct active days per 7-day window.
+
+### Emotion pearls prevalence
+
+- For each emotion, **% of pebbles in the period that have ≥1 pearl of this emotion**. A single pebble can contribute to multiple emotions, so the shares **do not need to sum to 100%**. Rank descending.
+- Snapshot = current period.
+- Over-time view = stacked area, last 12 weeks, **normalized to 100% per week** so the eye can see shifts in mix rather than volume.
+
+### Maslow domains prevalence
+
+- For each domain, % of pebbles linked to that domain in the current period.
+- Rank descending.
+- Below the chart: "Most-evolving domain (vs prev. period)" and "Most-decreasing domain", showing pp change.
+
+### Cairn participation
+
+- For each of weekly and monthly cairns, **% of eligible users who completed / partially-completed / missed** their cairn in the **last completed period**.
+- Eligible = users who were active at least one day in the period.
+- Three summary stats:
+  - Avg pebbles per completed cairn
+  - Rewards unlocked / week
+  - % of all users with ≥1 cairn ever
+
+### Visibility mix
+
+Pie chart of pebbles in the current period by visibility setting: Public, Private, Secret.
+
+### Quality signals
+
+A table of 8 healthy-habit indicators with current value and delta:
+
+| Metric | Definition |
+|---|---|
+| Median session duration | Median of session length in seconds, where a session = consecutive activity with gaps ≤ 30 min. |
+| Sessions / active user / week | Distinct sessions per WAU, weekly. |
+| Pebbles / active user / week | Total pebbles created divided by WAU. |
+| % revisits to past pebbles | % of sessions that include opening a pebble created more than 7 days earlier. |
+| D1 retention | % of new users active on day 1. |
+| D7 retention | % active on day 7. |
+| D30 retention | % active on day 30. |
+| Friction events / session | Count of `pebble_created_aborted`, `pebble_save_failed`, `error_shown` events per session. |
+
+## Data sources & contracts
+
+Each surface is backed by **one** materialized view. See `supabase/migrations/20260430_analytics_mvs.sql` for the DDL and `apps/admin/src/lib/analytics/types.ts` for the TS row types.
+
+| Surface | View |
+|---|---|
+| KPI strip | `mv_kpi_daily` |
+| Active users over time | `mv_active_users_daily` |
+| Retention cohorts | `mv_retention_cohorts_weekly` |
+| Pebbles volume + enrichment lines | `mv_pebble_volume_daily` |
+| Pebble enrichment donuts + ratios | `mv_pebble_enrichment_daily` |
+| Per-user averages over time | `mv_user_averages_weekly` |
+| Bounce karma distribution | `mv_bounce_distribution_daily` |
+| Emotions prevalence (snapshot + over time) | `mv_emotion_share_weekly` |
+| Domains prevalence | `mv_domain_share_weekly` |
+| Cairn participation | `mv_cairn_participation_weekly` |
+| Visibility mix | `mv_visibility_mix_daily` |
+| Quality signals | `mv_quality_signals_daily` |
+
+All MVs refresh nightly at **03:00 UTC** via `pg_cron`. Each MV includes a `bucket_date` column representing the day it was computed for; the page reads `where bucket_date = (select max(bucket_date) from mv_x)` for current values and a date range for time series.
+
+## Authorization
+
+This page is admin-only. Every fetcher must check that the caller's `user_id` has `role = 'admin'` (Supabase RLS policy on the MVs). Non-admins see 403.
+
+## Performance budget
+
+- Page TTFB: ≤ 200ms (admin shell already streams).
+- Chart hydration: ≤ 800ms total for all charts on first render.
+- MV row count: each MV should stay under 100k rows for v1; if a daily MV grows past that, split by month.
+
+## Open questions for the implementation session
+
+1. Where exactly does session live — is there an `events` table or do we derive sessions from `pebbles.created_at` gaps? This affects half of "Quality signals". **Resolve before writing `mv_quality_signals_daily`.**
+2. Are deleted pebbles soft-deleted? If yes, every count should filter `where deleted_at is null`.
+3. Is `users.created_at` the right cohort anchor or do we have a `signed_up_at` column?
+4. Where is the canonical mapping `pebble → domain`? Is it via `pebble_emotions` joining out to `emotion → primary_domain`, or a direct `pebble_domains` link?
+
+## Acceptance criteria
+
+- [ ] All 12 surfaces render with non-zero data on staging within 5s of page load.
+- [ ] Time range selector updates every chart consistently.
+- [ ] Each chart has loading, empty, and error states matching shadcn defaults.
+- [ ] All MVs refresh nightly via `pg_cron`; manual refresh trigger available via Supabase function `refresh_analytics_mvs()`.
+- [ ] Admin RLS enforced — verified by attempting access from a non-admin session and getting 403.
+- [ ] Storybook (or `/playground/analytics`) renders each chart with mock data fixtures so we can review components in isolation.
+- [ ] Lighthouse performance score ≥ 90 on the page.
+- [ ] Update `docs/arkaik/pebbles-arkaik.json` to add the Analytics screen, all MV data nodes, and the fetcher endpoints.
+
+## Out of scope (will be follow-ups)
+
+- Time-zone aware bucketing (per-user locale)
+- Drill-down from any chart into Users / Pebbles surfaces
+- Comparative cohort views (this cohort vs. that cohort)
+- Predictive churn risk
+- Geo / device / version breakdowns
+- Funnels surface

--- a/docs/poc/admin-analytics/analytics-mockup.html
+++ b/docs/poc/admin-analytics/analytics-mockup.html
@@ -1,0 +1,884 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Pebbles · Admin · Analytics</title>
+<link rel="stylesheet" href="docs/specs/admin-analytics/vendor/tailwind.css" />
+<script src="docs/specs/admin-analytics/vendor/react.js"></script>
+<script src="docs/specs/admin-analytics/vendor/react-dom.js"></script>
+<script src="docs/specs/admin-analytics/vendor/prop-types.js"></script>
+<script src="docs/specs/admin-analytics/vendor/recharts.js"></script>
+<script src="docs/specs/admin-analytics/vendor/babel.js"></script>
+<style>
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 240 10% 3.9%;
+    --muted: 240 4.8% 95.9%;
+    --muted-foreground: 240 3.8% 46.1%;
+    --border: 240 5.9% 90%;
+    --primary: 24 9.8% 10%;
+    --radius: 0.75rem;
+  }
+  html, body { font-family: 'Inter', system-ui, -apple-system, sans-serif; -webkit-font-smoothing: antialiased; }
+  .mono { font-family: 'JetBrains Mono', ui-monospace, monospace; }
+  .recharts-default-tooltip {
+    background: white !important;
+    border: 1px solid #e4e4e7 !important;
+    border-radius: 8px !important;
+    padding: 8px 12px !important;
+    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.05) !important;
+    font-size: 12px !important;
+  }
+  .recharts-tooltip-label { color: #18181b !important; font-weight: 600 !important; margin-bottom: 4px !important; }
+  .recharts-tooltip-item { color: #52525b !important; }
+  .scrollbar-thin::-webkit-scrollbar { height: 6px; width: 6px; }
+  .scrollbar-thin::-webkit-scrollbar-thumb { background: #d4d4d8; border-radius: 3px; }
+</style>
+</head>
+<body class="bg-zinc-50 text-zinc-900">
+<div id="root"></div>
+<div id="error" style="display:none;position:fixed;top:0;left:0;right:0;background:#fee;color:#900;padding:12px 16px;font-family:monospace;font-size:12px;z-index:9999;white-space:pre-wrap;border-bottom:1px solid #f00;"></div>
+<script>
+  // Surface any runtime errors visibly, instead of leaving the page blank.
+  function showErr(msg) {
+    var el = document.getElementById('error');
+    el.style.display = 'block';
+    el.textContent = (el.textContent ? el.textContent + '\n\n' : '') + msg;
+  }
+  window.addEventListener('error', function (e) {
+    showErr('JS error: ' + (e.message || e.error) + (e.filename ? ' @ ' + e.filename + ':' + e.lineno : ''));
+  });
+  window.addEventListener('unhandledrejection', function (e) {
+    showErr('Promise rejection: ' + (e.reason && e.reason.message || e.reason));
+  });
+  // Sanity check globals before Babel kicks in.
+  window.addEventListener('DOMContentLoaded', function () {
+    var missing = [];
+    if (typeof React === 'undefined')    missing.push('React');
+    if (typeof ReactDOM === 'undefined') missing.push('ReactDOM');
+    if (typeof Recharts === 'undefined') missing.push('Recharts');
+    if (typeof Babel === 'undefined')    missing.push('Babel');
+    if (missing.length) showErr('Missing globals: ' + missing.join(', '));
+  });
+</script>
+
+<script type="text/babel" data-presets="env,react" data-type="module">
+const {
+  LineChart, Line, BarChart, Bar, AreaChart, Area, PieChart, Pie, Cell,
+  XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
+  RadialBarChart, RadialBar, ComposedChart
+} = Recharts;
+
+const { useState, useMemo } = React;
+
+/* ============================================================
+   MOCK DATA
+   ============================================================ */
+
+const PALETTE = {
+  stone: '#78716c',
+  pebble: '#44403c',
+  sage: '#84a98c',
+  sand: '#d4a373',
+  sky: '#7aa9c7',
+  rose: '#c98a8a',
+  lime: '#a3b18a',
+  ink: '#27272a',
+  muted: '#a1a1aa',
+};
+
+const EMOTIONS = [
+  { name: 'Joy',      color: '#f5c97e' },
+  { name: 'Calm',     color: '#9bcfd1' },
+  { name: 'Love',     color: '#e9a3a3' },
+  { name: 'Pride',    color: '#c5a572' },
+  { name: 'Sadness',  color: '#8aa9c0' },
+  { name: 'Anger',    color: '#c87a7a' },
+  { name: 'Fear',     color: '#a89cc7' },
+  { name: 'Surprise', color: '#d8a8c5' },
+  { name: 'Awe',      color: '#7fb39c' },
+];
+
+const DOMAINS = [
+  { name: 'Physiological', color: '#c87a5a' },
+  { name: 'Safety',         color: '#7aa9c7' },
+  { name: 'Belonging',      color: '#e9a3a3' },
+  { name: 'Esteem',         color: '#f5c97e' },
+  { name: 'Cognitive',      color: '#a89cc7' },
+  { name: 'Aesthetic',      color: '#9bcfd1' },
+  { name: 'Self-actualization', color: '#84a98c' },
+  { name: 'Transcendence',  color: '#c5a572' },
+];
+
+// Deterministic pseudo-random so the mockup is stable
+function seeded(seed) {
+  let s = seed;
+  return () => {
+    s = (s * 1664525 + 1013904223) % 4294967296;
+    return s / 4294967296;
+  };
+}
+const rand = seeded(42);
+
+function generateTimeSeries(days) {
+  const out = [];
+  const start = new Date('2026-04-30');
+  start.setDate(start.getDate() - days + 1);
+  for (let i = 0; i < days; i++) {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    const baseUsers = 1200 + i * 9 + Math.sin(i / 6) * 80;
+    const dayOfWeek = d.getDay();
+    const weekendDip = (dayOfWeek === 0 || dayOfWeek === 6) ? 0.85 : 1;
+    const dau = Math.round(baseUsers * weekendDip + (rand() - 0.5) * 60);
+    const wau = Math.round(dau * (2.6 + rand() * 0.3));
+    const mau = Math.round(dau * (5.2 + rand() * 0.4));
+    const pebbles = Math.round(dau * (1.4 + rand() * 0.6));
+    out.push({
+      date: d.toISOString().slice(5, 10),
+      fullDate: d.toISOString().slice(0, 10),
+      dau, wau, mau,
+      pebbles,
+      pebblesWithPicture: Math.round(pebbles * (0.42 + rand() * 0.08)),
+      pebblesWithCustomGlyph: Math.round(pebbles * (0.28 + rand() * 0.06)),
+      pebblesInCollection: Math.round(pebbles * (0.55 + rand() * 0.07)),
+      newUsers: Math.round(35 + rand() * 30 + i * 0.4),
+      bouncesMaintained: Math.round(dau * (0.62 + rand() * 0.05)),
+    });
+  }
+  return out;
+}
+
+const tsData = generateTimeSeries(30);
+const tsData90 = generateTimeSeries(90);
+
+// Retention cohort matrix (rows = cohort weeks, cols = weeks since signup)
+const cohortLabels = ['Mar W1', 'Mar W2', 'Mar W3', 'Mar W4', 'Apr W1', 'Apr W2', 'Apr W3', 'Apr W4'];
+const cohortData = cohortLabels.map((label, rowIdx) => {
+  const size = 280 + Math.round(rand() * 200);
+  const weeks = 8 - rowIdx;
+  const cells = [];
+  let r = 100;
+  for (let w = 0; w < weeks; w++) {
+    if (w === 0) { cells.push(100); continue; }
+    const decay = w === 1 ? 0.62 : Math.pow(0.92, w - 1);
+    r = Math.max(8, Math.round(r * decay + (rand() - 0.5) * 6));
+    cells.push(r);
+  }
+  return { cohort: label, size, cells };
+});
+
+// Per-user averages over time (weekly snapshots)
+const avgWeekly = Array.from({ length: 12 }).map((_, i) => ({
+  week: `W${i + 1}`,
+  glyphs: +(3.2 + i * 0.18 + rand() * 0.4).toFixed(1),
+  souls: +(8.4 + i * 0.22 + rand() * 0.5).toFixed(1),
+  collections: +(2.1 + i * 0.09 + rand() * 0.3).toFixed(1),
+}));
+
+// Bounce karma distribution
+const bounceDist = [
+  { bucket: '0',     users: 180 },
+  { bucket: '1–10',  users: 420 },
+  { bucket: '11–25', users: 680 },
+  { bucket: '26–50', users: 920 },
+  { bucket: '51–100',users: 1340 },
+  { bucket: '100+',  users: 760 },
+];
+
+// Emotions prevalence (current period)
+const emotionsData = EMOTIONS.map((e, i) => ({
+  ...e,
+  share: +(rand() * 14 + 4).toFixed(1),
+})).sort((a, b) => b.share - a.share);
+const emotionsTotal = emotionsData.reduce((s, e) => s + e.share, 0);
+emotionsData.forEach(e => { e.share = +(e.share / emotionsTotal * 100).toFixed(1); });
+
+// Emotions over time (stacked area, weekly)
+const emotionsTimeline = Array.from({ length: 12 }).map((_, i) => {
+  const row = { week: `W${i + 1}` };
+  EMOTIONS.forEach((e, j) => {
+    const base = emotionsData.find(x => x.name === e.name).share;
+    row[e.name] = +(base + (rand() - 0.5) * 4).toFixed(1);
+  });
+  return row;
+});
+
+// Domains prevalence
+const domainsData = DOMAINS.map(d => ({
+  ...d,
+  share: +(rand() * 18 + 4).toFixed(1),
+})).sort((a, b) => b.share - a.share);
+const domTotal = domainsData.reduce((s, d) => s + d.share, 0);
+domainsData.forEach(d => { d.share = +(d.share / domTotal * 100).toFixed(1); });
+
+// Pebble composition donut (current)
+const compositionDonut = [
+  { name: 'With picture',       value: 46, color: '#84a98c' },
+  { name: 'Text-only',          value: 54, color: '#e4e4e7' },
+];
+const compositionGlyph = [
+  { name: 'Custom glyph',       value: 31, color: '#c5a572' },
+  { name: 'Default glyph',      value: 69, color: '#e4e4e7' },
+];
+const compositionColl = [
+  { name: 'In collection',      value: 58, color: '#7aa9c7' },
+  { name: 'Solo pebble',        value: 42, color: '#e4e4e7' },
+];
+
+// Cairn participation
+const cairnData = [
+  { name: 'Weekly cairn',  completed: 62, partial: 24, missed: 14 },
+  { name: 'Monthly cairn', completed: 41, partial: 32, missed: 27 },
+];
+
+/* ============================================================
+   PRIMITIVES (Shadcn-flavored)
+   ============================================================ */
+
+const Card = ({ children, className = '' }) => (
+  <div className={`bg-white border border-zinc-200 rounded-xl shadow-sm ${className}`}>{children}</div>
+);
+const CardHeader = ({ children, className = '' }) => (
+  <div className={`px-5 pt-5 pb-3 ${className}`}>{children}</div>
+);
+const CardTitle = ({ children, className = '' }) => (
+  <h3 className={`text-sm font-semibold text-zinc-900 ${className}`}>{children}</h3>
+);
+const CardDescription = ({ children }) => (
+  <p className="text-xs text-zinc-500 mt-0.5">{children}</p>
+);
+const CardContent = ({ children, className = '' }) => (
+  <div className={`px-5 pb-5 ${className}`}>{children}</div>
+);
+const Badge = ({ children, tone = 'neutral' }) => {
+  const tones = {
+    neutral: 'bg-zinc-100 text-zinc-700 border-zinc-200',
+    positive: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+    negative: 'bg-rose-50 text-rose-700 border-rose-200',
+    warning: 'bg-amber-50 text-amber-700 border-amber-200',
+  };
+  return <span className={`inline-flex items-center text-xs font-medium px-2 py-0.5 rounded-md border ${tones[tone]}`}>{children}</span>;
+};
+
+const Tabs = ({ value, onChange, items }) => (
+  <div className="inline-flex rounded-lg border border-zinc-200 bg-zinc-50 p-1">
+    {items.map(it => (
+      <button
+        key={it.value}
+        onClick={() => onChange(it.value)}
+        className={`px-3 py-1 text-xs font-medium rounded-md transition ${value === it.value ? 'bg-white text-zinc-900 shadow-sm' : 'text-zinc-500 hover:text-zinc-700'}`}>
+        {it.label}
+      </button>
+    ))}
+  </div>
+);
+
+/* ============================================================
+   DASHBOARD COMPONENTS
+   ============================================================ */
+
+const Sidebar = () => {
+  const items = [
+    { label: 'Overview',     icon: '◯' },
+    { label: 'Users',        icon: '◐' },
+    { label: 'Pebbles',      icon: '◉' },
+    { label: 'Collections',  icon: '◇' },
+    { label: 'Analytics',    icon: '◆', active: true },
+    { label: 'Cairns',       icon: '△' },
+    { label: 'Moderation',   icon: '◈' },
+    { label: 'System',       icon: '⌘' },
+  ];
+  return (
+    <aside className="w-56 border-r border-zinc-200 bg-white h-screen sticky top-0 px-3 py-5 flex flex-col">
+      <div className="px-2 pb-5 flex items-center gap-2">
+        <div className="w-7 h-7 rounded-md bg-zinc-900 flex items-center justify-center text-white text-xs font-bold">P</div>
+        <div>
+          <div className="text-sm font-semibold text-zinc-900 leading-tight">pbbls</div>
+          <div className="text-[10px] text-zinc-500 uppercase tracking-wider">admin</div>
+        </div>
+      </div>
+      <nav className="flex flex-col gap-0.5">
+        {items.map(it => (
+          <a key={it.label} href="#"
+            className={`flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-sm transition
+              ${it.active ? 'bg-zinc-100 text-zinc-900 font-medium' : 'text-zinc-600 hover:bg-zinc-50 hover:text-zinc-900'}`}>
+            <span className="text-zinc-400 w-4 text-center">{it.icon}</span>
+            {it.label}
+          </a>
+        ))}
+      </nav>
+      <div className="mt-auto px-2 py-2 border-t border-zinc-100">
+        <div className="flex items-center gap-2">
+          <div className="w-7 h-7 rounded-full bg-stone-300" />
+          <div>
+            <div className="text-xs font-medium text-zinc-900">Alexis Bohns</div>
+            <div className="text-[10px] text-zinc-500">Founder</div>
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+};
+
+const Header = ({ range, setRange }) => (
+  <div className="flex items-start justify-between mb-6">
+    <div>
+      <div className="flex items-center gap-2 text-xs text-zinc-500 mb-1">
+        <span>Admin</span>
+        <span>/</span>
+        <span className="text-zinc-700 font-medium">Analytics</span>
+      </div>
+      <h1 className="text-2xl font-semibold text-zinc-900 tracking-tight">Analytics</h1>
+      <p className="text-sm text-zinc-500 mt-1">Retention, engagement, usage and meaning across the Pebbles community.</p>
+    </div>
+    <div className="flex items-center gap-3">
+      <span className="text-xs text-zinc-500 mono">Last refresh: 2026-04-30 03:14 UTC</span>
+      <Tabs
+        value={range}
+        onChange={setRange}
+        items={[
+          { value: '7d',  label: '7d'  },
+          { value: '30d', label: '30d' },
+          { value: '90d', label: '90d' },
+          { value: '1y',  label: '1y'  },
+          { value: 'all', label: 'All' },
+        ]}
+      />
+      <button className="inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md border border-zinc-200 bg-white text-zinc-700 hover:bg-zinc-50">
+        Export CSV
+      </button>
+    </div>
+  </div>
+);
+
+const KpiCard = ({ label, value, delta, sub, sparkData, sparkKey, color = PALETTE.stone }) => {
+  const positive = delta && delta.startsWith('+');
+  return (
+    <Card>
+      <CardContent className="p-5">
+        <div className="text-xs text-zinc-500 font-medium">{label}</div>
+        <div className="flex items-baseline justify-between mt-1.5">
+          <div className="text-2xl font-semibold text-zinc-900 tabular-nums">{value}</div>
+          {delta && <Badge tone={positive ? 'positive' : 'negative'}>{delta}</Badge>}
+        </div>
+        {sub && <div className="text-xs text-zinc-500 mt-1">{sub}</div>}
+        {sparkData && (
+          <div className="h-10 -mx-1 mt-3">
+            <ResponsiveContainer>
+              <AreaChart data={sparkData}>
+                <defs>
+                  <linearGradient id={`grad-${label}`} x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%"  stopColor={color} stopOpacity={0.35} />
+                    <stop offset="100%" stopColor={color} stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <Area type="monotone" dataKey={sparkKey} stroke={color} strokeWidth={1.5} fill={`url(#grad-${label})`} />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+const KpiRow = () => (
+  <div className="grid grid-cols-2 lg:grid-cols-6 gap-3 mb-6">
+    <KpiCard label="Total users"     value="42,318" delta="+4.2%" sub="vs prev. period" sparkData={tsData} sparkKey="dau" color={PALETTE.stone} />
+    <KpiCard label="DAU"             value="1,486"  delta="+2.1%" sub="7-day avg"        sparkData={tsData} sparkKey="dau" color={PALETTE.sage} />
+    <KpiCard label="WAU"             value="8,907"  delta="+3.8%" sub="rolling 7d"       sparkData={tsData} sparkKey="wau" color={PALETTE.sky} />
+    <KpiCard label="MAU"             value="24,512" delta="+5.6%" sub="rolling 30d"      sparkData={tsData} sparkKey="mau" color={PALETTE.sand} />
+    <KpiCard label="Pebbles / day"   value="2,340"  delta="+6.4%" sub="7-day avg"        sparkData={tsData} sparkKey="pebbles" color={PALETTE.rose} />
+    <KpiCard label="DAU / MAU"       value="6.1%"   delta="-0.3pp" sub="stickiness"     sparkData={tsData} sparkKey="dau" color={PALETTE.lime} />
+  </div>
+);
+
+const ActivityTrend = () => {
+  const [metric, setMetric] = useState('dau');
+  return (
+    <Card className="col-span-12 lg:col-span-8">
+      <CardHeader>
+        <div className="flex items-start justify-between">
+          <div>
+            <CardTitle>Active users over time</CardTitle>
+            <CardDescription>Daily, weekly and monthly active collectors.</CardDescription>
+          </div>
+          <Tabs value={metric} onChange={setMetric} items={[
+            { value: 'dau', label: 'DAU' },
+            { value: 'wau', label: 'WAU' },
+            { value: 'mau', label: 'MAU' },
+            { value: 'all', label: 'All' },
+          ]}/>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="h-72">
+          <ResponsiveContainer>
+            <LineChart data={tsData} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#f4f4f5" />
+              <XAxis dataKey="date" tick={{ fontSize: 11, fill: '#71717a' }} axisLine={false} tickLine={false} />
+              <YAxis tick={{ fontSize: 11, fill: '#71717a' }} axisLine={false} tickLine={false} />
+              <Tooltip />
+              {(metric === 'dau' || metric === 'all') && <Line type="monotone" dataKey="dau" stroke={PALETTE.sage} strokeWidth={2} dot={false} name="DAU" />}
+              {(metric === 'wau' || metric === 'all') && <Line type="monotone" dataKey="wau" stroke={PALETTE.sky}  strokeWidth={2} dot={false} name="WAU" />}
+              {(metric === 'mau' || metric === 'all') && <Line type="monotone" dataKey="mau" stroke={PALETTE.sand} strokeWidth={2} dot={false} name="MAU" />}
+              {metric === 'all' && <Legend wrapperStyle={{ fontSize: 11 }} />}
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+const RetentionCohort = () => {
+  const max = 100;
+  const cellColor = (v) => {
+    if (v == null) return '#fafafa';
+    const t = v / max;
+    // Interpolate from very light to stone
+    const r = Math.round(245 - t * (245 - 68));
+    const g = Math.round(245 - t * (245 - 64));
+    const b = Math.round(244 - t * (244 - 60));
+    return `rgb(${r},${g},${b})`;
+  };
+  const cellText = (v) => v >= 45 ? '#fff' : '#3f3f46';
+  return (
+    <Card className="col-span-12 lg:col-span-4">
+      <CardHeader>
+        <CardTitle>Retention cohorts</CardTitle>
+        <CardDescription>% of cohort still active week over week.</CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-x-auto scrollbar-thin">
+        <table className="w-full text-xs mono">
+          <thead>
+            <tr className="text-zinc-500">
+              <th className="text-left font-medium pb-2 pr-2">Cohort</th>
+              <th className="text-right font-medium pb-2 pr-2">Size</th>
+              {Array.from({ length: 8 }).map((_, i) => (
+                <th key={i} className="text-center font-medium pb-2 px-1">W{i}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {cohortData.map(row => (
+              <tr key={row.cohort}>
+                <td className="py-1 pr-2 text-zinc-700">{row.cohort}</td>
+                <td className="py-1 pr-2 text-right text-zinc-500">{row.size}</td>
+                {Array.from({ length: 8 }).map((_, i) => {
+                  const v = row.cells[i];
+                  return (
+                    <td key={i} className="p-0.5">
+                      {v != null ? (
+                        <div className="h-7 flex items-center justify-center rounded text-[11px] font-medium"
+                          style={{ background: cellColor(v), color: cellText(v) }}>
+                          {v}
+                        </div>
+                      ) : (
+                        <div className="h-7" />
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  );
+};
+
+const PebbleVolume = () => {
+  return (
+    <Card className="col-span-12 lg:col-span-8">
+      <CardHeader>
+        <div className="flex items-start justify-between">
+          <div>
+            <CardTitle>Pebbles collected</CardTitle>
+            <CardDescription>Daily volume with enrichment breakdown.</CardDescription>
+          </div>
+          <Tabs value="day" onChange={() => {}} items={[
+            { value: 'day',   label: 'Day' },
+            { value: 'week',  label: 'Week' },
+            { value: 'month', label: 'Month' },
+            { value: 'year',  label: 'Year' },
+          ]}/>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="h-72">
+          <ResponsiveContainer>
+            <ComposedChart data={tsData} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#f4f4f5" />
+              <XAxis dataKey="date" tick={{ fontSize: 11, fill: '#71717a' }} axisLine={false} tickLine={false} />
+              <YAxis tick={{ fontSize: 11, fill: '#71717a' }} axisLine={false} tickLine={false} />
+              <Tooltip />
+              <Legend wrapperStyle={{ fontSize: 11 }} />
+              <Bar dataKey="pebbles"            stackId="a" fill="#e4e4e7" name="Total pebbles" radius={[4,4,0,0]} />
+              <Line type="monotone" dataKey="pebblesWithPicture"      stroke={PALETTE.sage} strokeWidth={2} dot={false} name="With picture" />
+              <Line type="monotone" dataKey="pebblesWithCustomGlyph"  stroke={PALETTE.sand} strokeWidth={2} dot={false} name="Custom glyph" />
+              <Line type="monotone" dataKey="pebblesInCollection"     stroke={PALETTE.sky}  strokeWidth={2} dot={false} name="In collection" />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+const Donut = ({ data, label, value }) => (
+  <div className="flex flex-col items-center">
+    <div className="relative w-32 h-32">
+      <ResponsiveContainer>
+        <PieChart>
+          <Pie data={data} dataKey="value" innerRadius={42} outerRadius={56} strokeWidth={0} startAngle={90} endAngle={-270}>
+            {data.map((d, i) => <Cell key={i} fill={d.color} />)}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <div className="text-xl font-semibold text-zinc-900 tabular-nums">{value}</div>
+        <div className="text-[10px] text-zinc-500 uppercase tracking-wider">{data[0].name.split(' ')[0]}</div>
+      </div>
+    </div>
+    <div className="text-xs font-medium text-zinc-700 mt-2">{label}</div>
+  </div>
+);
+
+const PebbleEnrichment = () => (
+  <Card className="col-span-12 lg:col-span-4">
+    <CardHeader>
+      <CardTitle>Pebble enrichment</CardTitle>
+      <CardDescription>Share of pebbles with each enrichment.</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <div className="grid grid-cols-3 gap-2">
+        <Donut data={compositionDonut} label="Picture"      value="46%" />
+        <Donut data={compositionGlyph} label="Custom glyph" value="31%" />
+        <Donut data={compositionColl}  label="Collection"   value="58%" />
+      </div>
+      <div className="mt-4 pt-4 border-t border-zinc-100 text-xs text-zinc-500 space-y-1.5">
+        <div className="flex justify-between"><span>Pebbles with ≥1 emotion pearl</span><span className="text-zinc-900 font-medium">82%</span></div>
+        <div className="flex justify-between"><span>Pebbles linked to ≥1 soul</span><span className="text-zinc-900 font-medium">71%</span></div>
+        <div className="flex justify-between"><span>Pebbles with thought attached</span><span className="text-zinc-900 font-medium">38%</span></div>
+        <div className="flex justify-between"><span>Pebbles with intensity set</span><span className="text-zinc-900 font-medium">94%</span></div>
+      </div>
+    </CardContent>
+  </Card>
+);
+
+const PerUserAverages = () => (
+  <Card className="col-span-12 lg:col-span-7">
+    <CardHeader>
+      <CardTitle>Per-user averages over time</CardTitle>
+      <CardDescription>Average glyphs, souls and collections per active user, weekly.</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <div className="grid grid-cols-3 gap-4 mb-4">
+        <div>
+          <div className="text-xs text-zinc-500">Avg glyphs / user</div>
+          <div className="flex items-baseline gap-2"><div className="text-xl font-semibold tabular-nums">5.4</div><Badge tone="positive">+0.6</Badge></div>
+        </div>
+        <div>
+          <div className="text-xs text-zinc-500">Avg souls / user</div>
+          <div className="flex items-baseline gap-2"><div className="text-xl font-semibold tabular-nums">11.2</div><Badge tone="positive">+1.1</Badge></div>
+        </div>
+        <div>
+          <div className="text-xs text-zinc-500">Avg collections / user</div>
+          <div className="flex items-baseline gap-2"><div className="text-xl font-semibold tabular-nums">3.1</div><Badge tone="positive">+0.4</Badge></div>
+        </div>
+      </div>
+      <div className="h-56">
+        <ResponsiveContainer>
+          <LineChart data={avgWeekly} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f4f4f5" />
+            <XAxis dataKey="week" tick={{ fontSize: 11, fill: '#71717a' }} axisLine={false} tickLine={false} />
+            <YAxis tick={{ fontSize: 11, fill: '#71717a' }} axisLine={false} tickLine={false} />
+            <Tooltip />
+            <Legend wrapperStyle={{ fontSize: 11 }} />
+            <Line type="monotone" dataKey="glyphs"      stroke={PALETTE.sand} strokeWidth={2} dot={{ r: 2 }} />
+            <Line type="monotone" dataKey="souls"       stroke={PALETTE.rose} strokeWidth={2} dot={{ r: 2 }} />
+            <Line type="monotone" dataKey="collections" stroke={PALETTE.sky}  strokeWidth={2} dot={{ r: 2 }} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </CardContent>
+  </Card>
+);
+
+const BounceKarma = () => (
+  <Card className="col-span-12 lg:col-span-5">
+    <CardHeader>
+      <CardTitle>Bounce karma distribution</CardTitle>
+      <CardDescription>Users by current bounce score.</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <div className="grid grid-cols-3 gap-4 mb-4">
+        <div>
+          <div className="text-xs text-zinc-500">Median bounce</div>
+          <div className="text-xl font-semibold tabular-nums">42</div>
+        </div>
+        <div>
+          <div className="text-xs text-zinc-500">% maintaining bounce</div>
+          <div className="text-xl font-semibold tabular-nums">63%</div>
+        </div>
+        <div>
+          <div className="text-xs text-zinc-500">Avg active days / week</div>
+          <div className="text-xl font-semibold tabular-nums">3.4</div>
+        </div>
+      </div>
+      <div className="h-48">
+        <ResponsiveContainer>
+          <BarChart data={bounceDist} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f4f4f5" />
+            <XAxis dataKey="bucket" tick={{ fontSize: 11, fill: '#71717a' }} axisLine={false} tickLine={false} />
+            <YAxis tick={{ fontSize: 11, fill: '#71717a' }} axisLine={false} tickLine={false} />
+            <Tooltip />
+            <Bar dataKey="users" fill={PALETTE.stone} radius={[4,4,0,0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </CardContent>
+  </Card>
+);
+
+const EmotionsPrevalence = () => (
+  <Card className="col-span-12 lg:col-span-6">
+    <CardHeader>
+      <div className="flex items-start justify-between">
+        <div>
+          <CardTitle>Emotion pearls prevalence</CardTitle>
+          <CardDescription>Share of pebbles tagged with each emotion.</CardDescription>
+        </div>
+        <Tabs value="now" onChange={() => {}} items={[
+          { value: 'now',  label: 'Snapshot' },
+          { value: 'time', label: 'Over time' },
+        ]}/>
+      </div>
+    </CardHeader>
+    <CardContent>
+      <div className="space-y-2">
+        {emotionsData.map(e => (
+          <div key={e.name} className="flex items-center gap-3">
+            <div className="w-20 text-xs text-zinc-700">{e.name}</div>
+            <div className="flex-1 h-5 bg-zinc-100 rounded overflow-hidden">
+              <div className="h-full rounded" style={{ width: `${e.share * 4.5}%`, background: e.color }} />
+            </div>
+            <div className="w-12 text-right text-xs mono text-zinc-700">{e.share}%</div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-5 pt-4 border-t border-zinc-100">
+        <div className="text-xs text-zinc-500 mb-2">Last 12 weeks</div>
+        <div className="h-32">
+          <ResponsiveContainer>
+            <AreaChart data={emotionsTimeline} margin={{ top: 4, right: 4, left: -24, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#f4f4f5" />
+              <XAxis dataKey="week" tick={{ fontSize: 10, fill: '#a1a1aa' }} axisLine={false} tickLine={false} />
+              <YAxis tick={{ fontSize: 10, fill: '#a1a1aa' }} axisLine={false} tickLine={false} />
+              <Tooltip />
+              {EMOTIONS.map(e => (
+                <Area key={e.name} type="monotone" dataKey={e.name} stackId="1" stroke={e.color} fill={e.color} fillOpacity={0.85} />
+              ))}
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    </CardContent>
+  </Card>
+);
+
+const DomainsPrevalence = () => (
+  <Card className="col-span-12 lg:col-span-6">
+    <CardHeader>
+      <CardTitle>Maslow domains prevalence</CardTitle>
+      <CardDescription>How pebbles distribute across the revisited Maslow's pyramid.</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <div className="h-72">
+        <ResponsiveContainer>
+          <BarChart data={domainsData} layout="vertical" margin={{ top: 4, right: 16, left: 8, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f4f4f5" horizontal={false} />
+            <XAxis type="number" tick={{ fontSize: 11, fill: '#71717a' }} axisLine={false} tickLine={false} />
+            <YAxis dataKey="name" type="category" width={120} tick={{ fontSize: 11, fill: '#52525b' }} axisLine={false} tickLine={false} />
+            <Tooltip />
+            <Bar dataKey="share" radius={[0,4,4,0]}>
+              {domainsData.map((d, i) => <Cell key={i} fill={d.color} />)}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="mt-2 pt-4 border-t border-zinc-100 text-xs text-zinc-500">
+        <div className="flex justify-between"><span>Most-evolving domain (vs prev. period)</span><span className="text-emerald-700 font-medium">Belonging +3.2pp</span></div>
+        <div className="flex justify-between mt-1"><span>Most-decreasing domain</span><span className="text-rose-700 font-medium">Esteem -1.4pp</span></div>
+      </div>
+    </CardContent>
+  </Card>
+);
+
+const CairnSection = () => (
+  <Card className="col-span-12 lg:col-span-6">
+    <CardHeader>
+      <CardTitle>Cairn participation</CardTitle>
+      <CardDescription>How users engage with weekly and monthly cairns.</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <div className="space-y-4">
+        {cairnData.map(c => (
+          <div key={c.name}>
+            <div className="flex items-center justify-between mb-1.5">
+              <div className="text-sm font-medium text-zinc-700">{c.name}</div>
+              <div className="text-xs text-zinc-500 mono">{c.completed}% completed</div>
+            </div>
+            <div className="flex h-3 rounded overflow-hidden bg-zinc-100">
+              <div className="bg-emerald-400" style={{ width: `${c.completed}%` }} title={`Completed ${c.completed}%`} />
+              <div className="bg-amber-300"  style={{ width: `${c.partial}%` }}   title={`Partial ${c.partial}%`} />
+              <div className="bg-zinc-300"   style={{ width: `${c.missed}%` }}    title={`Missed ${c.missed}%`} />
+            </div>
+            <div className="flex gap-3 mt-1.5 text-[11px] text-zinc-500">
+              <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm bg-emerald-400"/>Completed</span>
+              <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm bg-amber-300"/>Partial</span>
+              <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm bg-zinc-300"/>Missed</span>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-5 pt-4 border-t border-zinc-100 grid grid-cols-3 gap-2 text-xs">
+        <div>
+          <div className="text-zinc-500">Avg pebbles / cairn</div>
+          <div className="text-base font-semibold tabular-nums text-zinc-900">9.4</div>
+        </div>
+        <div>
+          <div className="text-zinc-500">Rewards unlocked / wk</div>
+          <div className="text-base font-semibold tabular-nums text-zinc-900">5,213</div>
+        </div>
+        <div>
+          <div className="text-zinc-500">% users with ≥1 cairn</div>
+          <div className="text-base font-semibold tabular-nums text-zinc-900">71%</div>
+        </div>
+      </div>
+    </CardContent>
+  </Card>
+);
+
+const VisibilityMix = () => {
+  const data = [
+    { name: 'Public',  value: 22, color: PALETTE.sage },
+    { name: 'Private', value: 61, color: PALETTE.stone },
+    { name: 'Secret',  value: 17, color: PALETTE.ink  },
+  ];
+  return (
+    <Card className="col-span-12 lg:col-span-3">
+      <CardHeader>
+        <CardTitle>Visibility mix</CardTitle>
+        <CardDescription>Pebbles by sharing level.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="h-44">
+          <ResponsiveContainer>
+            <PieChart>
+              <Pie data={data} dataKey="value" innerRadius={36} outerRadius={66} paddingAngle={2}>
+                {data.map((d, i) => <Cell key={i} fill={d.color} />)}
+              </Pie>
+              <Tooltip />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+        <div className="space-y-1.5 text-xs">
+          {data.map(d => (
+            <div key={d.name} className="flex items-center justify-between">
+              <span className="flex items-center gap-2"><span className="w-2.5 h-2.5 rounded-sm" style={{ background: d.color }}/>{d.name}</span>
+              <span className="mono text-zinc-700">{d.value}%</span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+const QualitySignals = () => {
+  const rows = [
+    { metric: 'Median session duration',           value: '4m 12s',  delta: '+18s',  positive: true },
+    { metric: 'Sessions / active user / week',     value: '5.7',     delta: '+0.4',  positive: true },
+    { metric: 'Pebbles / active user / week',      value: '8.1',     delta: '+0.6',  positive: true },
+    { metric: '% revisits to past pebbles',        value: '34%',     delta: '+2.1pp',positive: true },
+    { metric: 'D1 retention (new users)',          value: '54%',     delta: '+1.4pp',positive: true },
+    { metric: 'D7 retention (new users)',          value: '31%',     delta: '-0.8pp',positive: false },
+    { metric: 'D30 retention (new users)',         value: '19%',     delta: '+0.9pp',positive: true },
+    { metric: 'Friction events / session',         value: '0.42',    delta: '-0.05', positive: true },
+  ];
+  return (
+    <Card className="col-span-12 lg:col-span-3">
+      <CardHeader>
+        <CardTitle>Quality signals</CardTitle>
+        <CardDescription>Healthy-habit indicators.</CardDescription>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="divide-y divide-zinc-100">
+          {rows.map(r => (
+            <div key={r.metric} className="flex items-center justify-between px-5 py-2.5">
+              <div className="text-xs text-zinc-600">{r.metric}</div>
+              <div className="flex items-center gap-2">
+                <div className="text-sm font-medium tabular-nums">{r.value}</div>
+                <div className={`text-[10px] mono ${r.positive ? 'text-emerald-600' : 'text-rose-600'}`}>{r.delta}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+/* ============================================================
+   APP
+   ============================================================ */
+const App = () => {
+  const [range, setRange] = useState('30d');
+  return (
+    <div className="flex">
+      <Sidebar />
+      <main className="flex-1 p-8 max-w-[1600px]">
+        <Header range={range} setRange={setRange} />
+        <KpiRow />
+        <div className="grid grid-cols-12 gap-3 mb-3">
+          <ActivityTrend />
+          <RetentionCohort />
+        </div>
+        <div className="grid grid-cols-12 gap-3 mb-3">
+          <PebbleVolume />
+          <PebbleEnrichment />
+        </div>
+        <div className="grid grid-cols-12 gap-3 mb-3">
+          <PerUserAverages />
+          <BounceKarma />
+        </div>
+        <div className="grid grid-cols-12 gap-3 mb-3">
+          <EmotionsPrevalence />
+          <DomainsPrevalence />
+        </div>
+        <div className="grid grid-cols-12 gap-3 mb-3">
+          <CairnSection />
+          <VisibilityMix />
+          <QualitySignals />
+        </div>
+        <div className="text-[11px] text-zinc-400 mt-8 mono">
+          Mockup · Fake data · Materialized views refresh nightly · Built for spec refinement
+        </div>
+      </main>
+    </div>
+  );
+};
+
+try {
+  ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+} catch (e) {
+  showErr('Render error: ' + (e && e.stack ? e.stack : e));
+}
+</script>
+</body>
+</html>

--- a/docs/poc/admin-analytics/fetchers.ts
+++ b/docs/poc/admin-analytics/fetchers.ts
@@ -1,0 +1,237 @@
+/**
+ * Admin · Analytics · Server-side fetchers
+ * ----------------------------------------------------------------------------
+ * One thin async function per chart. All functions:
+ *   - run on the server (Server Components or Route Handlers).
+ *   - assume the caller has already authenticated as admin (RLS enforces it
+ *     too — defense in depth, not a substitute for the RLS policies in the
+ *     20260430_analytics_mvs.sql migration).
+ *   - return strongly-typed rows from the corresponding materialized view.
+ *
+ * Source of truth for shapes: ./types.ts
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import type {
+  ActiveUsersDailyRow,
+  BounceDistributionRow,
+  CairnParticipationRow,
+  DomainShareRow,
+  EmotionShareRow,
+  IsoDate,
+  KpiDailyRow,
+  PebbleEnrichmentDailyRow,
+  PebbleVolumeDailyRow,
+  QualitySignalsRow,
+  RetentionCohortRow,
+  TimeRange,
+  UserAveragesWeeklyRow,
+  VisibilityMixRow,
+} from "./types";
+import { dateRangeFor } from "./types";
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/** Server-only Supabase client with admin JWT context propagated. */
+function adminSupabase() {
+  // The admin shell sets these in the request scope. If you wire SSR cookies
+  // via @supabase/ssr, replace this with the cookie-aware client instead.
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  return createClient(url, anon, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Single-row "current value" fetcher (latest bucket_date in any daily MV)
+// ---------------------------------------------------------------------------
+
+export async function getKpiToday(): Promise<KpiDailyRow | null> {
+  const sb = adminSupabase();
+  const { data, error } = await sb
+    .from("mv_kpi_daily")
+    .select("*")
+    .order("bucket_date", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Time-series fetchers (one per chart)
+// ---------------------------------------------------------------------------
+
+export async function getActiveUsersSeries(
+  range: TimeRange
+): Promise<ActiveUsersDailyRow[]> {
+  const { start, end } = dateRangeFor(range);
+  const sb = adminSupabase();
+  const { data, error } = await sb
+    .from("mv_active_users_daily")
+    .select("*")
+    .gte("bucket_date", start)
+    .lte("bucket_date", end)
+    .order("bucket_date", { ascending: true });
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function getRetentionCohorts(): Promise<RetentionCohortRow[]> {
+  // Always return the last 8 cohorts regardless of the global range tab —
+  // retention cohorts are intrinsically tied to signup-week granularity.
+  const sb = adminSupabase();
+  const { data, error } = await sb
+    .from("mv_retention_cohorts_weekly")
+    .select("*")
+    .gte("cohort_week", isoWeeksAgo(8))
+    .order("cohort_week", { ascending: false })
+    .order("week_offset", { ascending: true });
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function getPebbleVolumeSeries(
+  range: TimeRange
+): Promise<PebbleVolumeDailyRow[]> {
+  const { start, end } = dateRangeFor(range);
+  const sb = adminSupabase();
+  const { data, error } = await sb
+    .from("mv_pebble_volume_daily")
+    .select("*")
+    .gte("bucket_date", start)
+    .lte("bucket_date", end)
+    .order("bucket_date", { ascending: true });
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function getPebbleEnrichmentToday(): Promise<PebbleEnrichmentDailyRow | null> {
+  const sb = adminSupabase();
+  const { data, error } = await sb
+    .from("mv_pebble_enrichment_daily")
+    .select("*")
+    .order("bucket_date", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  return data;
+}
+
+export async function getUserAveragesSeries(
+  weeks = 12
+): Promise<UserAveragesWeeklyRow[]> {
+  const sb = adminSupabase();
+  const { data, error } = await sb
+    .from("mv_user_averages_weekly")
+    .select("*")
+    .gte("bucket_week", isoWeeksAgo(weeks))
+    .order("bucket_week", { ascending: true });
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function getBounceDistributionToday(): Promise<BounceDistributionRow[]> {
+  const sb = adminSupabase();
+  const { data, error } = await sb
+    .from("mv_bounce_distribution_daily")
+    .select("*")
+    .eq("bucket_date", await latestBucketDate("mv_bounce_distribution_daily"))
+    .order("bucket_order", { ascending: true });
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function getEmotionShare(
+  range: TimeRange
+): Promise<EmotionShareRow[]> {
+  const { start, end } = dateRangeFor(range);
+  const sb = adminSupabase();
+  const { data, error } = await sb
+    .from("mv_emotion_share_weekly")
+    .select("*")
+    .gte("bucket_week", start)
+    .lte("bucket_week", end)
+    .order("bucket_week", { ascending: true })
+    .order("share_pct",  { ascending: false });
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function getDomainShare(
+  range: TimeRange
+): Promise<DomainShareRow[]> {
+  const { start, end } = dateRangeFor(range);
+  const sb = adminSupabase();
+  const { data, error } = await sb
+    .from("mv_domain_share_weekly")
+    .select("*")
+    .gte("bucket_week", start)
+    .lte("bucket_week", end)
+    .order("bucket_week", { ascending: true })
+    .order("domain_level", { ascending: true });
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function getCairnParticipation(): Promise<CairnParticipationRow[]> {
+  const sb = adminSupabase();
+  const { data, error } = await sb
+    .from("mv_cairn_participation_weekly")
+    .select("*")
+    .order("period",       { ascending: true })
+    .order("period_start", { ascending: false });
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function getVisibilityMix(
+  range: TimeRange
+): Promise<VisibilityMixRow[]> {
+  const { start, end } = dateRangeFor(range);
+  const sb = adminSupabase();
+  const { data, error } = await sb
+    .from("mv_visibility_mix_daily")
+    .select("*")
+    .gte("bucket_date", start)
+    .lte("bucket_date", end);
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function getQualitySignalsToday(): Promise<QualitySignalsRow | null> {
+  const sb = adminSupabase();
+  const { data, error } = await sb
+    .from("mv_quality_signals_daily")
+    .select("*")
+    .order("bucket_date", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isoWeeksAgo(weeks: number): IsoDate {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - weeks * 7);
+  return d.toISOString().slice(0, 10);
+}
+
+async function latestBucketDate(view: string): Promise<IsoDate> {
+  const sb = adminSupabase();
+  const { data, error } = await sb
+    .from(view)
+    .select("bucket_date")
+    .order("bucket_date", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  return (data?.bucket_date as IsoDate) ?? new Date().toISOString().slice(0, 10);
+}

--- a/docs/poc/admin-analytics/layout-overview.svg
+++ b/docs/poc/admin-analytics/layout-overview.svg
@@ -1,0 +1,372 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 1620" font-family="Inter, system-ui, sans-serif">
+  <style>
+    .bg { fill: #fafafa; }
+    .card { fill: #ffffff; stroke: #e4e4e7; stroke-width: 1; }
+    .nav { fill: #ffffff; stroke: #e4e4e7; stroke-width: 1; }
+    .title { font-size: 24px; font-weight: 600; fill: #18181b; }
+    .crumb { font-size: 11px; fill: #71717a; }
+    .desc  { font-size: 13px; fill: #71717a; }
+    .label { font-size: 13px; font-weight: 600; fill: #18181b; }
+    .sub   { font-size: 11px; fill: #71717a; }
+    .num   { font-size: 22px; font-weight: 600; fill: #18181b; }
+    .badge { fill: #ecfdf5; stroke: #a7f3d0; stroke-width: 1; }
+    .badgetxt { font-size: 10px; font-weight: 500; fill: #047857; }
+    .tag   { fill: #f4f4f5; stroke: #e4e4e7; stroke-width: 1; }
+    .tagtxt{ font-size: 11px; fill: #52525b; }
+    .navitem { font-size: 12px; fill: #52525b; }
+    .navactive { fill: #18181b; font-weight: 500; }
+    .pill { fill: #f4f4f5; }
+    .pillactive { fill: #ffffff; stroke: #e4e4e7; stroke-width: 1; }
+    .grid { stroke: #f4f4f5; stroke-width: 1; }
+    .axis { stroke: #d4d4d8; stroke-width: 1; }
+    .area { fill-opacity: 0.6; }
+    .stone { fill: #78716c; }
+    .sage  { fill: #84a98c; }
+    .sand  { fill: #d4a373; }
+    .sky   { fill: #7aa9c7; }
+    .rose  { fill: #c98a8a; }
+    .mute  { fill: #e4e4e7; }
+    .heat0 { fill: #f5f5f4; } .heat1 { fill: #d6d3d1; } .heat2 { fill: #a8a29e; } .heat3 { fill: #78716c; } .heat4 { fill: #44403c; }
+    .joy   { fill: #f5c97e; } .calm  { fill: #9bcfd1; } .love  { fill: #e9a3a3; } .pride { fill: #c5a572; }
+    .sad   { fill: #8aa9c0; } .anger { fill: #c87a7a; } .fear  { fill: #a89cc7; } .surp  { fill: #d8a8c5; } .awe { fill: #7fb39c; }
+  </style>
+
+  <rect class="bg" width="1440" height="1620"/>
+
+  <!-- Sidebar -->
+  <rect class="nav" x="0" y="0" width="220" height="1620"/>
+  <rect x="20" y="22" width="28" height="28" rx="6" fill="#18181b"/>
+  <text x="56" y="36" class="label">pbbls</text>
+  <text x="56" y="50" class="sub">ADMIN</text>
+  <g font-family="Inter">
+    <text x="32" y="100" class="navitem">○ Overview</text>
+    <text x="32" y="124" class="navitem">◐ Users</text>
+    <text x="32" y="148" class="navitem">◉ Pebbles</text>
+    <text x="32" y="172" class="navitem">◇ Collections</text>
+    <rect x="20" y="184" width="184" height="28" rx="6" fill="#f4f4f5"/>
+    <text x="32" y="202" class="navitem navactive">◆ Analytics</text>
+    <text x="32" y="226" class="navitem">△ Cairns</text>
+    <text x="32" y="250" class="navitem">◈ Moderation</text>
+    <text x="32" y="274" class="navitem">⌘ System</text>
+  </g>
+
+  <!-- Header -->
+  <text x="252" y="48" class="crumb">Admin / Analytics</text>
+  <text x="252" y="80" class="title">Analytics</text>
+  <text x="252" y="102" class="desc">Retention, engagement, usage and meaning across the Pebbles community.</text>
+  <text x="1180" y="48" class="sub">Last refresh: 2026-04-30 03:14 UTC</text>
+  <g transform="translate(1180, 64)">
+    <rect class="pill" width="180" height="30" rx="8"/>
+    <rect class="pillactive" x="34" y="3" width="34" height="24" rx="6"/>
+    <text x="14" y="20" class="tagtxt">7d</text>
+    <text x="44" y="20" class="tagtxt" font-weight="600">30d</text>
+    <text x="80" y="20" class="tagtxt">90d</text>
+    <text x="110" y="20" class="tagtxt">1y</text>
+    <text x="140" y="20" class="tagtxt">All</text>
+  </g>
+  <rect x="1370" y="64" width="60" height="30" rx="6" fill="#fff" stroke="#e4e4e7"/>
+  <text x="1380" y="84" class="tagtxt">Export</text>
+
+  <!-- KPI ROW (6 cards) -->
+  <g transform="translate(252, 130)">
+    <g transform="translate(0,0)">
+      <rect class="card" width="180" height="100" rx="12"/>
+      <text x="14" y="26" class="sub">Total users</text>
+      <text x="14" y="56" class="num">42,318</text>
+      <rect class="badge" x="120" y="42" width="48" height="18" rx="4"/>
+      <text x="125" y="55" class="badgetxt">+4.2%</text>
+      <path d="M14 90 Q40 78 70 82 T160 70" fill="none" stroke="#78716c" stroke-width="1.5"/>
+    </g>
+    <g transform="translate(196,0)">
+      <rect class="card" width="180" height="100" rx="12"/>
+      <text x="14" y="26" class="sub">DAU</text>
+      <text x="14" y="56" class="num">1,486</text>
+      <rect class="badge" x="120" y="42" width="48" height="18" rx="4"/>
+      <text x="125" y="55" class="badgetxt">+2.1%</text>
+      <path d="M14 90 Q40 80 70 70 T160 65" fill="none" stroke="#84a98c" stroke-width="1.5"/>
+    </g>
+    <g transform="translate(392,0)">
+      <rect class="card" width="180" height="100" rx="12"/>
+      <text x="14" y="26" class="sub">WAU</text>
+      <text x="14" y="56" class="num">8,907</text>
+      <rect class="badge" x="120" y="42" width="48" height="18" rx="4"/>
+      <text x="125" y="55" class="badgetxt">+3.8%</text>
+      <path d="M14 88 Q40 82 70 76 T160 60" fill="none" stroke="#7aa9c7" stroke-width="1.5"/>
+    </g>
+    <g transform="translate(588,0)">
+      <rect class="card" width="180" height="100" rx="12"/>
+      <text x="14" y="26" class="sub">MAU</text>
+      <text x="14" y="56" class="num">24,512</text>
+      <rect class="badge" x="120" y="42" width="48" height="18" rx="4"/>
+      <text x="125" y="55" class="badgetxt">+5.6%</text>
+      <path d="M14 90 Q40 80 70 74 T160 58" fill="none" stroke="#d4a373" stroke-width="1.5"/>
+    </g>
+    <g transform="translate(784,0)">
+      <rect class="card" width="180" height="100" rx="12"/>
+      <text x="14" y="26" class="sub">Pebbles / day</text>
+      <text x="14" y="56" class="num">2,340</text>
+      <rect class="badge" x="120" y="42" width="48" height="18" rx="4"/>
+      <text x="125" y="55" class="badgetxt">+6.4%</text>
+      <path d="M14 90 Q40 82 70 70 T160 55" fill="none" stroke="#c98a8a" stroke-width="1.5"/>
+    </g>
+    <g transform="translate(980,0)">
+      <rect class="card" width="180" height="100" rx="12"/>
+      <text x="14" y="26" class="sub">DAU / MAU</text>
+      <text x="14" y="56" class="num">6.1%</text>
+      <rect x="120" y="42" width="48" height="18" rx="4" fill="#fef2f2" stroke="#fecaca"/>
+      <text x="125" y="55" font-size="10" font-weight="500" fill="#b91c1c">-0.3pp</text>
+      <path d="M14 80 Q40 78 70 82 T160 88" fill="none" stroke="#a3b18a" stroke-width="1.5"/>
+    </g>
+  </g>
+
+  <!-- ROW 2: Activity trend (8 cols) + Retention cohort (4 cols) -->
+  <g transform="translate(252, 252)">
+    <rect class="card" width="772" height="320" rx="12"/>
+    <text x="20" y="32" class="label">Active users over time</text>
+    <text x="20" y="50" class="sub">Daily, weekly and monthly active collectors.</text>
+    <g transform="translate(560, 22)">
+      <rect class="pill" width="190" height="26" rx="6"/>
+      <rect class="pillactive" x="4" y="3" width="38" height="20" rx="4"/>
+      <text x="12" y="18" class="tagtxt" font-weight="600">DAU</text>
+      <text x="50" y="18" class="tagtxt">WAU</text>
+      <text x="90" y="18" class="tagtxt">MAU</text>
+      <text x="135" y="18" class="tagtxt">All</text>
+    </g>
+    <!-- chart area -->
+    <g transform="translate(40, 80)">
+      <line class="grid" x1="0" y1="0"   x2="700" y2="0"/>
+      <line class="grid" x1="0" y1="50"  x2="700" y2="50"/>
+      <line class="grid" x1="0" y1="100" x2="700" y2="100"/>
+      <line class="grid" x1="0" y1="150" x2="700" y2="150"/>
+      <line class="grid" x1="0" y1="200" x2="700" y2="200"/>
+      <path d="M0 180 Q60 160 120 150 T240 130 T360 110 T480 90 T600 75 T700 60" fill="none" stroke="#84a98c" stroke-width="2"/>
+      <path d="M0 150 Q60 140 120 120 T240 100 T360 85 T480 65 T600 50 T700 40" fill="none" stroke="#7aa9c7" stroke-width="2"/>
+      <path d="M0 110 Q60 95 120 85 T240 65 T360 55 T480 40 T600 30 T700 20" fill="none" stroke="#d4a373" stroke-width="2"/>
+      <text x="0" y="220" class="sub">Apr 1</text>
+      <text x="340" y="220" class="sub">Apr 15</text>
+      <text x="660" y="220" class="sub">Apr 30</text>
+    </g>
+  </g>
+
+  <g transform="translate(1040, 252)">
+    <rect class="card" width="372" height="320" rx="12"/>
+    <text x="20" y="32" class="label">Retention cohorts</text>
+    <text x="20" y="50" class="sub">% of cohort still active week over week.</text>
+    <g transform="translate(20, 70)" font-size="10" fill="#52525b">
+      <text x="0"  y="14">Cohort</text>
+      <text x="60" y="14">W0</text>
+      <text x="98" y="14">W1</text>
+      <text x="136" y="14">W2</text>
+      <text x="174" y="14">W3</text>
+      <text x="212" y="14">W4</text>
+      <text x="250" y="14">W5</text>
+      <text x="288" y="14">W6</text>
+      <text x="0" y="38">Mar W1</text>
+      <text x="0" y="62">Mar W2</text>
+      <text x="0" y="86">Mar W3</text>
+      <text x="0" y="110">Mar W4</text>
+      <text x="0" y="134">Apr W1</text>
+      <text x="0" y="158">Apr W2</text>
+      <text x="0" y="182">Apr W3</text>
+      <text x="0" y="206">Apr W4</text>
+    </g>
+    <g transform="translate(75, 76)">
+      <!-- Heat grid 8 rows x 7 cols -->
+      <g>
+        <rect class="heat4" x="0"  y="0"   width="34" height="20" rx="3"/><rect class="heat3" x="38" y="0"   width="34" height="20" rx="3"/><rect class="heat2" x="76" y="0"   width="34" height="20" rx="3"/><rect class="heat2" x="114" y="0"  width="34" height="20" rx="3"/><rect class="heat1" x="152" y="0"  width="34" height="20" rx="3"/><rect class="heat1" x="190" y="0"  width="34" height="20" rx="3"/><rect class="heat0" x="228" y="0"  width="34" height="20" rx="3"/>
+        <rect class="heat4" x="0"  y="24"  width="34" height="20" rx="3"/><rect class="heat3" x="38" y="24"  width="34" height="20" rx="3"/><rect class="heat2" x="76" y="24"  width="34" height="20" rx="3"/><rect class="heat2" x="114" y="24"  width="34" height="20" rx="3"/><rect class="heat1" x="152" y="24" width="34" height="20" rx="3"/><rect class="heat1" x="190" y="24" width="34" height="20" rx="3"/>
+        <rect class="heat4" x="0"  y="48"  width="34" height="20" rx="3"/><rect class="heat3" x="38" y="48"  width="34" height="20" rx="3"/><rect class="heat3" x="76" y="48"  width="34" height="20" rx="3"/><rect class="heat2" x="114" y="48" width="34" height="20" rx="3"/><rect class="heat1" x="152" y="48" width="34" height="20" rx="3"/>
+        <rect class="heat4" x="0"  y="72"  width="34" height="20" rx="3"/><rect class="heat3" x="38" y="72"  width="34" height="20" rx="3"/><rect class="heat2" x="76" y="72"  width="34" height="20" rx="3"/><rect class="heat2" x="114" y="72" width="34" height="20" rx="3"/>
+        <rect class="heat4" x="0"  y="96"  width="34" height="20" rx="3"/><rect class="heat3" x="38" y="96"  width="34" height="20" rx="3"/><rect class="heat3" x="76" y="96"  width="34" height="20" rx="3"/>
+        <rect class="heat4" x="0"  y="120" width="34" height="20" rx="3"/><rect class="heat3" x="38" y="120" width="34" height="20" rx="3"/>
+        <rect class="heat4" x="0"  y="144" width="34" height="20" rx="3"/>
+      </g>
+    </g>
+  </g>
+
+  <!-- ROW 3: Pebble volume (8) + Pebble enrichment (4) -->
+  <g transform="translate(252, 590)">
+    <rect class="card" width="772" height="320" rx="12"/>
+    <text x="20" y="32" class="label">Pebbles collected</text>
+    <text x="20" y="50" class="sub">Daily volume with enrichment breakdown.</text>
+    <g transform="translate(560, 22)">
+      <rect class="pill" width="190" height="26" rx="6"/>
+      <rect class="pillactive" x="4" y="3" width="38" height="20" rx="4"/>
+      <text x="14" y="18" class="tagtxt" font-weight="600">Day</text>
+      <text x="50" y="18" class="tagtxt">Week</text>
+      <text x="92" y="18" class="tagtxt">Month</text>
+      <text x="138" y="18" class="tagtxt">Year</text>
+    </g>
+    <!-- Stacked bars + lines -->
+    <g transform="translate(40, 80)">
+      <line class="grid" x1="0" y1="0" x2="700" y2="0"/>
+      <line class="grid" x1="0" y1="50" x2="700" y2="50"/>
+      <line class="grid" x1="0" y1="100" x2="700" y2="100"/>
+      <line class="grid" x1="0" y1="150" x2="700" y2="150"/>
+      <line class="grid" x1="0" y1="200" x2="700" y2="200"/>
+      <g>
+        <!-- 30 bars across 700px -->
+        <g class="mute">
+          <rect x="0"   y="100" width="18" height="100" rx="3"/>
+          <rect x="24"  y="90"  width="18" height="110" rx="3"/>
+          <rect x="48"  y="95"  width="18" height="105" rx="3"/>
+          <rect x="72"  y="80"  width="18" height="120" rx="3"/>
+          <rect x="96"  y="85"  width="18" height="115" rx="3"/>
+          <rect x="120" y="75"  width="18" height="125" rx="3"/>
+          <rect x="144" y="70"  width="18" height="130" rx="3"/>
+          <rect x="168" y="78"  width="18" height="122" rx="3"/>
+          <rect x="192" y="65"  width="18" height="135" rx="3"/>
+          <rect x="216" y="60"  width="18" height="140" rx="3"/>
+          <rect x="240" y="68"  width="18" height="132" rx="3"/>
+          <rect x="264" y="55"  width="18" height="145" rx="3"/>
+          <rect x="288" y="50"  width="18" height="150" rx="3"/>
+          <rect x="312" y="58"  width="18" height="142" rx="3"/>
+          <rect x="336" y="45"  width="18" height="155" rx="3"/>
+          <rect x="360" y="40"  width="18" height="160" rx="3"/>
+          <rect x="384" y="48"  width="18" height="152" rx="3"/>
+          <rect x="408" y="35"  width="18" height="165" rx="3"/>
+          <rect x="432" y="30"  width="18" height="170" rx="3"/>
+          <rect x="456" y="38"  width="18" height="162" rx="3"/>
+          <rect x="480" y="25"  width="18" height="175" rx="3"/>
+          <rect x="504" y="22"  width="18" height="178" rx="3"/>
+          <rect x="528" y="28"  width="18" height="172" rx="3"/>
+          <rect x="552" y="18"  width="18" height="182" rx="3"/>
+          <rect x="576" y="14"  width="18" height="186" rx="3"/>
+          <rect x="600" y="20"  width="18" height="180" rx="3"/>
+          <rect x="624" y="10"  width="18" height="190" rx="3"/>
+          <rect x="648" y="8"   width="18" height="192" rx="3"/>
+          <rect x="672" y="12"  width="18" height="188" rx="3"/>
+        </g>
+      </g>
+      <path d="M9 150 Q60 145 120 140 T240 125 T360 110 T480 95 T600 80 T690 70" fill="none" stroke="#84a98c" stroke-width="2"/>
+      <path d="M9 175 Q60 168 120 160 T240 148 T360 136 T480 122 T600 108 T690 100" fill="none" stroke="#d4a373" stroke-width="2"/>
+      <path d="M9 130 Q60 120 120 110 T240 95 T360 80 T480 64 T600 50 T690 40" fill="none" stroke="#7aa9c7" stroke-width="2"/>
+    </g>
+    <!-- legend -->
+    <g transform="translate(40, 296)" font-size="11" fill="#52525b">
+      <rect x="0" y="-9" width="10" height="10" class="mute"/><text x="14" y="0">Total pebbles</text>
+      <rect x="110" y="-9" width="10" height="10" class="sage"/><text x="124" y="0">With picture</text>
+      <rect x="220" y="-9" width="10" height="10" class="sand"/><text x="234" y="0">Custom glyph</text>
+      <rect x="335" y="-9" width="10" height="10" class="sky"/><text x="349" y="0">In collection</text>
+    </g>
+  </g>
+
+  <g transform="translate(1040, 590)">
+    <rect class="card" width="372" height="320" rx="12"/>
+    <text x="20" y="32" class="label">Pebble enrichment</text>
+    <text x="20" y="50" class="sub">Share of pebbles with each enrichment.</text>
+    <!-- 3 donuts -->
+    <g transform="translate(40, 90)">
+      <circle cx="40" cy="40" r="32" fill="#e4e4e7"/>
+      <path d="M40 8 A32 32 0 0 1 70.4 53 L40 40 Z" fill="#84a98c"/>
+      <text x="40" y="44" text-anchor="middle" font-size="14" font-weight="600" fill="#18181b">46%</text>
+      <text x="40" y="100" text-anchor="middle" class="sub">Picture</text>
+    </g>
+    <g transform="translate(146, 90)">
+      <circle cx="40" cy="40" r="32" fill="#e4e4e7"/>
+      <path d="M40 8 A32 32 0 0 1 65 60 L40 40 Z" fill="#d4a373"/>
+      <text x="40" y="44" text-anchor="middle" font-size="14" font-weight="600" fill="#18181b">31%</text>
+      <text x="40" y="100" text-anchor="middle" class="sub">Custom glyph</text>
+    </g>
+    <g transform="translate(252, 90)">
+      <circle cx="40" cy="40" r="32" fill="#e4e4e7"/>
+      <path d="M40 8 A32 32 0 1 1 14.5 60 L40 40 Z" fill="#7aa9c7"/>
+      <text x="40" y="44" text-anchor="middle" font-size="14" font-weight="600" fill="#18181b">58%</text>
+      <text x="40" y="100" text-anchor="middle" class="sub">Collection</text>
+    </g>
+    <!-- Sub ratios -->
+    <g transform="translate(20, 220)" font-size="11">
+      <text x="0" y="0" fill="#71717a">Pebbles with ≥1 emotion pearl</text><text x="320" y="0" text-anchor="end" font-weight="600" fill="#18181b">82%</text>
+      <text x="0" y="20" fill="#71717a">Pebbles linked to ≥1 soul</text><text x="320" y="20" text-anchor="end" font-weight="600" fill="#18181b">71%</text>
+      <text x="0" y="40" fill="#71717a">Pebbles with thought attached</text><text x="320" y="40" text-anchor="end" font-weight="600" fill="#18181b">38%</text>
+      <text x="0" y="60" fill="#71717a">Pebbles with intensity set</text><text x="320" y="60" text-anchor="end" font-weight="600" fill="#18181b">94%</text>
+    </g>
+  </g>
+
+  <!-- ROW 4: Per-user averages (7) + Bounce karma (5) -->
+  <g transform="translate(252, 928)">
+    <rect class="card" width="664" height="280" rx="12"/>
+    <text x="20" y="32" class="label">Per-user averages over time</text>
+    <text x="20" y="50" class="sub">Average glyphs, souls and collections per active user, weekly.</text>
+    <g transform="translate(20, 70)" font-size="11">
+      <text x="0" y="0" class="sub">Avg glyphs / user</text><text x="0" y="22" class="num" font-size="18">5.4</text>
+      <text x="180" y="0" class="sub">Avg souls / user</text><text x="180" y="22" class="num" font-size="18">11.2</text>
+      <text x="360" y="0" class="sub">Avg collections / user</text><text x="360" y="22" class="num" font-size="18">3.1</text>
+    </g>
+    <g transform="translate(40, 130)">
+      <line class="grid" x1="0" y1="0" x2="600" y2="0"/>
+      <line class="grid" x1="0" y1="50" x2="600" y2="50"/>
+      <line class="grid" x1="0" y1="100" x2="600" y2="100"/>
+      <path d="M0 90 Q60 85 120 75 T240 55 T360 40 T480 28 T600 15" fill="none" stroke="#d4a373" stroke-width="2"/>
+      <path d="M0 60 Q60 55 120 48 T240 35 T360 25 T480 18 T600 10" fill="none" stroke="#c98a8a" stroke-width="2"/>
+      <path d="M0 100 Q60 96 120 90 T240 80 T360 70 T480 62 T600 55" fill="none" stroke="#7aa9c7" stroke-width="2"/>
+    </g>
+  </g>
+
+  <g transform="translate(932, 928)">
+    <rect class="card" width="480" height="280" rx="12"/>
+    <text x="20" y="32" class="label">Bounce karma distribution</text>
+    <text x="20" y="50" class="sub">Users by current bounce score.</text>
+    <g transform="translate(20, 70)" font-size="11">
+      <text x="0" y="0" class="sub">Median bounce</text><text x="0" y="22" class="num" font-size="18">42</text>
+      <text x="140" y="0" class="sub">% maintaining</text><text x="140" y="22" class="num" font-size="18">63%</text>
+      <text x="280" y="0" class="sub">Active days/wk</text><text x="280" y="22" class="num" font-size="18">3.4</text>
+    </g>
+    <g transform="translate(40, 130)">
+      <rect x="0"   y="100" width="60" height="20" class="stone" rx="3"/>
+      <rect x="70"  y="60"  width="60" height="60" class="stone" rx="3"/>
+      <rect x="140" y="40"  width="60" height="80" class="stone" rx="3"/>
+      <rect x="210" y="20"  width="60" height="100" class="stone" rx="3"/>
+      <rect x="280" y="0"   width="60" height="120" class="stone" rx="3"/>
+      <rect x="350" y="50"  width="60" height="70" class="stone" rx="3"/>
+      <text x="20"  y="135" class="sub" text-anchor="middle">0</text>
+      <text x="100" y="135" class="sub" text-anchor="middle">1–10</text>
+      <text x="170" y="135" class="sub" text-anchor="middle">11–25</text>
+      <text x="240" y="135" class="sub" text-anchor="middle">26–50</text>
+      <text x="310" y="135" class="sub" text-anchor="middle">51–100</text>
+      <text x="380" y="135" class="sub" text-anchor="middle">100+</text>
+    </g>
+  </g>
+
+  <!-- ROW 5: Emotions (6) + Domains (6) -->
+  <g transform="translate(252, 1226)">
+    <rect class="card" width="572" height="280" rx="12"/>
+    <text x="20" y="32" class="label">Emotion pearls prevalence</text>
+    <text x="20" y="50" class="sub">Share of pebbles tagged with each emotion.</text>
+    <g transform="translate(20, 80)" font-size="11">
+      <text x="0" y="14" fill="#52525b">Joy</text>     <rect class="joy"   x="60" y="2" width="280" height="14" rx="2"/><text x="350" y="14" fill="#52525b">22.4%</text>
+      <text x="0" y="34" fill="#52525b">Calm</text>    <rect class="calm"  x="60" y="22" width="220" height="14" rx="2"/><text x="350" y="34" fill="#52525b">17.1%</text>
+      <text x="0" y="54" fill="#52525b">Love</text>    <rect class="love"  x="60" y="42" width="180" height="14" rx="2"/><text x="350" y="54" fill="#52525b">14.0%</text>
+      <text x="0" y="74" fill="#52525b">Pride</text>   <rect class="pride" x="60" y="62" width="140" height="14" rx="2"/><text x="350" y="74" fill="#52525b">11.0%</text>
+      <text x="0" y="94" fill="#52525b">Sadness</text> <rect class="sad"   x="60" y="82" width="120" height="14" rx="2"/><text x="350" y="94" fill="#52525b">9.2%</text>
+      <text x="0" y="114" fill="#52525b">Anger</text>  <rect class="anger" x="60" y="102" width="80" height="14" rx="2"/><text x="350" y="114" fill="#52525b">7.4%</text>
+      <text x="0" y="134" fill="#52525b">Fear</text>   <rect class="fear"  x="60" y="122" width="70" height="14" rx="2"/><text x="350" y="134" fill="#52525b">6.5%</text>
+      <text x="0" y="154" fill="#52525b">Surprise</text><rect class="surp" x="60" y="142" width="60" height="14" rx="2"/><text x="350" y="154" fill="#52525b">5.2%</text>
+      <text x="0" y="174" fill="#52525b">Awe</text>    <rect class="awe"   x="60" y="162" width="50" height="14" rx="2"/><text x="350" y="174" fill="#52525b">4.4%</text>
+    </g>
+    <text x="430" y="62" class="sub">Snapshot · Over time toggle</text>
+  </g>
+
+  <g transform="translate(840, 1226)">
+    <rect class="card" width="572" height="280" rx="12"/>
+    <text x="20" y="32" class="label">Maslow domains prevalence</text>
+    <text x="20" y="50" class="sub">How pebbles distribute across the revisited Maslow's pyramid.</text>
+    <g transform="translate(20, 80)" font-size="11">
+      <text x="0" y="14" fill="#52525b">Belonging</text>          <rect x="120" y="2"   width="240" height="14" fill="#e9a3a3" rx="2"/>
+      <text x="0" y="34" fill="#52525b">Esteem</text>             <rect x="120" y="22"  width="200" height="14" fill="#f5c97e" rx="2"/>
+      <text x="0" y="54" fill="#52525b">Safety</text>             <rect x="120" y="42"  width="170" height="14" fill="#7aa9c7" rx="2"/>
+      <text x="0" y="74" fill="#52525b">Cognitive</text>          <rect x="120" y="62"  width="140" height="14" fill="#a89cc7" rx="2"/>
+      <text x="0" y="94" fill="#52525b">Self-actualization</text> <rect x="120" y="82"  width="115" height="14" fill="#84a98c" rx="2"/>
+      <text x="0" y="114" fill="#52525b">Aesthetic</text>         <rect x="120" y="102" width="95" height="14" fill="#9bcfd1" rx="2"/>
+      <text x="0" y="134" fill="#52525b">Transcendence</text>     <rect x="120" y="122" width="70" height="14" fill="#c5a572" rx="2"/>
+      <text x="0" y="154" fill="#52525b">Physiological</text>     <rect x="120" y="142" width="50" height="14" fill="#c87a5a" rx="2"/>
+    </g>
+    <g transform="translate(20, 246)" font-size="10" fill="#71717a">
+      <text x="0" y="0">Most-evolving domain (vs prev. period)</text><text x="380" y="0" text-anchor="end" fill="#047857">Belonging +3.2pp</text>
+    </g>
+  </g>
+
+  <!-- Footnote -->
+  <text x="252" y="1572" class="sub">Layout map · See analytics-mockup.html for the live, interactive visual reference.</text>
+</svg>

--- a/docs/poc/admin-analytics/types.ts
+++ b/docs/poc/admin-analytics/types.ts
@@ -1,0 +1,229 @@
+/**
+ * Admin · Analytics · Data contracts
+ * ----------------------------------------------------------------------------
+ * One TypeScript type per materialized view, mirroring the SQL row shape
+ * exactly. These are the contracts each chart consumes.
+ *
+ * Source of truth: docs/specs/admin-analytics.md
+ *                  supabase/migrations/20260430_analytics_mvs.sql
+ *
+ * Naming:
+ *   - Row types end with `Row` (e.g. `KpiDailyRow`).
+ *   - View name ↔ row type mapping is exported as `ViewRow` for codegen-style
+ *     access elsewhere.
+ *
+ * NOTE: Do not put presentation logic here. Only data shapes.
+ */
+
+// ---------------------------------------------------------------------------
+// Shared primitives
+// ---------------------------------------------------------------------------
+
+/** ISO date string `YYYY-MM-DD`, always UTC. */
+export type IsoDate = string;
+
+/** Visibility levels for a pebble. */
+export type Visibility = "public" | "private" | "secret";
+
+/** Cairn period. */
+export type CairnPeriod = "weekly" | "monthly";
+
+/** Cairn outcome for a given user × period. */
+export type CairnStatus = "completed" | "partial" | "missed";
+
+/** Bounce histogram bucket label, ordered low→high. */
+export type BounceBucketLabel =
+  | "0"
+  | "1-10"
+  | "11-25"
+  | "26-50"
+  | "51-100"
+  | "100+";
+
+// ---------------------------------------------------------------------------
+// MV row types — one per materialized view
+// ---------------------------------------------------------------------------
+
+/** mv_kpi_daily — one row per day. Powers the KPI strip. */
+export interface KpiDailyRow {
+  bucket_date: IsoDate;
+  total_users: number;
+  dau: number;
+  pebbles_today: number;
+  wau: number;
+  mau: number;
+  /** DAU / MAU as a 0–100 percent value (not 0–1). */
+  dau_mau_pct: number | null;
+}
+
+/** mv_active_users_daily — daily DAU/WAU/MAU series for the line chart. */
+export interface ActiveUsersDailyRow {
+  bucket_date: IsoDate;
+  dau: number;
+  wau: number;
+  mau: number;
+}
+
+/** mv_retention_cohorts_weekly — one row per (cohort, week_offset). */
+export interface RetentionCohortRow {
+  /** Monday of the signup week (UTC). */
+  cohort_week: IsoDate;
+  /** Weeks since signup. 0 = signup week. */
+  week_offset: number;
+  cohort_size: number;
+  active_users: number;
+  /** % of cohort active that week. 0–100. */
+  retention_pct: number;
+}
+
+/** mv_pebble_volume_daily — pebble counts and enrichment counts per day. */
+export interface PebbleVolumeDailyRow {
+  bucket_date: IsoDate;
+  pebbles: number;
+  pebbles_with_picture: number;
+  pebbles_with_custom_glyph: number;
+  pebbles_in_collection: number;
+  active_users: number;
+}
+
+/** mv_pebble_enrichment_daily — pre-computed enrichment shares per day. */
+export interface PebbleEnrichmentDailyRow {
+  bucket_date: IsoDate;
+  total_pebbles: number;
+  /** All pct fields are 0–100. */
+  pct_with_picture: number;
+  pct_with_custom_glyph: number;
+  pct_in_collection: number;
+  pct_with_emotion: number;
+  pct_with_soul: number;
+  pct_with_thought: number;
+  pct_with_intensity: number;
+}
+
+/** mv_user_averages_weekly — averages of glyphs/souls/collections per active user, weekly. */
+export interface UserAveragesWeeklyRow {
+  /** Monday of the bucket week (UTC). */
+  bucket_week: IsoDate;
+  active_users: number;
+  avg_glyphs: number;
+  avg_souls: number;
+  avg_collections: number;
+}
+
+/** mv_bounce_distribution_daily — one row per histogram bucket per day. */
+export interface BounceDistributionRow {
+  bucket_date: IsoDate;
+  bucket_order: number;
+  bucket_label: BounceBucketLabel;
+  users: number;
+  median_score: number;
+  /** % of users whose bounce did not decrease vs 7 days ago. 0–100. */
+  pct_maintaining: number;
+  avg_active_days_per_week: number;
+}
+
+/** mv_emotion_share_weekly — share of pebbles tagged with each emotion, per week. */
+export interface EmotionShareRow {
+  bucket_week: IsoDate;
+  emotion_id: string;
+  emotion_name: string;
+  /** Hex color from the emotions catalog. */
+  color: string;
+  pebbles_with_emotion: number;
+  total_pebbles: number;
+  /** Share of pebbles in the week with ≥1 pearl of this emotion. 0–100. May NOT sum to 100 across emotions. */
+  share_pct: number;
+}
+
+/** mv_domain_share_weekly — share of pebbles linked to each Maslow domain, per week. */
+export interface DomainShareRow {
+  bucket_week: IsoDate;
+  domain_id: string;
+  domain_name: string;
+  /** Maslow level (1=Physiological, 8=Transcendence) — used for sort order. */
+  domain_level: number;
+  pebbles_in_domain: number;
+  total_pebbles: number;
+  share_pct: number;
+}
+
+/** mv_cairn_participation_weekly — one row per (period, period_start). */
+export interface CairnParticipationRow {
+  period: CairnPeriod;
+  period_start: IsoDate;
+  completed: number;
+  partial: number;
+  missed: number;
+  total: number;
+  completed_pct: number;
+  partial_pct: number;
+  missed_pct: number;
+}
+
+/** mv_visibility_mix_daily — pebble count by visibility per day. */
+export interface VisibilityMixRow {
+  bucket_date: IsoDate;
+  visibility: Visibility;
+  pebbles: number;
+}
+
+/** mv_quality_signals_daily — daily snapshot of habit-health metrics. */
+export interface QualitySignalsRow {
+  bucket_date: IsoDate;
+  median_session_seconds: number | null;
+  sessions_per_wau: number | null;
+  pebbles_per_wau: number | null;
+  pct_revisits_to_past_pebbles: number | null;
+  d1_retention: number | null;
+  d7_retention: number | null;
+  d30_retention: number | null;
+  friction_events_per_session: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// View name ↔ row type registry
+// ---------------------------------------------------------------------------
+
+/** Map of MV name → row type. Useful for typing generic fetchers. */
+export interface ViewRow {
+  mv_kpi_daily:                  KpiDailyRow;
+  mv_active_users_daily:         ActiveUsersDailyRow;
+  mv_retention_cohorts_weekly:   RetentionCohortRow;
+  mv_pebble_volume_daily:        PebbleVolumeDailyRow;
+  mv_pebble_enrichment_daily:    PebbleEnrichmentDailyRow;
+  mv_user_averages_weekly:       UserAveragesWeeklyRow;
+  mv_bounce_distribution_daily:  BounceDistributionRow;
+  mv_emotion_share_weekly:       EmotionShareRow;
+  mv_domain_share_weekly:        DomainShareRow;
+  mv_cairn_participation_weekly: CairnParticipationRow;
+  mv_visibility_mix_daily:       VisibilityMixRow;
+  mv_quality_signals_daily:      QualitySignalsRow;
+}
+
+export type ViewName = keyof ViewRow;
+
+// ---------------------------------------------------------------------------
+// Page-level types
+// ---------------------------------------------------------------------------
+
+/** Time range tab on the analytics page. Applies globally. */
+export type TimeRange = "7d" | "30d" | "90d" | "1y" | "all";
+
+/** Period bucket for the Pebbles volume chart. */
+export type VolumeBucket = "day" | "week" | "month" | "year";
+
+/** Toggle inside Active users over time. */
+export type ActivityMetric = "dau" | "wau" | "mau" | "all";
+
+/** Snapshot vs over-time toggle inside Emotions card. */
+export type EmotionsView = "snapshot" | "over_time";
+
+/** Returns the inclusive date range for a TimeRange tab, ending today (UTC). */
+export function dateRangeFor(range: TimeRange, today: Date = new Date()): { start: IsoDate; end: IsoDate } {
+  const end = today.toISOString().slice(0, 10);
+  if (range === "all") return { start: "1970-01-01", end };
+  const days = { "7d": 7, "30d": 30, "90d": 90, "1y": 365 }[range];
+  const startDate = new Date(today);
+  startDate.setUTCDate(startDate.getUTCDate() - days + 1);
+  return { start: startDate.toISOString().slice(0, 10), end };
+}


### PR DESCRIPTION
Lands the supporting material for the admin analytics work on `main`:

- **`docs/admin-analytics/ROADMAP.md`** — single source of truth for M28. Indexes the spec, the original POC, the shipped slice (#337/#338), the 5 buildable follow-up issues (#339–#343), the 4 data-foundations follow-ups (#344–#347), the deferred non-goals, and the architectural invariants every follow-up issue should follow.
- **`docs/poc/admin-analytics/`** — the original POC handoff from Claude Cowork that started this work: HTML mockup, SVG layout, MV DDL, TS contracts, server fetchers, kickoff prompt. Reference material only — schema audit notes in the roadmap explain which bits are buildable vs aspirational.

This PR is **docs-only**. No code, no migrations.

## Why a separate PR
Keeping it independent of #338 (the thin-slice implementation) so #338's diff stays focused on shipped code.

## Test plan
- [x] `docs/admin-analytics/ROADMAP.md` links resolve once merged
- [x] No build / lint impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)