### PR TITLE
feat(ui): consume emotion category palette in pebble render

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -503,6 +503,11 @@
 
 .pbbls-visual {
   @apply h-full;
+  color: var(--pebble-stroke-light);
+}
+
+.dark .pbbls-visual {
+  color: var(--pebble-stroke-dark);
 }
 
 /* Server-composed pebble SVGs (from the compose-pebble edge function) carry

--- a/apps/web/components/pebble/PebbleVisual.tsx
+++ b/apps/web/components/pebble/PebbleVisual.tsx
@@ -1,8 +1,11 @@
 "use client"
 
+import type { CSSProperties } from "react"
+
 import type { Mark, Pebble } from "@/lib/types"
 import type { RenderTier } from "@/lib/engine"
 import { EMOTIONS } from "@/lib/config/emotions"
+import { useEmotionPalettes } from "@/lib/data/useEmotionPalettes"
 import { usePebbleVisual } from "@/lib/hooks/usePebbleVisual"
 import { cn } from "@/lib/utils"
 
@@ -27,19 +30,25 @@ export function PebbleVisual({
   const isServerRender = pebble.render_svg !== null
   const svg = pebble.render_svg ?? fallback.svg
 
-  const emotion = EMOTIONS.find((e) => e.id === pebble.emotion_id)
-  const emotionName = emotion?.name ?? "Unknown"
+  const emotionName =
+    EMOTIONS.find((e) => e.id === pebble.emotion_id)?.name ?? "Unknown"
 
   // Server-composed SVGs use stroke="currentColor" and carry their own
-  // width/height attributes. Setting `color` on the wrapper resolves the
-  // `currentColor` strokes to the emotion hue (mirrors iOS PebbleRenderView).
-  // The CSS rule on `.pbbls-visual svg` (in globals.css) overrides the
-  // intrinsic width/height so the SVG fits its container.
+  // width/height attributes. The wrapper sets two CSS custom properties from
+  // the category palette; globals.css picks --pebble-stroke-light in light
+  // mode and --pebble-stroke-dark in dark mode, so theme switches are
+  // CSS-only (no JS subscription, no hydration mismatch).
   // The client-engine fallback already inlines the emotion color via
-  // `recolor()`, so the wrapper color is harmless there.
-  const wrapperStyle = isServerRender && emotion
-    ? { color: emotion.color }
-    : undefined
+  // `recolor()`, so leaving wrapperStyle undefined for it is harmless.
+  const { paletteByEmotionId } = useEmotionPalettes()
+  const palette = paletteByEmotionId.get(pebble.emotion_id)
+  const wrapperStyle: CSSProperties | undefined =
+    isServerRender && palette
+      ? ({
+          ["--pebble-stroke-light"]: palette.primary_color,
+          ["--pebble-stroke-dark"]: palette.secondary_color,
+        } as CSSProperties)
+      : undefined
 
   return (
     <div

--- a/apps/web/lib/data/useEmotionPalettes.ts
+++ b/apps/web/lib/data/useEmotionPalettes.ts
@@ -1,0 +1,109 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { createClient } from "@/lib/supabase/client"
+import { withTimeout } from "@/lib/utils/with-timeout"
+
+export type EmotionPalette = {
+  primary_color: string
+  secondary_color: string
+  light_color: string
+  surface_color: string
+}
+
+type PaletteMap = Map<string, EmotionPalette>
+
+type PaletteRow = {
+  id: string | null
+  primary_color: string | null
+  secondary_color: string | null
+  light_color: string | null
+  surface_color: string | null
+}
+
+// Module-level cache. Reference data is read-only and user-agnostic, so a
+// single fetch per page load (deduped via the in-flight promise) is enough —
+// matches the spec's "fetch-on-mount, in-memory, no persistence" decision.
+let cachedMap: PaletteMap | null = null
+let inflight: Promise<PaletteMap> | null = null
+
+async function fetchPalettes(): Promise<PaletteMap> {
+  const supabase = createClient()
+  const { data, error } = await withTimeout(
+    supabase
+      .from("v_emotions_with_palette")
+      .select("id, primary_color, secondary_color, light_color, surface_color"),
+    8000,
+    "fetch v_emotions_with_palette",
+  )
+  if (error) throw new Error(error.message)
+
+  const map: PaletteMap = new Map()
+  for (const row of (data ?? []) as PaletteRow[]) {
+    // Postgres view types every column as `string | null` (NOT NULL doesn't
+    // propagate through views). Narrow at the boundary: drop incomplete rows
+    // rather than `??`-fallback to legacy emotion.color, since Phase 2 ships
+    // `emotions.category_id NOT NULL` so any null here is a real data bug.
+    if (
+      row.id &&
+      row.primary_color &&
+      row.secondary_color &&
+      row.light_color &&
+      row.surface_color
+    ) {
+      map.set(row.id, {
+        primary_color: row.primary_color,
+        secondary_color: row.secondary_color,
+        light_color: row.light_color,
+        surface_color: row.surface_color,
+      })
+    }
+  }
+  return map
+}
+
+function loadOnce(): Promise<PaletteMap> {
+  if (cachedMap) return Promise.resolve(cachedMap)
+  if (inflight) return inflight
+  inflight = fetchPalettes()
+    .then((map) => {
+      cachedMap = map
+      return map
+    })
+    .finally(() => {
+      inflight = null
+    })
+  return inflight
+}
+
+export function useEmotionPalettes(): {
+  paletteByEmotionId: PaletteMap
+  loading: boolean
+} {
+  const [map, setMap] = useState<PaletteMap>(() => cachedMap ?? new Map())
+  const [loading, setLoading] = useState<boolean>(() => cachedMap === null)
+
+  useEffect(() => {
+    // If the cache was populated by a sibling consumer between this
+    // component's render and effect, useState's initializer already missed
+    // it — loadOnce resolves immediately in that case, so the .then handler
+    // syncs us up without a synchronous setState in the effect body.
+    let cancelled = false
+    loadOnce()
+      .then((next) => {
+        if (cancelled) return
+        setMap(next)
+        setLoading(false)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        console.error("[useEmotionPalettes]", err)
+        setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return { paletteByEmotionId: map, loading }
+}


### PR DESCRIPTION
Resolves #368.

## Summary

Switches web `PebbleVisual` from the legacy single hex on `emotion.color` (static `EMOTIONS` config) to the four-color palette delivered by `public.v_emotions_with_palette` (PR #367). New `useEmotionPalettes` hook fetches the view once per session and caches in memory — matches the spec's "fetch-on-mount, in-memory, no persistence" decision.

Theme dispatch is CSS-only: the wrapper sets `--pebble-stroke-light` / `--pebble-stroke-dark` from `palette.primary_color` / `palette.secondary_color`, and `globals.css` picks the right one based on the active `.dark` class — no `useTheme()` subscription, no hydration mismatch when `next-themes` flips.

## Key files

- **new** `apps/web/lib/data/useEmotionPalettes.ts` — module-level singleton + in-flight promise dedupes the fetch. Type-narrows `string | null` view columns at the boundary by dropping rows with any null palette field rather than `??`-fallback (Phase 2's `NOT NULL` on `category_id` is live, so any null here is a real data bug worth surfacing as "missing palette").
- **edit** `apps/web/components/pebble/PebbleVisual.tsx` — drops the `emotion.color` lookup; sets the two CSS custom properties on the wrapper. Keeps `EMOTIONS` for the aria-label name.
- **edit** `apps/web/app/globals.css` — `.pbbls-visual` reads `--pebble-stroke-light`; `.dark .pbbls-visual` overrides to `--pebble-stroke-dark`.

## Implementation notes

- **Engine fallback** (`apps/web/lib/engine/params.ts:13`) intentionally left on the static `EMOTIONS` color. It's outside the acceptance-criteria grep scope and only runs for unauthenticated landing previews and pre-render legacy rows; threading async palette state into a pure synchronous render function isn't worth the refactor, and it doubles as a sane fallback if the palette fetch fails.
- **Hex validation** — no `^#[0-9a-f]{6}$`-style validator exists anywhere under `apps/web` or `packages/`, so there's nothing to widen for `#RRGGBBAA`. Browsers parse it natively.
- **Palette mapping** — `primary_color` light / `secondary_color` dark, per design call from the issue's open question.

## Test plan

- [x] `grep -rn "\.color" apps/web/components/pebble/` returns no hits
- [x] `npm run lint --workspace=apps/web` passes
- [x] `npm run build --workspace=apps/web` passes
- [x] Manual: log in, open `/path`, confirm pebbles render with category-driven colors; toggle dark mode and verify the hue swaps from `primary_color` to `secondary_color`
- [x] Manual: spot-check pebbles across distinct categories (e.g. `anxious` vs `excited`) for visually distinct hues
- [ ] Manual: pause network, hard-reload `/path` — pebbles should render once the palette resolves (no crash during the loading window)

https://claude.ai/code/session_01SAHf16rrCS13qQjxiz2TFK

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAHf16rrCS13qQjxiz2TFK)_