### PR TITLE
feat(core): admin analytics emotion + domain share cards

### DIFF
--- a/apps/admin/app/(authed)/analytics/page.tsx
+++ b/apps/admin/app/(authed)/analytics/page.tsx
@@ -1,6 +1,8 @@
 import { Suspense } from "react"
 import { ActiveUsersChartCard } from "@/components/analytics/ActiveUsersChartCard"
 import { ChartCardSkeleton } from "@/components/analytics/ChartCardSkeleton"
+import { DomainShareCard } from "@/components/analytics/DomainShareCard"
+import { EmotionShareCard } from "@/components/analytics/EmotionShareCard"
 import { KpiStrip } from "@/components/analytics/KpiStrip"
 import { KpiStripSkeleton } from "@/components/analytics/KpiStripSkeleton"
 import { PebbleEnrichmentCard } from "@/components/analytics/PebbleEnrichmentCard"
@@ -57,6 +59,16 @@ export default async function AnalyticsPage({
         <div className="lg:col-span-12">
           <Suspense fallback={<ChartCardSkeleton />}>
             <UserAveragesCard />
+          </Suspense>
+        </div>
+        <div className="lg:col-span-6">
+          <Suspense fallback={<ChartCardSkeleton />}>
+            <EmotionShareCard range={range} />
+          </Suspense>
+        </div>
+        <div className="lg:col-span-6">
+          <Suspense fallback={<ChartCardSkeleton />}>
+            <DomainShareCard range={range} />
           </Suspense>
         </div>
       </div>

--- a/apps/admin/app/(authed)/playground/analytics/page.tsx
+++ b/apps/admin/app/(authed)/playground/analytics/page.tsx
@@ -1,4 +1,6 @@
 import { ActiveUsersChart } from "@/components/analytics/ActiveUsersChart"
+import { DomainShare } from "@/components/analytics/DomainShare"
+import { EmotionShare } from "@/components/analytics/EmotionShare"
 import { KpiCard } from "@/components/analytics/KpiCard"
 import { PebbleEnrichment } from "@/components/analytics/PebbleEnrichment"
 import { PebbleVolumeChart } from "@/components/analytics/PebbleVolumeChart"
@@ -30,6 +32,30 @@ import {
   emptyUserAveragesFixture,
   sparseUserAveragesFixture,
 } from "@/components/analytics/__fixtures__/userAverages"
+import {
+  denseEmotionShareCatalog,
+  denseEmotionShareSnapshot,
+  denseEmotionShareTotalPebbles,
+  denseEmotionShareWeekly,
+  emptyEmotionShareCatalog,
+  emptyEmotionShareSnapshot,
+  emptyEmotionShareTotalPebbles,
+  emptyEmotionShareWeekly,
+  sparseEmotionShareCatalog,
+  sparseEmotionShareSnapshot,
+  sparseEmotionShareTotalPebbles,
+  sparseEmotionShareWeekly,
+} from "@/components/analytics/__fixtures__/emotionShare"
+import {
+  denseDomainShareBottomMover,
+  denseDomainShareSnapshot,
+  denseDomainShareTopMover,
+  denseDomainShareTotalPebbles,
+  emptyDomainShareSnapshot,
+  emptyDomainShareTotalPebbles,
+  sparseDomainShareSnapshot,
+  sparseDomainShareTotalPebbles,
+} from "@/components/analytics/__fixtures__/domainShare"
 
 export default function AnalyticsPlaygroundPage() {
   const sparkValues = kpiFixture.map((r) => r.dau ?? 0)
@@ -192,6 +218,96 @@ export default function AnalyticsPlaygroundPage() {
           UserAverages — empty
         </h2>
         <UserAverages data={emptyUserAveragesFixture} />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          EmotionShare — dense
+        </h2>
+        <div className="max-w-xl">
+          <EmotionShare
+            snapshot={denseEmotionShareSnapshot}
+            weekly={denseEmotionShareWeekly}
+            catalog={denseEmotionShareCatalog}
+            totalPebbles={denseEmotionShareTotalPebbles}
+            rangeLabel="30 days"
+          />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          EmotionShare — sparse
+        </h2>
+        <div className="max-w-xl">
+          <EmotionShare
+            snapshot={sparseEmotionShareSnapshot}
+            weekly={sparseEmotionShareWeekly}
+            catalog={sparseEmotionShareCatalog}
+            totalPebbles={sparseEmotionShareTotalPebbles}
+            rangeLabel="30 days"
+          />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          EmotionShare — empty
+        </h2>
+        <div className="max-w-xl">
+          <EmotionShare
+            snapshot={emptyEmotionShareSnapshot}
+            weekly={emptyEmotionShareWeekly}
+            catalog={emptyEmotionShareCatalog}
+            totalPebbles={emptyEmotionShareTotalPebbles}
+            rangeLabel="30 days"
+          />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          DomainShare — dense (with movers)
+        </h2>
+        <div className="max-w-xl">
+          <DomainShare
+            rows={denseDomainShareSnapshot}
+            totalPebbles={denseDomainShareTotalPebbles}
+            rangeLabel="30 days"
+            topMover={denseDomainShareTopMover}
+            bottomMover={denseDomainShareBottomMover}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          DomainShare — sparse (no prior period)
+        </h2>
+        <div className="max-w-xl">
+          <DomainShare
+            rows={sparseDomainShareSnapshot}
+            totalPebbles={sparseDomainShareTotalPebbles}
+            rangeLabel="all time"
+            topMover={null}
+            bottomMover={null}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          DomainShare — empty
+        </h2>
+        <div className="max-w-xl">
+          <DomainShare
+            rows={emptyDomainShareSnapshot}
+            totalPebbles={emptyDomainShareTotalPebbles}
+            rangeLabel="30 days"
+            topMover={null}
+            bottomMover={null}
+          />
+        </div>
       </section>
     </div>
   )

--- a/apps/admin/components/analytics/DomainShare.tsx
+++ b/apps/admin/components/analytics/DomainShare.tsx
@@ -1,0 +1,174 @@
+import { ArrowDown, ArrowUp, Minus } from "lucide-react"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
+
+export type DomainShareSnapshot = {
+  domain_id: string
+  domain_slug: string
+  domain_name: string
+  domain_label: string
+  domain_level: number | null
+  pebbles_in_domain: number
+  share_pct: number
+}
+
+export type DomainShareMover = {
+  domain_id: string
+  domain_name: string
+  current_pct: number
+  previous_pct: number
+  /** Δ in percentage points. */
+  delta_pp: number
+}
+
+type DomainShareProps = {
+  rows: DomainShareSnapshot[]
+  totalPebbles: number
+  rangeLabel?: string
+  /** Null when the period is "all" (no comparable prior period). */
+  topMover: DomainShareMover | null
+  bottomMover: DomainShareMover | null
+}
+
+const DOMAIN_BAR_COLOR = "var(--chart-1)"
+
+export function DomainShare({
+  rows,
+  totalPebbles,
+  rangeLabel,
+  topMover,
+  bottomMover,
+}: DomainShareProps) {
+  if (totalPebbles === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No pebbles {rangeLabel ? `in the last ${rangeLabel.toLowerCase()}` : "yet"} —
+        domain share appears once users start collecting.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-5">
+      <ul className="space-y-2">
+        {rows.map((r) => (
+          <li
+            key={r.domain_id}
+            className="grid grid-cols-[8rem_1fr_3.5rem] items-center gap-3"
+          >
+            <span className="truncate text-sm">
+              {r.domain_name}
+              <span className="ml-1 text-xs text-muted-foreground/70">
+                {r.domain_label}
+              </span>
+            </span>
+            <span className="block h-2 overflow-hidden rounded-full bg-muted">
+              <span
+                className="block h-full rounded-full"
+                style={{
+                  width: `${Math.max(0, Math.min(100, r.share_pct))}%`,
+                  backgroundColor: DOMAIN_BAR_COLOR,
+                }}
+                aria-hidden
+              />
+            </span>
+            <span className="text-right text-sm font-medium tabular-nums">
+              {r.share_pct.toFixed(1)}%
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <div className="grid grid-cols-2 gap-3 border-t pt-4">
+        <MoverStat
+          label="Most-evolving"
+          mover={topMover}
+          fallback="No prior period"
+        />
+        <MoverStat
+          label="Most-decreasing"
+          mover={bottomMover}
+          fallback="No prior period"
+        />
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Based on {totalPebbles.toLocaleString()} pebble
+        {totalPebbles === 1 ? "" : "s"}
+        {rangeLabel ? ` in the last ${rangeLabel.toLowerCase()}` : ""}.
+        Pebbles can be linked to multiple domains, so shares may exceed 100%.
+      </p>
+    </div>
+  )
+}
+
+function MoverStat({
+  label,
+  mover,
+  fallback,
+}: {
+  label: string
+  mover: DomainShareMover | null
+  fallback: string
+}) {
+  if (!mover) {
+    return (
+      <div className="space-y-1">
+        <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {label}
+        </div>
+        <div className="text-sm text-muted-foreground">{fallback}</div>
+      </div>
+    )
+  }
+
+  const direction: "up" | "down" | "flat" =
+    mover.delta_pp === 0 ? "flat" : mover.delta_pp > 0 ? "up" : "down"
+  const Icon = direction === "up" ? ArrowUp : direction === "down" ? ArrowDown : Minus
+  const sign = mover.delta_pp > 0 ? "+" : ""
+  const description = `${mover.domain_name} moved from ${mover.previous_pct.toFixed(
+    1,
+  )}% to ${mover.current_pct.toFixed(1)}% vs. the previous period (${sign}${mover.delta_pp.toFixed(
+    1,
+  )} pp).`
+
+  return (
+    <div className="space-y-1">
+      <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <div
+              className="cursor-help space-y-1"
+              tabIndex={0}
+            >
+              <div className="truncate text-sm font-medium">
+                {mover.domain_name}
+              </div>
+              <div
+                className={cn(
+                  "flex items-center gap-1 text-sm font-medium tabular-nums underline decoration-dotted decoration-muted-foreground/50 underline-offset-4",
+                  direction === "up" && "text-emerald-700 dark:text-emerald-400",
+                  direction === "down" && "text-rose-700 dark:text-rose-400",
+                )}
+              >
+                <Icon className="size-3" aria-hidden />
+                <span>
+                  {sign}
+                  {mover.delta_pp.toFixed(1)} pp
+                </span>
+              </div>
+            </div>
+          }
+        />
+        <TooltipContent>{description}</TooltipContent>
+      </Tooltip>
+    </div>
+  )
+}

--- a/apps/admin/components/analytics/DomainShareCard.tsx
+++ b/apps/admin/components/analytics/DomainShareCard.tsx
@@ -1,0 +1,145 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getDomainShare } from "@/lib/analytics/fetchers"
+import {
+  TIME_RANGE_LABELS,
+  type DomainShareWeeklyRow,
+  type TimeRange,
+} from "@/lib/analytics/types"
+import { ErrorBlock } from "./ErrorBlock"
+import {
+  DomainShare,
+  type DomainShareMover,
+  type DomainShareSnapshot,
+} from "./DomainShare"
+
+type DomainShareCardProps = { range: TimeRange }
+
+export async function DomainShareCard({ range }: DomainShareCardProps) {
+  let result: { current: DomainShareWeeklyRow[]; previous: DomainShareWeeklyRow[] | null }
+  try {
+    result = await getDomainShare(range)
+  } catch (err) {
+    return (
+      <ErrorBlock
+        label="Failed to load domain share"
+        message={err instanceof Error ? err.message : String(err)}
+      />
+    )
+  }
+
+  const snapshot = aggregateSnapshot(result.current)
+  const totalPebbles = totalAcrossWeeks(result.current)
+
+  let topMover: DomainShareMover | null = null
+  let bottomMover: DomainShareMover | null = null
+  if (result.previous !== null) {
+    const prev = aggregateSnapshot(result.previous)
+    const movers = computeMovers(snapshot, prev)
+    topMover = movers.top
+    bottomMover = movers.bottom
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Domain share</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <DomainShare
+          rows={snapshot}
+          totalPebbles={totalPebbles}
+          rangeLabel={TIME_RANGE_LABELS[range]}
+          topMover={topMover}
+          bottomMover={bottomMover}
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+function aggregateSnapshot(
+  rows: DomainShareWeeklyRow[],
+): DomainShareSnapshot[] {
+  // Sum pebbles_in_domain per domain across weeks; sum total_pebbles by taking
+  // each week's total once (not once per domain row in that week).
+  const byDomain = new Map<string, DomainShareSnapshot>()
+  const weekTotals = new Map<string, number>()
+
+  for (const r of rows) {
+    if (!r.domain_id || !r.bucket_week) continue
+    const prev = byDomain.get(r.domain_id)
+    const count = r.pebbles_in_domain ?? 0
+    if (prev) {
+      prev.pebbles_in_domain += count
+    } else {
+      byDomain.set(r.domain_id, {
+        domain_id: r.domain_id,
+        domain_slug: r.domain_slug ?? r.domain_id,
+        domain_name: r.domain_name ?? "—",
+        domain_label: r.domain_label ?? "",
+        domain_level: r.domain_level,
+        pebbles_in_domain: count,
+        share_pct: 0,
+      })
+    }
+    if (!weekTotals.has(r.bucket_week)) {
+      weekTotals.set(r.bucket_week, r.total_pebbles ?? 0)
+    }
+  }
+
+  let total = 0
+  for (const t of weekTotals.values()) total += t
+
+  const out = Array.from(byDomain.values()).map((d) => ({
+    ...d,
+    share_pct: total > 0 ? round2((d.pebbles_in_domain / total) * 100) : 0,
+  }))
+  out.sort((a, b) => b.share_pct - a.share_pct)
+  return out
+}
+
+function totalAcrossWeeks(rows: DomainShareWeeklyRow[]): number {
+  const weekTotals = new Map<string, number>()
+  for (const r of rows) {
+    if (!r.bucket_week) continue
+    if (!weekTotals.has(r.bucket_week)) {
+      weekTotals.set(r.bucket_week, r.total_pebbles ?? 0)
+    }
+  }
+  let total = 0
+  for (const t of weekTotals.values()) total += t
+  return total
+}
+
+function computeMovers(
+  current: DomainShareSnapshot[],
+  previous: DomainShareSnapshot[],
+): { top: DomainShareMover | null; bottom: DomainShareMover | null } {
+  if (current.length === 0) return { top: null, bottom: null }
+  const prevByDomain = new Map(previous.map((p) => [p.domain_id, p]))
+
+  const movers: DomainShareMover[] = current.map((c) => {
+    const prev = prevByDomain.get(c.domain_id)
+    const prevPct = prev?.share_pct ?? 0
+    return {
+      domain_id: c.domain_id,
+      domain_name: c.domain_name,
+      current_pct: c.share_pct,
+      previous_pct: prevPct,
+      delta_pp: round2(c.share_pct - prevPct),
+    }
+  })
+
+  const top = [...movers].sort((a, b) => b.delta_pp - a.delta_pp)[0] ?? null
+  const bottom = [...movers].sort((a, b) => a.delta_pp - b.delta_pp)[0] ?? null
+
+  // If both extremes are zero, there's no meaningful movement to highlight.
+  if (top && top.delta_pp === 0 && bottom && bottom.delta_pp === 0) {
+    return { top: null, bottom: null }
+  }
+  return { top, bottom }
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}

--- a/apps/admin/components/analytics/EmotionShare.tsx
+++ b/apps/admin/components/analytics/EmotionShare.tsx
@@ -1,0 +1,40 @@
+import {
+  EmotionShareChart,
+  type EmotionShareSnapshot,
+  type EmotionShareWeeklyDatum,
+} from "./EmotionShareChart"
+
+export type EmotionShareProps = {
+  snapshot: EmotionShareSnapshot[]
+  weekly: EmotionShareWeeklyDatum[]
+  catalog: { slug: string; name: string; color: string }[]
+  totalPebbles: number
+  rangeLabel?: string
+}
+
+export function EmotionShare({
+  snapshot,
+  weekly,
+  catalog,
+  totalPebbles,
+  rangeLabel,
+}: EmotionShareProps) {
+  if (totalPebbles === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No pebbles {rangeLabel ? `in the last ${rangeLabel.toLowerCase()}` : "yet"} —
+        emotion share appears once users start collecting.
+      </p>
+    )
+  }
+
+  return (
+    <EmotionShareChart
+      snapshot={snapshot}
+      weekly={weekly}
+      catalog={catalog}
+      totalPebbles={totalPebbles}
+      rangeLabel={rangeLabel}
+    />
+  )
+}

--- a/apps/admin/components/analytics/EmotionShareCard.tsx
+++ b/apps/admin/components/analytics/EmotionShareCard.tsx
@@ -1,0 +1,159 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  getEmotionShare,
+  getEmotionShareLast12Weeks,
+} from "@/lib/analytics/fetchers"
+import {
+  TIME_RANGE_LABELS,
+  type EmotionShareWeeklyRow,
+  type TimeRange,
+} from "@/lib/analytics/types"
+import { ErrorBlock } from "./ErrorBlock"
+import { EmotionShare } from "./EmotionShare"
+import type {
+  EmotionShareSnapshot,
+  EmotionShareWeeklyDatum,
+} from "./EmotionShareChart"
+
+type EmotionShareCardProps = { range: TimeRange }
+
+export async function EmotionShareCard({ range }: EmotionShareCardProps) {
+  let snapshotRows: EmotionShareWeeklyRow[]
+  let weeklyRows: EmotionShareWeeklyRow[]
+  try {
+    ;[snapshotRows, weeklyRows] = await Promise.all([
+      getEmotionShare(range),
+      getEmotionShareLast12Weeks(),
+    ])
+  } catch (err) {
+    return (
+      <ErrorBlock
+        label="Failed to load emotion share"
+        message={err instanceof Error ? err.message : String(err)}
+      />
+    )
+  }
+
+  const snapshot = aggregateSnapshot(snapshotRows)
+  const totalPebbles = snapshot.reduce(
+    (acc, r) => acc + r.pebbles_with_emotion,
+    0,
+  )
+  const weekly = pivotWeekly(weeklyRows)
+  const catalog = buildCatalog(weeklyRows, snapshotRows)
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Emotion share</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <EmotionShare
+          snapshot={snapshot}
+          weekly={weekly}
+          catalog={catalog}
+          totalPebbles={totalPebbles}
+          rangeLabel={TIME_RANGE_LABELS[range]}
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+function aggregateSnapshot(
+  rows: EmotionShareWeeklyRow[],
+): EmotionShareSnapshot[] {
+  // Sum pebbles_with_emotion per emotion across weeks; sum total_pebbles by
+  // taking each week's total once (not once per emotion row).
+  const byEmotion = new Map<string, EmotionShareSnapshot>()
+  const weekTotals = new Map<string, number>()
+
+  for (const r of rows) {
+    if (!r.emotion_id || !r.bucket_week) continue
+    const prev = byEmotion.get(r.emotion_id)
+    const count = r.pebbles_with_emotion ?? 0
+    if (prev) {
+      prev.pebbles_with_emotion += count
+    } else {
+      byEmotion.set(r.emotion_id, {
+        emotion_id: r.emotion_id,
+        emotion_slug: r.emotion_slug ?? r.emotion_id,
+        emotion_name: r.emotion_name ?? "—",
+        color: r.color ?? "var(--muted)",
+        pebbles_with_emotion: count,
+        total_pebbles: 0,
+        share_pct: 0,
+      })
+    }
+    if (!weekTotals.has(r.bucket_week)) {
+      weekTotals.set(r.bucket_week, r.total_pebbles ?? 0)
+    }
+  }
+
+  let total = 0
+  for (const t of weekTotals.values()) total += t
+
+  const out = Array.from(byEmotion.values()).map((e) => ({
+    ...e,
+    total_pebbles: total,
+    share_pct: total > 0 ? round2((e.pebbles_with_emotion / total) * 100) : 0,
+  }))
+  out.sort((a, b) => b.share_pct - a.share_pct)
+  return out
+}
+
+function pivotWeekly(rows: EmotionShareWeeklyRow[]): EmotionShareWeeklyDatum[] {
+  const byWeek = new Map<string, EmotionShareWeeklyDatum>()
+  for (const r of rows) {
+    if (!r.bucket_week || !r.emotion_slug) continue
+    let entry = byWeek.get(r.bucket_week)
+    if (!entry) {
+      entry = { bucket_week: r.bucket_week, shares: {} }
+      byWeek.set(r.bucket_week, entry)
+    }
+    entry.shares[r.emotion_slug] = r.share_pct ?? 0
+  }
+  return Array.from(byWeek.values()).sort((a, b) =>
+    a.bucket_week < b.bucket_week ? -1 : 1,
+  )
+}
+
+function buildCatalog(
+  weekly: EmotionShareWeeklyRow[],
+  snapshot: EmotionShareWeeklyRow[],
+): { slug: string; name: string; color: string }[] {
+  // Rank emotions by total pebbles_with_emotion across the snapshot range so
+  // the legend and stack order match the snapshot bars.
+  const totals = new Map<
+    string,
+    { slug: string; name: string; color: string; total: number }
+  >()
+  const seed = (rows: EmotionShareWeeklyRow[]) => {
+    for (const r of rows) {
+      if (!r.emotion_slug) continue
+      const prev = totals.get(r.emotion_slug)
+      const count = r.pebbles_with_emotion ?? 0
+      if (prev) {
+        prev.total += count
+      } else {
+        totals.set(r.emotion_slug, {
+          slug: r.emotion_slug,
+          name: r.emotion_name ?? "—",
+          color: r.color ?? "var(--muted)",
+          total: count,
+        })
+      }
+    }
+  }
+  seed(snapshot)
+  // Include any emotion present only in the 12-week window so the area chart
+  // doesn't drop weeks it would otherwise render.
+  seed(weekly)
+  return Array.from(totals.values())
+    .sort((a, b) => b.total - a.total)
+    .map(({ slug, name, color }) => ({ slug, name, color }))
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}

--- a/apps/admin/components/analytics/EmotionShareChart.tsx
+++ b/apps/admin/components/analytics/EmotionShareChart.tsx
@@ -1,0 +1,203 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts"
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart"
+import { Button } from "@/components/ui/button"
+
+export type EmotionShareSnapshot = {
+  emotion_id: string
+  emotion_slug: string
+  emotion_name: string
+  color: string
+  pebbles_with_emotion: number
+  total_pebbles: number
+  share_pct: number
+}
+
+export type EmotionShareWeeklyDatum = {
+  bucket_week: string
+  /** share_pct per emotion slug, normalized to sum to 100% within the week. */
+  shares: Record<string, number>
+}
+
+export type EmotionShareView = "snapshot" | "over_time"
+
+type EmotionShareChartProps = {
+  snapshot: EmotionShareSnapshot[]
+  weekly: EmotionShareWeeklyDatum[]
+  /** Slug → display name + color, in stable rank order for the legend. */
+  catalog: { slug: string; name: string; color: string }[]
+  totalPebbles: number
+  rangeLabel?: string
+  initialView?: EmotionShareView
+}
+
+const VIEWS: { key: EmotionShareView; label: string }[] = [
+  { key: "snapshot", label: "Snapshot" },
+  { key: "over_time", label: "Over time (12w)" },
+]
+
+export function EmotionShareChart({
+  snapshot,
+  weekly,
+  catalog,
+  totalPebbles,
+  rangeLabel,
+  initialView = "snapshot",
+}: EmotionShareChartProps) {
+  const [view, setView] = useState<EmotionShareView>(initialView)
+
+  const config = useMemo<ChartConfig>(() => {
+    const out: ChartConfig = {}
+    for (const c of catalog) {
+      out[c.slug] = { label: c.name, color: c.color }
+    }
+    return out
+  }, [catalog])
+
+  // Recharts data shape: one object per week with keyed numeric values.
+  const weeklyRows = useMemo(
+    () =>
+      weekly.map((w) => ({
+        bucket_week: w.bucket_week,
+        ...w.shares,
+      })),
+    [weekly],
+  )
+
+  const isEmpty =
+    (view === "snapshot" && snapshot.length === 0) ||
+    (view === "over_time" && weekly.length === 0)
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-1" role="tablist" aria-label="View">
+        {VIEWS.map((v) => (
+          <Button
+            key={v.key}
+            variant={v.key === view ? "default" : "ghost"}
+            size="sm"
+            role="tab"
+            aria-selected={v.key === view}
+            onClick={() => setView(v.key)}
+          >
+            {v.label}
+          </Button>
+        ))}
+      </div>
+
+      {isEmpty ? (
+        <div
+          className="flex h-72 items-center justify-center text-sm text-muted-foreground"
+          aria-live="polite"
+        >
+          No pebbles in this range
+        </div>
+      ) : view === "snapshot" ? (
+        <SnapshotBars
+          rows={snapshot}
+          totalPebbles={totalPebbles}
+          rangeLabel={rangeLabel}
+        />
+      ) : (
+        <ChartContainer config={config} className="h-72 w-full">
+          <AreaChart
+            data={weeklyRows}
+            stackOffset="expand"
+            margin={{ left: 4, right: 12, top: 8, bottom: 4 }}
+          >
+            <CartesianGrid vertical={false} strokeDasharray="3 3" />
+            <XAxis
+              dataKey="bucket_week"
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              minTickGap={32}
+              tickFormatter={(v: string) => v.slice(5)}
+            />
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              width={36}
+              tickFormatter={(v: number) => `${Math.round(v * 100)}%`}
+            />
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  formatter={(value, name) => {
+                    const pct = typeof value === "number" ? value : Number(value)
+                    return [
+                      `${pct.toFixed(1)}%`,
+                      config[String(name)]?.label ?? name,
+                    ]
+                  }}
+                />
+              }
+            />
+            <ChartLegend content={<ChartLegendContent />} />
+            {catalog.map((c) => (
+              <Area
+                key={c.slug}
+                dataKey={c.slug}
+                type="monotone"
+                stackId="emotion"
+                stroke={`var(--color-${c.slug})`}
+                fill={`var(--color-${c.slug})`}
+                fillOpacity={0.65}
+                strokeWidth={1}
+              />
+            ))}
+          </AreaChart>
+        </ChartContainer>
+      )}
+    </div>
+  )
+}
+
+function SnapshotBars({
+  rows,
+  totalPebbles,
+  rangeLabel,
+}: {
+  rows: EmotionShareSnapshot[]
+  totalPebbles: number
+  rangeLabel?: string
+}) {
+  return (
+    <div className="space-y-2">
+      <ul className="space-y-2">
+        {rows.map((r) => (
+          <li key={r.emotion_id} className="grid grid-cols-[7rem_1fr_3.5rem] items-center gap-3">
+            <span className="truncate text-sm">{r.emotion_name}</span>
+            <span className="block h-2 overflow-hidden rounded-full bg-muted">
+              <span
+                className="block h-full rounded-full"
+                style={{
+                  width: `${Math.max(0, Math.min(100, r.share_pct))}%`,
+                  backgroundColor: r.color,
+                }}
+                aria-hidden
+              />
+            </span>
+            <span className="text-right text-sm font-medium tabular-nums">
+              {r.share_pct.toFixed(1)}%
+            </span>
+          </li>
+        ))}
+      </ul>
+      <p className="text-xs text-muted-foreground">
+        Based on {totalPebbles.toLocaleString()} pebble
+        {totalPebbles === 1 ? "" : "s"}
+        {rangeLabel ? ` in the last ${rangeLabel.toLowerCase()}` : ""}.
+      </p>
+    </div>
+  )
+}

--- a/apps/admin/components/analytics/__fixtures__/domainShare.ts
+++ b/apps/admin/components/analytics/__fixtures__/domainShare.ts
@@ -1,0 +1,93 @@
+import type {
+  DomainShareMover,
+  DomainShareSnapshot,
+} from "../DomainShare"
+
+const DOMAIN_BASE: {
+  slug: string
+  name: string
+  label: string
+  level: number
+  weight: number
+}[] = [
+  { slug: "zoe", name: "Zoē", label: "Health & body", level: 1, weight: 24 },
+  {
+    slug: "asphaleia",
+    name: "Asphaleia",
+    label: "Security & comfort",
+    level: 2,
+    weight: 18,
+  },
+  { slug: "philia", name: "Philía", label: "Relationships", level: 3, weight: 32 },
+  {
+    slug: "time",
+    name: "Timē",
+    label: "Recognition & community",
+    level: 4,
+    weight: 14,
+  },
+  {
+    slug: "eudaimonia",
+    name: "Eudaimonia",
+    label: "Self-actualization",
+    level: 5,
+    weight: 22,
+  },
+]
+
+export const denseDomainShareSnapshot: DomainShareSnapshot[] = (() => {
+  const total = 1820
+  return DOMAIN_BASE.map((d) => {
+    const share = d.weight // already in 0..100ish range; pebbles can have multiple domains
+    const pebbles = Math.round((share / 100) * total)
+    return {
+      domain_id: d.slug,
+      domain_slug: d.slug,
+      domain_name: d.name,
+      domain_label: d.label,
+      domain_level: d.level,
+      pebbles_in_domain: pebbles,
+      share_pct: round2(share),
+    }
+  }).sort((a, b) => b.share_pct - a.share_pct)
+})()
+
+export const denseDomainShareTopMover: DomainShareMover = {
+  domain_id: "philia",
+  domain_name: "Philía",
+  current_pct: 32,
+  previous_pct: 25,
+  delta_pp: 7,
+}
+
+export const denseDomainShareBottomMover: DomainShareMover = {
+  domain_id: "asphaleia",
+  domain_name: "Asphaleia",
+  current_pct: 18,
+  previous_pct: 24,
+  delta_pp: -6,
+}
+
+export const denseDomainShareTotalPebbles = 1820
+
+export const sparseDomainShareSnapshot: DomainShareSnapshot[] = (() => {
+  const total = 30
+  return DOMAIN_BASE.slice(0, 3).map((d, i) => ({
+    domain_id: d.slug,
+    domain_slug: d.slug,
+    domain_name: d.name,
+    domain_label: d.label,
+    domain_level: d.level,
+    pebbles_in_domain: 12 - i * 3,
+    share_pct: round2(((12 - i * 3) / total) * 100),
+  })).sort((a, b) => b.share_pct - a.share_pct)
+})()
+
+export const sparseDomainShareTotalPebbles = 30
+
+export const emptyDomainShareSnapshot: DomainShareSnapshot[] = []
+export const emptyDomainShareTotalPebbles = 0
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}

--- a/apps/admin/components/analytics/__fixtures__/emotionShare.ts
+++ b/apps/admin/components/analytics/__fixtures__/emotionShare.ts
@@ -1,0 +1,118 @@
+import type {
+  EmotionShareSnapshot,
+  EmotionShareWeeklyDatum,
+} from "../EmotionShareChart"
+
+const TODAY = new Date()
+
+function isoWeekStart(weeksAgo: number): string {
+  const d = new Date(TODAY)
+  d.setUTCDate(d.getUTCDate() - weeksAgo * 7)
+  const dow = d.getUTCDay()
+  const offset = (dow + 6) % 7
+  d.setUTCDate(d.getUTCDate() - offset)
+  return d.toISOString().slice(0, 10)
+}
+
+const CATALOG_BASE: { slug: string; name: string; color: string; weight: number }[] =
+  [
+    { slug: "joy", name: "Joy", color: "#FACC15", weight: 28 },
+    { slug: "gratitude", name: "Gratitude", color: "#34D399", weight: 18 },
+    { slug: "love", name: "Love", color: "#EC4899", weight: 14 },
+    { slug: "anxiety", name: "Anxiety", color: "#8B5CF6", weight: 12 },
+    { slug: "sadness", name: "Sadness", color: "#60A5FA", weight: 9 },
+    { slug: "anger", name: "Anger", color: "#EF4444", weight: 7 },
+    { slug: "nostalgia", name: "Nostalgia", color: "#D4A373", weight: 6 },
+    { slug: "awe", name: "Awe", color: "#818CF8", weight: 6 },
+  ]
+
+export const denseEmotionShareCatalog = CATALOG_BASE.map(
+  ({ slug, name, color }) => ({ slug, name, color }),
+)
+
+export const denseEmotionShareSnapshot: EmotionShareSnapshot[] = (() => {
+  const totalWeight = CATALOG_BASE.reduce((acc, c) => acc + c.weight, 0)
+  const totalPebbles = 1820
+  return CATALOG_BASE.map((c) => {
+    const share = (c.weight / totalWeight) * 100
+    return {
+      emotion_id: c.slug,
+      emotion_slug: c.slug,
+      emotion_name: c.name,
+      color: c.color,
+      pebbles_with_emotion: Math.round((c.weight / totalWeight) * totalPebbles),
+      total_pebbles: totalPebbles,
+      share_pct: round2(share),
+    }
+  }).sort((a, b) => b.share_pct - a.share_pct)
+})()
+
+export const denseEmotionShareWeekly: EmotionShareWeeklyDatum[] = Array.from(
+  { length: 12 },
+  (_, i) => {
+    const weeksAgo = 11 - i
+    const wave = Math.sin(i / 2.5)
+    const weights = CATALOG_BASE.map((c, j) => {
+      const drift = wave * (j % 2 === 0 ? 1 : -1) * 1.5
+      return Math.max(0.5, c.weight + drift)
+    })
+    const sum = weights.reduce((a, b) => a + b, 0)
+    const shares: Record<string, number> = {}
+    CATALOG_BASE.forEach((c, j) => {
+      shares[c.slug] = round2((weights[j] / sum) * 100)
+    })
+    return { bucket_week: isoWeekStart(weeksAgo), shares }
+  },
+)
+
+export const denseEmotionShareTotalPebbles = denseEmotionShareSnapshot.reduce(
+  (acc, r) => acc + r.pebbles_with_emotion,
+  0,
+)
+
+export const sparseEmotionShareCatalog = denseEmotionShareCatalog.slice(0, 3)
+
+export const sparseEmotionShareSnapshot: EmotionShareSnapshot[] = (() => {
+  const total = 42
+  const rows = [
+    { ...CATALOG_BASE[0], weight: 5 },
+    { ...CATALOG_BASE[1], weight: 3 },
+    { ...CATALOG_BASE[2], weight: 2 },
+  ]
+  const weightSum = rows.reduce((a, r) => a + r.weight, 0)
+  return rows
+    .map((r) => ({
+      emotion_id: r.slug,
+      emotion_slug: r.slug,
+      emotion_name: r.name,
+      color: r.color,
+      pebbles_with_emotion: Math.round((r.weight / weightSum) * total),
+      total_pebbles: total,
+      share_pct: round2((r.weight / weightSum) * 100),
+    }))
+    .sort((a, b) => b.share_pct - a.share_pct)
+})()
+
+export const sparseEmotionShareWeekly: EmotionShareWeeklyDatum[] = Array.from(
+  { length: 4 },
+  (_, i) => {
+    const weeksAgo = 3 - i
+    const shares: Record<string, number> = {
+      joy: 50 - i * 4,
+      gratitude: 30 + i * 2,
+      love: 20 + i * 2,
+    }
+    return { bucket_week: isoWeekStart(weeksAgo), shares }
+  },
+)
+
+export const sparseEmotionShareTotalPebbles = 42
+
+export const emptyEmotionShareCatalog: typeof denseEmotionShareCatalog = []
+export const emptyEmotionShareSnapshot: EmotionShareSnapshot[] = []
+export const emptyEmotionShareWeekly: EmotionShareWeeklyDatum[] = []
+export const emptyEmotionShareTotalPebbles = 0
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}

--- a/apps/admin/lib/analytics/fetchers.ts
+++ b/apps/admin/lib/analytics/fetchers.ts
@@ -1,7 +1,10 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server"
-import { dateRangeFor } from "./date"
+import { dateRangeFor, periodLengthDays, shiftIsoDate } from "./date"
 import type {
   ActiveUsersDailyRow,
+  DomainShareWeeklyRow,
+  EmotionShareWeeklyRow,
+  IsoDate,
   KpiDailyRow,
   PebbleEnrichmentRow,
   PebbleVolumeRow,
@@ -111,6 +114,88 @@ export async function getUserAveragesSeries(
     throw new Error(error.message)
   }
   return data ?? []
+}
+
+/**
+ * Weekly emotion share rows over the snapshot range. Used by the emotion-share
+ * card for both the snapshot view (aggregated across weeks) and the stacked-
+ * area over-time view. The RPC enforces `is_admin(auth.uid())`.
+ */
+export async function getEmotionShare(
+  range: TimeRange,
+): Promise<EmotionShareWeeklyRow[]> {
+  const { start, end } = dateRangeFor(range)
+  return fetchEmotionShare(start, end)
+}
+
+/**
+ * Always-12-weeks emotion share rows for the over-time stacked area, regardless
+ * of the active time-range tab. The over-time framing in the spec is fixed at
+ * 12 weeks so the chart shape stays comparable across snapshots.
+ */
+export async function getEmotionShareLast12Weeks(): Promise<EmotionShareWeeklyRow[]> {
+  const today = new Date()
+  const end = today.toISOString().slice(0, 10)
+  // 12 weeks back, week-start aligned by the SQL view (date_trunc('week', ...)).
+  const start = shiftIsoDate(end, -7 * 11)
+  return fetchEmotionShare(start, end)
+}
+
+async function fetchEmotionShare(
+  start: IsoDate,
+  end: IsoDate,
+): Promise<EmotionShareWeeklyRow[]> {
+  const supabase = await createServerSupabaseClient()
+  const { data, error } = await supabase.rpc("get_emotion_share", {
+    p_start: start,
+    p_end: end,
+  })
+  if (error) {
+    console.error("[analytics] getEmotionShare failed:", error.message)
+    throw new Error(error.message)
+  }
+  return data ?? []
+}
+
+/**
+ * Weekly domain share rows for the snapshot range, plus a parallel set for the
+ * matching previous period (used to compute "biggest movers" deltas in pp).
+ * Returns null for `previous` when the active range is "all" (no prior period).
+ * Both RPC calls enforce `is_admin(auth.uid())`.
+ */
+export async function getDomainShare(
+  range: TimeRange,
+): Promise<{
+  current: DomainShareWeeklyRow[]
+  previous: DomainShareWeeklyRow[] | null
+}> {
+  const { start, end } = dateRangeFor(range)
+  const supabase = await createServerSupabaseClient()
+  const { data, error } = await supabase.rpc("get_domain_share", {
+    p_start: start,
+    p_end: end,
+  })
+  if (error) {
+    console.error("[analytics] getDomainShare current failed:", error.message)
+    throw new Error(error.message)
+  }
+  const current = data ?? []
+
+  const days = periodLengthDays(range)
+  if (days === null) {
+    return { current, previous: null }
+  }
+  const prevEnd = shiftIsoDate(start, -1)
+  const prevStart = shiftIsoDate(prevEnd, -(days - 1))
+  const { data: prevData, error: prevError } = await supabase.rpc(
+    "get_domain_share",
+    { p_start: prevStart, p_end: prevEnd },
+  )
+  if (prevError) {
+    console.error("[analytics] getDomainShare previous failed:", prevError.message)
+    throw new Error(prevError.message)
+  }
+  return { current, previous: prevData ?? [] }
 }
 
 /**

--- a/apps/admin/lib/analytics/types.ts
+++ b/apps/admin/lib/analytics/types.ts
@@ -58,6 +58,35 @@ export interface PebbleEnrichmentRow {
   pct_with_intensity: number | null
 }
 
+export interface EmotionShareWeeklyRow {
+  /** Monday of the ISO week (UTC), ISO date string. */
+  bucket_week: IsoDate | null
+  emotion_id: string | null
+  emotion_slug: string | null
+  emotion_name: string | null
+  /** Hex color from the emotions reference table. */
+  color: string | null
+  pebbles_with_emotion: number | null
+  total_pebbles: number | null
+  /** 0–100 percent share of pebbles in this week assigned this emotion. */
+  share_pct: number | null
+}
+
+export interface DomainShareWeeklyRow {
+  /** Monday of the ISO week (UTC), ISO date string. */
+  bucket_week: IsoDate | null
+  domain_id: string | null
+  domain_slug: string | null
+  domain_name: string | null
+  domain_label: string | null
+  /** Maslow rank derived from seeded slug order. NULL for unknown slugs. */
+  domain_level: number | null
+  pebbles_in_domain: number | null
+  total_pebbles: number | null
+  /** 0–100 percent share of pebbles in this week linked to this domain. */
+  share_pct: number | null
+}
+
 export interface UserAveragesWeeklyRow {
   /** Monday of the ISO week (UTC), ISO date string. */
   bucket_week: IsoDate | null

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -1175,6 +1175,42 @@
       "description": "SECURITY DEFINER plpgsql RPC, gated on is_admin(auth.uid()). No arguments. Returns rows from v_analytics_retention_cohorts_weekly for the last 8 cohorts (most recent signup weeks). Raises insufficient_privilege (42501) for non-admins.",
       "status": "development",
       "platforms": ["web"]
+    },
+    {
+      "id": "DM-v-analytics-emotion-share-weekly",
+      "project_id": "pebbles",
+      "species": "data-model",
+      "title": "v_analytics_emotion_share_weekly",
+      "description": "Postgres view: one row per (ISO week, emotion). Columns: bucket_week, emotion_id, emotion_slug, emotion_name, color, pebbles_with_emotion, total_pebbles, share_pct. Source: pebbles.emotion_id (NOT NULL FK), so each pebble counts toward exactly one emotion and share_pct sums to 100% per week.",
+      "status": "development",
+      "platforms": ["web"]
+    },
+    {
+      "id": "DM-v-analytics-domain-share-weekly",
+      "project_id": "pebbles",
+      "species": "data-model",
+      "title": "v_analytics_domain_share_weekly",
+      "description": "Postgres view: one row per (ISO week, domain). Columns: bucket_week, domain_id, domain_slug, domain_name, domain_label, domain_level, pebbles_in_domain, total_pebbles, share_pct. Source: pebble_domains many-to-many, so a pebble can be linked to multiple domains and shares may exceed 100%. domain_level is derived from the seeded Maslow slug order (zoe, asphaleia, philia, time, eudaimonia).",
+      "status": "development",
+      "platforms": ["web"]
+    },
+    {
+      "id": "API-get-emotion-share",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "get_emotion_share",
+      "description": "SECURITY DEFINER plpgsql RPC, gated on is_admin(auth.uid()). Takes p_start and p_end dates (week-truncated internally). Returns rows from v_analytics_emotion_share_weekly within the range, ordered by bucket_week asc, share_pct desc. The admin emotion-share card aggregates these rows for the snapshot view and renders them directly for the 12-week stacked-area over-time view.",
+      "status": "development",
+      "platforms": ["web"]
+    },
+    {
+      "id": "API-get-domain-share",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "get_domain_share",
+      "description": "SECURITY DEFINER plpgsql RPC, gated on is_admin(auth.uid()). Takes p_start and p_end dates (week-truncated internally). Returns rows from v_analytics_domain_share_weekly within the range, ordered by bucket_week asc, domain_level asc. The admin domain-share card calls this RPC twice (current + previous period) to compute 'biggest movers' deltas in pp.",
+      "status": "development",
+      "platforms": ["web"]
     }
   ],
   "edges": [
@@ -1387,6 +1423,12 @@
     { "id": "e-V-admin-analytics-DM-v-analytics-retention-cohorts-weekly", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "DM-v-analytics-retention-cohorts-weekly", "edge_type": "displays" },
     { "id": "e-API-get-retention-cohorts-DM-v-analytics-retention-cohorts-weekly", "project_id": "pebbles", "source_id": "API-get-retention-cohorts", "target_id": "DM-v-analytics-retention-cohorts-weekly", "edge_type": "queries" },
     { "id": "e-API-get-retention-cohorts-DM-pebble", "project_id": "pebbles", "source_id": "API-get-retention-cohorts", "target_id": "DM-pebble", "edge_type": "queries" },
-    { "id": "e-API-get-retention-cohorts-DM-account", "project_id": "pebbles", "source_id": "API-get-retention-cohorts", "target_id": "DM-account", "edge_type": "queries" }
+    { "id": "e-API-get-retention-cohorts-DM-account", "project_id": "pebbles", "source_id": "API-get-retention-cohorts", "target_id": "DM-account", "edge_type": "queries" },
+    { "id": "e-V-admin-analytics-API-get-emotion-share", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "API-get-emotion-share", "edge_type": "calls" },
+    { "id": "e-V-admin-analytics-API-get-domain-share", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "API-get-domain-share", "edge_type": "calls" },
+    { "id": "e-V-admin-analytics-DM-v-analytics-emotion-share-weekly", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "DM-v-analytics-emotion-share-weekly", "edge_type": "displays" },
+    { "id": "e-V-admin-analytics-DM-v-analytics-domain-share-weekly", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "DM-v-analytics-domain-share-weekly", "edge_type": "displays" },
+    { "id": "e-API-get-emotion-share-DM-v-analytics-emotion-share-weekly", "project_id": "pebbles", "source_id": "API-get-emotion-share", "target_id": "DM-v-analytics-emotion-share-weekly", "edge_type": "queries" },
+    { "id": "e-API-get-domain-share-DM-v-analytics-domain-share-weekly", "project_id": "pebbles", "source_id": "API-get-domain-share", "target_id": "DM-v-analytics-domain-share-weekly", "edge_type": "queries" }
   ]
 }

--- a/packages/supabase/supabase/migrations/20260501000003_analytics_meaning_share.sql
+++ b/packages/supabase/supabase/migrations/20260501000003_analytics_meaning_share.sql
@@ -1,0 +1,164 @@
+-- =============================================================================
+-- Admin · Analytics · Meaning row (emotion share + domain share)
+-- =============================================================================
+-- Issue: #342
+-- Reference: docs/poc/admin-analytics/20260430_analytics_mvs.sql
+--            §§ mv_emotion_share_weekly + mv_domain_share_weekly
+--
+-- Schema notes (vs. the POC reference SQL):
+--   - Emotion source is `pebbles.emotion_id` (NOT NULL FK), not the
+--     `pebble_emotions` join the POC assumed. Each pebble counts toward
+--     exactly one emotion, so emotion shares sum to 100% per week.
+--   - `domains` has no `level` column — only (id, slug, name, label). We
+--     derive `domain_level` from the seeded slug order so the over-time and
+--     snapshot views can keep stacking domains in Maslow order.
+--   - Soft-delete does not exist in this project, so no deleted_at filters.
+-- =============================================================================
+
+drop function if exists public.get_domain_share(date, date);
+drop function if exists public.get_emotion_share(date, date);
+drop view if exists public.v_analytics_domain_share_weekly;
+drop view if exists public.v_analytics_emotion_share_weekly;
+
+-- -----------------------------------------------------------------------------
+-- v_analytics_emotion_share_weekly
+-- One row per (ISO week, emotion). Each pebble has exactly one emotion via
+-- pebbles.emotion_id, so share_pct sums to 100% within a bucket_week.
+-- -----------------------------------------------------------------------------
+create view public.v_analytics_emotion_share_weekly as
+with weekly_pebbles as (
+  select
+    date_trunc('week', p.created_at)::date as bucket_week,
+    p.id,
+    p.emotion_id
+  from public.pebbles p
+),
+totals as (
+  select bucket_week, count(*)::int as total_pebbles
+  from weekly_pebbles
+  group by bucket_week
+)
+select
+  wp.bucket_week,
+  e.id    as emotion_id,
+  e.slug  as emotion_slug,
+  e.name  as emotion_name,
+  e.color,
+  count(*)::int                                                  as pebbles_with_emotion,
+  t.total_pebbles,
+  round(100.0 * count(*) / nullif(t.total_pebbles, 0), 2)        as share_pct
+from weekly_pebbles wp
+join public.emotions e on e.id = wp.emotion_id
+join totals t          on t.bucket_week = wp.bucket_week
+group by wp.bucket_week, e.id, e.slug, e.name, e.color, t.total_pebbles;
+
+-- -----------------------------------------------------------------------------
+-- v_analytics_domain_share_weekly
+-- One row per (ISO week, domain). A pebble can be linked to multiple domains
+-- via pebble_domains, so domain shares do NOT need to sum to 100%.
+-- domain_level is derived from the seeded Maslow slug order; new slugs not in
+-- the array sort last (NULLs last).
+-- -----------------------------------------------------------------------------
+create view public.v_analytics_domain_share_weekly as
+with weekly_pebbles as (
+  select
+    date_trunc('week', p.created_at)::date as bucket_week,
+    p.id
+  from public.pebbles p
+),
+totals as (
+  select bucket_week, count(*)::int as total_pebbles
+  from weekly_pebbles
+  group by bucket_week
+)
+select
+  wp.bucket_week,
+  d.id                                                                       as domain_id,
+  d.slug                                                                     as domain_slug,
+  d.name                                                                     as domain_name,
+  d.label                                                                    as domain_label,
+  array_position(
+    array['zoe','asphaleia','philia','time','eudaimonia']::text[],
+    d.slug
+  )                                                                          as domain_level,
+  count(distinct wp.id)::int                                                 as pebbles_in_domain,
+  t.total_pebbles,
+  round(100.0 * count(distinct wp.id) / nullif(t.total_pebbles, 0), 2)       as share_pct
+from weekly_pebbles wp
+join public.pebble_domains pd on pd.pebble_id = wp.id
+join public.domains d         on d.id = pd.domain_id
+join totals t                 on t.bucket_week = wp.bucket_week
+group by wp.bucket_week, d.id, d.slug, d.name, d.label, t.total_pebbles;
+
+-- -----------------------------------------------------------------------------
+-- get_emotion_share(p_start, p_end)
+-- Weekly rows from v_analytics_emotion_share_weekly whose bucket_week falls
+-- within [p_start, p_end] (week-truncated). The card uses these rows for both
+-- the snapshot (aggregating across weeks) and the stacked-area over-time view.
+-- Enforces is_admin(auth.uid()).
+-- -----------------------------------------------------------------------------
+create or replace function public.get_emotion_share(
+  p_start date,
+  p_end   date
+)
+returns setof public.v_analytics_emotion_share_weekly
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_start date := date_trunc('week', p_start::timestamptz)::date;
+  v_end   date := date_trunc('week', p_end::timestamptz)::date;
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'insufficient_privilege' using errcode = '42501';
+  end if;
+
+  return query
+    select * from public.v_analytics_emotion_share_weekly
+    where bucket_week between v_start and v_end
+    order by bucket_week asc, share_pct desc;
+end;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- get_domain_share(p_start, p_end)
+-- Weekly rows from v_analytics_domain_share_weekly whose bucket_week falls
+-- within [p_start, p_end]. The domain card aggregates across weeks for the
+-- snapshot and calls this RPC twice (current + previous period) to compute
+-- "biggest movers" deltas in pp.
+-- Enforces is_admin(auth.uid()).
+-- -----------------------------------------------------------------------------
+create or replace function public.get_domain_share(
+  p_start date,
+  p_end   date
+)
+returns setof public.v_analytics_domain_share_weekly
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_start date := date_trunc('week', p_start::timestamptz)::date;
+  v_end   date := date_trunc('week', p_end::timestamptz)::date;
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'insufficient_privilege' using errcode = '42501';
+  end if;
+
+  return query
+    select * from public.v_analytics_domain_share_weekly
+    where bucket_week between v_start and v_end
+    order by bucket_week asc, domain_level asc nulls last;
+end;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- Permissions: lock the views, expose the RPCs to authenticated callers
+-- (the RPCs gate on is_admin(auth.uid())).
+-- -----------------------------------------------------------------------------
+revoke all on public.v_analytics_emotion_share_weekly from public, anon, authenticated;
+revoke all on public.v_analytics_domain_share_weekly  from public, anon, authenticated;
+
+grant execute on function public.get_emotion_share(date, date) to authenticated;
+grant execute on function public.get_domain_share(date, date)  to authenticated;

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -790,6 +790,33 @@ export type Database = {
         }
         Relationships: []
       }
+      v_analytics_domain_share_weekly: {
+        Row: {
+          bucket_week: string | null
+          domain_id: string | null
+          domain_label: string | null
+          domain_level: number | null
+          domain_name: string | null
+          domain_slug: string | null
+          pebbles_in_domain: number | null
+          share_pct: number | null
+          total_pebbles: number | null
+        }
+        Relationships: []
+      }
+      v_analytics_emotion_share_weekly: {
+        Row: {
+          bucket_week: string | null
+          color: string | null
+          emotion_id: string | null
+          emotion_name: string | null
+          emotion_slug: string | null
+          pebbles_with_emotion: number | null
+          share_pct: number | null
+          total_pebbles: number | null
+        }
+        Relationships: []
+      }
       v_analytics_kpi_daily: {
         Row: {
           bucket_date: string | null
@@ -972,6 +999,45 @@ export type Database = {
         SetofOptions: {
           from: "*"
           to: "v_analytics_active_users_daily"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
+      get_domain_share: {
+        Args: { p_end: string; p_start: string }
+        Returns: {
+          bucket_week: string | null
+          domain_id: string | null
+          domain_label: string | null
+          domain_level: number | null
+          domain_name: string | null
+          domain_slug: string | null
+          pebbles_in_domain: number | null
+          share_pct: number | null
+          total_pebbles: number | null
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "v_analytics_domain_share_weekly"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
+      get_emotion_share: {
+        Args: { p_end: string; p_start: string }
+        Returns: {
+          bucket_week: string | null
+          color: string | null
+          emotion_id: string | null
+          emotion_name: string | null
+          emotion_slug: string | null
+          pebbles_with_emotion: number | null
+          share_pct: number | null
+          total_pebbles: number | null
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "v_analytics_emotion_share_weekly"
           isOneToOne: false
           isSetofReturn: true
         }


### PR DESCRIPTION
Resolves #342.

## Summary

Adds the meaning row of `/analytics` (6/6 split): emotion share + domain share.

- **`v_analytics_emotion_share_weekly`** + `get_emotion_share(p_start, p_end)` RPC. Source is `pebbles.emotion_id` (single NOT NULL FK), not `pebble_emotions` — each pebble counts toward exactly one emotion, so weekly shares sum to 100%.
- **`v_analytics_domain_share_weekly`** + `get_domain_share(p_start, p_end)` RPC. `domain_level` is derived from the seeded Maslow slug order (`zoe → asphaleia → philia → time → eudaimonia`) since `domains` has no `level` column.
- **`EmotionShareCard`** — snapshot bars + 12-week stacked-area over-time toggle (normalized, sums to 100% per week).
- **`DomainShareCard`** — snapshot bars + "biggest movers" stats vs. previous period in pp. Two RPC calls compose current + previous windows; "all" range hides the movers (no comparable prior period).
- Playground fixtures (dense/sparse/empty) and Arkaik bundle updated.

## Key files

- `packages/supabase/supabase/migrations/20260501000003_analytics_meaning_share.sql`
- `apps/admin/components/analytics/EmotionShareCard.tsx` / `EmotionShare.tsx` / `EmotionShareChart.tsx`
- `apps/admin/components/analytics/DomainShareCard.tsx` / `DomainShare.tsx`
- `apps/admin/lib/analytics/fetchers.ts` (added `getEmotionShare`, `getEmotionShareLast12Weeks`, `getDomainShare`)
- `apps/admin/app/(authed)/analytics/page.tsx` (wires the meaning row)
- `apps/admin/app/(authed)/playground/analytics/page.tsx` (fixtures)

## Implementation notes

- `get_domain_share` is called twice from the fetcher to compute deltas — one round-trip for the current period, one for the matched previous period (skipped when range = "all").
- The weekly RPC rows are aggregated client-side for the snapshot view (sum `pebbles_with_emotion` / `pebbles_in_domain`, divide by the sum of distinct weekly `total_pebbles`) so a single RPC powers both views.
- Emotion catalog ordering is rank-by-pebbles so the snapshot bars and stacked-area legend match.

## Test plan

- [ ] Both cards render with non-zero data on staging
- [ ] Snapshot ↔ over-time toggle works on the emotion card; stack normalizes to 100%
- [ ] "Biggest movers" computed correctly (spot-check delta in pp vs. previous-period totals)
- [ ] Loading / empty / error states render via Suspense + ErrorBlock
- [ ] Playground fixtures render at `/playground/analytics`
- [ ] `npm run lint --workspace=apps/admin` ✓ (verified)
- [ ] `npm run build --workspace=apps/admin` ✓ (verified)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YR56aXk1k7TqELvXQzQ2F4)_