### PR TITLE
feat(core): admin analytics retention cohort heatmap

### DIFF
--- a/apps/admin/app/(authed)/analytics/page.tsx
+++ b/apps/admin/app/(authed)/analytics/page.tsx
@@ -3,6 +3,7 @@ import { ActiveUsersChartCard } from "@/components/analytics/ActiveUsersChartCar
 import { ChartCardSkeleton } from "@/components/analytics/ChartCardSkeleton"
 import { KpiStrip } from "@/components/analytics/KpiStrip"
 import { KpiStripSkeleton } from "@/components/analytics/KpiStripSkeleton"
+import { RetentionHeatmapCard } from "@/components/analytics/RetentionHeatmap"
 import { TimeRangeTabs } from "@/components/analytics/TimeRangeTabs"
 import { isTimeRange, type TimeRange } from "@/lib/analytics/types"
 
@@ -27,9 +28,18 @@ export default async function AnalyticsPage({
         <KpiStrip range={range} />
       </Suspense>
 
-      <Suspense fallback={<ChartCardSkeleton />}>
-        <ActiveUsersChartCard range={range} />
-      </Suspense>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
+        <div className="lg:col-span-8">
+          <Suspense fallback={<ChartCardSkeleton />}>
+            <ActiveUsersChartCard range={range} />
+          </Suspense>
+        </div>
+        <div className="lg:col-span-4">
+          <Suspense fallback={<ChartCardSkeleton />}>
+            <RetentionHeatmapCard />
+          </Suspense>
+        </div>
+      </div>
     </section>
   )
 }

--- a/apps/admin/app/(authed)/analytics/page.tsx
+++ b/apps/admin/app/(authed)/analytics/page.tsx
@@ -3,7 +3,7 @@ import { ActiveUsersChartCard } from "@/components/analytics/ActiveUsersChartCar
 import { ChartCardSkeleton } from "@/components/analytics/ChartCardSkeleton"
 import { KpiStrip } from "@/components/analytics/KpiStrip"
 import { KpiStripSkeleton } from "@/components/analytics/KpiStripSkeleton"
-import { RetentionHeatmapCard } from "@/components/analytics/RetentionHeatmap"
+import { RetentionHeatmapCard } from "@/components/analytics/RetentionHeatmapCard"
 import { TimeRangeTabs } from "@/components/analytics/TimeRangeTabs"
 import { isTimeRange, type TimeRange } from "@/lib/analytics/types"
 

--- a/apps/admin/app/(authed)/playground/analytics/page.tsx
+++ b/apps/admin/app/(authed)/playground/analytics/page.tsx
@@ -1,5 +1,6 @@
 import { ActiveUsersChart } from "@/components/analytics/ActiveUsersChart"
 import { KpiCard } from "@/components/analytics/KpiCard"
+import { RetentionHeatmap } from "@/components/analytics/RetentionHeatmap"
 import { Sparkline } from "@/components/analytics/Sparkline"
 import {
   denseFixture,
@@ -7,6 +8,10 @@ import {
   sparseFixture,
 } from "@/components/analytics/__fixtures__/activeUsers"
 import { kpiFixture } from "@/components/analytics/__fixtures__/kpi"
+import {
+  denseRetentionFixture,
+  emptyRetentionFixture,
+} from "@/components/analytics/__fixtures__/retentionCohorts"
 
 export default function AnalyticsPlaygroundPage() {
   const sparkValues = kpiFixture.map((r) => r.dau ?? 0)
@@ -82,6 +87,24 @@ export default function AnalyticsPlaygroundPage() {
           ActiveUsersChart — empty
         </h2>
         <ActiveUsersChart data={emptyFixture} />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          RetentionHeatmap — 8 cohorts, varying retention
+        </h2>
+        <div className="max-w-md">
+          <RetentionHeatmap rows={denseRetentionFixture} />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          RetentionHeatmap — empty
+        </h2>
+        <div className="max-w-md">
+          <RetentionHeatmap rows={emptyRetentionFixture} />
+        </div>
       </section>
     </div>
   )

--- a/apps/admin/components/analytics/RetentionHeatmap.tsx
+++ b/apps/admin/components/analytics/RetentionHeatmap.tsx
@@ -1,0 +1,194 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getRetentionCohorts } from "@/lib/analytics/fetchers"
+import type { RetentionCohortRow } from "@/lib/analytics/types"
+import { ErrorBlock } from "./ErrorBlock"
+
+export async function RetentionHeatmapCard() {
+  let rows: RetentionCohortRow[]
+  try {
+    rows = await getRetentionCohorts()
+  } catch (err) {
+    return (
+      <ErrorBlock
+        label="Failed to load retention cohorts"
+        message={err instanceof Error ? err.message : String(err)}
+      />
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Retention by signup cohort</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <RetentionHeatmap rows={rows} />
+      </CardContent>
+    </Card>
+  )
+}
+
+type RetentionHeatmapProps = {
+  rows: RetentionCohortRow[]
+}
+
+// 8 buckets, 10% steps, light → stone. Listed as full class strings so
+// Tailwind doesn't tree-shake them.
+const BUCKET_CLASSES = [
+  "bg-stone-50 text-stone-700",
+  "bg-stone-100 text-stone-700",
+  "bg-stone-200 text-stone-800",
+  "bg-stone-300 text-stone-900",
+  "bg-stone-400 text-stone-50",
+  "bg-stone-500 text-stone-50",
+  "bg-stone-600 text-stone-50",
+  "bg-stone-700 text-stone-50",
+] as const
+
+function bucketClass(pct: number): string {
+  // pct in [0, 100]. Bucket 0 = [0, 10), …, bucket 7 = [70, 100].
+  const idx = Math.min(7, Math.max(0, Math.floor(pct / 10)))
+  return BUCKET_CLASSES[idx]
+}
+
+function formatCohortLabel(isoDate: string): string {
+  // isoDate is the Monday of the cohort week (UTC). Show as "MMM D".
+  const d = new Date(`${isoDate}T00:00:00Z`)
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  })
+}
+
+export function RetentionHeatmap({ rows }: RetentionHeatmapProps) {
+  // Drop rows missing the keys we need to render.
+  const valid = rows.filter(
+    (r): r is RetentionCohortRow & {
+      cohort_week: string
+      week_offset: number
+      cohort_size: number
+      retention_pct: number
+    } =>
+      r.cohort_week !== null &&
+      r.week_offset !== null &&
+      r.cohort_size !== null &&
+      r.retention_pct !== null,
+  )
+
+  if (valid.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No cohorts yet. The heatmap appears once users start signing up.
+      </p>
+    )
+  }
+
+  // Cohort weeks: oldest on top → ascending sort.
+  const cohortWeeks = Array.from(new Set(valid.map((r) => r.cohort_week))).sort()
+  const maxOffset = valid.reduce((m, r) => Math.max(m, r.week_offset), 0)
+  const offsets = Array.from({ length: maxOffset + 1 }, (_, i) => i)
+
+  // Index cells by cohort_week + week_offset.
+  const cellByKey = new Map<
+    string,
+    { retention_pct: number; cohort_size: number; active_users: number | null }
+  >()
+  const sizeByCohort = new Map<string, number>()
+  for (const r of valid) {
+    cellByKey.set(`${r.cohort_week}|${r.week_offset}`, {
+      retention_pct: r.retention_pct,
+      cohort_size: r.cohort_size,
+      active_users: r.active_users,
+    })
+    sizeByCohort.set(r.cohort_week, r.cohort_size)
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="overflow-x-auto">
+        <table className="w-full border-separate border-spacing-1 text-xs">
+          <thead>
+            <tr>
+              <th className="sticky left-0 bg-card text-left font-medium text-muted-foreground">
+                Cohort
+              </th>
+              <th className="text-right font-medium text-muted-foreground">Size</th>
+              {offsets.map((w) => (
+                <th
+                  key={w}
+                  className="text-center font-medium text-muted-foreground"
+                  scope="col"
+                >
+                  W{w}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {cohortWeeks.map((week) => {
+              const size = sizeByCohort.get(week) ?? 0
+              return (
+                <tr key={week}>
+                  <th
+                    scope="row"
+                    className="sticky left-0 whitespace-nowrap bg-card pr-2 text-left font-medium text-muted-foreground"
+                  >
+                    {formatCohortLabel(week)}
+                  </th>
+                  <td className="pr-2 text-right tabular-nums text-muted-foreground">
+                    {size}
+                  </td>
+                  {offsets.map((w) => {
+                    const cell = cellByKey.get(`${week}|${w}`)
+                    if (!cell) {
+                      return (
+                        <td
+                          key={w}
+                          className="rounded-sm bg-muted/30"
+                          aria-label={`Cohort ${formatCohortLabel(week)}, week ${w}: no data`}
+                        />
+                      )
+                    }
+                    const pct = cell.retention_pct
+                    const display = Math.round(pct)
+                    return (
+                      <td
+                        key={w}
+                        className={`rounded-sm text-center tabular-nums ${bucketClass(pct)}`}
+                        title={`${formatCohortLabel(week)} · W${w}: ${pct}% (${cell.active_users ?? 0}/${cell.cohort_size})`}
+                      >
+                        <div className="flex h-7 w-9 items-center justify-center">
+                          {display}
+                        </div>
+                      </td>
+                    )
+                  })}
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <Legend />
+    </div>
+  )
+}
+
+function Legend() {
+  return (
+    <div
+      className="flex items-center gap-2 text-xs text-muted-foreground"
+      aria-hidden
+    >
+      <span>0%</span>
+      <div className="flex">
+        {BUCKET_CLASSES.map((cls, i) => (
+          <span key={i} className={`h-3 w-4 ${cls.split(" ")[0]}`} />
+        ))}
+      </div>
+      <span>70%+</span>
+    </div>
+  )
+}

--- a/apps/admin/components/analytics/RetentionHeatmap.tsx
+++ b/apps/admin/components/analytics/RetentionHeatmap.tsx
@@ -1,32 +1,4 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { getRetentionCohorts } from "@/lib/analytics/fetchers"
 import type { RetentionCohortRow } from "@/lib/analytics/types"
-import { ErrorBlock } from "./ErrorBlock"
-
-export async function RetentionHeatmapCard() {
-  let rows: RetentionCohortRow[]
-  try {
-    rows = await getRetentionCohorts()
-  } catch (err) {
-    return (
-      <ErrorBlock
-        label="Failed to load retention cohorts"
-        message={err instanceof Error ? err.message : String(err)}
-      />
-    )
-  }
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Retention by signup cohort</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <RetentionHeatmap rows={rows} />
-      </CardContent>
-    </Card>
-  )
-}
 
 type RetentionHeatmapProps = {
   rows: RetentionCohortRow[]

--- a/apps/admin/components/analytics/RetentionHeatmapCard.tsx
+++ b/apps/admin/components/analytics/RetentionHeatmapCard.tsx
@@ -1,0 +1,30 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getRetentionCohorts } from "@/lib/analytics/fetchers"
+import type { RetentionCohortRow } from "@/lib/analytics/types"
+import { ErrorBlock } from "./ErrorBlock"
+import { RetentionHeatmap } from "./RetentionHeatmap"
+
+export async function RetentionHeatmapCard() {
+  let rows: RetentionCohortRow[]
+  try {
+    rows = await getRetentionCohorts()
+  } catch (err) {
+    return (
+      <ErrorBlock
+        label="Failed to load retention cohorts"
+        message={err instanceof Error ? err.message : String(err)}
+      />
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Retention by signup cohort</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <RetentionHeatmap rows={rows} />
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/admin/components/analytics/__fixtures__/retentionCohorts.ts
+++ b/apps/admin/components/analytics/__fixtures__/retentionCohorts.ts
@@ -1,0 +1,44 @@
+import type { RetentionCohortRow } from "@/lib/analytics/types"
+
+const TODAY = new Date()
+
+function mondayUtc(daysAgo: number): string {
+  const d = new Date(TODAY)
+  d.setUTCDate(d.getUTCDate() - daysAgo)
+  // Snap to Monday (UTC). getUTCDay(): 0 = Sun, 1 = Mon, …
+  const dow = d.getUTCDay()
+  const offsetToMonday = (dow + 6) % 7
+  d.setUTCDate(d.getUTCDate() - offsetToMonday)
+  return d.toISOString().slice(0, 10)
+}
+
+/** 8 cohorts (oldest → newest), with retention curves that fade over weeks. */
+export const denseRetentionFixture: RetentionCohortRow[] = (() => {
+  const rows: RetentionCohortRow[] = []
+  const cohortCount = 8
+  // Cohort sizes: oldest were smaller, recent ones larger.
+  const sizes = [12, 18, 22, 27, 31, 38, 44, 51]
+
+  for (let c = 0; c < cohortCount; c++) {
+    const ageWeeks = cohortCount - 1 - c // 7, 6, …, 0
+    const cohort_week = mondayUtc(ageWeeks * 7 + 7)
+    const size = sizes[c]
+    const maxOffset = ageWeeks
+    for (let w = 0; w <= maxOffset; w++) {
+      // Retention decays: ~100, 60, 45, 35, 28, 23, 19, 16
+      const decayed = w === 0 ? 100 : Math.round(100 * Math.exp(-0.45 * w) + (c % 3) * 2)
+      const pct = Math.max(0, Math.min(100, decayed))
+      const active = Math.round((pct / 100) * size)
+      rows.push({
+        cohort_week,
+        week_offset: w,
+        cohort_size: size,
+        active_users: active,
+        retention_pct: pct,
+      })
+    }
+  }
+  return rows
+})()
+
+export const emptyRetentionFixture: RetentionCohortRow[] = []

--- a/apps/admin/lib/analytics/fetchers.ts
+++ b/apps/admin/lib/analytics/fetchers.ts
@@ -55,7 +55,10 @@ export async function getRetentionCohorts(): Promise<RetentionCohortRow[]> {
   const { data, error } = await supabase.rpc("get_retention_cohorts")
   if (error) {
     console.error("[analytics] getRetentionCohorts failed:", error.message)
-    throw error
+    // PostgrestError isn't an Error subclass; rewrap so consumers (e.g.
+    // ErrorBlock with `err instanceof Error ? err.message : String(err)`)
+    // get a readable string instead of "[object Object]".
+    throw new Error(error.message)
   }
   return data ?? []
 }

--- a/apps/admin/lib/analytics/fetchers.ts
+++ b/apps/admin/lib/analytics/fetchers.ts
@@ -1,6 +1,11 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server"
 import { dateRangeFor } from "./date"
-import type { ActiveUsersDailyRow, KpiDailyRow, TimeRange } from "./types"
+import type {
+  ActiveUsersDailyRow,
+  KpiDailyRow,
+  RetentionCohortRow,
+  TimeRange,
+} from "./types"
 
 /**
  * Fetch the rows needed by the KPI strip:
@@ -36,6 +41,20 @@ export async function getActiveUsersSeries(
   })
   if (error) {
     console.error("[analytics] getActiveUsersSeries failed:", error.message)
+    throw error
+  }
+  return data ?? []
+}
+
+/**
+ * Last 8 weekly signup cohorts and their per-week retention percentages.
+ * The RPC enforces `is_admin(auth.uid())`.
+ */
+export async function getRetentionCohorts(): Promise<RetentionCohortRow[]> {
+  const supabase = await createServerSupabaseClient()
+  const { data, error } = await supabase.rpc("get_retention_cohorts")
+  if (error) {
+    console.error("[analytics] getRetentionCohorts failed:", error.message)
     throw error
   }
   return data ?? []

--- a/apps/admin/lib/analytics/types.ts
+++ b/apps/admin/lib/analytics/types.ts
@@ -29,6 +29,17 @@ export interface ActiveUsersDailyRow {
   mau: number | null
 }
 
+export interface RetentionCohortRow {
+  /** Monday of the cohort signup week (UTC), ISO date string. */
+  cohort_week: IsoDate | null
+  /** Weeks since signup (0 = signup week). */
+  week_offset: number | null
+  cohort_size: number | null
+  active_users: number | null
+  /** 0–100 retention percent for this (cohort, week_offset) cell. */
+  retention_pct: number | null
+}
+
 export type TimeRange = "7d" | "30d" | "90d" | "1y" | "all"
 
 export type ActivityMetric = "dau" | "wau" | "mau" | "all"

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -1118,7 +1118,7 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Admin · Analytics",
-      "description": "Back-office analytics page (admin-only). Thin slice (PR #337): KPI strip (Total users, DAU, WAU, MAU, Pebbles/day, DAU/MAU) + Active users line chart with DAU/WAU/MAU toggle. Global time-range tabs (7d/30d/90d/1y/All) URL-driven via ?range=. Six other buildable surfaces (retention, volume, enrichment, per-user, domain share, visibility, single-emotion share) follow on the same milestone (M28).",
+      "description": "Back-office analytics page (admin-only). Thin slice (PR #337): KPI strip (Total users, DAU, WAU, MAU, Pebbles/day, DAU/MAU) + Active users line chart with DAU/WAU/MAU toggle. Global time-range tabs (7d/30d/90d/1y/All) URL-driven via ?range=. Layout extension (#339): Active users chart shrinks to 8/12 and a Retention cohort heatmap (last 8 weekly signup cohorts) fills 4/12. Five other buildable surfaces (volume, enrichment, per-user, domain share, visibility, single-emotion share) follow on the same milestone (M28).",
       "status": "development",
       "platforms": ["web"]
     },
@@ -1155,6 +1155,24 @@
       "species": "api-endpoint",
       "title": "get_active_users_series",
       "description": "SECURITY DEFINER plpgsql RPC, gated on is_admin(auth.uid()). Takes p_start and p_end dates. Returns rows from v_analytics_active_users_daily in [p_start, p_end] ordered ascending. Raises insufficient_privilege (42501) for non-admins.",
+      "status": "development",
+      "platforms": ["web"]
+    },
+    {
+      "id": "DM-v-analytics-retention-cohorts-weekly",
+      "project_id": "pebbles",
+      "species": "data-model",
+      "title": "v_analytics_retention_cohorts_weekly",
+      "description": "Postgres view: one row per (cohort_week, week_offset). Cohort = users grouped by signup week (Mon–Sun, UTC) from auth.users.created_at. Columns: cohort_week, week_offset, cohort_size, active_users, retention_pct. retention_pct = % of cohort users who created >=1 pebble in that week_offset.",
+      "status": "development",
+      "platforms": ["web"]
+    },
+    {
+      "id": "API-get-retention-cohorts",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "get_retention_cohorts",
+      "description": "SECURITY DEFINER plpgsql RPC, gated on is_admin(auth.uid()). No arguments. Returns rows from v_analytics_retention_cohorts_weekly for the last 8 cohorts (most recent signup weeks). Raises insufficient_privilege (42501) for non-admins.",
       "status": "development",
       "platforms": ["web"]
     }
@@ -1364,6 +1382,11 @@
     { "id": "e-API-get-kpi-daily-DM-pebble", "project_id": "pebbles", "source_id": "API-get-kpi-daily", "target_id": "DM-pebble", "edge_type": "queries" },
     { "id": "e-API-get-kpi-daily-DM-account", "project_id": "pebbles", "source_id": "API-get-kpi-daily", "target_id": "DM-account", "edge_type": "queries" },
     { "id": "e-API-get-active-users-series-DM-v-analytics-active-users-daily", "project_id": "pebbles", "source_id": "API-get-active-users-series", "target_id": "DM-v-analytics-active-users-daily", "edge_type": "queries" },
-    { "id": "e-API-get-active-users-series-DM-pebble", "project_id": "pebbles", "source_id": "API-get-active-users-series", "target_id": "DM-pebble", "edge_type": "queries" }
+    { "id": "e-API-get-active-users-series-DM-pebble", "project_id": "pebbles", "source_id": "API-get-active-users-series", "target_id": "DM-pebble", "edge_type": "queries" },
+    { "id": "e-V-admin-analytics-API-get-retention-cohorts", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "API-get-retention-cohorts", "edge_type": "calls" },
+    { "id": "e-V-admin-analytics-DM-v-analytics-retention-cohorts-weekly", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "DM-v-analytics-retention-cohorts-weekly", "edge_type": "displays" },
+    { "id": "e-API-get-retention-cohorts-DM-v-analytics-retention-cohorts-weekly", "project_id": "pebbles", "source_id": "API-get-retention-cohorts", "target_id": "DM-v-analytics-retention-cohorts-weekly", "edge_type": "queries" },
+    { "id": "e-API-get-retention-cohorts-DM-pebble", "project_id": "pebbles", "source_id": "API-get-retention-cohorts", "target_id": "DM-pebble", "edge_type": "queries" },
+    { "id": "e-API-get-retention-cohorts-DM-account", "project_id": "pebbles", "source_id": "API-get-retention-cohorts", "target_id": "DM-account", "edge_type": "queries" }
   ]
 }

--- a/packages/supabase/supabase/migrations/20260501000000_analytics_retention_cohorts.sql
+++ b/packages/supabase/supabase/migrations/20260501000000_analytics_retention_cohorts.sql
@@ -1,0 +1,86 @@
+-- =============================================================================
+-- Admin · Analytics · Retention cohort heatmap
+-- =============================================================================
+-- Builds on 20260430000000_analytics_thin_slice.sql.
+--
+-- Cohort = users grouped by signup week (Mon–Sun, UTC) from auth.users.
+-- Cell [cohort, week_offset] = % of cohort users who created >=1 pebble in
+-- the week N weeks after their signup week. week_offset = 0 is the signup week
+-- itself (always 100% by definition for any cohort that has activity).
+--
+-- The view is a plain view (volume is small at this stage). Access goes through
+-- get_retention_cohorts() which gates on is_admin(auth.uid()) and returns
+-- the last 8 cohorts.
+-- =============================================================================
+
+drop view if exists public.v_analytics_retention_cohorts_weekly;
+
+create view public.v_analytics_retention_cohorts_weekly as
+with cohorts as (
+  select
+    date_trunc('week', u.created_at)::date as cohort_week,
+    u.id                                   as user_id
+  from auth.users u
+),
+cohort_size as (
+  select cohort_week, count(*)::int as size
+  from cohorts
+  group by cohort_week
+),
+activity as (
+  select
+    c.cohort_week,
+    floor(
+      extract(epoch from (date_trunc('week', p.created_at) - c.cohort_week)) / 604800
+    )::int as week_offset,
+    c.user_id
+  from cohorts c
+  join public.pebbles p
+    on p.user_id = c.user_id
+   and p.created_at >= c.cohort_week
+)
+select
+  a.cohort_week,
+  a.week_offset,
+  cs.size                                                                       as cohort_size,
+  count(distinct a.user_id)::int                                                as active_users,
+  round((count(distinct a.user_id)::numeric / cs.size) * 100, 1)                as retention_pct
+from activity a
+join cohort_size cs using (cohort_week)
+group by a.cohort_week, a.week_offset, cs.size;
+
+-- -----------------------------------------------------------------------------
+-- get_retention_cohorts()
+-- Returns last 8 cohorts (most recent signup weeks) with all their week_offset
+-- rows. Ordering left to the caller.
+-- -----------------------------------------------------------------------------
+create or replace function public.get_retention_cohorts()
+returns setof public.v_analytics_retention_cohorts_weekly
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'insufficient_privilege' using errcode = '42501';
+  end if;
+
+  return query
+    with last_cohorts as (
+      select distinct cohort_week
+      from public.v_analytics_retention_cohorts_weekly
+      order by cohort_week desc
+      limit 8
+    )
+    select v.*
+    from public.v_analytics_retention_cohorts_weekly v
+    join last_cohorts lc using (cohort_week);
+end;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- Permissions: lock the view, expose the RPC.
+-- -----------------------------------------------------------------------------
+revoke all on public.v_analytics_retention_cohorts_weekly from public, anon, authenticated;
+
+grant execute on function public.get_retention_cohorts() to authenticated;

--- a/packages/supabase/supabase/migrations/20260501000000_analytics_retention_cohorts.sql
+++ b/packages/supabase/supabase/migrations/20260501000000_analytics_retention_cohorts.sql
@@ -6,7 +6,12 @@
 -- Cohort = users grouped by signup week (Mon–Sun, UTC) from auth.users.
 -- Cell [cohort, week_offset] = % of cohort users who created >=1 pebble in
 -- the week N weeks after their signup week. week_offset = 0 is the signup week
--- itself (always 100% by definition for any cohort that has activity).
+-- itself and is fixed at 100% by definition (every cohort member is "active"
+-- in their own signup week, regardless of pebble activity).
+--
+-- The view emits the full (cohort_week × week_offset) grid via generate_series,
+-- so cohorts with zero pebble activity still surface (filled with 0%) and
+-- weeks with no actives render as 0% (not "no data").
 --
 -- The view is a plain view (volume is small at this stage). Access goes through
 -- get_retention_cohorts() which gates on is_admin(auth.uid()) and returns
@@ -16,43 +21,61 @@
 drop view if exists public.v_analytics_retention_cohorts_weekly;
 
 create view public.v_analytics_retention_cohorts_weekly as
-with cohorts as (
+with users_with_cohort as (
   select
-    date_trunc('week', u.created_at)::date as cohort_week,
-    u.id                                   as user_id
+    u.id                                       as user_id,
+    date_trunc('week', u.created_at)::date     as cohort_week
   from auth.users u
 ),
 cohort_size as (
   select cohort_week, count(*)::int as size
-  from cohorts
+  from users_with_cohort
   group by cohort_week
+),
+-- Full (cohort_week × week_offset) grid: every cohort gets a row for every
+-- week from 0 up to the current week, including cohorts with no pebbles.
+grid as (
+  select
+    cs.cohort_week,
+    cs.size                                                                 as cohort_size,
+    gs::int                                                                 as week_offset
+  from cohort_size cs
+  cross join lateral generate_series(
+    0,
+    greatest(0, ((date_trunc('week', current_date)::date - cs.cohort_week) / 7)::int)
+  ) as gs
 ),
 activity as (
   select
-    c.cohort_week,
-    floor(
-      extract(epoch from (date_trunc('week', p.created_at) - c.cohort_week)) / 604800
-    )::int as week_offset,
-    c.user_id
-  from cohorts c
-  join public.pebbles p
-    on p.user_id = c.user_id
-   and p.created_at >= c.cohort_week
+    uc.cohort_week,
+    ((date_trunc('week', p.created_at)::date - uc.cohort_week) / 7)::int    as week_offset,
+    count(distinct p.user_id)::int                                          as active_users
+  from users_with_cohort uc
+  join public.pebbles p on p.user_id = uc.user_id
+  where p.created_at >= uc.cohort_week
+  group by uc.cohort_week, week_offset
 )
 select
-  a.cohort_week,
-  a.week_offset,
-  cs.size                                                                       as cohort_size,
-  count(distinct a.user_id)::int                                                as active_users,
-  round((count(distinct a.user_id)::numeric / cs.size) * 100, 1)                as retention_pct
-from activity a
-join cohort_size cs using (cohort_week)
-group by a.cohort_week, a.week_offset, cs.size;
+  g.cohort_week,
+  g.week_offset,
+  g.cohort_size,
+  -- W0 = 100% by definition: every cohort member is "active" in their signup week.
+  case when g.week_offset = 0 then g.cohort_size
+       else coalesce(a.active_users, 0)
+  end                                                                       as active_users,
+  case
+    when g.cohort_size = 0 then 0::numeric
+    when g.week_offset = 0 then 100::numeric
+    else round((coalesce(a.active_users, 0)::numeric / g.cohort_size) * 100, 1)
+  end                                                                       as retention_pct
+from grid g
+left join activity a using (cohort_week, week_offset);
 
 -- -----------------------------------------------------------------------------
 -- get_retention_cohorts()
 -- Returns last 8 cohorts (most recent signup weeks) with all their week_offset
--- rows. Ordering left to the caller.
+-- rows. Cohorts are derived from auth.users so signup weeks with zero pebble
+-- activity still appear. Ordering left to the caller.
 -- -----------------------------------------------------------------------------
 create or replace function public.get_retention_cohorts()
 returns setof public.v_analytics_retention_cohorts_weekly
@@ -67,9 +90,10 @@ begin
 
   return query
     with last_cohorts as (
-      select distinct cohort_week
-      from public.v_analytics_retention_cohorts_weekly
-      order by cohort_week desc
+      select date_trunc('week', u.created_at)::date as cohort_week
+      from auth.users u
+      group by 1
+      order by 1 desc
       limit 8
     )
     select v.*

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -802,6 +802,16 @@ export type Database = {
         }
         Relationships: []
       }
+      v_analytics_retention_cohorts_weekly: {
+        Row: {
+          active_users: number | null
+          cohort_size: number | null
+          cohort_week: string | null
+          retention_pct: number | null
+          week_offset: number | null
+        }
+        Relationships: []
+      }
       v_bounce: {
         Row: {
           active_days: number | null
@@ -948,6 +958,22 @@ export type Database = {
         SetofOptions: {
           from: "*"
           to: "v_analytics_kpi_daily"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
+      get_retention_cohorts: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          active_users: number | null
+          cohort_size: number | null
+          cohort_week: string | null
+          retention_pct: number | null
+          week_offset: number | null
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "v_analytics_retention_cohorts_weekly"
           isOneToOne: false
           isSetofReturn: true
         }


### PR DESCRIPTION
Resolves #339.

## Summary
- Adds `v_analytics_retention_cohorts_weekly` view + `get_retention_cohorts()` RPC (SECURITY DEFINER, `is_admin(auth.uid())` gated, returns the last 8 weekly signup cohorts). Sources `auth.users` directly; no `deleted_at` filter since the project doesn't soft-delete.
- New `RetentionHeatmap` server component + `RetentionHeatmapCard` Suspense wrapper. 8-bucket stone color scale at 10% steps, oldest cohort on top, with loading / empty / error states. W0 = 100% by definition.
- `/analytics` page now lays out the Active Users chart at 8/12 and the heatmap at 4/12 on `lg+`.
- Playground fixture (8 cohorts with varying retention) + empty fixture wired into `/playground/analytics`.
- Arkaik bundle updated with the new view and RPC nodes, edges, and a refreshed analytics page description.

## Key files
- `packages/supabase/supabase/migrations/20260501000000_analytics_retention_cohorts.sql`
- `packages/supabase/types/database.ts` (added view + RPC entries by hand; Supabase CLI not available in this environment)
- `apps/admin/lib/analytics/types.ts`, `apps/admin/lib/analytics/fetchers.ts`
- `apps/admin/components/analytics/RetentionHeatmap.tsx`
- `apps/admin/components/analytics/__fixtures__/retentionCohorts.ts`
- `apps/admin/app/(authed)/analytics/page.tsx`
- `apps/admin/app/(authed)/playground/analytics/page.tsx`
- `docs/arkaik/bundle.json`

## Implementation notes
- Cohort = users grouped by signup week (`date_trunc('week', created_at)`, Mon–Sun UTC). Cell `[cohort, week_offset]` = % of cohort users who created ≥1 pebble in that offset week.
- View is plain (non-materialized); volume doesn't warrant an MV today.
- View is `revoke`d from `public, anon, authenticated`; access is via the RPC only.
- `database.ts` types updated by hand because the local Supabase CLI is unavailable in this env. Should be regenerated via `npm run db:types --workspace=packages/supabase` next time the local stack is running.

## Test plan
- [ ] `npm run lint --workspace=apps/admin` (green locally)
- [ ] `npm run build --workspace=apps/admin` (green locally)
- [ ] `npm run build --workspace=packages/supabase` (`tsc --noEmit`, green locally)
- [ ] On staging: visit `/analytics` as admin, confirm heatmap renders with non-zero cells beside the active-users chart at 8+4 layout
- [ ] Visit `/playground/analytics`, confirm `RetentionHeatmap — 8 cohorts` and `RetentionHeatmap — empty` render
- [ ] Confirm non-admins get `insufficient_privilege` from the RPC


---
_Generated by [Claude Code](https://claude.ai/code/session_01SugkjKtFwBzYyhYS2rh2pE)_