### PR TITLE
feat(core): bounce karma distribution card on admin analytics

### DIFF
--- a/apps/admin/app/(authed)/analytics/page.tsx
+++ b/apps/admin/app/(authed)/analytics/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react"
 import { ActiveUsersChartCard } from "@/components/analytics/ActiveUsersChartCard"
+import { BounceDistributionCard } from "@/components/analytics/BounceDistributionCard"
 import { ChartCardSkeleton } from "@/components/analytics/ChartCardSkeleton"
 import { DomainShareCard } from "@/components/analytics/DomainShareCard"
 import { EmotionShareCard } from "@/components/analytics/EmotionShareCard"
@@ -54,11 +55,14 @@ export default async function AnalyticsPage({
             <PebbleEnrichmentCard range={range} />
           </Suspense>
         </div>
-        {/* Per-user weekly averages — paired with bounce-karma distribution
-            (5/12) once #344 ships. Until then this card is full-width. */}
-        <div className="lg:col-span-12">
+        <div className="lg:col-span-7">
           <Suspense fallback={<ChartCardSkeleton />}>
             <UserAveragesCard />
+          </Suspense>
+        </div>
+        <div className="lg:col-span-5">
+          <Suspense fallback={<ChartCardSkeleton />}>
+            <BounceDistributionCard />
           </Suspense>
         </div>
         <div className="lg:col-span-6">

--- a/apps/admin/app/(authed)/playground/analytics/page.tsx
+++ b/apps/admin/app/(authed)/playground/analytics/page.tsx
@@ -1,4 +1,5 @@
 import { ActiveUsersChart } from "@/components/analytics/ActiveUsersChart"
+import { BounceDistribution } from "@/components/analytics/BounceDistribution"
 import { DomainShare } from "@/components/analytics/DomainShare"
 import { EmotionShare } from "@/components/analytics/EmotionShare"
 import { KpiCard } from "@/components/analytics/KpiCard"
@@ -46,6 +47,11 @@ import {
   sparseEmotionShareTotalPebbles,
   sparseEmotionShareWeekly,
 } from "@/components/analytics/__fixtures__/emotionShare"
+import {
+  denseBounceDistributionFixture,
+  emptyBounceDistributionFixture,
+  sparseBounceDistributionFixture,
+} from "@/components/analytics/__fixtures__/bounceDistribution"
 import {
   denseDomainShareBottomMover,
   denseDomainShareSnapshot,
@@ -306,6 +312,45 @@ export default function AnalyticsPlaygroundPage() {
             rangeLabel="30 days"
             topMover={null}
             bottomMover={null}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          BounceDistribution — dense
+        </h2>
+        <div className="max-w-xl">
+          <BounceDistribution
+            buckets={denseBounceDistributionFixture.buckets}
+            totalUsers={denseBounceDistributionFixture.totalUsers}
+            stats={denseBounceDistributionFixture.stats}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          BounceDistribution — sparse
+        </h2>
+        <div className="max-w-xl">
+          <BounceDistribution
+            buckets={sparseBounceDistributionFixture.buckets}
+            totalUsers={sparseBounceDistributionFixture.totalUsers}
+            stats={sparseBounceDistributionFixture.stats}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          BounceDistribution — empty
+        </h2>
+        <div className="max-w-xl">
+          <BounceDistribution
+            buckets={emptyBounceDistributionFixture.buckets}
+            totalUsers={emptyBounceDistributionFixture.totalUsers}
+            stats={emptyBounceDistributionFixture.stats}
           />
         </div>
       </section>

--- a/apps/admin/components/analytics/BounceDistribution.tsx
+++ b/apps/admin/components/analytics/BounceDistribution.tsx
@@ -1,0 +1,120 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import {
+  BounceDistributionChart,
+  type BounceDistributionDatum,
+} from "./BounceDistributionChart"
+
+export type BounceDistributionStats = {
+  /** Median current bounce score across all users. Null when zero users. */
+  medianScore: number | null
+  /** % of users whose current bounce >= bounce 7 days ago. 0–100, null when no users. */
+  pctMaintaining: number | null
+  /** Avg distinct active days/week across MAU. 0–7, null when no MAU. */
+  avgActiveDaysPerWeek: number | null
+}
+
+export type BounceDistributionProps = {
+  buckets: BounceDistributionDatum[]
+  totalUsers: number
+  stats: BounceDistributionStats
+}
+
+export function BounceDistribution({
+  buckets,
+  totalUsers,
+  stats,
+}: BounceDistributionProps) {
+  if (totalUsers === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No users yet — bounce karma distribution appears once users earn karma.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <Stat
+          label="Median bounce"
+          value={formatNumber(stats.medianScore)}
+          description={describeMedian(stats.medianScore, totalUsers)}
+        />
+        <Stat
+          label="% maintaining"
+          value={formatPct(stats.pctMaintaining)}
+          description={describeMaintaining(stats.pctMaintaining, totalUsers)}
+        />
+        <Stat
+          label="Avg active days / week"
+          value={formatNumber(stats.avgActiveDaysPerWeek)}
+          description={describeActiveDays(stats.avgActiveDaysPerWeek)}
+        />
+      </div>
+
+      <BounceDistributionChart data={buckets} />
+    </div>
+  )
+}
+
+function Stat({
+  label,
+  value,
+  description,
+}: {
+  label: string
+  value: string
+  description: string
+}) {
+  return (
+    <div className="space-y-1">
+      <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <span
+              className="cursor-help text-2xl font-semibold tabular-nums underline decoration-dotted decoration-muted-foreground/50 underline-offset-4"
+              tabIndex={0}
+            >
+              {value}
+            </span>
+          }
+        />
+        <TooltipContent>{description}</TooltipContent>
+      </Tooltip>
+    </div>
+  )
+}
+
+function formatNumber(n: number | null): string {
+  if (n === null) return "—"
+  return Math.round(n * 100) / 100 % 1 === 0 ? n.toFixed(0) : n.toFixed(2)
+}
+
+function formatPct(n: number | null): string {
+  if (n === null) return "—"
+  return `${n.toFixed(1)}%`
+}
+
+function describeMedian(n: number | null, totalUsers: number): string {
+  if (n === null) return "Median needs at least one user with a bounce score."
+  const userPhrase = totalUsers === 1 ? "the 1 user" : `the ${totalUsers} users`
+  return `Today, ${userPhrase} sit at a median bounce of ${formatNumber(n)} karma.`
+}
+
+function describeMaintaining(n: number | null, totalUsers: number): string {
+  if (n === null) return "% maintaining needs at least one user with a bounce score."
+  const userPhrase = totalUsers === 1 ? "the 1 user" : `the ${totalUsers} users`
+  return `${n.toFixed(1)}% of ${userPhrase} have a current bounce at or above where it was 7 days ago.`
+}
+
+function describeActiveDays(n: number | null): string {
+  if (n === null) return "Avg active days needs at least one MAU."
+  return `Across the last 30 days' active users (MAU), each one logged on average ${formatNumber(n)} distinct days with a pebble in the last 7 days.`
+}

--- a/apps/admin/components/analytics/BounceDistributionCard.tsx
+++ b/apps/admin/components/analytics/BounceDistributionCard.tsx
@@ -1,0 +1,79 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getBounceDistributionToday } from "@/lib/analytics/fetchers"
+import type { BounceDistributionRow } from "@/lib/analytics/types"
+import { BounceDistribution, type BounceDistributionStats } from "./BounceDistribution"
+import type { BounceDistributionDatum } from "./BounceDistributionChart"
+import { ErrorBlock } from "./ErrorBlock"
+
+// The view always returns six bucket rows in this order. Matching this list
+// here means the chart still renders the full histogram (with zero bars) when
+// the RPC is empty mid-deploy, and pins the X-axis order independent of how
+// the RPC chooses to sort its rows.
+const BUCKET_ORDER: { order: number; label: string }[] = [
+  { order: 0, label: "0" },
+  { order: 1, label: "1-10" },
+  { order: 2, label: "11-25" },
+  { order: 3, label: "26-50" },
+  { order: 4, label: "51-100" },
+  { order: 5, label: "100+" },
+]
+
+export async function BounceDistributionCard() {
+  let rows: BounceDistributionRow[]
+  try {
+    rows = await getBounceDistributionToday()
+  } catch (err) {
+    return (
+      <ErrorBlock
+        label="Failed to load bounce karma distribution"
+        message={err instanceof Error ? err.message : String(err)}
+      />
+    )
+  }
+
+  const { buckets, totalUsers, stats } = projectRows(rows)
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Bounce karma distribution</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <BounceDistribution
+          buckets={buckets}
+          totalUsers={totalUsers}
+          stats={stats}
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+function projectRows(rows: BounceDistributionRow[]): {
+  buckets: BounceDistributionDatum[]
+  totalUsers: number
+  stats: BounceDistributionStats
+} {
+  const byOrder = new Map<number, BounceDistributionRow>()
+  for (const r of rows) {
+    if (r.bucket_order !== null) byOrder.set(r.bucket_order, r)
+  }
+
+  const buckets: BounceDistributionDatum[] = BUCKET_ORDER.map(({ order, label }) => ({
+    bucket_label: label,
+    users: byOrder.get(order)?.users ?? 0,
+  }))
+
+  const totalUsers = buckets.reduce((acc, b) => acc + b.users, 0)
+
+  // Summary stats are denormalized onto every row — read whichever row was
+  // returned (preferring bucket 0 for determinism). All-null when no rows.
+  const sample = byOrder.get(0) ?? rows[0]
+  const stats: BounceDistributionStats = {
+    medianScore: sample?.median_score ?? null,
+    pctMaintaining: sample?.pct_maintaining ?? null,
+    avgActiveDaysPerWeek: sample?.avg_active_days_per_week ?? null,
+  }
+
+  return { buckets, totalUsers, stats }
+}

--- a/apps/admin/components/analytics/BounceDistributionChart.tsx
+++ b/apps/admin/components/analytics/BounceDistributionChart.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { Bar, BarChart, CartesianGrid, LabelList, XAxis, YAxis } from "recharts"
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart"
+
+export type BounceDistributionDatum = {
+  bucket_label: string
+  users: number
+}
+
+const config: ChartConfig = {
+  users: { label: "Users", color: "var(--chart-1)" },
+}
+
+type Props = {
+  data: BounceDistributionDatum[]
+}
+
+export function BounceDistributionChart({ data }: Props) {
+  const total = data.reduce((acc, r) => acc + r.users, 0)
+  if (total === 0) {
+    return (
+      <div
+        className="flex h-56 items-center justify-center text-sm text-muted-foreground"
+        aria-live="polite"
+      >
+        No users yet — bounce karma appears once users start collecting.
+      </div>
+    )
+  }
+
+  return (
+    <ChartContainer config={config} className="h-56 w-full">
+      <BarChart data={data} margin={{ left: 4, right: 12, top: 16, bottom: 4 }}>
+        <CartesianGrid vertical={false} strokeDasharray="3 3" />
+        <XAxis
+          dataKey="bucket_label"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+        />
+        <YAxis tickLine={false} axisLine={false} width={32} allowDecimals={false} />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <Bar
+          dataKey="users"
+          fill="var(--color-users)"
+          radius={[2, 2, 0, 0]}
+        >
+          <LabelList
+            dataKey="users"
+            position="top"
+            className="fill-foreground text-xs tabular-nums"
+          />
+        </Bar>
+      </BarChart>
+    </ChartContainer>
+  )
+}

--- a/apps/admin/components/analytics/__fixtures__/bounceDistribution.ts
+++ b/apps/admin/components/analytics/__fixtures__/bounceDistribution.ts
@@ -1,0 +1,44 @@
+import type { BounceDistributionStats } from "../BounceDistribution"
+import type { BounceDistributionDatum } from "../BounceDistributionChart"
+
+export type BounceDistributionFixture = {
+  buckets: BounceDistributionDatum[]
+  totalUsers: number
+  stats: BounceDistributionStats
+}
+
+const LABELS = ["0", "1-10", "11-25", "26-50", "51-100", "100+"] as const
+
+function buckets(values: readonly number[]): BounceDistributionDatum[] {
+  return LABELS.map((label, i) => ({ bucket_label: label, users: values[i] ?? 0 }))
+}
+
+export const denseBounceDistributionFixture: BounceDistributionFixture = {
+  buckets: buckets([12, 38, 47, 26, 14, 5]),
+  totalUsers: 12 + 38 + 47 + 26 + 14 + 5,
+  stats: {
+    medianScore: 19,
+    pctMaintaining: 71.4,
+    avgActiveDaysPerWeek: 2.8,
+  },
+}
+
+export const sparseBounceDistributionFixture: BounceDistributionFixture = {
+  buckets: buckets([3, 4, 1, 0, 0, 0]),
+  totalUsers: 3 + 4 + 1,
+  stats: {
+    medianScore: 4,
+    pctMaintaining: 50,
+    avgActiveDaysPerWeek: 1.25,
+  },
+}
+
+export const emptyBounceDistributionFixture: BounceDistributionFixture = {
+  buckets: buckets([0, 0, 0, 0, 0, 0]),
+  totalUsers: 0,
+  stats: {
+    medianScore: null,
+    pctMaintaining: null,
+    avgActiveDaysPerWeek: null,
+  },
+}

--- a/apps/admin/lib/analytics/fetchers.ts
+++ b/apps/admin/lib/analytics/fetchers.ts
@@ -2,6 +2,7 @@ import { createServerSupabaseClient } from "@/lib/supabase/server"
 import { dateRangeFor, periodLengthDays, shiftIsoDate } from "./date"
 import type {
   ActiveUsersDailyRow,
+  BounceDistributionRow,
   DomainShareWeeklyRow,
   EmotionShareWeeklyRow,
   IsoDate,
@@ -111,6 +112,21 @@ export async function getUserAveragesSeries(
   })
   if (error) {
     console.error("[analytics] getUserAveragesSeries failed:", error.message)
+    throw new Error(error.message)
+  }
+  return data ?? []
+}
+
+/**
+ * Today's bounce-karma distribution: one row per histogram bucket plus the
+ * three summary stats (median, % maintaining, avg active days/week)
+ * denormalized onto every row. The RPC enforces `is_admin(auth.uid())`.
+ */
+export async function getBounceDistributionToday(): Promise<BounceDistributionRow[]> {
+  const supabase = await createServerSupabaseClient()
+  const { data, error } = await supabase.rpc("get_bounce_distribution_today")
+  if (error) {
+    console.error("[analytics] getBounceDistributionToday failed:", error.message)
     throw new Error(error.message)
   }
   return data ?? []

--- a/apps/admin/lib/analytics/types.ts
+++ b/apps/admin/lib/analytics/types.ts
@@ -87,6 +87,21 @@ export interface DomainShareWeeklyRow {
   share_pct: number | null
 }
 
+export interface BounceDistributionRow {
+  bucket_date: IsoDate | null
+  /** 0..5 ordering, matches the canonical bucket sequence. */
+  bucket_order: number | null
+  /** Human-readable bucket: "0", "1-10", "11-25", "26-50", "51-100", "100+". */
+  bucket_label: string | null
+  users: number | null
+  /** Median current bounce score across all users. Null when zero users. */
+  median_score: number | null
+  /** % of users whose current bounce >= their bounce 7 days ago. 0–100. */
+  pct_maintaining: number | null
+  /** Avg distinct active days in the last 7 days, across all MAU. 0–7. */
+  avg_active_days_per_week: number | null
+}
+
 export interface UserAveragesWeeklyRow {
   /** Monday of the ISO week (UTC), ISO date string. */
   bucket_week: IsoDate | null

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -1211,6 +1211,33 @@
       "description": "SECURITY DEFINER plpgsql RPC, gated on is_admin(auth.uid()). Takes p_start and p_end dates (week-truncated internally). Returns rows from v_analytics_domain_share_weekly within the range, ordered by bucket_week asc, domain_level asc. The admin domain-share card calls this RPC twice (current + previous period) to compute 'biggest movers' deltas in pp.",
       "status": "development",
       "platforms": ["web"]
+    },
+    {
+      "id": "DM-bounce",
+      "project_id": "pebbles",
+      "species": "data-model",
+      "title": "bounces",
+      "description": "Postgres table: snapshot of each user's running bounce karma score. Columns: user_id (PK, FK auth.users), score (int, default 0; cumulative sum of karma_events.delta — may be transiently negative if reversals exceed gains, the analytics view floors at 0), updated_at. Maintained atomically by trigger karma_events_apply_to_bounce on every karma_events insert (upserts the delta in the same transaction). Backfilled at migration time from sum(karma_events.delta) per user. RLS: users can read their own row; writes only via the trigger (security definer).",
+      "status": "development",
+      "platforms": ["web"]
+    },
+    {
+      "id": "DM-v-analytics-bounce-distribution-today",
+      "project_id": "pebbles",
+      "species": "data-model",
+      "title": "v_analytics_bounce_distribution_today",
+      "description": "Postgres view: histogram of users by current bounce score (six buckets: 0, 1-10, 11-25, 26-50, 51-100, 100+) plus three summary stats denormalized onto every row — median_score, pct_maintaining (% of users whose current bounce >= bounce 7 days ago, reconstructed from karma_events), avg_active_days_per_week (avg distinct active days in the last 7 days across MAU). Always emits all six bucket rows, even when empty.",
+      "status": "development",
+      "platforms": ["web"]
+    },
+    {
+      "id": "API-get-bounce-distribution-today",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "get_bounce_distribution_today",
+      "description": "SECURITY DEFINER plpgsql RPC, gated on is_admin(auth.uid()). No arguments. Returns the six histogram-bucket rows from v_analytics_bounce_distribution_today ordered by bucket_order asc. Backs the bounce karma distribution card on the admin analytics page. Raises insufficient_privilege (42501) for non-admins.",
+      "status": "development",
+      "platforms": ["web"]
     }
   ],
   "edges": [
@@ -1429,6 +1456,11 @@
     { "id": "e-V-admin-analytics-DM-v-analytics-emotion-share-weekly", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "DM-v-analytics-emotion-share-weekly", "edge_type": "displays" },
     { "id": "e-V-admin-analytics-DM-v-analytics-domain-share-weekly", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "DM-v-analytics-domain-share-weekly", "edge_type": "displays" },
     { "id": "e-API-get-emotion-share-DM-v-analytics-emotion-share-weekly", "project_id": "pebbles", "source_id": "API-get-emotion-share", "target_id": "DM-v-analytics-emotion-share-weekly", "edge_type": "queries" },
-    { "id": "e-API-get-domain-share-DM-v-analytics-domain-share-weekly", "project_id": "pebbles", "source_id": "API-get-domain-share", "target_id": "DM-v-analytics-domain-share-weekly", "edge_type": "queries" }
+    { "id": "e-API-get-domain-share-DM-v-analytics-domain-share-weekly", "project_id": "pebbles", "source_id": "API-get-domain-share", "target_id": "DM-v-analytics-domain-share-weekly", "edge_type": "queries" },
+    { "id": "e-V-admin-analytics-API-get-bounce-distribution-today", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "API-get-bounce-distribution-today", "edge_type": "calls" },
+    { "id": "e-V-admin-analytics-DM-v-analytics-bounce-distribution-today", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "DM-v-analytics-bounce-distribution-today", "edge_type": "displays" },
+    { "id": "e-API-get-bounce-distribution-today-DM-v-analytics-bounce-distribution-today", "project_id": "pebbles", "source_id": "API-get-bounce-distribution-today", "target_id": "DM-v-analytics-bounce-distribution-today", "edge_type": "queries" },
+    { "id": "e-API-get-bounce-distribution-today-DM-bounce", "project_id": "pebbles", "source_id": "API-get-bounce-distribution-today", "target_id": "DM-bounce", "edge_type": "queries" },
+    { "id": "e-API-get-bounce-distribution-today-DM-pebble", "project_id": "pebbles", "source_id": "API-get-bounce-distribution-today", "target_id": "DM-pebble", "edge_type": "queries" }
   ]
 }

--- a/packages/supabase/supabase/migrations/20260501000004_bounces_and_analytics_distribution.sql
+++ b/packages/supabase/supabase/migrations/20260501000004_bounces_and_analytics_distribution.sql
@@ -1,0 +1,207 @@
+-- =============================================================================
+-- Bounce score snapshot + Admin · Analytics · Bounce distribution
+-- =============================================================================
+-- Issue: #344
+-- Reference: docs/poc/admin-analytics/20260430_analytics_mvs.sql
+--            § mv_bounce_distribution_daily
+--
+-- Adds the missing data foundation for "bounce karma":
+--
+--   1. public.bounces (user_id, score, updated_at)
+--      Snapshot of each user's running karma total. Maintained atomically by
+--      a trigger on public.karma_events insert (each insert upserts the
+--      delta into bounces in the same transaction). Backfilled once at
+--      migration time from sum(karma_events.delta) per user.
+--
+--   2. v_analytics_bounce_distribution_today
+--      Histogram of users by current bounce score, with three summary stats:
+--      median bounce, % maintaining (current >= score 7 days ago, computed
+--      from karma_events to avoid needing a snapshot history table), and
+--      avg active days / week across MAU (active day = day with >=1 pebble).
+--
+--   3. get_bounce_distribution_today() RPC, gated on is_admin(auth.uid()).
+--
+-- Terminology: "bounce" is the table noun; "score" is the integer column.
+-- The UI says "bounce karma" but the data layer uses score for brevity.
+-- Negative cumulative scores (possible if reversals exceed prior gains) are
+-- stored as-is; the analytics view buckets anything <= 0 into the "0" bin.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. public.bounces snapshot table
+-- -----------------------------------------------------------------------------
+create table if not exists public.bounces (
+  user_id    uuid primary key references auth.users(id) on delete cascade,
+  score      integer not null default 0,
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists bounces_score_idx on public.bounces (score);
+
+alter table public.bounces enable row level security;
+
+-- Users can read their own bounce; admins can read all (via is_admin in RPCs).
+drop policy if exists "bounces_select_self" on public.bounces;
+create policy "bounces_select_self" on public.bounces
+  for select using (user_id = auth.uid());
+
+-- No INSERT/UPDATE/DELETE policies: writes happen exclusively through the
+-- karma_events trigger (security definer). Direct writes from clients are
+-- rejected by RLS.
+
+-- -----------------------------------------------------------------------------
+-- 2. Trigger: keep bounces in sync with karma_events
+-- -----------------------------------------------------------------------------
+create or replace function public.apply_karma_event_to_bounce()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.bounces (user_id, score, updated_at)
+  values (new.user_id, new.delta, now())
+  on conflict (user_id) do update
+    set score      = public.bounces.score + excluded.score,
+        updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists karma_events_apply_to_bounce on public.karma_events;
+create trigger karma_events_apply_to_bounce
+  after insert on public.karma_events
+  for each row execute function public.apply_karma_event_to_bounce();
+
+-- -----------------------------------------------------------------------------
+-- 3. One-shot backfill from existing karma_events
+-- Idempotent: re-running this migration replays sum(delta) per user. The
+-- on conflict clause overwrites whatever the trigger may have left behind
+-- (e.g. partial inserts mid-migration).
+-- -----------------------------------------------------------------------------
+insert into public.bounces (user_id, score, updated_at)
+select ke.user_id, sum(ke.delta)::int, now()
+from public.karma_events ke
+group by ke.user_id
+on conflict (user_id) do update
+  set score      = excluded.score,
+      updated_at = excluded.updated_at;
+
+-- -----------------------------------------------------------------------------
+-- 4. v_analytics_bounce_distribution_today
+-- One row per histogram bucket (always 6 rows, even if some are empty so the
+-- chart doesn't have to coalesce). Summary stats are denormalized onto every
+-- row to keep the page query a single SELECT.
+-- -----------------------------------------------------------------------------
+drop function if exists public.get_bounce_distribution_today();
+drop view if exists public.v_analytics_bounce_distribution_today;
+
+create view public.v_analytics_bounce_distribution_today as
+with all_buckets(bucket_order, bucket_label, lo, hi) as (
+  values
+    (0, '0',      0,    0),
+    (1, '1-10',   1,    10),
+    (2, '11-25',  11,   25),
+    (3, '26-50',  26,   50),
+    (4, '51-100', 51,   100),
+    (5, '100+',   101,  2147483647)
+),
+scored as (
+  -- Floor at 0 only for bucketing; the underlying score column may be negative.
+  select greatest(b.score, 0) as score
+  from public.bounces b
+),
+binned as (
+  select ab.bucket_order, ab.bucket_label,
+         count(s.score)::int as users
+  from all_buckets ab
+  left join scored s on s.score between ab.lo and ab.hi
+  group by ab.bucket_order, ab.bucket_label
+),
+median as (
+  select percentile_cont(0.5) within group (order by score)::numeric as median_score
+  from scored
+),
+maintaining as (
+  -- A user "maintains" if their current score is >= the score they had 7 days
+  -- ago. We reconstruct the 7-day-ago score from karma_events rather than
+  -- relying on a snapshot history table (which doesn't exist yet).
+  select
+    case when count(*) = 0 then null
+         else round(100.0 * count(*) filter (where curr >= prev) / count(*), 1)
+    end as pct_maintaining
+  from (
+    select
+      b.user_id,
+      greatest(b.score, 0) as curr,
+      greatest(coalesce((
+        select sum(ke.delta)::int
+        from public.karma_events ke
+        where ke.user_id = b.user_id
+          and ke.created_at < now() - interval '7 days'
+      ), 0), 0) as prev
+    from public.bounces b
+  ) x
+),
+mau as (
+  -- MAU = users with >=1 pebble in the last 30 days.
+  select distinct p.user_id
+  from public.pebbles p
+  where p.created_at >= now() - interval '30 days'
+),
+active_days as (
+  -- For each MAU user, count distinct calendar days with >=1 pebble in the
+  -- last 7 days. Average across MAU. Users with zero days in the window
+  -- still count as 0 in the average so the metric reflects all MAU.
+  select
+    case when count(*) = 0 then null
+         else round(avg(coalesce(d.days, 0))::numeric, 2)
+    end as avg_active_days_per_week
+  from mau m
+  left join lateral (
+    select count(distinct p.created_at::date) as days
+    from public.pebbles p
+    where p.user_id = m.user_id
+      and p.created_at >= now() - interval '7 days'
+  ) d on true
+)
+select
+  current_date            as bucket_date,
+  b.bucket_order,
+  b.bucket_label,
+  b.users,
+  med.median_score,
+  mt.pct_maintaining,
+  ad.avg_active_days_per_week
+from binned b
+cross join median       med
+cross join maintaining  mt
+cross join active_days  ad;
+
+-- -----------------------------------------------------------------------------
+-- 5. get_bounce_distribution_today() RPC
+-- Enforces is_admin(auth.uid()).
+-- -----------------------------------------------------------------------------
+create or replace function public.get_bounce_distribution_today()
+returns setof public.v_analytics_bounce_distribution_today
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'insufficient_privilege' using errcode = '42501';
+  end if;
+
+  return query
+    select * from public.v_analytics_bounce_distribution_today
+    order by bucket_order asc;
+end;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- Permissions
+-- -----------------------------------------------------------------------------
+revoke all on public.v_analytics_bounce_distribution_today from public, anon, authenticated;
+
+grant execute on function public.get_bounce_distribution_today() to authenticated;

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -39,6 +39,24 @@ export type Database = {
   }
   public: {
     Tables: {
+      bounces: {
+        Row: {
+          score: number
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          score?: number
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          score?: number
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       card_types: {
         Row: {
           id: string
@@ -781,6 +799,18 @@ export type Database = {
       }
     }
     Views: {
+      v_analytics_bounce_distribution_today: {
+        Row: {
+          avg_active_days_per_week: number | null
+          bucket_date: string | null
+          bucket_label: string | null
+          bucket_order: number | null
+          median_score: number | null
+          pct_maintaining: number | null
+          users: number | null
+        }
+        Relationships: []
+      }
       v_analytics_active_users_daily: {
         Row: {
           bucket_date: string | null
@@ -999,6 +1029,24 @@ export type Database = {
         SetofOptions: {
           from: "*"
           to: "v_analytics_active_users_daily"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
+      get_bounce_distribution_today: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          avg_active_days_per_week: number | null
+          bucket_date: string | null
+          bucket_label: string | null
+          bucket_order: number | null
+          median_score: number | null
+          pct_maintaining: number | null
+          users: number | null
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "v_analytics_bounce_distribution_today"
           isOneToOne: false
           isSetofReturn: true
         }


### PR DESCRIPTION
Resolves #344.

Adds the missing data foundation for "bounce karma" (snapshot table maintained by trigger on `karma_events`) and the analytics card it unblocks.

## Summary

- **`public.bounces (user_id, score, updated_at)`** snapshot table; `AFTER INSERT` trigger on `karma_events` upserts the delta atomically. Backfilled at migration time from `sum(karma_events.delta)` per user. RLS: users read self; writes only via the trigger.
- **`v_analytics_bounce_distribution_today`** + **`get_bounce_distribution_today()`** RPC (admin-gated): six histogram buckets (`0`, `1-10`, `11-25`, `26-50`, `51-100`, `100+`) plus three summary stats denormalized onto every row — median bounce, % maintaining vs 7 days ago, avg active days/week across MAU.
- **`BounceDistributionCard`** on `/analytics`, paired 7/12 + 5/12 with the per-user averages card. Fixtures + playground variants for dense / sparse / empty.
- Arkaik map updated (`DM-bounce`, `DM-v-analytics-bounce-distribution-today`, `API-get-bounce-distribution-today` + edges).

## Design decisions (issue's open questions)

1. **Storage**: snapshot table maintained by trigger (option preferred in the issue). Atomic with the karma write.
2. **Backfill**: one-shot in the migration; idempotent via `on conflict do update`.
3. **Terminology**: data column is `score`; UI label is "Bounce karma".
4. **Negatives**: stored signed in the table (preserves info); analytics view floors at `0` when bucketing.
5. **% maintaining**: reconstructs the 7-day-ago score from `karma_events` (no snapshot history table needed yet).

## Key files

- `packages/supabase/supabase/migrations/20260501000004_bounces_and_analytics_distribution.sql` — table, trigger, backfill, analytics view, RPC
- `packages/supabase/types/database.ts` — manual entries for new table/view/RPC (regenerate via `npm run db:types` for the canonical version)
- `apps/admin/components/analytics/BounceDistribution{Card,,Chart}.tsx` + `__fixtures__/bounceDistribution.ts`
- `apps/admin/lib/analytics/{fetchers,types}.ts` — `getBounceDistributionToday` + `BounceDistributionRow`
- `apps/admin/app/(authed)/analytics/page.tsx` — wires the card into the 7/12 + 5/12 row
- `apps/admin/app/(authed)/playground/analytics/page.tsx` — dense/sparse/empty variants
- `docs/arkaik/bundle.json` — data nodes + endpoint + edges

## Labels & milestone

Proposing to inherit from #344: labels `feat`, `db`, `core`, `supabase`, `admin`; milestone `M28 · Admin Analytics`. Confirm and I'll apply.

## Test plan

- [x] Run migration in Supabase Studio (done by author).
- [x] Create a new pebble as a regular user → verify `bounces.score` increments by the karma delta.
- [x] Open `/analytics` as admin → bounce karma distribution card renders with non-zero buckets.
- [x] Open `/analytics` as non-admin (or unauthenticated) → RPC raises `insufficient_privilege`; card shows the error block.
- [x] Visit `/playground/analytics` → dense / sparse / empty `BounceDistribution` variants render correctly.
- [x] `npm run lint --workspace=apps/admin` ✅
- [x] `npm run build --workspace=apps/admin` ✅
- [x] `npm run lint --workspace=apps/web` ✅ (database.ts type addition)

https://claude.ai/code/session_01EFxiT3y3DgHy47F67hLDTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFxiT3y3DgHy47F67hLDTZ)_