### PR TITLE
feat(admin): introduce release date for log entries

### DIFF
--- a/apps/admin/app/(authed)/logs/_components/LogForm.tsx
+++ b/apps/admin/app/(authed)/logs/_components/LogForm.tsx
@@ -39,7 +39,7 @@ export function LogForm({
 
   return (
     <form action={formAction} className="space-y-8">
-      <div className="flex gap-4">
+      <div className="flex flex-wrap gap-4">
         <FieldSelect
           label="Species"
           name="species"
@@ -58,6 +58,7 @@ export function LogForm({
           defaultValue={log?.status}
           options={STATUS_OPTIONS}
         />
+        <ReleasedAtField defaultValue={log?.released_at ?? null} />
       </div>
 
       <Tabs defaultValue="en" className="flex flex-col space-y-4">
@@ -143,6 +144,35 @@ export function LogForm({
       </div>
     </form>
   )
+}
+
+function ReleasedAtField({ defaultValue }: { defaultValue: string | null }) {
+  const id = useId()
+  // <input type="datetime-local"> wants "YYYY-MM-DDTHH:mm" in the local zone.
+  // Slice off the offset/seconds from the ISO UTC value so the picker shows it
+  // in the admin's local time; the action converts the submitted local string
+  // back to an ISO timestamp.
+  const localValue = defaultValue ? toLocalDateTimeInputValue(defaultValue) : ""
+  return (
+    <div className="space-y-2 text-sm">
+      <Label htmlFor={id} className="text-foreground font-medium">
+        Release date
+      </Label>
+      <Input
+        id={id}
+        name="released_at"
+        type="datetime-local"
+        defaultValue={localValue}
+      />
+    </div>
+  )
+}
+
+function toLocalDateTimeInputValue(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ""
+  const pad = (n: number) => String(n).padStart(2, "0")
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
 function FieldSelect({

--- a/apps/admin/app/(authed)/logs/actions.ts
+++ b/apps/admin/app/(authed)/logs/actions.ts
@@ -26,6 +26,11 @@ function readLogFields(formData: FormData): { values: LogInsert; error?: string 
   const external_url = formData.get("external_url")?.toString().trim() || null
   const cover_image_path = formData.get("cover_image_path")?.toString().trim() || null
   const published = formData.get("published") === "on"
+  const released_at_raw = formData.get("released_at")?.toString().trim() || null
+  // <input type="datetime-local"> submits a naive local datetime; new Date()
+  // interprets that in the admin's zone, so toISOString() gives back the
+  // correct UTC instant.
+  const released_at = released_at_raw ? new Date(released_at_raw).toISOString() : null
 
   if (!isLogSpecies(species)) return { error: "Species is required.", values: {} as LogInsert }
   if (!isLogPlatform(platform)) return { error: "Platform is required.", values: {} as LogInsert }
@@ -47,6 +52,7 @@ function readLogFields(formData: FormData): { values: LogInsert; error?: string 
       external_url,
       cover_image_path,
       published,
+      released_at,
     },
   }
 }
@@ -57,9 +63,14 @@ export async function createLog(_: LogFormResult, formData: FormData): Promise<L
 
   const supabase = await createServerSupabaseClient()
   const published_at = parsed.values.published ? new Date().toISOString() : null
+  // Auto-stamp release date when shipping if the admin didn't provide one.
+  const released_at =
+    parsed.values.status === "shipped" && !parsed.values.released_at
+      ? new Date().toISOString()
+      : parsed.values.released_at
   const { data, error } = await supabase
     .from("logs")
-    .insert({ ...parsed.values, published_at })
+    .insert({ ...parsed.values, published_at, released_at })
     .select("id")
     .single()
 
@@ -82,31 +93,42 @@ export async function updateLog(
 
   const supabase = await createServerSupabaseClient()
 
+  // We need the existing row to (a) preserve published_at across re-saves and
+  // (b) decide whether this update is the transition into 'shipped' that
+  // should auto-stamp released_at.
+  const { data: existing, error: readError } = await supabase
+    .from("logs")
+    .select("published, published_at, status, released_at")
+    .eq("id", id)
+    .single()
+  if (readError) {
+    console.error("[logs/updateLog] read existing failed:", readError.message)
+    return { error: "Could not load the existing log to update." }
+  }
+
   // Preserve published_at if the row was already published and stays published.
   // If newly published: stamp now(). If unpublished: clear it.
   let published_at: string | null = null
   if (parsed.values.published) {
-    const { data: existing, error: readError } = await supabase
-      .from("logs")
-      .select("published, published_at")
-      .eq("id", id)
-      .single()
-    if (readError) {
-      console.error("[logs/updateLog] read existing failed:", readError.message)
-      return { error: "Could not load the existing log to update." }
-    }
     if (existing.published && existing.published_at) {
       published_at = existing.published_at
     } else {
       published_at = new Date().toISOString()
     }
-  } else {
-    published_at = null
+  }
+
+  // Auto-stamp released_at when the admin transitions the log into 'shipped'
+  // without setting a date themselves. If they provided a date, honor it.
+  // For non-shipped statuses, we still persist whatever the admin entered (or
+  // null) so they can pre-fill a planned release date.
+  let released_at: string | null = parsed.values.released_at
+  if (parsed.values.status === "shipped" && !released_at) {
+    released_at = existing.released_at ?? new Date().toISOString()
   }
 
   const { error } = await supabase
     .from("logs")
-    .update({ ...parsed.values, published_at })
+    .update({ ...parsed.values, published_at, released_at })
     .eq("id", id)
 
   if (error) {

--- a/apps/admin/app/(authed)/logs/actions.ts
+++ b/apps/admin/app/(authed)/logs/actions.ts
@@ -64,10 +64,10 @@ export async function createLog(_: LogFormResult, formData: FormData): Promise<L
   const supabase = await createServerSupabaseClient()
   const published_at = parsed.values.published ? new Date().toISOString() : null
   // Auto-stamp release date when shipping if the admin didn't provide one.
-  const released_at =
+  const released_at: string | null =
     parsed.values.status === "shipped" && !parsed.values.released_at
       ? new Date().toISOString()
-      : parsed.values.released_at
+      : (parsed.values.released_at ?? null)
   const { data, error } = await supabase
     .from("logs")
     .insert({ ...parsed.values, published_at, released_at })
@@ -121,7 +121,7 @@ export async function updateLog(
   // without setting a date themselves. If they provided a date, honor it.
   // For non-shipped statuses, we still persist whatever the admin entered (or
   // null) so they can pre-fill a planned release date.
-  let released_at: string | null = parsed.values.released_at
+  let released_at: string | null = parsed.values.released_at ?? null
   if (parsed.values.status === "shipped" && !released_at) {
     released_at = existing.released_at ?? new Date().toISOString()
   }

--- a/packages/supabase/supabase/migrations/20260509000002_logs_released_at.sql
+++ b/packages/supabase/supabase/migrations/20260509000002_logs_released_at.sql
@@ -1,0 +1,18 @@
+-- Migration: Logs released_at
+-- Adds an explicit release date for shipped log entries so that batch-curated
+-- features can be sorted/displayed by their actual ship date rather than by
+-- when the admin happened to record them.
+--
+-- The admin form auto-populates this column when a log transitions to
+-- 'shipped' and the user has not provided a date. Existing shipped rows are
+-- backfilled from published_at (when published) or updated_at as a best-effort
+-- approximation of when they shipped.
+
+alter table public.logs
+  add column released_at timestamptz;
+
+update public.logs
+  set released_at = coalesce(published_at, updated_at)
+  where status = 'shipped' and released_at is null;
+
+create index logs_released_at_idx on public.logs (released_at desc);

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -431,6 +431,7 @@ export type Database = {
           platform: string
           published: boolean
           published_at: string | null
+          released_at: string | null
           species: string
           status: string
           summary_en: string
@@ -449,6 +450,7 @@ export type Database = {
           platform: string
           published?: boolean
           published_at?: string | null
+          released_at?: string | null
           species: string
           status: string
           summary_en: string
@@ -467,6 +469,7 @@ export type Database = {
           platform?: string
           published?: boolean
           published_at?: string | null
+          released_at?: string | null
           species?: string
           status?: string
           summary_en?: string


### PR DESCRIPTION
Resolves #383

## Summary
- New `released_at` column on `public.logs`, indexed desc, with a backfill of existing shipped rows from `published_at`/`updated_at`.
- Admin log edit form gains a "Release date" `datetime-local` input next to status; the value round-trips through the admin's local zone.
- Server actions auto-stamp `released_at` when a log transitions to `shipped` and the admin didn't supply a date. An admin-supplied date is always honored, and `updateLog` preserves an existing `released_at` if the field is cleared while the log stays shipped.

## Key files
- `packages/supabase/supabase/migrations/20260509000002_logs_released_at.sql`
- `packages/supabase/types/database.ts`
- `apps/admin/app/(authed)/logs/_components/LogForm.tsx`
- `apps/admin/app/(authed)/logs/actions.ts`

## Test plan
- [ ] Run migration locally (`db:reset`) and confirm existing shipped logs get `released_at` backfilled.
- [ ] Edit a backlog feature with no release date, switch status to `shipped`, save — `released_at` is stamped to ~now.
- [ ] Edit a backlog feature, set release date to yesterday, switch status to `shipped`, save — saved `released_at` matches the entered date.
- [ ] Edit an already-shipped log, clear the release-date input, save — previous `released_at` is preserved.
- [ ] Edit a non-shipped log, set a release date, save — value persists without auto-stamping.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLKnBXJWUih4DSYobG3spN)_