### PR TITLE
feat(core): admin analytics quality signals table (Phase A)

### DIFF
--- a/apps/admin/app/(authed)/analytics/page.tsx
+++ b/apps/admin/app/(authed)/analytics/page.tsx
@@ -8,6 +8,7 @@ import { KpiStrip } from "@/components/analytics/KpiStrip"
 import { KpiStripSkeleton } from "@/components/analytics/KpiStripSkeleton"
 import { PebbleEnrichmentCard } from "@/components/analytics/PebbleEnrichmentCard"
 import { PebbleVolumeChartCard } from "@/components/analytics/PebbleVolumeChartCard"
+import { QualitySignalsTableCard } from "@/components/analytics/QualitySignalsTableCard"
 import { RetentionHeatmapCard } from "@/components/analytics/RetentionHeatmapCard"
 import { TimeRangeTabs } from "@/components/analytics/TimeRangeTabs"
 import { UserAveragesCard } from "@/components/analytics/UserAveragesCard"
@@ -73,6 +74,11 @@ export default async function AnalyticsPage({
         <div className="lg:col-span-6">
           <Suspense fallback={<ChartCardSkeleton />}>
             <DomainShareCard range={range} />
+          </Suspense>
+        </div>
+        <div className="lg:col-span-12">
+          <Suspense fallback={<ChartCardSkeleton />}>
+            <QualitySignalsTableCard />
           </Suspense>
         </div>
       </div>

--- a/apps/admin/app/(authed)/playground/analytics/page.tsx
+++ b/apps/admin/app/(authed)/playground/analytics/page.tsx
@@ -5,6 +5,7 @@ import { EmotionShare } from "@/components/analytics/EmotionShare"
 import { KpiCard } from "@/components/analytics/KpiCard"
 import { PebbleEnrichment } from "@/components/analytics/PebbleEnrichment"
 import { PebbleVolumeChart } from "@/components/analytics/PebbleVolumeChart"
+import { QualitySignalsTable } from "@/components/analytics/QualitySignalsTable"
 import { RetentionHeatmap } from "@/components/analytics/RetentionHeatmap"
 import { Sparkline } from "@/components/analytics/Sparkline"
 import { UserAverages } from "@/components/analytics/UserAverages"
@@ -52,6 +53,11 @@ import {
   emptyBounceDistributionFixture,
   sparseBounceDistributionFixture,
 } from "@/components/analytics/__fixtures__/bounceDistribution"
+import {
+  denseQualitySignalsFixture,
+  emptyQualitySignalsFixture,
+  sparseQualitySignalsFixture,
+} from "@/components/analytics/__fixtures__/qualitySignals"
 import {
   denseDomainShareBottomMover,
   denseDomainShareSnapshot,
@@ -352,6 +358,33 @@ export default function AnalyticsPlaygroundPage() {
             totalUsers={emptyBounceDistributionFixture.totalUsers}
             stats={emptyBounceDistributionFixture.stats}
           />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          QualitySignalsTable — dense (4 of 8 populated)
+        </h2>
+        <div className="max-w-2xl">
+          <QualitySignalsTable rows={denseQualitySignalsFixture} />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          QualitySignalsTable — sparse (no comparable prior period)
+        </h2>
+        <div className="max-w-2xl">
+          <QualitySignalsTable rows={sparseQualitySignalsFixture} />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          QualitySignalsTable — empty
+        </h2>
+        <div className="max-w-2xl">
+          <QualitySignalsTable rows={emptyQualitySignalsFixture} />
         </div>
       </section>
     </div>

--- a/apps/admin/components/analytics/QualitySignalsTable.tsx
+++ b/apps/admin/components/analytics/QualitySignalsTable.tsx
@@ -1,0 +1,173 @@
+import { ArrowDown, ArrowUp, Minus } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
+import type { QualitySignalRow, QualitySignalUnit } from "@/lib/analytics/types"
+
+export type QualitySignalsTableProps = {
+  rows: QualitySignalRow[]
+}
+
+export function QualitySignalsTable({ rows }: QualitySignalsTableProps) {
+  if (rows.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No data yet — quality signals appear once users start collecting.
+      </p>
+    )
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Indicator</TableHead>
+          <TableHead className="text-right">Value</TableHead>
+          <TableHead className="text-right">Δ vs prior period</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((row) => (
+          <Row key={row.indicator_key ?? row.indicator_order} row={row} />
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+function Row({ row }: { row: QualitySignalRow }) {
+  const available = row.available === true
+  const unit = (row.unit ?? "pebbles") as QualitySignalUnit
+  const label = row.indicator_label ?? row.indicator_key ?? "—"
+
+  const valueDisplay = available ? formatValue(row.value, unit) : "—"
+  const description = available
+    ? describe(label, row.value, row.previous_value, unit)
+    : "Data not collected yet — this metric becomes available in Phase B/C."
+
+  return (
+    <TableRow className={cn(!available && "opacity-60")}>
+      <TableCell className="font-medium">{label}</TableCell>
+      <TableCell className="text-right">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <span
+                className="cursor-help tabular-nums underline decoration-dotted decoration-muted-foreground/50 underline-offset-4"
+                tabIndex={0}
+              >
+                {valueDisplay}
+              </span>
+            }
+          />
+          <TooltipContent>{description}</TooltipContent>
+        </Tooltip>
+      </TableCell>
+      <TableCell className="text-right">
+        {available ? (
+          <DeltaCell value={row.value} previous={row.previous_value} unit={unit} />
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </TableCell>
+    </TableRow>
+  )
+}
+
+function DeltaCell({
+  value,
+  previous,
+  unit,
+}: {
+  value: number | null
+  previous: number | null
+  unit: QualitySignalUnit
+}) {
+  if (value === null || previous === null) {
+    return <span className="text-muted-foreground">—</span>
+  }
+  const delta = round2(value - previous)
+  const direction: "up" | "down" | "flat" =
+    delta === 0 ? "flat" : delta > 0 ? "up" : "down"
+  const Icon = direction === "up" ? ArrowUp : direction === "down" ? ArrowDown : Minus
+  const sign = delta > 0 ? "+" : ""
+  return (
+    <Badge
+      variant="secondary"
+      className={cn(
+        "gap-1",
+        direction === "up" && "text-emerald-700 dark:text-emerald-400",
+        direction === "down" && "text-rose-700 dark:text-rose-400",
+      )}
+    >
+      <Icon className="size-3" aria-hidden />
+      <span className="tabular-nums">
+        {sign}
+        {formatDelta(delta, unit)}
+      </span>
+    </Badge>
+  )
+}
+
+function formatValue(value: number | null, unit: QualitySignalUnit): string {
+  if (value === null) return "—"
+  switch (unit) {
+    case "percent":
+      return `${value.toFixed(1)}%`
+    case "seconds":
+      return formatSeconds(value)
+    default:
+      return value.toFixed(2)
+  }
+}
+
+function formatDelta(delta: number, unit: QualitySignalUnit): string {
+  switch (unit) {
+    case "percent":
+      return `${delta.toFixed(1)}pp`
+    case "seconds":
+      return `${Math.round(delta)}s`
+    default:
+      return delta.toFixed(2)
+  }
+}
+
+function formatSeconds(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`
+  const m = Math.floor(seconds / 60)
+  const s = Math.round(seconds - m * 60)
+  return s === 0 ? `${m}m` : `${m}m ${s}s`
+}
+
+function describe(
+  label: string,
+  value: number | null,
+  previous: number | null,
+  unit: QualitySignalUnit,
+): string {
+  if (value === null) {
+    return `${label} has no value yet — not enough data in the current window.`
+  }
+  const current = formatValue(value, unit)
+  if (previous === null) {
+    return `${label} sits at ${current} today; no comparable prior-period value yet.`
+  }
+  const prior = formatValue(previous, unit)
+  return `${label} sits at ${current} today, vs ${prior} in the matching prior period.`
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}

--- a/apps/admin/components/analytics/QualitySignalsTableCard.tsx
+++ b/apps/admin/components/analytics/QualitySignalsTableCard.tsx
@@ -1,0 +1,30 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getQualitySignalsToday } from "@/lib/analytics/fetchers"
+import type { QualitySignalRow } from "@/lib/analytics/types"
+import { ErrorBlock } from "./ErrorBlock"
+import { QualitySignalsTable } from "./QualitySignalsTable"
+
+export async function QualitySignalsTableCard() {
+  let rows: QualitySignalRow[]
+  try {
+    rows = await getQualitySignalsToday()
+  } catch (err) {
+    return (
+      <ErrorBlock
+        label="Failed to load quality signals"
+        message={err instanceof Error ? err.message : String(err)}
+      />
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Quality signals</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <QualitySignalsTable rows={rows} />
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/admin/components/analytics/__fixtures__/qualitySignals.ts
+++ b/apps/admin/components/analytics/__fixtures__/qualitySignals.ts
@@ -1,0 +1,124 @@
+import type { QualitySignalRow } from "@/lib/analytics/types"
+
+const TODAY = "2026-05-01"
+
+const PLACEHOLDERS: Pick<
+  QualitySignalRow,
+  "indicator_order" | "indicator_key" | "indicator_label" | "unit"
+>[] = [
+  { indicator_order: 1, indicator_key: "median_session_seconds",      indicator_label: "Median session duration",         unit: "seconds" },
+  { indicator_order: 2, indicator_key: "sessions_per_wau",            indicator_label: "Sessions per active user / week", unit: "sessions" },
+  { indicator_order: 4, indicator_key: "pct_revisits_to_past_pebbles",indicator_label: "% revisits to past pebbles",       unit: "percent" },
+  { indicator_order: 8, indicator_key: "friction_events_per_session", indicator_label: "Friction events / session",        unit: "events" },
+]
+
+function placeholder(order: number): QualitySignalRow {
+  const p = PLACEHOLDERS.find((x) => x.indicator_order === order)
+  if (!p) throw new Error(`No placeholder for order ${order}`)
+  return {
+    bucket_date: TODAY,
+    indicator_order: p.indicator_order,
+    indicator_key: p.indicator_key,
+    indicator_label: p.indicator_label,
+    unit: p.unit,
+    value: null,
+    previous_value: null,
+    available: false,
+  }
+}
+
+export const denseQualitySignalsFixture: QualitySignalRow[] = [
+  placeholder(1),
+  placeholder(2),
+  {
+    bucket_date: TODAY,
+    indicator_order: 3,
+    indicator_key: "pebbles_per_wau",
+    indicator_label: "Pebbles per active user / week",
+    unit: "pebbles",
+    value: 8.42,
+    previous_value: 7.96,
+    available: true,
+  },
+  placeholder(4),
+  {
+    bucket_date: TODAY,
+    indicator_order: 5,
+    indicator_key: "d1_retention",
+    indicator_label: "D1 retention",
+    unit: "percent",
+    value: 42.9,
+    previous_value: 38.1,
+    available: true,
+  },
+  {
+    bucket_date: TODAY,
+    indicator_order: 6,
+    indicator_key: "d7_retention",
+    indicator_label: "D7 retention",
+    unit: "percent",
+    value: 27.3,
+    previous_value: 31.0,
+    available: true,
+  },
+  {
+    bucket_date: TODAY,
+    indicator_order: 7,
+    indicator_key: "d30_retention",
+    indicator_label: "D30 retention",
+    unit: "percent",
+    value: 14.0,
+    previous_value: 14.0,
+    available: true,
+  },
+  placeholder(8),
+]
+
+export const sparseQualitySignalsFixture: QualitySignalRow[] = [
+  placeholder(1),
+  placeholder(2),
+  {
+    bucket_date: TODAY,
+    indicator_order: 3,
+    indicator_key: "pebbles_per_wau",
+    indicator_label: "Pebbles per active user / week",
+    unit: "pebbles",
+    value: 1.5,
+    previous_value: null,
+    available: true,
+  },
+  placeholder(4),
+  {
+    bucket_date: TODAY,
+    indicator_order: 5,
+    indicator_key: "d1_retention",
+    indicator_label: "D1 retention",
+    unit: "percent",
+    value: null,
+    previous_value: null,
+    available: true,
+  },
+  {
+    bucket_date: TODAY,
+    indicator_order: 6,
+    indicator_key: "d7_retention",
+    indicator_label: "D7 retention",
+    unit: "percent",
+    value: null,
+    previous_value: null,
+    available: true,
+  },
+  {
+    bucket_date: TODAY,
+    indicator_order: 7,
+    indicator_key: "d30_retention",
+    indicator_label: "D30 retention",
+    unit: "percent",
+    value: null,
+    previous_value: null,
+    available: true,
+  },
+  placeholder(8),
+]
+
+export const emptyQualitySignalsFixture: QualitySignalRow[] = []

--- a/apps/admin/lib/analytics/fetchers.ts
+++ b/apps/admin/lib/analytics/fetchers.ts
@@ -9,6 +9,7 @@ import type {
   KpiDailyRow,
   PebbleEnrichmentRow,
   PebbleVolumeRow,
+  QualitySignalRow,
   RetentionCohortRow,
   TimeRange,
   UserAveragesWeeklyRow,
@@ -212,6 +213,22 @@ export async function getDomainShare(
     throw new Error(prevError.message)
   }
   return { current, previous: prevData ?? [] }
+}
+
+/**
+ * Today's 8-row Quality signals table (current value + matching prior-period
+ * value per indicator). Four rows are computable from existing data; the other
+ * four return `available = false` until sessions / pebble_views / analytics
+ * events land. The RPC enforces `is_admin(auth.uid())`.
+ */
+export async function getQualitySignalsToday(): Promise<QualitySignalRow[]> {
+  const supabase = await createServerSupabaseClient()
+  const { data, error } = await supabase.rpc("get_quality_signals_today")
+  if (error) {
+    console.error("[analytics] getQualitySignalsToday failed:", error.message)
+    throw new Error(error.message)
+  }
+  return (data ?? []) as QualitySignalRow[]
 }
 
 /**

--- a/apps/admin/lib/analytics/types.ts
+++ b/apps/admin/lib/analytics/types.ts
@@ -102,6 +102,25 @@ export interface BounceDistributionRow {
   avg_active_days_per_week: number | null
 }
 
+export type QualitySignalUnit = "percent" | "seconds" | "pebbles" | "sessions" | "events"
+
+export interface QualitySignalRow {
+  bucket_date: IsoDate | null
+  /** 1..8 ordering, matches the spec / mockup row order. */
+  indicator_order: number | null
+  /** Stable machine key (e.g. "d1_retention"). */
+  indicator_key: string | null
+  /** Human label for the row (e.g. "D1 retention"). */
+  indicator_label: string | null
+  unit: QualitySignalUnit | null
+  /** Current-period value. Null when `available = false` or computation has no denominator. */
+  value: number | null
+  /** Same metric for the matching prior period. Null when `available = false`. */
+  previous_value: number | null
+  /** True when the metric is computable from existing data; false for Phase B/C placeholders. */
+  available: boolean | null
+}
+
 export interface UserAveragesWeeklyRow {
   /** Monday of the ISO week (UTC), ISO date string. */
   bucket_week: IsoDate | null

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -1238,6 +1238,24 @@
       "description": "SECURITY DEFINER plpgsql RPC, gated on is_admin(auth.uid()). No arguments. Returns the six histogram-bucket rows from v_analytics_bounce_distribution_today ordered by bucket_order asc. Backs the bounce karma distribution card on the admin analytics page. Raises insufficient_privilege (42501) for non-admins.",
       "status": "development",
       "platforms": ["web"]
+    },
+    {
+      "id": "DM-v-analytics-quality-signals-today",
+      "project_id": "pebbles",
+      "species": "data-model",
+      "title": "v_analytics_quality_signals_today",
+      "description": "Postgres view: 8 rows describing today's habit-health indicators for the admin Quality signals table. Each row has indicator_order, indicator_key, indicator_label, unit, value (current period), previous_value (matching prior period), and available (false for the four indicators whose source data isn't captured yet — median session duration, sessions/WAU, % revisits to past pebbles, friction events/session). Phase A computes pebbles/WAU and D1 / D7 / D30 retention from public.pebbles + auth.users; the other four rows return null until sessions, pebble_views, and a normalized analytics_events table land in Phases B and C of issue #346.",
+      "status": "development",
+      "platforms": ["web"]
+    },
+    {
+      "id": "API-get-quality-signals-today",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "get_quality_signals_today",
+      "description": "SECURITY DEFINER plpgsql RPC, gated on is_admin(auth.uid()). No arguments. Returns all eight rows from v_analytics_quality_signals_today ordered by indicator_order asc. Backs the Quality signals card on the admin analytics page. Raises insufficient_privilege (42501) for non-admins.",
+      "status": "development",
+      "platforms": ["web"]
     }
   ],
   "edges": [
@@ -1461,6 +1479,11 @@
     { "id": "e-V-admin-analytics-DM-v-analytics-bounce-distribution-today", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "DM-v-analytics-bounce-distribution-today", "edge_type": "displays" },
     { "id": "e-API-get-bounce-distribution-today-DM-v-analytics-bounce-distribution-today", "project_id": "pebbles", "source_id": "API-get-bounce-distribution-today", "target_id": "DM-v-analytics-bounce-distribution-today", "edge_type": "queries" },
     { "id": "e-API-get-bounce-distribution-today-DM-bounce", "project_id": "pebbles", "source_id": "API-get-bounce-distribution-today", "target_id": "DM-bounce", "edge_type": "queries" },
-    { "id": "e-API-get-bounce-distribution-today-DM-pebble", "project_id": "pebbles", "source_id": "API-get-bounce-distribution-today", "target_id": "DM-pebble", "edge_type": "queries" }
+    { "id": "e-API-get-bounce-distribution-today-DM-pebble", "project_id": "pebbles", "source_id": "API-get-bounce-distribution-today", "target_id": "DM-pebble", "edge_type": "queries" },
+    { "id": "e-V-admin-analytics-API-get-quality-signals-today", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "API-get-quality-signals-today", "edge_type": "calls" },
+    { "id": "e-V-admin-analytics-DM-v-analytics-quality-signals-today", "project_id": "pebbles", "source_id": "V-admin-analytics", "target_id": "DM-v-analytics-quality-signals-today", "edge_type": "displays" },
+    { "id": "e-API-get-quality-signals-today-DM-v-analytics-quality-signals-today", "project_id": "pebbles", "source_id": "API-get-quality-signals-today", "target_id": "DM-v-analytics-quality-signals-today", "edge_type": "queries" },
+    { "id": "e-API-get-quality-signals-today-DM-pebble", "project_id": "pebbles", "source_id": "API-get-quality-signals-today", "target_id": "DM-pebble", "edge_type": "queries" },
+    { "id": "e-API-get-quality-signals-today-DM-account", "project_id": "pebbles", "source_id": "API-get-quality-signals-today", "target_id": "DM-account", "edge_type": "queries" }
   ]
 }

--- a/packages/supabase/supabase/migrations/20260501000005_analytics_quality_signals.sql
+++ b/packages/supabase/supabase/migrations/20260501000005_analytics_quality_signals.sql
@@ -35,16 +35,14 @@ with
       count(*)::numeric / nullif(count(distinct p.user_id), 0)
     , 2) as v
     from public.pebbles p
-    where p.deleted_at is null
-      and p.created_at >= now() - interval '7 days'
+    where p.created_at >= now() - interval '7 days'
   ),
   pebbles_per_wau_previous as (
     select round(
       count(*)::numeric / nullif(count(distinct p.user_id), 0)
     , 2) as v
     from public.pebbles p
-    where p.deleted_at is null
-      and p.created_at >= now() - interval '14 days'
+    where p.created_at >= now() - interval '14 days'
       and p.created_at <  now() - interval '7 days'
   ),
   -- D1 retention: cohort signed up yesterday, active today.
@@ -55,7 +53,6 @@ with
          from auth.users u
          join public.pebbles p
            on p.user_id = u.id
-          and p.deleted_at is null
           and p.created_at::date = current_date
         where u.created_at::date = current_date - 1)::numeric
       / nullif((select count(*) from auth.users u
@@ -68,7 +65,6 @@ with
          from auth.users u
          join public.pebbles p
            on p.user_id = u.id
-          and p.deleted_at is null
           and p.created_at::date = current_date - 1
         where u.created_at::date = current_date - 2)::numeric
       / nullif((select count(*) from auth.users u
@@ -83,7 +79,6 @@ with
          from auth.users u
          join public.pebbles p
            on p.user_id = u.id
-          and p.deleted_at is null
           and p.created_at::date between current_date - 6 and current_date
         where u.created_at::date = current_date - 7)::numeric
       / nullif((select count(*) from auth.users u
@@ -96,7 +91,6 @@ with
          from auth.users u
          join public.pebbles p
            on p.user_id = u.id
-          and p.deleted_at is null
           and p.created_at::date between current_date - 13 and current_date - 7
         where u.created_at::date = current_date - 14)::numeric
       / nullif((select count(*) from auth.users u
@@ -111,7 +105,6 @@ with
          from auth.users u
          join public.pebbles p
            on p.user_id = u.id
-          and p.deleted_at is null
           and p.created_at::date between current_date - 29 and current_date
         where u.created_at::date = current_date - 30)::numeric
       / nullif((select count(*) from auth.users u
@@ -124,7 +117,6 @@ with
          from auth.users u
          join public.pebbles p
            on p.user_id = u.id
-          and p.deleted_at is null
           and p.created_at::date between current_date - 59 and current_date - 30
         where u.created_at::date = current_date - 60)::numeric
       / nullif((select count(*) from auth.users u

--- a/packages/supabase/supabase/migrations/20260501000005_analytics_quality_signals.sql
+++ b/packages/supabase/supabase/migrations/20260501000005_analytics_quality_signals.sql
@@ -1,0 +1,181 @@
+-- =============================================================================
+-- Admin · Analytics · Quality signals (Phase A)
+-- =============================================================================
+-- Issue: #346
+-- Reference: docs/poc/admin-analytics/20260430_analytics_mvs.sql
+--            § mv_quality_signals_daily
+--
+-- Phase A scope: render the 8-row Quality signals table with the four metrics
+-- that are computable from existing data:
+--
+--   1. pebbles_per_wau     — pebbles / distinct authors over the last 7 days
+--   2. d1_retention        — % of users who signed up yesterday and pebbled today
+--   3. d7_retention        — % of users who signed up 7 days ago and pebbled in week 1
+--   4. d30_retention       — % of users who signed up 30 days ago and pebbled in days 1-30
+--
+-- The other four metrics depend on data Pebbles doesn't capture yet
+-- (sessions table, pebble_views, normalized analytics_events). They are emitted
+-- as rows with `available = false`, value = null, so the UI can render eight
+-- rows from a single query and label the missing ones with "data not
+-- collected yet" instead of hardcoding the 4-of-8 split client-side.
+--
+-- Each row carries `value` (current period) and `previous_value` (the same
+-- metric computed for the matching prior period) so the table can show a delta
+-- without a second RPC call. `unit` lets the client pick its formatter.
+-- =============================================================================
+
+drop function if exists public.get_quality_signals_today();
+drop view if exists public.v_analytics_quality_signals_today;
+
+create view public.v_analytics_quality_signals_today as
+with
+  -- Pebbles per WAU: last 7 days vs the prior 7 days.
+  pebbles_per_wau_current as (
+    select round(
+      count(*)::numeric / nullif(count(distinct p.user_id), 0)
+    , 2) as v
+    from public.pebbles p
+    where p.deleted_at is null
+      and p.created_at >= now() - interval '7 days'
+  ),
+  pebbles_per_wau_previous as (
+    select round(
+      count(*)::numeric / nullif(count(distinct p.user_id), 0)
+    , 2) as v
+    from public.pebbles p
+    where p.deleted_at is null
+      and p.created_at >= now() - interval '14 days'
+      and p.created_at <  now() - interval '7 days'
+  ),
+  -- D1 retention: cohort signed up yesterday, active today.
+  -- Previous period: cohort signed up two days ago, active yesterday.
+  d1_current as (
+    select round(100.0 *
+      (select count(distinct u.id)
+         from auth.users u
+         join public.pebbles p
+           on p.user_id = u.id
+          and p.deleted_at is null
+          and p.created_at::date = current_date
+        where u.created_at::date = current_date - 1)::numeric
+      / nullif((select count(*) from auth.users u
+                  where u.created_at::date = current_date - 1), 0)
+    , 1) as v
+  ),
+  d1_previous as (
+    select round(100.0 *
+      (select count(distinct u.id)
+         from auth.users u
+         join public.pebbles p
+           on p.user_id = u.id
+          and p.deleted_at is null
+          and p.created_at::date = current_date - 1
+        where u.created_at::date = current_date - 2)::numeric
+      / nullif((select count(*) from auth.users u
+                  where u.created_at::date = current_date - 2), 0)
+    , 1) as v
+  ),
+  -- D7 retention: cohort signed up 7 days ago, active any day in days 1-7
+  -- after signup. Previous period: cohort signed up 14 days ago.
+  d7_current as (
+    select round(100.0 *
+      (select count(distinct u.id)
+         from auth.users u
+         join public.pebbles p
+           on p.user_id = u.id
+          and p.deleted_at is null
+          and p.created_at::date between current_date - 6 and current_date
+        where u.created_at::date = current_date - 7)::numeric
+      / nullif((select count(*) from auth.users u
+                  where u.created_at::date = current_date - 7), 0)
+    , 1) as v
+  ),
+  d7_previous as (
+    select round(100.0 *
+      (select count(distinct u.id)
+         from auth.users u
+         join public.pebbles p
+           on p.user_id = u.id
+          and p.deleted_at is null
+          and p.created_at::date between current_date - 13 and current_date - 7
+        where u.created_at::date = current_date - 14)::numeric
+      / nullif((select count(*) from auth.users u
+                  where u.created_at::date = current_date - 14), 0)
+    , 1) as v
+  ),
+  -- D30 retention: cohort signed up 30 days ago, active in days 1-30 after
+  -- signup. Previous period: cohort signed up 60 days ago.
+  d30_current as (
+    select round(100.0 *
+      (select count(distinct u.id)
+         from auth.users u
+         join public.pebbles p
+           on p.user_id = u.id
+          and p.deleted_at is null
+          and p.created_at::date between current_date - 29 and current_date
+        where u.created_at::date = current_date - 30)::numeric
+      / nullif((select count(*) from auth.users u
+                  where u.created_at::date = current_date - 30), 0)
+    , 1) as v
+  ),
+  d30_previous as (
+    select round(100.0 *
+      (select count(distinct u.id)
+         from auth.users u
+         join public.pebbles p
+           on p.user_id = u.id
+          and p.deleted_at is null
+          and p.created_at::date between current_date - 59 and current_date - 30
+        where u.created_at::date = current_date - 60)::numeric
+      / nullif((select count(*) from auth.users u
+                  where u.created_at::date = current_date - 60), 0)
+    , 1) as v
+  )
+select
+  current_date as bucket_date,
+  t.indicator_order,
+  t.indicator_key,
+  t.indicator_label,
+  t.unit,
+  t.value,
+  t.previous_value,
+  t.available
+from (values
+  -- Order matches the spec / mockup. `available = false` marks indicators
+  -- whose source data isn't captured yet (Phase B + C).
+  (1, 'median_session_seconds',      'Median session duration',         'seconds',  null::numeric,                              null::numeric,                               false),
+  (2, 'sessions_per_wau',            'Sessions per active user / week', 'sessions', null::numeric,                              null::numeric,                               false),
+  (3, 'pebbles_per_wau',             'Pebbles per active user / week',  'pebbles',  (select v from pebbles_per_wau_current),    (select v from pebbles_per_wau_previous),    true),
+  (4, 'pct_revisits_to_past_pebbles','% revisits to past pebbles',      'percent',  null::numeric,                              null::numeric,                               false),
+  (5, 'd1_retention',                'D1 retention',                    'percent',  (select v from d1_current),                 (select v from d1_previous),                 true),
+  (6, 'd7_retention',                'D7 retention',                    'percent',  (select v from d7_current),                 (select v from d7_previous),                 true),
+  (7, 'd30_retention',               'D30 retention',                   'percent',  (select v from d30_current),                (select v from d30_previous),                true),
+  (8, 'friction_events_per_session', 'Friction events / session',       'events',   null::numeric,                              null::numeric,                               false)
+) as t(indicator_order, indicator_key, indicator_label, unit, value, previous_value, available);
+
+-- -----------------------------------------------------------------------------
+-- get_quality_signals_today() RPC. Enforces is_admin(auth.uid()).
+-- -----------------------------------------------------------------------------
+create or replace function public.get_quality_signals_today()
+returns setof public.v_analytics_quality_signals_today
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'insufficient_privilege' using errcode = '42501';
+  end if;
+
+  return query
+    select * from public.v_analytics_quality_signals_today
+    order by indicator_order asc;
+end;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- Permissions: lock the view, expose the RPC.
+-- -----------------------------------------------------------------------------
+revoke all on public.v_analytics_quality_signals_today from public, anon, authenticated;
+
+grant execute on function public.get_quality_signals_today() to authenticated;

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -881,6 +881,19 @@ export type Database = {
         }
         Relationships: []
       }
+      v_analytics_quality_signals_today: {
+        Row: {
+          available: boolean | null
+          bucket_date: string | null
+          indicator_key: string | null
+          indicator_label: string | null
+          indicator_order: number | null
+          previous_value: number | null
+          unit: string | null
+          value: number | null
+        }
+        Relationships: []
+      }
       v_analytics_retention_cohorts_weekly: {
         Row: {
           active_users: number | null
@@ -1128,6 +1141,25 @@ export type Database = {
           pebbles_in_collection: number | null
           pebbles_with_picture: number | null
         }[]
+      }
+      get_quality_signals_today: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          available: boolean | null
+          bucket_date: string | null
+          indicator_key: string | null
+          indicator_label: string | null
+          indicator_order: number | null
+          previous_value: number | null
+          unit: string | null
+          value: number | null
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "v_analytics_quality_signals_today"
+          isOneToOne: false
+          isSetofReturn: true
+        }
       }
       get_retention_cohorts: {
         Args: Record<PropertyKey, never>


### PR DESCRIPTION
Resolves #346 (Phase A only).

## Summary

Adds the 8-row Quality signals table to `/analytics`. Four indicators are computable from existing data — **pebbles per WAU, D1 / D7 / D30 retention** — each shown with its current value and the matching prior-period delta. The other four rows (median session duration, sessions/WAU, % revisits to past pebbles, friction events/session) render as `—` with a "data not collected yet" tooltip until the sessions, `pebble_views`, and normalized analytics-events foundations land in Phases B and C.

The 4-of-8 split is server-driven via an `available` boolean per row, so the UI doesn't need to hardcode which indicators are populated.

## Key files

**Database**
- `packages/supabase/supabase/migrations/20260501000005_analytics_quality_signals.sql` — `v_analytics_quality_signals_today` view + `get_quality_signals_today()` SECURITY DEFINER RPC, gated on `is_admin(auth.uid())`. View is revoked from `anon` / `authenticated`.
- `packages/supabase/types/database.ts` — view + RPC typings.

**Admin app**
- `apps/admin/lib/analytics/types.ts` — `QualitySignalRow`, `QualitySignalUnit`.
- `apps/admin/lib/analytics/fetchers.ts` — `getQualitySignalsToday()`.
- `apps/admin/components/analytics/QualitySignalsTable.tsx` — presentational table with per-cell tooltip (sentence describing each value) and pp/seconds/decimal-aware delta badges.
- `apps/admin/components/analytics/QualitySignalsTableCard.tsx` — server component, awaits the fetcher, renders skeleton/error.
- `apps/admin/components/analytics/__fixtures__/qualitySignals.ts` — dense / sparse / empty fixtures.
- `apps/admin/app/(authed)/playground/analytics/page.tsx` — three playground variants.
- `apps/admin/app/(authed)/analytics/page.tsx` — full-width row at the bottom of the grid.

**Map**
- `docs/arkaik/bundle.json` — adds `DM-v-analytics-quality-signals-today`, `API-get-quality-signals-today`, and 4 edges.

## Implementation notes

- D1: cohort signed up `current_date - 1`, active on `current_date`. Prior period: cohort `current_date - 2`, active `current_date - 1`.
- D7 / D30: cohort signed up N days ago, active any day in days 1–N. Prior period: cohort 2N days ago.
- Pebbles/WAU: `count(pebbles) / count(distinct user_id)` over the last 7 days vs the prior 7-day window.
- No `deleted_at` filters — Pebbles has no soft-delete (per `20260430000000_analytics_thin_slice.sql` § "Soft-delete does not exist in this project").
- Phase B and C remain tracked under #346 acceptance.

## Test plan

- [ ] Run the migration in Supabase Studio (already done by maintainer).
- [ ] Visit `/analytics` as admin, confirm the Quality signals table renders 8 rows: 4 with numeric values + delta badges, 4 with `—` and the "data not collected yet" tooltip.
- [ ] Hover each value: tooltip restates it as a complete sentence (period + value + prior period).
- [ ] Visit `/playground/analytics`, confirm the dense / sparse / empty variants render as expected.
- [ ] Sign in as a non-admin user and confirm the RPC raises `insufficient_privilege` (the card's `ErrorBlock` should render).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BZ9wZV9XZDPur1PZfbykkR)_