### PR TITLE
feat(db): emotion categories, palette view, and category_id constraint

### DIFF
--- a/docs/superpowers/plans/2026-05-06-emotion-categories-palettes.md
+++ b/docs/superpowers/plans/2026-05-06-emotion-categories-palettes.md
@@ -1,0 +1,346 @@
+# Emotion categories and color palettes — Phase 1 implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the schema for emotion categories and color palettes (issue #366, Phase 1 only — schema additions + view, no data, no client wiring).
+
+**Architecture:** One additive Supabase migration file: a new `public.emotion_categories` reference table with an inlined 8-digit-hex palette, a nullable `category_id` column on `public.emotions`, a supporting index, and an `INNER JOIN` view `public.v_emotions_with_palette`. The `NOT NULL` constraint on `category_id` lands in a separate Phase 2 PR once the user has populated data manually in Supabase Studio. `emotions.color` is preserved untouched for backwards compatibility with shipped iOS clients.
+
+**Tech Stack:** Supabase Postgres, Supabase CLI, TypeScript (`packages/supabase/types/database.ts` generation).
+
+**Spec:** `docs/superpowers/specs/2026-05-06-emotion-categories-palettes-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `packages/supabase/supabase/migrations/20260506000000_emotion_categories.sql` | Create | Phase 1 DDL: new table, RLS, alter `emotions`, index, view |
+| `packages/supabase/types/database.ts` | Modify (regenerate) | Reflect schema additions; auto-generated, committed |
+
+No application code changes in this PR. Client wiring (iOS service, web hook, render code) is a separate follow-up issue.
+
+---
+
+## Task 1: Create the feature branch
+
+**Files:** none (branch only)
+
+- [ ] **Step 1: Verify clean working tree**
+
+Run: `git status`
+Expected: `nothing to commit, working tree clean` and current branch `main`.
+
+- [ ] **Step 2: Pull latest main**
+
+Run: `git pull --ff-only origin main`
+
+- [ ] **Step 3: Create the branch**
+
+Run: `git checkout -b feat/366-emotion-categories-palettes`
+
+Branch name follows the project convention `type/issueNumber-description` (per `CLAUDE.md`).
+
+---
+
+## Task 2: Write the Phase 1 migration file
+
+**Files:**
+- Create: `packages/supabase/supabase/migrations/20260506000000_emotion_categories.sql`
+
+- [ ] **Step 1: Create the migration file with the full DDL**
+
+Write the file with this exact content:
+
+```sql
+-- Migration: Emotion categories and color palettes — Phase 1 (schema only)
+-- Issue: https://github.com/Bohns/pbbls/issues/366
+-- Spec:  docs/superpowers/specs/2026-05-06-emotion-categories-palettes-design.md
+--
+-- Notes:
+--   - Adds public.emotion_categories with an inlined 4-color palette.
+--     All palette colors are 8-digit hex (#RRGGBBAA). Opaque colors are
+--     FF-padded; surface is seeded by convention as primary + 1A (10% alpha).
+--   - Adds public.emotions.category_id as nullable. The NOT NULL constraint
+--     follows in a separate Phase 2 migration once data has been populated
+--     manually in Supabase Studio.
+--   - Leaves public.emotions.color untouched (soft-deprecated). Shipped iOS
+--     clients still read it; new clients will use the view below.
+--   - public.v_emotions_with_palette is an INNER JOIN — emotions with a null
+--     category_id are excluded from view results until Phase 2 lands. No
+--     client consumes the view in this PR, so the partial-list-during-rollout
+--     window is internal-state only.
+
+-- ============================================================
+-- TABLES
+-- ============================================================
+
+create table public.emotion_categories (
+  id uuid primary key default gen_random_uuid(),
+  slug text unique not null,
+  name text not null,
+  primary_color text not null,
+  secondary_color text not null,
+  light_color text not null,
+  surface_color text not null
+);
+
+-- ============================================================
+-- ALTER EXISTING
+-- ============================================================
+
+alter table public.emotions
+  add column category_id uuid references public.emotion_categories(id);
+
+create index emotions_category_id_idx
+  on public.emotions (category_id);
+
+-- ============================================================
+-- ACCESS CONTROL
+-- ============================================================
+
+alter table public.emotion_categories enable row level security;
+
+create policy "emotion_categories_select" on public.emotion_categories
+  for select using (true);
+
+-- ============================================================
+-- VIEWS
+-- ============================================================
+
+create view public.v_emotions_with_palette as
+select
+  e.id,
+  e.slug,
+  e.name,
+  e.color,
+  c.id              as category_id,
+  c.slug            as category_slug,
+  c.name            as category_name,
+  c.primary_color,
+  c.secondary_color,
+  c.light_color,
+  c.surface_color
+from public.emotions e
+join public.emotion_categories c on c.id = e.category_id;
+```
+
+- [ ] **Step 2: Sanity-check the file**
+
+Run: `wc -l packages/supabase/supabase/migrations/20260506000000_emotion_categories.sql`
+Expected: ~50 lines.
+
+Run: `head -5 packages/supabase/supabase/migrations/20260506000000_emotion_categories.sql`
+Expected: starts with `-- Migration: Emotion categories...`.
+
+---
+
+## Task 3: Apply the migration to the remote Supabase project
+
+The user's workflow avoids local Docker (per project memory). Two ways to apply:
+
+- **Option A — paste into Supabase Studio SQL editor** (matches user's stated preference earlier in brainstorming): open Studio → SQL Editor → paste the contents of the new migration file → run.
+- **Option B — `supabase db push` from the linked CLI** (no Docker required if `db:link` was previously run with the project ref): `npm run db:push --workspace=packages/supabase`.
+
+Either path produces the same result. Pick one.
+
+- [ ] **Step 1: Apply the migration**
+
+Run **one** of:
+
+```bash
+# Option A: copy the file's contents into Supabase Studio → SQL Editor → Run
+cat packages/supabase/supabase/migrations/20260506000000_emotion_categories.sql
+```
+
+```bash
+# Option B: push via CLI
+npm run db:push --workspace=packages/supabase
+```
+
+- [ ] **Step 2: Verify the schema in Supabase Studio**
+
+Open Studio → Table Editor. Confirm:
+- `emotion_categories` table exists with columns `id`, `slug`, `name`, `primary_color`, `secondary_color`, `light_color`, `surface_color`.
+- `emotions` table now has a `category_id` column (nullable, foreign key to `emotion_categories.id`).
+- Database → Indexes shows `emotions_category_id_idx`.
+- Database → Policies shows `emotion_categories_select`.
+
+In SQL Editor, run:
+
+```sql
+select * from public.v_emotions_with_palette limit 1;
+```
+
+Expected: 0 rows (no emotion has `category_id` populated yet — INNER JOIN behavior). Query succeeds; no error.
+
+---
+
+## Task 4: Regenerate TypeScript types
+
+The package's `db:types` script is wired to `--local`, which requires Docker. Since the user avoids local Supabase, regenerate from the remote project instead.
+
+- [ ] **Step 1: Generate types from the remote project**
+
+Use **one** of:
+
+- **Option A — Supabase MCP tool** (preferred per `packages/supabase/CLAUDE.md` fallback note): call `generate_typescript_types` against the linked remote project, pipe the result into `packages/supabase/types/database.ts`.
+
+- **Option B — local Docker, one-shot**:
+
+```bash
+npm run db:start --workspace=packages/supabase
+npm run db:reset --workspace=packages/supabase
+npm run db:types --workspace=packages/supabase
+npm run db:stop --workspace=packages/supabase
+```
+
+- [ ] **Step 2: Verify the generated types include the new schema**
+
+Run:
+```bash
+grep -c "emotion_categories" packages/supabase/types/database.ts
+```
+Expected: ≥ 3 (table definition + Row/Insert/Update types).
+
+Run:
+```bash
+grep -c "v_emotions_with_palette" packages/supabase/types/database.ts
+```
+Expected: ≥ 1 (view definition).
+
+Run:
+```bash
+grep -A2 "category_id" packages/supabase/types/database.ts | head -20
+```
+Expected: `category_id` typed as `string | null` (nullable in Phase 1; will tighten to `string` in Phase 2).
+
+---
+
+## Task 5: Workspace-scoped build check
+
+This is a small, schema-only change touching `packages/supabase`. Per the project's task-size triage, lint/build only the affected workspace.
+
+- [ ] **Step 1: Type-check the supabase package**
+
+Run: `npm run build --workspace=packages/supabase`
+Expected: passes (the package's `build` script runs `tsc --noEmit`).
+
+- [ ] **Step 2: Confirm no consumer is broken**
+
+The new `category_id` column appears as `string | null` on the generated `emotions` Row type. No existing code references it, so this is additive-only. To be safe, also build the consumers that import the regenerated types:
+
+Run: `npm run build --workspace=apps/web`
+Expected: passes.
+
+(`apps/ios` is built by Xcode, not npm — skipped here.)
+
+---
+
+## Task 6: Commit
+
+- [ ] **Step 1: Stage the migration and the regenerated types**
+
+Run:
+```bash
+git add packages/supabase/supabase/migrations/20260506000000_emotion_categories.sql
+git add packages/supabase/types/database.ts
+```
+
+- [ ] **Step 2: Verify nothing else is staged**
+
+Run: `git status`
+Expected: only the two files above appear under "Changes to be committed".
+
+- [ ] **Step 3: Commit with a conventional-commit message**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(db): emotion_categories table and palette view (phase 1)
+
+Adds public.emotion_categories with an inlined 4-color palette
+(primary/secondary/light/surface, all 8-digit hex), a nullable
+emotions.category_id FK, an index, and an INNER JOIN view
+public.v_emotions_with_palette. Schema only — palette rows and
+category_id values are populated manually in Supabase Studio.
+NOT NULL on category_id follows in a Phase 2 migration.
+
+Refs #366
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Push and open the PR
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin feat/366-emotion-categories-palettes`
+
+- [ ] **Step 2: Inspect issue #366 for labels and milestone to inherit**
+
+Run: `gh issue view 366 --json labels,milestone`
+
+Per project convention (`CLAUDE.md` PR checklist), propose inheriting the issue's labels and milestone. Issue #366 is currently labelled `question`. Since the PR ships a feature, swap `question` for `feat`. Scope label(s) must include `db` (schema change). Confirm milestone with the user before opening the PR if the issue has none.
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create \
+  --title "feat(db): emotion_categories table and palette view (phase 1)" \
+  --label feat --label db \
+  --body "$(cat <<'EOF'
+Resolves part of #366 (Phase 1 — schema only).
+
+## Summary
+
+- New `public.emotion_categories` reference table with inlined 4-color palette (primary/secondary/light/surface, all 8-digit hex).
+- New nullable `public.emotions.category_id` FK + index.
+- New view `public.v_emotions_with_palette` (INNER JOIN — un-categorized emotions are hidden until Phase 2 lands).
+- `public.emotions.color` is left untouched for backwards compatibility with shipped iOS clients.
+
+## Out of scope (future PRs)
+
+- Phase 2: `ALTER COLUMN category_id SET NOT NULL` once data is populated.
+- Client wiring: iOS service that fetches `v_emotions_with_palette` on mount; web equivalent; updating render code.
+- iOS `Color(hex:)` extended to handle 8-digit hex (length-dispatch on 6 vs 8).
+- Theming.
+
+## Test plan
+
+- [ ] Migration applies cleanly to the remote Supabase project.
+- [ ] `select * from public.v_emotions_with_palette limit 1` returns 0 rows pre-backfill (INNER JOIN behavior).
+- [ ] After manual data population in Studio, the same query returns one row per categorized emotion with all four palette columns populated as 8-digit hex.
+- [ ] `npm run build --workspace=packages/supabase` passes.
+- [ ] `npm run build --workspace=apps/web` passes.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+If the issue has a milestone, append `--milestone "<name>"` (confirm with user first per project memory).
+
+- [ ] **Step 4: Confirm the PR opened**
+
+The command output prints the PR URL. Verify in browser that the PR has the correct title, labels, body, and that CI (if any) is queued.
+
+---
+
+## Out of plan (Phase 2 — separate future PR)
+
+Once the user has populated all 7 palette rows and set `category_id` on every emotion, a Phase 2 PR will:
+
+1. Create a new migration file (e.g. `<later-date>_emotions_category_not_null.sql`) containing only:
+   ```sql
+   alter table public.emotions alter column category_id set not null;
+   ```
+2. Apply it (Studio or `db:push`).
+3. Regenerate types (`category_id` will now be `string`, not `string | null`).
+4. Commit and PR.
+
+This is intentionally not part of this plan — it's gated on user data work.

--- a/docs/superpowers/specs/2026-05-06-emotion-categories-palettes-design.md
+++ b/docs/superpowers/specs/2026-05-06-emotion-categories-palettes-design.md
@@ -1,0 +1,110 @@
+# Emotion categories and color palettes — design
+
+**Issue:** [#366](https://github.com/Bohns/pbbls/issues/366) — `[Conception] Emotion categories and color palettes`
+**Date:** 2026-05-06
+**Scope:** Schema only. Data population and client wiring are out of scope for this spec.
+
+## Goal
+
+Group emotions explicitly under categories, and let each category carry a four-color palette (primary, secondary, light, surface). The current `public.emotions.color` column becomes a legacy artifact — color is now a property of the category, not the emotion.
+
+## Scope decisions
+
+These were settled in brainstorming and bound the design:
+
+- **Categories + palettes only.** No theming in this iteration. The design must not preclude theming (a future `themes` + `theme_palettes` sibling structure remains possible) but does not implement it.
+- **Palette inlined on `emotion_categories`.** No separate `palettes` table. Palette reuse across categories is not a near-term need; the future theming shape doesn't require palette to be its own table today.
+- **All four palette colors stored as 8-digit hex (`#RRGGBBAA`).** Uniform format across `primary_color`, `secondary_color`, `light_color`, `surface_color`. Opaque colors are `FF`-padded (`#7B5E99FF`); surface is seeded by convention as primary + `1A` (10% alpha) → `#7B5E991A`. Single source of truth in the DB; clients do not compute alpha. Designers can override alpha on any field per category if needed.
+- **Plain text columns for hex.** No JSON bag of pre-rendered formats. Legacy `emotions.color` stays 6-digit hex. iOS `Color(hex:)` will be extended to dispatch on string length (6 or 8) — about six lines.
+- **Performance: fetch-on-mount, in-memory cache per session.** No persistence layer, no version key. Data is small (~5 KB) and changes rarely.
+- **`emotions.color` is soft-deprecated, not dropped.** Shipped iOS apps query `from("emotions")` and read `.color` directly (`apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift:220`, `EditPebbleSheet.swift:162`, `PebbleReadView.swift:52`). Removing the column would break legacy installs.
+- **Data ownership shifts to the user.** Palette rows and `emotions.category_id` values are populated manually in Supabase Studio, not in the seed file. The seed file is left untouched.
+
+## Schema
+
+### New table — `public.emotion_categories`
+
+| column            | type | notes                              |
+|-------------------|------|------------------------------------|
+| `id`              | `uuid` primary key default `gen_random_uuid()` | |
+| `slug`            | `text` unique not null | e.g. `fear`, `joy`, `peace`        |
+| `name`            | `text` not null        | display label (`"Fear"`, `"Joy"`)  |
+| `primary_color`   | `text` not null        | 8-digit hex, e.g. `#7B5E99FF`      |
+| `secondary_color` | `text` not null        | 8-digit hex, e.g. `#AE91CCFF`      |
+| `light_color`     | `text` not null        | 8-digit hex, e.g. `#F2EFF5FF`      |
+| `surface_color`   | `text` not null        | 8-digit hex, alpha baked, e.g. `#7B5E991A` |
+
+RLS enabled with `select using (true)` (matches existing reference-table pattern in `20260411000000_reference_tables.sql`).
+
+No `description` column — YAGNI; can be added later if a designer needs it.
+
+### Altered table — `public.emotions`
+
+One additive column:
+
+```
+category_id uuid references public.emotion_categories(id)
+```
+
+Nullable in **Phase 1** (see Rollout below). Set to `NOT NULL` in **Phase 2** after the user has populated values for all 38 rows.
+
+`emotions.color` is left untouched. New clients ignore it; old clients keep using it.
+
+### Index
+
+```
+create index emotions_category_id_idx on public.emotions(category_id);
+```
+
+For the view's join.
+
+### View — `public.v_emotions_with_palette`
+
+INNER JOIN of `emotions` and `emotion_categories` on `category_id`. New clients fetch this once on app mount.
+
+Columns returned:
+
+- `id`, `slug`, `name`, `color` (legacy) — from `emotions`
+- `category_id`, `category_slug`, `category_name`
+- `primary_color`, `secondary_color`, `light_color`, `surface_color` — from `emotion_categories`
+
+INNER JOIN means emotions with a null `category_id` are hidden from view results during the manual-population window between Phase 1 and Phase 2. This is intentional — clients are not wired to consume the view in this PR, so partial-list-during-rollout is not a concern, and post-Phase-2 the generated TypeScript types are non-null on every palette field (LEFT JOIN would force `string | null` forever, even after the underlying column is `NOT NULL`).
+
+The view is a `select` join — no SECURITY DEFINER, RLS on underlying tables governs access. Both `emotions` and `emotion_categories` have `select using (true)` policies, so the view is readable by any authenticated user.
+
+## Rollout
+
+Two SQL phases with manual data work between them:
+
+**Phase 1 — schema (one migration file):**
+- `packages/supabase/supabase/migrations/20260506000000_emotion_categories.sql`
+- Creates `emotion_categories`, RLS, alter `emotions` to add nullable `category_id`, index, view.
+- Regenerate `packages/supabase/types/database.ts` and commit.
+
+**Manual step (user, in Supabase Studio):**
+- Insert 7 rows into `emotion_categories` (anger, fear, joy, peace, pride, sadness, shame) with palette values from issue #366.
+- Update `category_id` for all 38 rows in `emotions`.
+
+**Phase 2 — tighten constraint (separate migration file, after data population):**
+- New migration file dated when Phase 2 is created (e.g. `20260520000000_emotions_category_not_null.sql`).
+- `ALTER TABLE public.emotions ALTER COLUMN category_id SET NOT NULL;`
+- Regenerate types.
+
+Splitting into two migrations is deliberate: it lets the user run Phase 1, populate data at their own pace, and run Phase 2 only when they're ready. Bundling Phase 2's `NOT NULL` into Phase 1 would force the migration to fail until every row is populated, which couples DDL deployment to data work.
+
+## Out of scope
+
+The following are explicitly NOT part of this spec — each is its own future issue:
+
+- **Theming** (multiple palette/category mappings, user-selectable theme).
+- **Client wiring** (iOS service that fetches `v_emotions_with_palette` on mount; web equivalent; updating render code to consume category palette instead of `emotion.color`).
+- **iOS 8-digit hex parser** (extend `Color(hex:)` at `apps/ios/Pebbles/Features/Path/Read/PebbleMetaPill.swift:101` to dispatch on string length 6 vs 8). Required before iOS can render any palette color; lives in the client-wiring follow-up.
+- **Dropping `emotions.color`.** Possible only after every shipped iOS version reading the column has been deprecated. Not on the near-term roadmap.
+- **Admin UI for editing palettes.** Editing happens in Supabase Studio for now.
+- **Seed file changes.** Reference-data seed is no longer the source of truth for emotions/categories; data lives only in the remote DB.
+
+## Risks
+
+- **`db:reset` no longer reproduces production state** for emotion/category data. This is already true for the user's workflow (per project memory: prefer remote Supabase over local Docker), but worth flagging if a contributor tries to bring up a fresh local instance.
+- **Type generation between Phase 1 and Phase 2** will type `category_id` as `string | null`. Code written against the Phase-1-generated types must handle the null case. After Phase 2 the type tightens to `string`. Anything coded against the view is unaffected — INNER JOIN guarantees a non-null category at query level.
+- **`v_emotions_with_palette` is partial during the manual-population window.** Emotions whose `category_id` is null are excluded from view results until Phase 2 lands. No client consumes the view in this PR, so this is an internal-state risk only.

--- a/packages/supabase/supabase/migrations/20260506000000_emotion_categories.sql
+++ b/packages/supabase/supabase/migrations/20260506000000_emotion_categories.sql
@@ -1,0 +1,70 @@
+-- Migration: Emotion categories and color palettes — Phase 1 (schema only)
+-- Issue: https://github.com/Bohns/pbbls/issues/366
+-- Spec:  docs/superpowers/specs/2026-05-06-emotion-categories-palettes-design.md
+--
+-- Notes:
+--   - Adds public.emotion_categories with an inlined 4-color palette.
+--     All palette colors are 8-digit hex (#RRGGBBAA). Opaque colors are
+--     FF-padded; surface is seeded by convention as primary + 1A (10% alpha).
+--   - Adds public.emotions.category_id as nullable. The NOT NULL constraint
+--     follows in a separate Phase 2 migration once data has been populated
+--     manually in Supabase Studio.
+--   - Leaves public.emotions.color untouched (soft-deprecated). Shipped iOS
+--     clients still read it; new clients will use the view below.
+--   - public.v_emotions_with_palette is an INNER JOIN — emotions with a null
+--     category_id are excluded from view results until Phase 2 lands. No
+--     client consumes the view in this PR, so the partial-list-during-rollout
+--     window is internal-state only.
+
+-- ============================================================
+-- TABLES
+-- ============================================================
+
+create table public.emotion_categories (
+  id uuid primary key default gen_random_uuid(),
+  slug text unique not null,
+  name text not null,
+  primary_color text not null,
+  secondary_color text not null,
+  light_color text not null,
+  surface_color text not null
+);
+
+-- ============================================================
+-- ALTER EXISTING
+-- ============================================================
+
+alter table public.emotions
+  add column category_id uuid references public.emotion_categories(id);
+
+create index emotions_category_id_idx
+  on public.emotions (category_id);
+
+-- ============================================================
+-- ACCESS CONTROL
+-- ============================================================
+
+alter table public.emotion_categories enable row level security;
+
+create policy "emotion_categories_select" on public.emotion_categories
+  for select using (true);
+
+-- ============================================================
+-- VIEWS
+-- ============================================================
+
+create view public.v_emotions_with_palette as
+select
+  e.id,
+  e.slug,
+  e.name,
+  e.color,
+  c.id              as category_id,
+  c.slug            as category_slug,
+  c.name            as category_name,
+  c.primary_color,
+  c.secondary_color,
+  c.light_color,
+  c.surface_color
+from public.emotions e
+join public.emotion_categories c on c.id = e.category_id;

--- a/packages/supabase/supabase/migrations/20260506000001_emotions_category_not_null.sql
+++ b/packages/supabase/supabase/migrations/20260506000001_emotions_category_not_null.sql
@@ -1,0 +1,14 @@
+-- Migration: Emotions.category_id NOT NULL — Phase 2
+-- Issue: https://github.com/Bohns/pbbls/issues/366
+-- Spec:  docs/superpowers/specs/2026-05-06-emotion-categories-palettes-design.md
+--
+-- Tightens the constraint on public.emotions.category_id after manual
+-- backfill in Supabase Studio. Phase 1 (20260506000000) added the column
+-- as nullable to decouple DDL from data work; Phase 2 locks it down now
+-- that every row has a category_id.
+--
+-- After this migration, public.v_emotions_with_palette returns one row
+-- per emotion (the INNER JOIN can no longer drop rows).
+
+alter table public.emotions
+  alter column category_id set not null;

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -236,21 +236,21 @@ export type Database = {
       }
       emotions: {
         Row: {
-          category_id: string | null
+          category_id: string
           color: string
           id: string
           name: string
           slug: string
         }
         Insert: {
-          category_id?: string | null
+          category_id: string
           color: string
           id?: string
           name: string
           slug: string
         }
         Update: {
-          category_id?: string | null
+          category_id?: string
           color?: string
           id?: string
           name?: string

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -55,7 +55,22 @@ export type Database = {
           updated_at?: string
           user_id?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "bounces_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "v_bounce"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "bounces_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "v_karma_summary"
+            referencedColumns: ["user_id"]
+          },
+        ]
       }
       card_types: {
         Row: {
@@ -189,32 +204,80 @@ export type Database = {
           },
         ]
       }
+      emotion_categories: {
+        Row: {
+          id: string
+          light_color: string
+          name: string
+          primary_color: string
+          secondary_color: string
+          slug: string
+          surface_color: string
+        }
+        Insert: {
+          id?: string
+          light_color: string
+          name: string
+          primary_color: string
+          secondary_color: string
+          slug: string
+          surface_color: string
+        }
+        Update: {
+          id?: string
+          light_color?: string
+          name?: string
+          primary_color?: string
+          secondary_color?: string
+          slug?: string
+          surface_color?: string
+        }
+        Relationships: []
+      }
       emotions: {
         Row: {
+          category_id: string | null
           color: string
           id: string
           name: string
           slug: string
         }
         Insert: {
+          category_id?: string | null
           color: string
           id?: string
           name: string
           slug: string
         }
         Update: {
+          category_id?: string | null
           color?: string
           id?: string
           name?: string
           slug?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "emotions_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "emotion_categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "emotions_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "v_emotions_with_palette"
+            referencedColumns: ["category_id"]
+          },
+        ]
       }
       glyphs: {
         Row: {
           created_at: string
           id: string
-          is_custom: boolean
+          is_custom: boolean | null
           name: string | null
           shape_id: string | null
           strokes: Json
@@ -225,7 +288,7 @@ export type Database = {
         Insert: {
           created_at?: string
           id?: string
-          is_custom?: never
+          is_custom?: boolean | null
           name?: string | null
           shape_id?: string | null
           strokes?: Json
@@ -236,7 +299,7 @@ export type Database = {
         Update: {
           created_at?: string
           id?: string
-          is_custom?: never
+          is_custom?: boolean | null
           name?: string | null
           shape_id?: string | null
           strokes?: Json
@@ -482,6 +545,13 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "pebble_domains_domain_id_fkey"
+            columns: ["domain_id"]
+            isOneToOne: false
+            referencedRelation: "v_analytics_domain_share_weekly"
+            referencedColumns: ["domain_id"]
+          },
+          {
             foreignKeyName: "pebble_domains_pebble_id_fkey"
             columns: ["pebble_id"]
             isOneToOne: false
@@ -613,6 +683,20 @@ export type Database = {
             columns: ["emotion_id"]
             isOneToOne: false
             referencedRelation: "emotions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "pebbles_emotion_id_fkey"
+            columns: ["emotion_id"]
+            isOneToOne: false
+            referencedRelation: "v_analytics_emotion_share_weekly"
+            referencedColumns: ["emotion_id"]
+          },
+          {
+            foreignKeyName: "pebbles_emotion_id_fkey"
+            columns: ["emotion_id"]
+            isOneToOne: false
+            referencedRelation: "v_emotions_with_palette"
             referencedColumns: ["id"]
           },
           {
@@ -802,6 +886,15 @@ export type Database = {
       }
     }
     Views: {
+      v_analytics_active_users_daily: {
+        Row: {
+          bucket_date: string | null
+          dau: number | null
+          mau: number | null
+          wau: number | null
+        }
+        Relationships: []
+      }
       v_analytics_bounce_distribution_today: {
         Row: {
           avg_active_days_per_week: number | null
@@ -811,15 +904,6 @@ export type Database = {
           median_score: number | null
           pct_maintaining: number | null
           users: number | null
-        }
-        Relationships: []
-      }
-      v_analytics_active_users_daily: {
-        Row: {
-          bucket_date: string | null
-          dau: number | null
-          mau: number | null
-          wau: number | null
         }
         Relationships: []
       }
@@ -927,6 +1011,22 @@ export type Database = {
         }
         Relationships: []
       }
+      v_emotions_with_palette: {
+        Row: {
+          category_id: string | null
+          category_name: string | null
+          category_slug: string | null
+          color: string | null
+          id: string | null
+          light_color: string | null
+          name: string | null
+          primary_color: string | null
+          secondary_color: string | null
+          slug: string | null
+          surface_color: string | null
+        }
+        Relationships: []
+      }
       v_karma_summary: {
         Row: {
           pebbles_count: number | null
@@ -998,6 +1098,20 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "pebbles_emotion_id_fkey"
+            columns: ["emotion_id"]
+            isOneToOne: false
+            referencedRelation: "v_analytics_emotion_share_weekly"
+            referencedColumns: ["emotion_id"]
+          },
+          {
+            foreignKeyName: "pebbles_emotion_id_fkey"
+            columns: ["emotion_id"]
+            isOneToOne: false
+            referencedRelation: "v_emotions_with_palette"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "pebbles_glyph_id_fkey"
             columns: ["glyph_id"]
             isOneToOne: false
@@ -1052,7 +1166,7 @@ export type Database = {
         }
       }
       get_bounce_distribution_today: {
-        Args: Record<PropertyKey, never>
+        Args: never
         Returns: {
           avg_active_days_per_week: number | null
           bucket_date: string | null
@@ -1129,28 +1243,28 @@ export type Database = {
       get_pebble_enrichment: {
         Args: { p_end: string; p_start: string }
         Returns: {
-          pct_in_collection: number | null
-          pct_with_custom_glyph: number | null
-          pct_with_intensity: number | null
-          pct_with_picture: number | null
-          pct_with_soul: number | null
-          pct_with_thought: number | null
-          total_pebbles: number | null
+          pct_in_collection: number
+          pct_with_custom_glyph: number
+          pct_with_intensity: number
+          pct_with_picture: number
+          pct_with_soul: number
+          pct_with_thought: number
+          total_pebbles: number
         }[]
       }
       get_pebble_volume_series: {
         Args: { p_bucket?: string; p_end: string; p_start: string }
         Returns: {
-          active_users: number | null
-          bucket_date: string | null
-          pebbles: number | null
-          pebbles_in_collection: number | null
-          pebbles_with_custom_glyph: number | null
-          pebbles_with_picture: number | null
+          active_users: number
+          bucket_date: string
+          pebbles: number
+          pebbles_in_collection: number
+          pebbles_with_custom_glyph: number
+          pebbles_with_picture: number
         }[]
       }
       get_quality_signals_today: {
-        Args: Record<PropertyKey, never>
+        Args: never
         Returns: {
           available: boolean | null
           bucket_date: string | null
@@ -1169,7 +1283,7 @@ export type Database = {
         }
       }
       get_retention_cohorts: {
-        Args: Record<PropertyKey, never>
+        Args: never
         Returns: {
           active_users: number | null
           cohort_size: number | null


### PR DESCRIPTION
Resolves #366.

## Summary

- New `public.emotion_categories` reference table with inlined 4-color palette (primary/secondary/light/surface, all 8-digit hex `#RRGGBBAA`).
- New `public.emotions.category_id` FK + index `emotions_category_id_idx`. Added as nullable in Phase 1, tightened to `NOT NULL` in Phase 2 after manual backfill.
- New view `public.v_emotions_with_palette` (INNER JOIN). Now returns one row per emotion since every row has a category_id.
- `public.emotions.color` is left untouched for backwards compatibility with shipped iOS clients that read it directly.

## Migrations

- `20260506000000_emotion_categories.sql` — Phase 1: schema additions (table, FK, index, RLS, view).
- `20260506000001_emotions_category_not_null.sql` — Phase 2: `ALTER COLUMN category_id SET NOT NULL`.

Data (7 palette rows + `category_id` on all 38 emotions) was populated manually in Supabase Studio between the two migrations and is not committed to the repo (per spec — reference data lives only in the remote DB now).

## Out of scope (future PRs)

- Client wiring: iOS service that fetches `v_emotions_with_palette` on mount; web equivalent; updating render code to consume category palette.
- iOS `Color(hex:)` extended to handle 8-digit hex (length-dispatch on 6 vs 8).
- Theming.

## Test plan

- [x] Both migrations applied to remote Supabase (Phase 1 via `db:push`; Phase 2 ran in Studio + tracked via `migration repair`).
- [x] `select * from public.v_emotions_with_palette` returns one row per emotion with all four palette columns populated as 8-digit hex.
- [x] `npm run build --workspace=packages/supabase` passes.
- [x] `npm run build --workspace=apps/web` passes.

## Spec & plan

- Spec: \`docs/superpowers/specs/2026-05-06-emotion-categories-palettes-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-06-emotion-categories-palettes.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)