### PR TITLE
fix(auth): wait for profile fetch before onboarding redirect

### DIFF
--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 
 export default function LoginPage() {
-  const { login, signInWithApple, signInWithGoogle, profile, isAuthenticated, isLoading } =
+  const { login, signInWithApple, signInWithGoogle, profile, isAuthenticated, isLoading, isProfileLoading } =
     useAuth()
   const router = useRouter()
 
@@ -24,10 +24,10 @@ export default function LoginPage() {
   const [submitting, setSubmitting] = useState(false)
 
   useEffect(() => {
-    if (!isLoading && isAuthenticated) {
+    if (!isLoading && !isProfileLoading && isAuthenticated) {
       router.replace(profile?.onboarding_completed ? "/path" : "/onboarding")
     }
-  }, [isLoading, isAuthenticated, profile, router])
+  }, [isLoading, isProfileLoading, isAuthenticated, profile, router])
 
   if (isLoading || isAuthenticated) return null
 

--- a/apps/web/components/onboarding/OnboardingGate.tsx
+++ b/apps/web/components/onboarding/OnboardingGate.tsx
@@ -7,15 +7,15 @@ import { useAuth } from "@/lib/data/auth-context"
 export function OnboardingGate() {
   const pathname = usePathname()
   const router = useRouter()
-  const { profile, isAuthenticated, isLoading } = useAuth()
+  const { profile, isAuthenticated, isLoading, isProfileLoading } = useAuth()
 
   useEffect(() => {
-    if (isLoading) return
+    if (isLoading || isProfileLoading) return
     if (pathname === "/" || pathname.startsWith("/onboarding") || pathname === "/login" || pathname === "/register" || pathname.startsWith("/docs")) return
     if (isAuthenticated && (!profile || !profile.onboarding_completed)) {
       router.replace("/onboarding")
     }
-  }, [pathname, router, profile, isAuthenticated, isLoading])
+  }, [pathname, router, profile, isAuthenticated, isLoading, isProfileLoading])
 
   return null
 }

--- a/apps/web/lib/data/auth-context.ts
+++ b/apps/web/lib/data/auth-context.ts
@@ -23,6 +23,13 @@ export type AuthContextValue = {
   isAuthenticated: boolean
   /** True while the initial session is being rehydrated. */
   isLoading: boolean
+  /**
+   * True while the profile row is being fetched after the session is known.
+   * Profile fetching is fire-and-forget (to avoid a Supabase auth deadlock),
+   * so callers that key off `profile` must wait on this flag too — otherwise
+   * they'll see a transient `profile === null` and treat it as "no profile".
+   */
+  isProfileLoading: boolean
   login(input: LoginInput): Promise<void>
   register(input: RegisterInput): Promise<void>
   signInWithApple(): Promise<void>

--- a/apps/web/lib/data/useSupabaseAuth.ts
+++ b/apps/web/lib/data/useSupabaseAuth.ts
@@ -27,6 +27,7 @@ export function useSupabaseAuth(): AuthContextValue {
   // Always start as true on both server and client to avoid hydration mismatch.
   // The client-side effect sets it to false after session check.
   const [isLoading, setIsLoading] = useState(true)
+  const [isProfileLoading, setIsProfileLoading] = useState(true)
 
   // Dev-only watchdog: warns if auth stays in loading state too long,
   // which indicates a hang (deadlock, network issue, missing callback).
@@ -70,6 +71,7 @@ export function useSupabaseAuth(): AuthContextValue {
         setUser(null)
         setProfile(null)
         setIsLoading(false)
+        setIsProfileLoading(false)
         return
       }
 
@@ -80,6 +82,7 @@ export function useSupabaseAuth(): AuthContextValue {
         created_at: session.user.created_at,
       })
       setIsLoading(false)
+      setIsProfileLoading(true)
 
       // Profile fetch is fire-and-forget — must NOT block this callback
       // or it deadlocks the Supabase client's internal auth lock.
@@ -95,6 +98,8 @@ export function useSupabaseAuth(): AuthContextValue {
         if (!cancelled) setProfile(data as Profile | null)
       }).catch((err) => {
         console.warn("[auth] profile fetch failed:", (err as Error).message)
+      }).finally(() => {
+        if (!cancelled) setIsProfileLoading(false)
       })
     })
 
@@ -204,6 +209,7 @@ export function useSupabaseAuth(): AuthContextValue {
     profile,
     isAuthenticated: user !== null,
     isLoading,
+    isProfileLoading,
     login,
     register,
     signInWithApple,


### PR DESCRIPTION
Resolves #372

## Summary

The onboarding slider was being shown on every login and hard refresh, even for users who had already completed it.

## Root cause

In `useSupabaseAuth`, `isLoading` flips to `false` as soon as the session is rehydrated. The profile fetch is intentionally fire-and-forget (awaiting it inside `onAuthStateChange` deadlocks the Supabase auth lock), so there is a window where `isAuthenticated && profile === null && !isLoading`. Both `OnboardingGate` and the login page treated that transient `null` profile as "no profile" and redirected to `/onboarding`.

## Fix

Expose a separate `isProfileLoading` flag on `AuthContextValue`. It's `true` while the profile fetch is in flight and resolves in a `.finally`. `OnboardingGate` and `LoginPage` now wait on it before redirecting.

## Key files

- `apps/web/lib/data/useSupabaseAuth.ts` — track `isProfileLoading`, reset in `.finally`
- `apps/web/lib/data/auth-context.ts` — add `isProfileLoading` to `AuthContextValue`
- `apps/web/components/onboarding/OnboardingGate.tsx` — wait on `isProfileLoading`
- `apps/web/app/login/page.tsx` — wait on `isProfileLoading`

## Test plan

- [ ] Log in as a user with `onboarding_completed = true` → lands on `/path`, no onboarding flash
- [ ] Hard refresh while authenticated → stays on current page, no `/onboarding` redirect
- [ ] Log in as a brand-new user (no profile row) → still redirected to `/onboarding`
- [ ] Existing user mid-onboarding (`onboarding_completed = false`) → still redirected to `/onboarding`

---
_Generated by [Claude Code](https://claude.ai/code/session_01CrFCPFqKJPdTnctVx6ir66)_