### PR TITLE
feat(ui): set and edit glyph name on web

### DIFF
--- a/apps/web/app/glyphs/[id]/page.tsx
+++ b/apps/web/app/glyphs/[id]/page.tsx
@@ -16,12 +16,16 @@ export default function GlyphDetailPage({
 }) {
   const { id } = use(params)
   const { mark, loading } = useMark(id)
-  const { removeMark } = useMarks()
+  const { removeMark, updateMark } = useMarks()
   const router = useRouter()
 
   const handleDelete = async () => {
     await removeMark(id)
     router.push("/glyphs")
+  }
+
+  const handleUpdateName = async (name: string | null) => {
+    await updateMark(id, { name })
   }
 
   return (
@@ -39,7 +43,11 @@ export default function GlyphDetailPage({
       {loading ? (
         <p className="text-sm text-muted-foreground">Loading…</p>
       ) : mark ? (
-        <GlyphDetail mark={mark} onDelete={handleDelete} />
+        <GlyphDetail
+          mark={mark}
+          onDelete={handleDelete}
+          onUpdateName={handleUpdateName}
+        />
       ) : (
         <GlyphNotFound />
       )}

--- a/apps/web/components/carve/CarveEditor.tsx
+++ b/apps/web/components/carve/CarveEditor.tsx
@@ -9,6 +9,7 @@ import type { MarkStroke } from "@/lib/types"
 import { DrawingCanvas } from "@/components/carve/DrawingCanvas"
 import { CarveToolbar } from "@/components/carve/CarveToolbar"
 import { StampPicker } from "@/components/carve/StampPicker"
+import { Input } from "@/components/ui/input"
 
 type CarveEditorProps = {
   markId?: string
@@ -24,6 +25,7 @@ export function CarveEditor({ onSaved }: CarveEditorProps) {
   const [strokeWidth, setStrokeWidth] = useState(4)
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
+  const [name, setName] = useState("")
 
   // Pick a consistent shape for this editor session
   const shape = useMemo(
@@ -61,10 +63,12 @@ export function CarveEditor({ onSaved }: CarveEditorProps) {
     if (saving || strokes.length === 0) return
     setSaving(true)
     try {
+      const trimmed = name.trim()
       const mark = await addMark({
         shape_id: shape.id,
         strokes,
         viewBox: shape.viewBox,
+        name: trimmed.length > 0 ? trimmed : undefined,
       })
       vibrate([10, 50, 10])
       setSaved(true)
@@ -72,11 +76,12 @@ export function CarveEditor({ onSaved }: CarveEditorProps) {
     } finally {
       setSaving(false)
     }
-  }, [saving, strokes, addMark, shape, vibrate, onSaved])
+  }, [saving, strokes, addMark, shape, vibrate, onSaved, name])
 
   const handleNewMark = useCallback(() => {
     setStrokes([])
     setSaved(false)
+    setName("")
   }, [])
 
   if (saved) {
@@ -89,7 +94,7 @@ export function CarveEditor({ onSaved }: CarveEditorProps) {
         transition={{ type: "spring", stiffness: 300, damping: 25 }}
       >
         <p className="text-lg font-medium" aria-live="polite">
-          Glyph saved
+          {name.trim() ? `“${name.trim()}” saved` : "Glyph saved"}
         </p>
         <svg
           viewBox={shape.viewBox}
@@ -154,6 +159,16 @@ export function CarveEditor({ onSaved }: CarveEditorProps) {
           ? "No strokes drawn"
           : `${strokes.length} stroke${strokes.length === 1 ? "" : "s"} drawn`}
       </p>
+
+      <Input
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Name (optional)"
+        aria-label="Glyph name"
+        maxLength={80}
+        className="w-full max-w-xs"
+      />
 
       <CarveToolbar
         strokeCount={strokes.length}

--- a/apps/web/components/glyphs/GlyphDetail.tsx
+++ b/apps/web/components/glyphs/GlyphDetail.tsx
@@ -1,29 +1,95 @@
 "use client"
 
-import { Trash2 } from "lucide-react"
+import { useState, type FormEvent, type KeyboardEvent } from "react"
+import { Pencil, Trash2 } from "lucide-react"
 import { PEBBLE_SHAPES } from "@/lib/config"
 import type { Mark } from "@/lib/types"
 import { GlyphPreview } from "@/components/glyphs/GlyphPreview"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
 
 type GlyphDetailProps = {
   mark: Mark
   onDelete: () => void
+  onUpdateName: (name: string | null) => Promise<void>
 }
 
-export function GlyphDetail({ mark, onDelete }: GlyphDetailProps) {
+export function GlyphDetail({ mark, onDelete, onUpdateName }: GlyphDetailProps) {
   const shape = PEBBLE_SHAPES.find((s) => s.id === mark.shape_id)
   const created = new Intl.DateTimeFormat(undefined, {
     dateStyle: "long",
   }).format(new Date(mark.created_at))
 
+  const [isEditing, setIsEditing] = useState(false)
+  const [editValue, setEditValue] = useState(mark.name ?? "")
+
+  const handleSave = async (e?: FormEvent) => {
+    e?.preventDefault()
+    const trimmed = editValue.trim()
+    const current = mark.name ?? ""
+    if (trimmed === current) {
+      setIsEditing(false)
+      return
+    }
+    await onUpdateName(trimmed.length > 0 ? trimmed : null)
+    setIsEditing(false)
+  }
+
+  const handleCancel = () => {
+    setEditValue(mark.name ?? "")
+    setIsEditing(false)
+  }
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") handleCancel()
+  }
+
   return (
     <article>
       <header className="mb-6">
-        <h1 className="text-2xl font-semibold">
-          {mark.name || "Untitled glyph"}
-        </h1>
+        {isEditing ? (
+          <form onSubmit={handleSave} className="flex items-center gap-2">
+            <Input
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Name (optional)"
+              aria-label="Glyph name"
+              autoFocus
+              maxLength={80}
+              className="text-2xl font-semibold"
+            />
+            <Button type="submit" size="sm">
+              Save
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleCancel}
+            >
+              Cancel
+            </Button>
+          </form>
+        ) : (
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-semibold">
+              {mark.name || "Untitled glyph"}
+            </h1>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={() => {
+                setEditValue(mark.name ?? "")
+                setIsEditing(true)
+              }}
+              aria-label="Edit glyph name"
+            >
+              <Pencil className="size-3.5" />
+            </Button>
+          </div>
+        )}
 
         <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
           {shape && <span>{shape.name}</span>}

--- a/apps/web/lib/data/data-provider.ts
+++ b/apps/web/lib/data/data-provider.ts
@@ -58,7 +58,10 @@ export type CreateCollectionInput = Omit<Collection, "id" | "created_at" | "upda
 export type UpdateCollectionInput = Partial<Omit<Collection, "id" | "created_at" | "updated_at">>
 
 export type CreateMarkInput = Omit<Mark, "id" | "created_at" | "updated_at">
-export type UpdateMarkInput = Partial<Omit<Mark, "id" | "created_at" | "updated_at">>
+// `name: null` clears the column; `name: undefined` leaves it unchanged.
+export type UpdateMarkInput = Partial<
+  Omit<Mark, "id" | "name" | "created_at" | "updated_at">
+> & { name?: string | null }
 
 // ---------------------------------------------------------------------------
 // DataProvider interface — implemented by SupabaseProvider.


### PR DESCRIPTION
Resolves #307

Mirrors the iOS UX (issue #300) so web users can name glyphs during carving and rename them from the detail view.

## Changes

- `apps/web/components/carve/CarveEditor.tsx` — adds an optional `Name` input next to the canvas; trimmed value is passed to `addMark` (or `undefined` when blank). Saved-state heading echoes the name when present.
- `apps/web/components/glyphs/GlyphDetail.tsx` — header gains an inline rename UI (pencil → `Input` + Save/Cancel, Esc to cancel), modeled on `SoulDetailHeader`. Clearing the field sends `name: null` to clear the column.
- `apps/web/app/glyphs/[id]/page.tsx` — wires `updateMark` to a new `onUpdateName` handler.
- `apps/web/lib/data/data-provider.ts` — `UpdateMarkInput.name` is now `string | null | undefined` (`null` clears, `undefined` no-ops), matching iOS `GlyphService.updateName` semantics. The Supabase provider already passes the value through unchanged.

`GlyphCard` and `GlyphPickerGrid` already render `mark.name` with a fallback, so no changes were needed there.

## Verification

- `npm run lint --workspace=apps/web` ✓
- `npm run build --workspace=apps/web` ✓

## Labels & milestone

Proposing to inherit from #307: `feat`, `core`, `web` + milestone `M27 · Align Webapp with iOS`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGyqzEvxSsDfXX1EY1vxUZ)_