### PR TITLE
fix(path): improve profile card layout responsiveness

### DIFF
--- a/apps/web/components/path/PathProfileCard.tsx
+++ b/apps/web/components/path/PathProfileCard.tsx
@@ -42,8 +42,8 @@ export function PathProfileCard() {
       aria-label={t("profileAria", { name: profile.display_name })}
     >
       <div className="flex gap-2 px-4 py-3 md:flex-col md:space-y-4 p-4 justify-between items-center md:items-stretch">
-        <div className="flex items-center md:gap-3">
-          <div className="hidden md:flex md:flex-col md:w-full">
+        <div className="flex items-center md:gap-3 md:w-full">
+          <div className="hidden md:flex md:flex-col md:flex-1 md:min-w-0">
             <p className="text-sm font-semibold truncate">{profile.display_name}</p>
             <p className="text-xs text-muted-foreground truncate">{user.email}</p>
           </div>


### PR DESCRIPTION
Resolves #

## Changes
- Modified `PathProfileCard.tsx` to improve responsive layout behavior
- Updated parent container to apply `md:w-full` for better width handling on medium screens and above
- Changed inner text container from `md:w-full` to `md:flex-1 md:min-w-0` to enable proper flex shrinking and prevent text overflow

## Notes
These changes address layout issues where the profile name and email text could overflow or not properly constrain on medium-sized screens. The `md:flex-1` allows the text container to grow and shrink with available space, while `md:min-w-0` ensures text truncation works correctly within flex containers.

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01QYSxHNr1DmdiKekcZcdyfM