### PR TITLE
feat(core): admin analytics pebble volume + enrichment

### DIFF
--- a/apps/admin/app/(authed)/analytics/page.tsx
+++ b/apps/admin/app/(authed)/analytics/page.tsx
@@ -48,7 +48,7 @@ export default async function AnalyticsPage({
         </div>
         <div className="lg:col-span-4">
           <Suspense fallback={<ChartCardSkeleton />}>
-            <PebbleEnrichmentCard />
+            <PebbleEnrichmentCard range={range} />
           </Suspense>
         </div>
       </div>

--- a/apps/admin/app/(authed)/analytics/page.tsx
+++ b/apps/admin/app/(authed)/analytics/page.tsx
@@ -3,6 +3,8 @@ import { ActiveUsersChartCard } from "@/components/analytics/ActiveUsersChartCar
 import { ChartCardSkeleton } from "@/components/analytics/ChartCardSkeleton"
 import { KpiStrip } from "@/components/analytics/KpiStrip"
 import { KpiStripSkeleton } from "@/components/analytics/KpiStripSkeleton"
+import { PebbleEnrichmentCard } from "@/components/analytics/PebbleEnrichmentCard"
+import { PebbleVolumeChartCard } from "@/components/analytics/PebbleVolumeChartCard"
 import { RetentionHeatmapCard } from "@/components/analytics/RetentionHeatmapCard"
 import { TimeRangeTabs } from "@/components/analytics/TimeRangeTabs"
 import { isTimeRange, type TimeRange } from "@/lib/analytics/types"
@@ -37,6 +39,16 @@ export default async function AnalyticsPage({
         <div className="lg:col-span-4">
           <Suspense fallback={<ChartCardSkeleton />}>
             <RetentionHeatmapCard />
+          </Suspense>
+        </div>
+        <div className="lg:col-span-8">
+          <Suspense fallback={<ChartCardSkeleton />}>
+            <PebbleVolumeChartCard range={range} />
+          </Suspense>
+        </div>
+        <div className="lg:col-span-4">
+          <Suspense fallback={<ChartCardSkeleton />}>
+            <PebbleEnrichmentCard />
           </Suspense>
         </div>
       </div>

--- a/apps/admin/app/(authed)/playground/analytics/page.tsx
+++ b/apps/admin/app/(authed)/playground/analytics/page.tsx
@@ -1,5 +1,7 @@
 import { ActiveUsersChart } from "@/components/analytics/ActiveUsersChart"
 import { KpiCard } from "@/components/analytics/KpiCard"
+import { PebbleEnrichment } from "@/components/analytics/PebbleEnrichment"
+import { PebbleVolumeChart } from "@/components/analytics/PebbleVolumeChart"
 import { RetentionHeatmap } from "@/components/analytics/RetentionHeatmap"
 import { Sparkline } from "@/components/analytics/Sparkline"
 import {
@@ -8,6 +10,16 @@ import {
   sparseFixture,
 } from "@/components/analytics/__fixtures__/activeUsers"
 import { kpiFixture } from "@/components/analytics/__fixtures__/kpi"
+import {
+  denseEnrichmentFixture,
+  emptyEnrichmentFixture,
+  sparseEnrichmentFixture,
+} from "@/components/analytics/__fixtures__/pebbleEnrichment"
+import {
+  denseVolumeFixture,
+  emptyVolumeFixture,
+  sparseVolumeFixture,
+} from "@/components/analytics/__fixtures__/pebbleVolume"
 import {
   denseRetentionFixture,
   emptyRetentionFixture,
@@ -104,6 +116,54 @@ export default function AnalyticsPlaygroundPage() {
         </h2>
         <div className="max-w-md">
           <RetentionHeatmap rows={emptyRetentionFixture} />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          PebbleVolumeChart — dense (90 days)
+        </h2>
+        <PebbleVolumeChart data={denseVolumeFixture} />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          PebbleVolumeChart — sparse (12 days)
+        </h2>
+        <PebbleVolumeChart data={sparseVolumeFixture} />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          PebbleVolumeChart — empty
+        </h2>
+        <PebbleVolumeChart data={emptyVolumeFixture} />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          PebbleEnrichment — dense
+        </h2>
+        <div className="max-w-sm">
+          <PebbleEnrichment row={denseEnrichmentFixture} />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          PebbleEnrichment — sparse
+        </h2>
+        <div className="max-w-sm">
+          <PebbleEnrichment row={sparseEnrichmentFixture} />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          PebbleEnrichment — empty
+        </h2>
+        <div className="max-w-sm">
+          <PebbleEnrichment row={emptyEnrichmentFixture} />
         </div>
       </section>
     </div>

--- a/apps/admin/components/analytics/PebbleEnrichment.tsx
+++ b/apps/admin/components/analytics/PebbleEnrichment.tsx
@@ -2,6 +2,7 @@ import type { PebbleEnrichmentRow } from "@/lib/analytics/types"
 
 type PebbleEnrichmentProps = {
   row: PebbleEnrichmentRow | null
+  rangeLabel?: string
 }
 
 type Donut = {
@@ -105,11 +106,11 @@ function RatioRow({ ratio }: { ratio: Ratio }) {
   )
 }
 
-export function PebbleEnrichment({ row }: PebbleEnrichmentProps) {
+export function PebbleEnrichment({ row, rangeLabel }: PebbleEnrichmentProps) {
   if (!row || row.total_pebbles === null || row.total_pebbles === 0) {
     return (
       <p className="text-sm text-muted-foreground">
-        No pebbles yet — enrichment metrics appear once users start collecting.
+        No pebbles {rangeLabel ? `in the last ${rangeLabel.toLowerCase()}` : "yet"} — enrichment metrics appear once users start collecting.
       </p>
     )
   }
@@ -148,7 +149,8 @@ export function PebbleEnrichment({ row }: PebbleEnrichmentProps) {
 
       <p className="text-xs text-muted-foreground">
         Based on {row.total_pebbles.toLocaleString()} pebble
-        {row.total_pebbles === 1 ? "" : "s"} on {row.bucket_date ?? "—"}.
+        {row.total_pebbles === 1 ? "" : "s"}
+        {rangeLabel ? ` in the last ${rangeLabel.toLowerCase()}` : ""}.
       </p>
     </div>
   )

--- a/apps/admin/components/analytics/PebbleEnrichment.tsx
+++ b/apps/admin/components/analytics/PebbleEnrichment.tsx
@@ -1,0 +1,155 @@
+import type { PebbleEnrichmentRow } from "@/lib/analytics/types"
+
+type PebbleEnrichmentProps = {
+  row: PebbleEnrichmentRow | null
+}
+
+type Donut = {
+  label: string
+  pct: number | null
+}
+
+type Ratio = {
+  label: string
+  pct: number | null
+  hint?: string
+}
+
+const DONUT_SIZE = 80
+const DONUT_STROKE = 10
+
+function DonutSvg({ pct, label }: { pct: number; label: string }) {
+  // Centered donut with stroke-dasharray to draw the filled arc.
+  const radius = (DONUT_SIZE - DONUT_STROKE) / 2
+  const circumference = 2 * Math.PI * radius
+  const filled = (Math.max(0, Math.min(100, pct)) / 100) * circumference
+  const remaining = circumference - filled
+
+  return (
+    <svg
+      width={DONUT_SIZE}
+      height={DONUT_SIZE}
+      viewBox={`0 0 ${DONUT_SIZE} ${DONUT_SIZE}`}
+      role="img"
+      aria-label={`${label}: ${Math.round(pct)}%`}
+    >
+      <circle
+        cx={DONUT_SIZE / 2}
+        cy={DONUT_SIZE / 2}
+        r={radius}
+        fill="none"
+        stroke="var(--muted)"
+        strokeWidth={DONUT_STROKE}
+      />
+      <circle
+        cx={DONUT_SIZE / 2}
+        cy={DONUT_SIZE / 2}
+        r={radius}
+        fill="none"
+        stroke="var(--foreground)"
+        strokeWidth={DONUT_STROKE}
+        strokeDasharray={`${filled} ${remaining}`}
+        strokeDashoffset={circumference / 4}
+        strokeLinecap="round"
+        transform={`rotate(-90 ${DONUT_SIZE / 2} ${DONUT_SIZE / 2})`}
+      />
+      <text
+        x="50%"
+        y="50%"
+        textAnchor="middle"
+        dominantBaseline="central"
+        className="fill-foreground text-[14px] font-medium tabular-nums"
+      >
+        {Math.round(pct)}%
+      </text>
+    </svg>
+  )
+}
+
+function DonutTile({ donut }: { donut: Donut }) {
+  return (
+    <div className="flex flex-col items-center gap-2">
+      {donut.pct === null ? (
+        <div
+          className="flex items-center justify-center rounded-full bg-muted text-xs text-muted-foreground"
+          style={{ width: DONUT_SIZE, height: DONUT_SIZE }}
+          aria-label={`${donut.label}: no data`}
+        >
+          —
+        </div>
+      ) : (
+        <DonutSvg pct={donut.pct} label={donut.label} />
+      )}
+      <span className="text-center text-xs text-muted-foreground">
+        {donut.label}
+      </span>
+    </div>
+  )
+}
+
+function RatioRow({ ratio }: { ratio: Ratio }) {
+  return (
+    <li className="flex items-baseline justify-between gap-3 text-sm">
+      <span className="text-muted-foreground">
+        {ratio.label}
+        {ratio.hint ? (
+          <span className="ml-1 text-xs text-muted-foreground/70">
+            {ratio.hint}
+          </span>
+        ) : null}
+      </span>
+      <span className="font-medium tabular-nums">
+        {ratio.pct === null ? "—" : `${Math.round(ratio.pct)}%`}
+      </span>
+    </li>
+  )
+}
+
+export function PebbleEnrichment({ row }: PebbleEnrichmentProps) {
+  if (!row || row.total_pebbles === null || row.total_pebbles === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No pebbles yet — enrichment metrics appear once users start collecting.
+      </p>
+    )
+  }
+
+  // The original spec called for three donuts (picture / custom glyph /
+  // collection); custom glyph is dropped (no `glyphs.is_custom` — see #347)
+  // so only two donuts remain.
+  const donuts: Donut[] = [
+    { label: "With picture", pct: row.pct_with_picture },
+    { label: "In collection", pct: row.pct_in_collection },
+  ]
+
+  const ratios: Ratio[] = [
+    { label: "With thought", pct: row.pct_with_thought },
+    { label: "Linked to ≥1 soul", pct: row.pct_with_soul },
+    {
+      label: "Intensity set",
+      pct: row.pct_with_intensity,
+      hint: "(sanity check)",
+    },
+  ]
+
+  return (
+    <div className="space-y-5">
+      <div className="grid grid-cols-2 gap-3">
+        {donuts.map((d) => (
+          <DonutTile key={d.label} donut={d} />
+        ))}
+      </div>
+
+      <ul className="space-y-2 border-t pt-4">
+        {ratios.map((r) => (
+          <RatioRow key={r.label} ratio={r} />
+        ))}
+      </ul>
+
+      <p className="text-xs text-muted-foreground">
+        Based on {row.total_pebbles.toLocaleString()} pebble
+        {row.total_pebbles === 1 ? "" : "s"} on {row.bucket_date ?? "—"}.
+      </p>
+    </div>
+  )
+}

--- a/apps/admin/components/analytics/PebbleEnrichmentCard.tsx
+++ b/apps/admin/components/analytics/PebbleEnrichmentCard.tsx
@@ -1,0 +1,30 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getPebbleEnrichmentToday } from "@/lib/analytics/fetchers"
+import type { PebbleEnrichmentRow } from "@/lib/analytics/types"
+import { ErrorBlock } from "./ErrorBlock"
+import { PebbleEnrichment } from "./PebbleEnrichment"
+
+export async function PebbleEnrichmentCard() {
+  let row: PebbleEnrichmentRow | null
+  try {
+    row = await getPebbleEnrichmentToday()
+  } catch (err) {
+    return (
+      <ErrorBlock
+        label="Failed to load pebble enrichment"
+        message={err instanceof Error ? err.message : String(err)}
+      />
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Pebble enrichment</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <PebbleEnrichment row={row} />
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/admin/components/analytics/PebbleEnrichmentCard.tsx
+++ b/apps/admin/components/analytics/PebbleEnrichmentCard.tsx
@@ -1,13 +1,19 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { getPebbleEnrichmentToday } from "@/lib/analytics/fetchers"
-import type { PebbleEnrichmentRow } from "@/lib/analytics/types"
+import { getPebbleEnrichment } from "@/lib/analytics/fetchers"
+import {
+  TIME_RANGE_LABELS,
+  type PebbleEnrichmentRow,
+  type TimeRange,
+} from "@/lib/analytics/types"
 import { ErrorBlock } from "./ErrorBlock"
 import { PebbleEnrichment } from "./PebbleEnrichment"
 
-export async function PebbleEnrichmentCard() {
+type PebbleEnrichmentCardProps = { range: TimeRange }
+
+export async function PebbleEnrichmentCard({ range }: PebbleEnrichmentCardProps) {
   let row: PebbleEnrichmentRow | null
   try {
-    row = await getPebbleEnrichmentToday()
+    row = await getPebbleEnrichment(range)
   } catch (err) {
     return (
       <ErrorBlock
@@ -23,7 +29,7 @@ export async function PebbleEnrichmentCard() {
         <CardTitle>Pebble enrichment</CardTitle>
       </CardHeader>
       <CardContent>
-        <PebbleEnrichment row={row} />
+        <PebbleEnrichment row={row} rangeLabel={TIME_RANGE_LABELS[range]} />
       </CardContent>
     </Card>
   )

--- a/apps/admin/components/analytics/PebbleVolumeChart.tsx
+++ b/apps/admin/components/analytics/PebbleVolumeChart.tsx
@@ -1,0 +1,177 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Bar, CartesianGrid, ComposedChart, Line, XAxis, YAxis } from "recharts"
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart"
+import { Button } from "@/components/ui/button"
+import {
+  VOLUME_BUCKETS,
+  VOLUME_BUCKET_LABELS,
+  type VolumeBucket,
+} from "@/lib/analytics/types"
+
+/** PebbleVolumeChart receives daily rows with non-null bucket_date (filtered upstream). */
+export type PebbleVolumeChartDatum = {
+  bucket_date: string
+  pebbles: number
+  pebbles_with_picture: number
+  pebbles_in_collection: number
+}
+
+type PebbleVolumeChartProps = {
+  data: PebbleVolumeChartDatum[]
+  initialBucket?: VolumeBucket
+}
+
+const config: ChartConfig = {
+  pebbles: { label: "Pebbles", color: "var(--chart-1)" },
+  pebbles_with_picture: { label: "With picture", color: "var(--chart-2)" },
+  pebbles_in_collection: { label: "In collection", color: "var(--chart-3)" },
+}
+
+/** Truncate an ISO date string to the start of the requested bucket (UTC). */
+function bucketStart(iso: string, bucket: VolumeBucket): string {
+  const d = new Date(`${iso}T00:00:00Z`)
+  switch (bucket) {
+    case "day":
+      return iso
+    case "week": {
+      // Monday (UTC). getUTCDay(): 0 = Sun, 1 = Mon, …
+      const dow = d.getUTCDay()
+      const offset = (dow + 6) % 7
+      d.setUTCDate(d.getUTCDate() - offset)
+      return d.toISOString().slice(0, 10)
+    }
+    case "month":
+      return `${iso.slice(0, 7)}-01`
+    case "year":
+      return `${iso.slice(0, 4)}-01-01`
+  }
+}
+
+function aggregate(
+  data: PebbleVolumeChartDatum[],
+  bucket: VolumeBucket,
+): PebbleVolumeChartDatum[] {
+  if (bucket === "day") return data
+  const byKey = new Map<string, PebbleVolumeChartDatum>()
+  for (const row of data) {
+    const key = bucketStart(row.bucket_date, bucket)
+    const acc = byKey.get(key)
+    if (acc) {
+      acc.pebbles += row.pebbles
+      acc.pebbles_with_picture += row.pebbles_with_picture
+      acc.pebbles_in_collection += row.pebbles_in_collection
+    } else {
+      byKey.set(key, {
+        bucket_date: key,
+        pebbles: row.pebbles,
+        pebbles_with_picture: row.pebbles_with_picture,
+        pebbles_in_collection: row.pebbles_in_collection,
+      })
+    }
+  }
+  return Array.from(byKey.values()).sort((a, b) =>
+    a.bucket_date < b.bucket_date ? -1 : 1,
+  )
+}
+
+function formatTick(iso: string, bucket: VolumeBucket): string {
+  const d = new Date(`${iso}T00:00:00Z`)
+  if (bucket === "year") return iso.slice(0, 4)
+  if (bucket === "month") {
+    return d.toLocaleDateString("en-US", {
+      month: "short",
+      year: "2-digit",
+      timeZone: "UTC",
+    })
+  }
+  // day / week — month-day
+  return iso.slice(5)
+}
+
+export function PebbleVolumeChart({
+  data,
+  initialBucket = "day",
+}: PebbleVolumeChartProps) {
+  const [bucket, setBucket] = useState<VolumeBucket>(initialBucket)
+  const series = useMemo(() => aggregate(data, bucket), [data, bucket])
+
+  return (
+    <div>
+      <div
+        className="mb-3 flex items-center gap-1"
+        role="tablist"
+        aria-label="Bucket"
+      >
+        {VOLUME_BUCKETS.map((b) => (
+          <Button
+            key={b}
+            variant={b === bucket ? "default" : "ghost"}
+            size="sm"
+            role="tab"
+            aria-selected={b === bucket}
+            onClick={() => setBucket(b)}
+          >
+            {VOLUME_BUCKET_LABELS[b]}
+          </Button>
+        ))}
+      </div>
+
+      {series.length === 0 ? (
+        <div
+          className="flex h-72 items-center justify-center text-sm text-muted-foreground"
+          aria-live="polite"
+        >
+          No pebbles in this range
+        </div>
+      ) : (
+        <ChartContainer config={config} className="h-72 w-full">
+          <ComposedChart
+            data={series}
+            margin={{ left: 4, right: 12, top: 8, bottom: 4 }}
+          >
+            <CartesianGrid vertical={false} strokeDasharray="3 3" />
+            <XAxis
+              dataKey="bucket_date"
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              minTickGap={32}
+              tickFormatter={(v: string) => formatTick(v, bucket)}
+            />
+            <YAxis tickLine={false} axisLine={false} width={36} />
+            <ChartTooltip content={<ChartTooltipContent />} />
+            <ChartLegend content={<ChartLegendContent />} />
+            <Bar
+              dataKey="pebbles"
+              fill="var(--color-pebbles)"
+              radius={[2, 2, 0, 0]}
+            />
+            <Line
+              dataKey="pebbles_with_picture"
+              type="monotone"
+              stroke="var(--color-pebbles_with_picture)"
+              strokeWidth={2}
+              dot={false}
+            />
+            <Line
+              dataKey="pebbles_in_collection"
+              type="monotone"
+              stroke="var(--color-pebbles_in_collection)"
+              strokeWidth={2}
+              dot={false}
+            />
+          </ComposedChart>
+        </ChartContainer>
+      )}
+    </div>
+  )
+}

--- a/apps/admin/components/analytics/PebbleVolumeChartCard.tsx
+++ b/apps/admin/components/analytics/PebbleVolumeChartCard.tsx
@@ -1,0 +1,46 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getPebbleVolumeSeries } from "@/lib/analytics/fetchers"
+import type { PebbleVolumeRow, TimeRange } from "@/lib/analytics/types"
+import { ErrorBlock } from "./ErrorBlock"
+import {
+  PebbleVolumeChart,
+  type PebbleVolumeChartDatum,
+} from "./PebbleVolumeChart"
+
+type PebbleVolumeChartCardProps = { range: TimeRange }
+
+export async function PebbleVolumeChartCard({ range }: PebbleVolumeChartCardProps) {
+  let rows: PebbleVolumeRow[]
+  try {
+    // Always fetch at daily granularity; the client component aggregates for
+    // the Day/Week/Month/Year toggle.
+    rows = await getPebbleVolumeSeries(range, "day")
+  } catch (err) {
+    return (
+      <ErrorBlock
+        label="Failed to load pebble volume chart"
+        message={err instanceof Error ? err.message : String(err)}
+      />
+    )
+  }
+
+  const data: PebbleVolumeChartDatum[] = rows
+    .filter((r): r is PebbleVolumeRow & { bucket_date: string } => r.bucket_date !== null)
+    .map((r) => ({
+      bucket_date: r.bucket_date,
+      pebbles: r.pebbles ?? 0,
+      pebbles_with_picture: r.pebbles_with_picture ?? 0,
+      pebbles_in_collection: r.pebbles_in_collection ?? 0,
+    }))
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Pebbles collected</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <PebbleVolumeChart data={data} />
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/admin/components/analytics/__fixtures__/pebbleEnrichment.ts
+++ b/apps/admin/components/analytics/__fixtures__/pebbleEnrichment.ts
@@ -1,0 +1,25 @@
+import type { PebbleEnrichmentRow } from "@/lib/analytics/types"
+
+const TODAY = new Date().toISOString().slice(0, 10)
+
+export const denseEnrichmentFixture: PebbleEnrichmentRow = {
+  bucket_date: TODAY,
+  total_pebbles: 142,
+  pct_with_picture: 41,
+  pct_in_collection: 56,
+  pct_with_thought: 73,
+  pct_with_soul: 48,
+  pct_with_intensity: 100,
+}
+
+export const sparseEnrichmentFixture: PebbleEnrichmentRow = {
+  bucket_date: TODAY,
+  total_pebbles: 4,
+  pct_with_picture: 0,
+  pct_in_collection: 25,
+  pct_with_thought: 50,
+  pct_with_soul: 0,
+  pct_with_intensity: 100,
+}
+
+export const emptyEnrichmentFixture: PebbleEnrichmentRow | null = null

--- a/apps/admin/components/analytics/__fixtures__/pebbleEnrichment.ts
+++ b/apps/admin/components/analytics/__fixtures__/pebbleEnrichment.ts
@@ -1,9 +1,6 @@
 import type { PebbleEnrichmentRow } from "@/lib/analytics/types"
 
-const TODAY = new Date().toISOString().slice(0, 10)
-
 export const denseEnrichmentFixture: PebbleEnrichmentRow = {
-  bucket_date: TODAY,
   total_pebbles: 142,
   pct_with_picture: 41,
   pct_in_collection: 56,
@@ -13,7 +10,6 @@ export const denseEnrichmentFixture: PebbleEnrichmentRow = {
 }
 
 export const sparseEnrichmentFixture: PebbleEnrichmentRow = {
-  bucket_date: TODAY,
   total_pebbles: 4,
   pct_with_picture: 0,
   pct_in_collection: 25,

--- a/apps/admin/components/analytics/__fixtures__/pebbleVolume.ts
+++ b/apps/admin/components/analytics/__fixtures__/pebbleVolume.ts
@@ -1,0 +1,40 @@
+import type { PebbleVolumeChartDatum } from "../PebbleVolumeChart"
+
+const TODAY = new Date()
+function iso(daysAgo: number): string {
+  const d = new Date(TODAY)
+  d.setUTCDate(d.getUTCDate() - daysAgo)
+  return d.toISOString().slice(0, 10)
+}
+
+/** 90 days of pebble volume with picture/collection overlays. */
+export const denseVolumeFixture: PebbleVolumeChartDatum[] = Array.from(
+  { length: 90 },
+  (_, i) => {
+    const day = 89 - i
+    const pebbles = 40 + Math.round(20 * Math.sin(i / 5)) + Math.round(i / 3)
+    return {
+      bucket_date: iso(day),
+      pebbles,
+      pebbles_with_picture: Math.round(pebbles * 0.4),
+      pebbles_in_collection: Math.round(pebbles * 0.55),
+    }
+  },
+)
+
+/** Sparse week with single-digit volume to stress-test small numbers. */
+export const sparseVolumeFixture: PebbleVolumeChartDatum[] = Array.from(
+  { length: 12 },
+  (_, i) => {
+    const day = 11 - i
+    const pebbles = i % 3 === 0 ? 0 : 1 + (i % 4)
+    return {
+      bucket_date: iso(day),
+      pebbles,
+      pebbles_with_picture: Math.max(0, pebbles - 1),
+      pebbles_in_collection: Math.round(pebbles / 2),
+    }
+  },
+)
+
+export const emptyVolumeFixture: PebbleVolumeChartDatum[] = []

--- a/apps/admin/lib/analytics/fetchers.ts
+++ b/apps/admin/lib/analytics/fetchers.ts
@@ -3,8 +3,11 @@ import { dateRangeFor } from "./date"
 import type {
   ActiveUsersDailyRow,
   KpiDailyRow,
+  PebbleEnrichmentRow,
+  PebbleVolumeRow,
   RetentionCohortRow,
   TimeRange,
+  VolumeBucket,
 } from "./types"
 
 /**
@@ -44,6 +47,43 @@ export async function getActiveUsersSeries(
     throw error
   }
   return data ?? []
+}
+
+/**
+ * Pebble volume bars + overlay-line counts (`with picture`, `in collection`)
+ * for the global time range, aggregated at the requested bucket granularity.
+ * The RPC enforces `is_admin(auth.uid())`.
+ */
+export async function getPebbleVolumeSeries(
+  range: TimeRange,
+  bucket: VolumeBucket = "day",
+): Promise<PebbleVolumeRow[]> {
+  const { start, end } = dateRangeFor(range)
+  const supabase = await createServerSupabaseClient()
+  const { data, error } = await supabase.rpc("get_pebble_volume_series", {
+    p_start: start,
+    p_end: end,
+    p_bucket: bucket,
+  })
+  if (error) {
+    console.error("[analytics] getPebbleVolumeSeries failed:", error.message)
+    throw new Error(error.message)
+  }
+  return data ?? []
+}
+
+/**
+ * Latest enrichment snapshot (most recent day with ≥1 pebble). One row.
+ * The RPC enforces `is_admin(auth.uid())`.
+ */
+export async function getPebbleEnrichmentToday(): Promise<PebbleEnrichmentRow | null> {
+  const supabase = await createServerSupabaseClient()
+  const { data, error } = await supabase.rpc("get_pebble_enrichment_today")
+  if (error) {
+    console.error("[analytics] getPebbleEnrichmentToday failed:", error.message)
+    throw new Error(error.message)
+  }
+  return data?.[0] ?? null
 }
 
 /**

--- a/apps/admin/lib/analytics/fetchers.ts
+++ b/apps/admin/lib/analytics/fetchers.ts
@@ -73,14 +73,21 @@ export async function getPebbleVolumeSeries(
 }
 
 /**
- * Latest enrichment snapshot (most recent day with ≥1 pebble). One row.
+ * Enrichment shares (donuts + secondary ratios) aggregated over the global
+ * time range. Returns null when zero pebbles were created in the window.
  * The RPC enforces `is_admin(auth.uid())`.
  */
-export async function getPebbleEnrichmentToday(): Promise<PebbleEnrichmentRow | null> {
+export async function getPebbleEnrichment(
+  range: TimeRange,
+): Promise<PebbleEnrichmentRow | null> {
+  const { start, end } = dateRangeFor(range)
   const supabase = await createServerSupabaseClient()
-  const { data, error } = await supabase.rpc("get_pebble_enrichment_today")
+  const { data, error } = await supabase.rpc("get_pebble_enrichment", {
+    p_start: start,
+    p_end: end,
+  })
   if (error) {
-    console.error("[analytics] getPebbleEnrichmentToday failed:", error.message)
+    console.error("[analytics] getPebbleEnrichment failed:", error.message)
     throw new Error(error.message)
   }
   return data?.[0] ?? null

--- a/apps/admin/lib/analytics/types.ts
+++ b/apps/admin/lib/analytics/types.ts
@@ -49,7 +49,6 @@ export interface PebbleVolumeRow {
 }
 
 export interface PebbleEnrichmentRow {
-  bucket_date: IsoDate | null
   total_pebbles: number | null
   /** 0–100 percent values. Null when total_pebbles = 0. */
   pct_with_picture: number | null

--- a/apps/admin/lib/analytics/types.ts
+++ b/apps/admin/lib/analytics/types.ts
@@ -40,9 +40,39 @@ export interface RetentionCohortRow {
   retention_pct: number | null
 }
 
+export interface PebbleVolumeRow {
+  bucket_date: IsoDate | null
+  pebbles: number | null
+  pebbles_with_picture: number | null
+  pebbles_in_collection: number | null
+  active_users: number | null
+}
+
+export interface PebbleEnrichmentRow {
+  bucket_date: IsoDate | null
+  total_pebbles: number | null
+  /** 0–100 percent values. Null when total_pebbles = 0. */
+  pct_with_picture: number | null
+  pct_in_collection: number | null
+  pct_with_thought: number | null
+  pct_with_soul: number | null
+  pct_with_intensity: number | null
+}
+
 export type TimeRange = "7d" | "30d" | "90d" | "1y" | "all"
 
 export type ActivityMetric = "dau" | "wau" | "mau" | "all"
+
+export type VolumeBucket = "day" | "week" | "month" | "year"
+
+export const VOLUME_BUCKETS: readonly VolumeBucket[] = ["day", "week", "month", "year"] as const
+
+export const VOLUME_BUCKET_LABELS: Record<VolumeBucket, string> = {
+  day: "Day",
+  week: "Week",
+  month: "Month",
+  year: "Year",
+}
 
 export const TIME_RANGES: readonly TimeRange[] = ["7d", "30d", "90d", "1y", "all"] as const
 

--- a/packages/supabase/supabase/migrations/20260501000001_analytics_pebble_volume_enrichment.sql
+++ b/packages/supabase/supabase/migrations/20260501000001_analytics_pebble_volume_enrichment.sql
@@ -1,0 +1,219 @@
+-- =============================================================================
+-- Admin · Analytics · Pebble volume + enrichment
+-- =============================================================================
+-- Builds on 20260430000000_analytics_thin_slice.sql.
+--
+-- Volume bars + enrichment overlay lines (with picture / in collection) and
+-- a donut card with three primary shares + secondary ratios.
+--
+-- Schema notes (vs. the POC reference SQL):
+--   - "with picture"      derives from EXISTS in `snaps`
+--                         (pebbles.picture_url does not exist).
+--   - "in collection"     derives from EXISTS in `collection_pebbles`
+--                         (pebbles.collection_id does not exist).
+--   - `glyphs.is_custom`  does not exist — `% with custom glyph` is dropped
+--                         (tracked in #347).
+--   - `pebbles.emotion_id` is NOT NULL — `% with ≥1 emotion pearl` is always
+--                         100% and is dropped from the secondary ratios.
+--   - `pebbles.intensity` is NOT NULL (1..3) — `% with intensity` is left in
+--                         as a sanity-check metric (always 100%).
+--
+-- Soft-delete does not exist in this project, so no deleted_at filters.
+-- =============================================================================
+
+drop view if exists public.v_analytics_pebble_enrichment_daily;
+drop view if exists public.v_analytics_pebble_volume_daily;
+
+-- -----------------------------------------------------------------------------
+-- v_analytics_pebble_volume_daily
+-- One row per calendar day from the earliest pebble's created_at to today.
+-- Days without pebbles are gap-filled with zeros so bar charts render without
+-- holes.
+-- -----------------------------------------------------------------------------
+create view public.v_analytics_pebble_volume_daily as
+with days as (
+  select generate_series(
+    coalesce((select min(created_at)::date from public.pebbles), current_date),
+    current_date,
+    interval '1 day'
+  )::date as bucket_date
+),
+day_pebbles as (
+  select
+    p.created_at::date                                  as bucket_date,
+    count(*)::int                                       as pebbles,
+    count(*) filter (
+      where exists (
+        select 1 from public.snaps s where s.pebble_id = p.id
+      )
+    )::int                                              as pebbles_with_picture,
+    count(*) filter (
+      where exists (
+        select 1 from public.collection_pebbles cp where cp.pebble_id = p.id
+      )
+    )::int                                              as pebbles_in_collection,
+    count(distinct p.user_id)::int                      as active_users
+  from public.pebbles p
+  group by p.created_at::date
+)
+select
+  d.bucket_date,
+  coalesce(dp.pebbles, 0)               as pebbles,
+  coalesce(dp.pebbles_with_picture, 0)  as pebbles_with_picture,
+  coalesce(dp.pebbles_in_collection, 0) as pebbles_in_collection,
+  coalesce(dp.active_users, 0)          as active_users
+from days d
+left join day_pebbles dp using (bucket_date);
+
+-- -----------------------------------------------------------------------------
+-- v_analytics_pebble_enrichment_daily
+-- Pre-computes the share fields for the donuts + secondary ratios. Only days
+-- with at least one pebble produce a row; the get_pebble_enrichment_today RPC
+-- selects the latest row.
+-- -----------------------------------------------------------------------------
+create view public.v_analytics_pebble_enrichment_daily as
+with base as (
+  select
+    p.created_at::date                                            as bucket_date,
+    p.id,
+    p.description,
+    p.intensity,
+    exists (select 1 from public.snaps s
+              where s.pebble_id = p.id)                           as has_picture,
+    exists (select 1 from public.collection_pebbles cp
+              where cp.pebble_id = p.id)                          as in_collection,
+    exists (select 1 from public.pebble_souls ps
+              where ps.pebble_id = p.id)                          as has_soul
+  from public.pebbles p
+)
+select
+  bucket_date,
+  count(*)::int                                                                  as total_pebbles,
+  round(100.0 * count(*) filter (where has_picture)
+                / nullif(count(*), 0), 1)                                        as pct_with_picture,
+  round(100.0 * count(*) filter (where in_collection)
+                / nullif(count(*), 0), 1)                                        as pct_in_collection,
+  round(100.0 * count(*) filter (where description is not null
+                                   and length(description) > 0)
+                / nullif(count(*), 0), 1)                                        as pct_with_thought,
+  round(100.0 * count(*) filter (where has_soul)
+                / nullif(count(*), 0), 1)                                        as pct_with_soul,
+  round(100.0 * count(*) filter (where intensity is not null)
+                / nullif(count(*), 0), 1)                                        as pct_with_intensity
+from base
+group by bucket_date;
+
+-- -----------------------------------------------------------------------------
+-- get_pebble_volume_series(p_start, p_end, p_bucket)
+-- Aggregates pebble counts over [p_start, p_end] at the requested bucket
+-- granularity ('day' | 'week' | 'month' | 'year'). The series is gap-filled
+-- with zeros so the chart has a bar for every period in the range, including
+-- empty ones. Reads from public.pebbles directly so distinct-user counts
+-- remain accurate at higher buckets.
+-- -----------------------------------------------------------------------------
+create or replace function public.get_pebble_volume_series(
+  p_start  date,
+  p_end    date,
+  p_bucket text default 'day'
+)
+returns table (
+  bucket_date           date,
+  pebbles               bigint,
+  pebbles_with_picture  bigint,
+  pebbles_in_collection bigint,
+  active_users          bigint
+)
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'insufficient_privilege' using errcode = '42501';
+  end if;
+
+  if p_bucket not in ('day', 'week', 'month', 'year') then
+    raise exception 'invalid p_bucket: %, expected day|week|month|year', p_bucket
+      using errcode = '22023';
+  end if;
+
+  return query
+  with buckets as (
+    select date_trunc(p_bucket, gs)::date as bucket_date
+    from generate_series(
+      date_trunc(p_bucket, p_start::timestamptz),
+      date_trunc(p_bucket, p_end::timestamptz),
+      ('1 ' || p_bucket)::interval
+    ) as gs
+  ),
+  data as (
+    select
+      date_trunc(p_bucket, p.created_at)::date as bucket_date,
+      count(*)                                                                       as pebbles,
+      count(*) filter (
+        where exists (select 1 from public.snaps s where s.pebble_id = p.id)
+      )                                                                              as pebbles_with_picture,
+      count(*) filter (
+        where exists (
+          select 1 from public.collection_pebbles cp where cp.pebble_id = p.id
+        )
+      )                                                                              as pebbles_in_collection,
+      count(distinct p.user_id)                                                      as active_users
+    from public.pebbles p
+    where p.created_at::date between p_start and p_end
+    group by date_trunc(p_bucket, p.created_at)
+  )
+  select
+    b.bucket_date,
+    coalesce(d.pebbles, 0)::bigint                as pebbles,
+    coalesce(d.pebbles_with_picture, 0)::bigint   as pebbles_with_picture,
+    coalesce(d.pebbles_in_collection, 0)::bigint  as pebbles_in_collection,
+    coalesce(d.active_users, 0)::bigint           as active_users
+  from buckets b
+  left join data d using (bucket_date)
+  order by b.bucket_date asc;
+end;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- get_pebble_enrichment_today()
+-- Returns the latest row from v_analytics_pebble_enrichment_daily (i.e. the
+-- most recent day that had at least one pebble). Empty result if no pebbles
+-- exist yet.
+-- -----------------------------------------------------------------------------
+create or replace function public.get_pebble_enrichment_today()
+returns setof public.v_analytics_pebble_enrichment_daily
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_latest date;
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'insufficient_privilege' using errcode = '42501';
+  end if;
+
+  select max(bucket_date)
+    into v_latest
+    from public.v_analytics_pebble_enrichment_daily;
+
+  if v_latest is null then
+    return;
+  end if;
+
+  return query
+    select * from public.v_analytics_pebble_enrichment_daily
+    where bucket_date = v_latest;
+end;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- Permissions: lock the views, expose the RPCs to authenticated callers
+-- (the RPCs gate on is_admin(auth.uid())).
+-- -----------------------------------------------------------------------------
+revoke all on public.v_analytics_pebble_volume_daily     from public, anon, authenticated;
+revoke all on public.v_analytics_pebble_enrichment_daily from public, anon, authenticated;
+
+grant execute on function public.get_pebble_volume_series(date, date, text) to authenticated;
+grant execute on function public.get_pebble_enrichment_today()              to authenticated;

--- a/packages/supabase/supabase/migrations/20260501000001_analytics_pebble_volume_enrichment.sql
+++ b/packages/supabase/supabase/migrations/20260501000001_analytics_pebble_volume_enrichment.sql
@@ -176,35 +176,65 @@ end;
 $$;
 
 -- -----------------------------------------------------------------------------
--- get_pebble_enrichment_today()
--- Returns the latest row from v_analytics_pebble_enrichment_daily (i.e. the
--- most recent day that had at least one pebble). Empty result if no pebbles
--- exist yet.
+-- get_pebble_enrichment(p_start, p_end)
+-- Returns one row of share fields aggregated over [p_start, p_end]. Computed
+-- from public.pebbles directly so weighting is by absolute pebble count
+-- (averaging daily percentages would mis-weight low-volume days).
+-- Returns no rows when there are zero pebbles in the window.
 -- -----------------------------------------------------------------------------
-create or replace function public.get_pebble_enrichment_today()
-returns setof public.v_analytics_pebble_enrichment_daily
+drop function if exists public.get_pebble_enrichment_today();
+
+create or replace function public.get_pebble_enrichment(
+  p_start date,
+  p_end   date
+)
+returns table (
+  total_pebbles      bigint,
+  pct_with_picture   numeric,
+  pct_in_collection  numeric,
+  pct_with_thought   numeric,
+  pct_with_soul      numeric,
+  pct_with_intensity numeric
+)
 language plpgsql
 security definer
 set search_path = public, auth
 as $$
-declare
-  v_latest date;
 begin
   if not public.is_admin(auth.uid()) then
     raise exception 'insufficient_privilege' using errcode = '42501';
   end if;
 
-  select max(bucket_date)
-    into v_latest
-    from public.v_analytics_pebble_enrichment_daily;
-
-  if v_latest is null then
-    return;
-  end if;
-
   return query
-    select * from public.v_analytics_pebble_enrichment_daily
-    where bucket_date = v_latest;
+  with base as (
+    select
+      p.id,
+      p.description,
+      p.intensity,
+      exists (select 1 from public.snaps s
+                where s.pebble_id = p.id)             as has_picture,
+      exists (select 1 from public.collection_pebbles cp
+                where cp.pebble_id = p.id)            as in_collection,
+      exists (select 1 from public.pebble_souls ps
+                where ps.pebble_id = p.id)            as has_soul
+    from public.pebbles p
+    where p.created_at::date between p_start and p_end
+  )
+  select
+    count(*)::bigint                                                           as total_pebbles,
+    round(100.0 * count(*) filter (where has_picture)
+                  / nullif(count(*), 0), 1)                                    as pct_with_picture,
+    round(100.0 * count(*) filter (where in_collection)
+                  / nullif(count(*), 0), 1)                                    as pct_in_collection,
+    round(100.0 * count(*) filter (where description is not null
+                                     and length(description) > 0)
+                  / nullif(count(*), 0), 1)                                    as pct_with_thought,
+    round(100.0 * count(*) filter (where has_soul)
+                  / nullif(count(*), 0), 1)                                    as pct_with_soul,
+    round(100.0 * count(*) filter (where intensity is not null)
+                  / nullif(count(*), 0), 1)                                    as pct_with_intensity
+  from base
+  having count(*) > 0;
 end;
 $$;
 
@@ -216,4 +246,4 @@ revoke all on public.v_analytics_pebble_volume_daily     from public, anon, auth
 revoke all on public.v_analytics_pebble_enrichment_daily from public, anon, authenticated;
 
 grant execute on function public.get_pebble_volume_series(date, date, text) to authenticated;
-grant execute on function public.get_pebble_enrichment_today()              to authenticated;
+grant execute on function public.get_pebble_enrichment(date, date)          to authenticated;

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -802,6 +802,28 @@ export type Database = {
         }
         Relationships: []
       }
+      v_analytics_pebble_enrichment_daily: {
+        Row: {
+          bucket_date: string | null
+          pct_in_collection: number | null
+          pct_with_intensity: number | null
+          pct_with_picture: number | null
+          pct_with_soul: number | null
+          pct_with_thought: number | null
+          total_pebbles: number | null
+        }
+        Relationships: []
+      }
+      v_analytics_pebble_volume_daily: {
+        Row: {
+          active_users: number | null
+          bucket_date: string | null
+          pebbles: number | null
+          pebbles_in_collection: number | null
+          pebbles_with_picture: number | null
+        }
+        Relationships: []
+      }
       v_analytics_retention_cohorts_weekly: {
         Row: {
           active_users: number | null
@@ -961,6 +983,34 @@ export type Database = {
           isOneToOne: false
           isSetofReturn: true
         }
+      }
+      get_pebble_enrichment_today: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          bucket_date: string | null
+          pct_in_collection: number | null
+          pct_with_intensity: number | null
+          pct_with_picture: number | null
+          pct_with_soul: number | null
+          pct_with_thought: number | null
+          total_pebbles: number | null
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "v_analytics_pebble_enrichment_daily"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
+      get_pebble_volume_series: {
+        Args: { p_bucket?: string; p_end: string; p_start: string }
+        Returns: {
+          active_users: number | null
+          bucket_date: string | null
+          pebbles: number | null
+          pebbles_in_collection: number | null
+          pebbles_with_picture: number | null
+        }[]
       }
       get_retention_cohorts: {
         Args: Record<PropertyKey, never>

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -984,10 +984,9 @@ export type Database = {
           isSetofReturn: true
         }
       }
-      get_pebble_enrichment_today: {
-        Args: Record<PropertyKey, never>
+      get_pebble_enrichment: {
+        Args: { p_end: string; p_start: string }
         Returns: {
-          bucket_date: string | null
           pct_in_collection: number | null
           pct_with_intensity: number | null
           pct_with_picture: number | null
@@ -995,12 +994,6 @@ export type Database = {
           pct_with_thought: number | null
           total_pebbles: number | null
         }[]
-        SetofOptions: {
-          from: "*"
-          to: "v_analytics_pebble_enrichment_daily"
-          isOneToOne: false
-          isSetofReturn: true
-        }
       }
       get_pebble_volume_series: {
         Args: { p_bucket?: string; p_end: string; p_start: string }


### PR DESCRIPTION
Resolves #340

## Summary

Adds the volume row of `/analytics`:
- **Pebble volume bars** (8/12) — bars per Day/Week/Month/Year with two overlay lines (`with picture`, `in collection`).
- **Pebble enrichment** (4/12) — donuts + secondary ratios.

## Schema (one new migration)

`packages/supabase/supabase/migrations/20260501000001_analytics_pebble_volume_enrichment.sql`

- `v_analytics_pebble_volume_daily` — gap-filled daily counts.
- `v_analytics_pebble_enrichment_daily` — pre-computed share fields.
- `get_pebble_volume_series(p_start, p_end, p_bucket)` — `is_admin` gated, accepts `day | week | month | year`, gap-fills the requested bucket.
- `get_pebble_enrichment_today()` — `is_admin` gated, returns the latest day with ≥1 pebble.

Picture / collection presence derive from `EXISTS` in `snaps` / `collection_pebbles` (no `pebbles.picture_url` or `pebbles.collection_id` columns). Custom-glyph metric dropped (no `glyphs.is_custom`, see #347). Always-100% emotion-pearl ratio dropped. `% with intensity` retained as a sanity-check metric.

## Components

- `PebbleVolumeChartCard.tsx` (SC) + `PebbleVolumeChart.tsx` (Client, recharts `ComposedChart`, local Day/Week/Month/Year toggle that aggregates daily data client-side).
- `PebbleEnrichmentCard.tsx` (SC) + `PebbleEnrichment.tsx` (hand-rolled SVG donuts + ratios list).
- Fixtures + playground sections (dense / sparse / empty) for both.

## Notes

- Toggle is **local state** per the issue spec — SC always fetches at daily resolution and the client aggregates. RPC's `p_bucket` arg is wired but the SC always passes `day`; ready to switch to URL state if we want fewer rows over the wire for `range=all`.
- Two donuts (picture, collection) instead of three — custom-glyph slot is empty until #347.

## Test plan

- [x] `/analytics` renders both new cards on staging with non-zero data.
- [x] Day / Week / Month / Year toggle re-aggregates without a network round-trip.
- [x] Range tab change re-fetches and the bucket toggle still works after.
- [x] Loading skeletons appear via Suspense; throwing the RPC surfaces the inline `ErrorBlock`.
- [x] Donut card shows the empty state when there are no pebbles yet.
- [x] `/playground/analytics` renders dense / sparse / empty fixtures for both components.
- [x] Non-admin users get `insufficient_privilege` from the RPCs (no data leaks).

https://claude.ai/code/session_01YKDfWKbAwJbLW81T7Vrzw8

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKDfWKbAwJbLW81T7Vrzw8)_