### PR TITLE
quality(ios): extract snap upload coordinator from pebble sheets

### DIFF
--- a/apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
@@ -18,30 +18,16 @@ struct CreatePebbleSheet: View {
     @State private var isSaving = false
     @State private var saveError: String?
 
-    /// In-flight processed bytes kept around so the user can retry an upload
-    /// without re-picking the photo.
-    @State private var processedForRetry: ProcessedImage?
-
     @State private var isPhotoPickerPresented = false
+
+    /// Lazily constructed in `.task` so we have access to `supabase.client`.
+    /// Nil only for the very first body render before `.task` fires.
+    @State private var snaps: SnapUploadCoordinator?
 
     private let logger = Logger(subsystem: "app.pbbls.ios", category: "create-pebble")
 
-    private var snapRepo: PebbleSnapRepository {
-        PebbleSnapRepository(client: supabase.client)
-    }
-
     private var currentUserId: UUID? {
         supabase.session?.user.id
-    }
-
-    private var pendingSnapState: AttachedSnap.UploadState? {
-        if case .pending(let snap) = draft.formSnap { return snap.state }
-        return nil
-    }
-
-    private var pendingSnapId: UUID? {
-        if case .pending(let snap) = draft.formSnap { return snap.id }
-        return nil
     }
 
     var body: some View {
@@ -68,30 +54,19 @@ struct CreatePebbleSheet: View {
                 }
                 .pebblesScreen()
         }
-        .task { await loadReferences() }
+        .task {
+            if snaps == nil {
+                snaps = SnapUploadCoordinator(repo: PebbleSnapRepository(client: supabase.client))
+            }
+            await loadReferences()
+        }
         .sheet(isPresented: $isPhotoPickerPresented) {
             PhotoPickerView { picked in
                 isPhotoPickerPresented = false
-                if let picked {
-                    Task { await handlePicked(picked) }
+                if let picked, let userId = currentUserId, let snaps {
+                    Task { await snaps.handlePicked(picked, userId: userId) }
                 }
             }
-        }
-        // Retry: chip mutates snap.state from .failed to .uploading; re-run upload.
-        .onChange(of: pendingSnapState) { oldState, newState in
-            if oldState == .failed,
-               newState == .uploading,
-               let processed = processedForRetry,
-               let userId = currentUserId {
-                Task { await uploadCurrentSnap(processed: processed, userId: userId) }
-            }
-        }
-        // Remove: chip clears the snap; fire compensating Storage delete for the
-        // files that were already uploaded under that id.
-        .onChange(of: pendingSnapId) { oldId, newId in
-            guard let oldId, newId == nil, let userId = currentUserId else { return }
-            processedForRetry = nil
-            Task { await snapRepo.deleteFiles(snapId: oldId, userId: userId) }
         }
     }
 
@@ -114,97 +89,26 @@ struct CreatePebbleSheet: View {
                 collections: collections,
                 saveError: saveError,
                 showsPhotoSection: true,
-                photoPickerPresented: $isPhotoPickerPresented
+                photoPickerPresented: $isPhotoPickerPresented,
+                formSnap: snaps?.formSnap,
+                onRetryPending: {
+                    if let userId = currentUserId, let snaps {
+                        Task { await snaps.retryCurrent(userId: userId) }
+                    }
+                },
+                onRemovePending: {
+                    if let userId = currentUserId, let snaps {
+                        Task { await snaps.removePending(userId: userId) }
+                    }
+                }
             )
         }
     }
 
-    // MARK: - upload orchestration
-
-    private func handlePicked(_ picked: PhotoPickerView.PickedItem) async {
-        logger.notice("handlePicked: started uti=\(picked.uti, privacy: .public)")
-
-        guard let userId = currentUserId else {
-            logger.error("handlePicked: no current user id")
-            return
-        }
-
-        // Load bytes from the item provider. PHPicker's loadDataRepresentation
-        // is callback-based; wrap in a continuation.
-        let data: Data
-        do {
-            data = try await loadData(from: picked.itemProvider, uti: picked.uti)
-            logger.notice("handlePicked: loaded \(data.count, privacy: .public) bytes")
-        } catch {
-            logger.error("picker data load failed: \(error.localizedDescription, privacy: .private)")
-            saveError = "Couldn't read the image."
-            return
-        }
-
-        // Process off the main actor — re-encode is CPU-bound.
-        let processed: ProcessedImage
-        let uti = picked.uti
-        do {
-            processed = try await Task.detached(priority: .userInitiated) {
-                try ImagePipeline.process(data, uti: uti)
-            }.value
-        } catch {
-            logger.error("image pipeline failed: \(String(describing: error), privacy: .public)")
-            saveError = userMessageForPebbleSaveError(error)
-            return
-        }
-
-        let snapId = UUID()
-        draft.formSnap = .pending(AttachedSnap(id: snapId, localThumb: processed.thumb, state: .uploading))
-        processedForRetry = processed
-
-        await uploadCurrentSnap(processed: processed, userId: userId)
-    }
-
-    private func loadData(from provider: NSItemProvider, uti: String) async throws -> Data {
-        try await withCheckedThrowingContinuation { continuation in
-            provider.loadDataRepresentation(forTypeIdentifier: uti) { data, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else if let data {
-                    continuation.resume(returning: data)
-                } else {
-                    continuation.resume(throwing: URLError(.cannotDecodeContentData))
-                }
-            }
-        }
-    }
-
-    private func uploadCurrentSnap(processed: ProcessedImage, userId: UUID) async {
-        guard case .pending(var snap) = draft.formSnap else { return }
-        logger.notice("uploadCurrentSnap: started snap=\(snap.id, privacy: .public)")
-
-        do {
-            try await snapRepo.uploadProcessed(processed, snapId: snap.id, userId: userId)
-            logger.notice("uploadCurrentSnap: success snap=\(snap.id, privacy: .public)")
-            snap.state = .uploaded
-            draft.formSnap = .pending(snap)
-        } catch {
-            logger.warning("snap upload failed (first attempt): \(error.localizedDescription, privacy: .private)")
-            try? await Task.sleep(nanoseconds: 2_000_000_000)
-            do {
-                try await snapRepo.uploadProcessed(processed, snapId: snap.id, userId: userId)
-                snap.state = .uploaded
-                draft.formSnap = .pending(snap)
-            } catch {
-                logger.error("snap upload failed (retry): \(error.localizedDescription, privacy: .private)")
-                snap.state = .failed
-                draft.formSnap = .pending(snap)
-            }
-        }
-    }
-
     private func cancelAndCleanup() async {
-        // Clearing the snap triggers the .onChange(of: pendingSnapId)
-        // observer, which fires the compensating Storage delete.
-        draft.formSnap = nil
-        // Give the .onChange handler a tick to fire before dismissing.
-        try? await Task.sleep(nanoseconds: 50_000_000)
+        if let userId = currentUserId, let snaps {
+            await snaps.cancelAndCleanup(userId: userId)
+        }
         dismiss()
     }
 
@@ -252,12 +156,12 @@ struct CreatePebbleSheet: View {
     private func save() async {
         guard draft.isValid else { return }
 
-        if case .pending(let snap) = draft.formSnap, snap.state == .uploading {
+        if snaps?.isUploading == true {
             logger.notice("save blocked: snap still uploading")
             saveError = "Photo is still uploading."
             return
         }
-        if case .pending(let snap) = draft.formSnap, snap.state == .failed {
+        if snaps?.hasFailed == true {
             logger.notice("save blocked: snap upload failed")
             saveError = "Photo upload failed. Retry or remove it."
             return
@@ -272,7 +176,7 @@ struct CreatePebbleSheet: View {
         isSaving = true
         saveError = nil
 
-        let payload = PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: userId)
+        let payload = PebbleCreatePayload(from: draft, formSnap: snaps?.formSnap, userId: userId)
         let requestBody = ComposePebbleRequest(payload: payload)
 
         do {
@@ -304,9 +208,8 @@ struct CreatePebbleSheet: View {
     /// Save failed and we cannot recover — fire the compensating snap delete
     /// (if a snap was attached) and surface a user-facing message.
     private func handleSaveFailure(_ error: Error) async {
-        if let userId = currentUserId,
-           case .pending(let snap) = draft.formSnap {
-            await snapRepo.deleteFiles(snapId: snap.id, userId: userId)
+        if let userId = currentUserId, let snaps {
+            await snaps.handleSaveFailure(userId: userId)
         }
         saveError = userMessageForPebbleSaveError(error)
         isSaving = false

--- a/apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
@@ -272,7 +272,7 @@ struct CreatePebbleSheet: View {
         isSaving = true
         saveError = nil
 
-        let payload = PebbleCreatePayload(from: draft, userId: userId)
+        let payload = PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: userId)
         let requestBody = ComposePebbleRequest(payload: payload)
 
         do {

--- a/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
@@ -11,7 +11,6 @@ import os
 /// 3. Save calls the `compose-pebble-update` edge function which updates the row
 ///    (via `update_pebble` RPC internally) and returns a fresh `render_svg`.
 /// 4. `onSaved()` notifies the parent (`PathView`) so it can refetch the list.
-// swiftlint:disable:next type_body_length
 struct EditPebbleSheet: View {
     let pebbleId: UUID
     let onSaved: () -> Void
@@ -35,27 +34,16 @@ struct EditPebbleSheet: View {
     @State private var saveError: String?
 
     @State private var isPhotoPickerPresented = false
-    @State private var processedForRetry: ProcessedImage?
     @State private var isRemovingExistingSnap = false
+
+    /// Lazily constructed in `.task` so we have access to `supabase.client`.
+    /// Seeded with the loaded snap (if any) after `load()` succeeds.
+    @State private var snaps: SnapUploadCoordinator?
 
     private let logger = Logger(subsystem: "app.pbbls.ios", category: "edit-pebble")
 
     private var currentUserId: UUID? {
         supabase.session?.user.id
-    }
-
-    private var snapRepo: PebbleSnapRepository {
-        PebbleSnapRepository(client: supabase.client)
-    }
-
-    private var pendingSnapState: AttachedSnap.UploadState? {
-        if case .pending(let snap) = draft.formSnap { return snap.state }
-        return nil
-    }
-
-    private var pendingSnapId: UUID? {
-        if case .pending(let snap) = draft.formSnap { return snap.id }
-        return nil
     }
 
     var body: some View {
@@ -65,7 +53,9 @@ struct EditPebbleSheet: View {
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel") { dismiss() }
+                        Button("Cancel") {
+                            Task { await cancelAndCleanup() }
+                        }
                     }
                     ToolbarItem(placement: .confirmationAction) {
                         if isSaving {
@@ -80,27 +70,19 @@ struct EditPebbleSheet: View {
                 }
                 .pebblesScreen()
         }
-        .task { await load() }
+        .task {
+            if snaps == nil {
+                snaps = SnapUploadCoordinator(repo: PebbleSnapRepository(client: supabase.client))
+            }
+            await load()
+        }
         .sheet(isPresented: $isPhotoPickerPresented) {
             PhotoPickerView { picked in
                 isPhotoPickerPresented = false
-                if let picked {
-                    Task { await handlePicked(picked) }
+                if let picked, let userId = currentUserId, let snaps {
+                    Task { await snaps.handlePicked(picked, userId: userId) }
                 }
             }
-        }
-        .onChange(of: pendingSnapState) { oldState, newState in
-            if oldState == .failed,
-               newState == .uploading,
-               let processed = processedForRetry,
-               let userId = currentUserId {
-                Task { await uploadCurrentSnap(processed: processed, userId: userId) }
-            }
-        }
-        .onChange(of: pendingSnapId) { oldId, newId in
-            guard let oldId, newId == nil, let userId = currentUserId else { return }
-            processedForRetry = nil
-            Task { await snapRepo.deleteFiles(snapId: oldId, userId: userId) }
         }
     }
 
@@ -130,9 +112,39 @@ struct EditPebbleSheet: View {
                 photoPickerPresented: $isPhotoPickerPresented,
                 isRemovingExistingSnap: isRemovingExistingSnap,
                 onRemoveExistingSnap: {
-                    Task { await removeExistingSnap() }
+                    Task { await removeExisting() }
+                },
+                formSnap: snaps?.formSnap,
+                onRetryPending: {
+                    if let userId = currentUserId, let snaps {
+                        Task { await snaps.retryCurrent(userId: userId) }
+                    }
+                },
+                onRemovePending: {
+                    if let userId = currentUserId, let snaps {
+                        Task { await snaps.removePending(userId: userId) }
+                    }
                 }
             )
+        }
+    }
+
+    private func cancelAndCleanup() async {
+        if let userId = currentUserId, let snaps {
+            await snaps.cancelAndCleanup(userId: userId)
+        }
+        dismiss()
+    }
+
+    private func removeExisting() async {
+        guard let snaps else { return }
+        isRemovingExistingSnap = true
+        defer { isRemovingExistingSnap = false }
+        do {
+            try await snaps.removeExisting()
+        } catch {
+            logger.error("delete_pebble_media failed: \(error.localizedDescription, privacy: .private)")
+            saveError = "Couldn't remove the photo. Please try again."
         }
     }
 
@@ -188,6 +200,9 @@ struct EditPebbleSheet: View {
             self.strokeColor = palettes.palette(for: detail.emotion.id)?
                 .strokeHex(for: colorScheme) ?? Color.pebblesAccentHex
             self.sizeGroup = detail.valence.sizeGroup
+            if let existing = detail.snaps.first {
+                snaps?.seedExisting(.existing(id: existing.id, storagePath: existing.storagePath))
+            }
             self.isLoading = false
         } catch {
             logger.error("edit pebble load failed: \(error.localizedDescription, privacy: .private)")
@@ -196,116 +211,16 @@ struct EditPebbleSheet: View {
         }
     }
 
-    private func handlePicked(_ picked: PhotoPickerView.PickedItem) async {
-        logger.notice("handlePicked: started uti=\(picked.uti, privacy: .public)")
-
-        guard let userId = currentUserId else {
-            logger.error("handlePicked: no current user id")
-            return
-        }
-
-        let data: Data
-        do {
-            data = try await loadData(from: picked.itemProvider, uti: picked.uti)
-            logger.notice("handlePicked: loaded \(data.count, privacy: .public) bytes")
-        } catch {
-            logger.error("picker data load failed: \(error.localizedDescription, privacy: .private)")
-            saveError = "Couldn't read the image."
-            return
-        }
-
-        let processed: ProcessedImage
-        let uti = picked.uti
-        do {
-            processed = try await Task.detached(priority: .userInitiated) {
-                try ImagePipeline.process(data, uti: uti)
-            }.value
-        } catch {
-            logger.error("image pipeline failed: \(String(describing: error), privacy: .public)")
-            saveError = userMessageForPebbleSaveError(error)
-            return
-        }
-
-        let snapId = UUID()
-        draft.formSnap = .pending(
-            AttachedSnap(id: snapId, localThumb: processed.thumb, state: .uploading)
-        )
-        processedForRetry = processed
-
-        await uploadCurrentSnap(processed: processed, userId: userId)
-    }
-
-    private func loadData(from provider: NSItemProvider, uti: String) async throws -> Data {
-        try await withCheckedThrowingContinuation { continuation in
-            provider.loadDataRepresentation(forTypeIdentifier: uti) { data, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else if let data {
-                    continuation.resume(returning: data)
-                } else {
-                    continuation.resume(throwing: URLError(.cannotDecodeContentData))
-                }
-            }
-        }
-    }
-
-    private func uploadCurrentSnap(processed: ProcessedImage, userId: UUID) async {
-        guard case .pending(var snap) = draft.formSnap else { return }
-        logger.notice("uploadCurrentSnap: started snap=\(snap.id, privacy: .public)")
-
-        do {
-            try await snapRepo.uploadProcessed(processed, snapId: snap.id, userId: userId)
-            logger.notice("uploadCurrentSnap: success snap=\(snap.id, privacy: .public)")
-            snap.state = .uploaded
-            draft.formSnap = .pending(snap)
-        } catch {
-            logger.warning("snap upload failed (first attempt): \(error.localizedDescription, privacy: .private)")
-            try? await Task.sleep(nanoseconds: 2_000_000_000)
-            do {
-                try await snapRepo.uploadProcessed(processed, snapId: snap.id, userId: userId)
-                snap.state = .uploaded
-                draft.formSnap = .pending(snap)
-            } catch {
-                logger.error("snap upload failed (retry): \(error.localizedDescription, privacy: .private)")
-                snap.state = .failed
-                draft.formSnap = .pending(snap)
-            }
-        }
-    }
-
-    /// Tap-X handler for an `.existing` snap row. Calls `delete_pebble_media`
-    /// to commit the removal in the DB, then fires fire-and-forget Storage
-    /// cleanup using the returned `storage_path`. Cancel does not undo this —
-    /// see the design spec.
-    private func removeExistingSnap() async {
-        guard case .existing(let id, _) = draft.formSnap else { return }
-        isRemovingExistingSnap = true
-        defer { isRemovingExistingSnap = false }
-
-        do {
-            let storagePath: String = try await supabase.client
-                .rpc("delete_pebble_media", params: ["p_snap_id": id.uuidString])
-                .execute()
-                .value
-            // Fire-and-forget Storage cleanup. Logged on failure inside the helper.
-            await snapRepo.deleteFiles(storagePrefix: storagePath)
-            draft.formSnap = nil
-        } catch {
-            logger.error("delete_pebble_media failed: \(error.localizedDescription, privacy: .private)")
-            saveError = "Couldn't remove the photo. Please try again."
-        }
-    }
-
     // swiftlint:disable:next function_body_length
     private func save() async {
         guard draft.isValid else { return }
 
-        if case .pending(let snap) = draft.formSnap, snap.state == .uploading {
+        if snaps?.isUploading == true {
             logger.notice("save blocked: snap still uploading")
             saveError = "Photo is still uploading."
             return
         }
-        if case .pending(let snap) = draft.formSnap, snap.state == .failed {
+        if snaps?.hasFailed == true {
             logger.notice("save blocked: snap upload failed")
             saveError = "Photo upload failed. Retry or remove it."
             return
@@ -320,7 +235,7 @@ struct EditPebbleSheet: View {
             self.isSaving = false
             return
         }
-        let payload = PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: userId)
+        let payload = PebbleUpdatePayload(from: draft, formSnap: snaps?.formSnap, userId: userId)
         let requestBody = ComposePebbleUpdateRequest(pebbleId: pebbleId, payload: payload)
 
         do {
@@ -352,14 +267,20 @@ struct EditPebbleSheet: View {
                     bodyString = "<non-http error>"
                 }
                 logger.error("compose-pebble-update failed: \(functionsError.localizedDescription, privacy: .private) body=\(bodyString, privacy: .private)")
-                self.saveError = userMessageForPebbleSaveError(functionsError)
-                self.isSaving = false
+                await handleSaveFailure(functionsError)
             }
         } catch {
             logger.error("update pebble failed: \(error.localizedDescription, privacy: .private)")
-            self.saveError = userMessageForPebbleSaveError(error)
-            self.isSaving = false
+            await handleSaveFailure(error)
         }
+    }
+
+    private func handleSaveFailure(_ error: Error) async {
+        if let userId = currentUserId, let snaps {
+            await snaps.handleSaveFailure(userId: userId)
+        }
+        self.saveError = userMessageForPebbleSaveError(error)
+        self.isSaving = false
     }
 }
 

--- a/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
@@ -320,7 +320,7 @@ struct EditPebbleSheet: View {
             self.isSaving = false
             return
         }
-        let payload = PebbleUpdatePayload(from: draft, userId: userId)
+        let payload = PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: userId)
         let requestBody = ComposePebbleUpdateRequest(pebbleId: pebbleId, payload: payload)
 
         do {

--- a/apps/ios/Pebbles/Features/Path/Models/PebbleCreatePayload.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/PebbleCreatePayload.swift
@@ -77,8 +77,8 @@ extension PebbleCreatePayload {
     /// derive the snap's `storage_path` (the RPC re-derives ownership from
     /// `auth.uid()` server-side, so this value is not security-sensitive).
     /// Precondition: `draft.isValid == true`.
-    init(from draft: PebbleDraft, userId: UUID) {
-        precondition(draft.isValid, "PebbleCreatePayload(from:userId:) called with invalid draft")
+    init(from draft: PebbleDraft, formSnap: FormSnap?, userId: UUID) {
+        precondition(draft.isValid, "PebbleCreatePayload(from:formSnap:userId:) called with invalid draft")
         self.name = draft.name.trimmingCharacters(in: .whitespaces)
         let trimmedDescription = draft.description.trimmingCharacters(in: .whitespaces)
         self.description = trimmedDescription.isEmpty ? nil : trimmedDescription
@@ -92,7 +92,7 @@ extension PebbleCreatePayload {
         self.collectionIds = draft.collectionId.map { [$0] } ?? []
         self.glyphId = draft.glyphId
         self.snaps = {
-            switch draft.formSnap {
+            switch formSnap {
             case .none:
                 return nil
             case .pending(let snap):

--- a/apps/ios/Pebbles/Features/Path/Models/PebbleDraft.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/PebbleDraft.swift
@@ -13,7 +13,6 @@ struct PebbleDraft {
     var soulIds: [UUID] = []              // optional, empty = no souls
     var collectionId: UUID?               // optional
     var glyphId: UUID?                    // optional — set via GlyphPickerSheet
-    var formSnap: FormSnap?               // optional — `.existing` from DB or `.pending` local upload
     var visibility: Visibility = .private // mandatory
 
     /// True when every mandatory field is set. Drives the Save button's disabled state.
@@ -37,8 +36,8 @@ extension PebbleDraft {
     /// - `soulIds` is populated from `detail.souls.map(\.id)`; empty when no souls are linked.
     /// - `collectionId` takes the first element when present, nil otherwise.
     /// - `valence` is derived from `(positiveness, intensity)` by `PebbleDetail.valence`.
-    /// - `formSnap` is `.existing(...)` when the detail has at least one snap, else nil
-    ///   (the spec caps `max_media_per_pebble` at 1).
+    /// - Snap state is *not* part of the draft; the caller seeds it onto a
+    ///   `SnapUploadCoordinator` instead.
     init(from detail: PebbleDetail) {
         self.happenedAt = detail.happenedAt
         self.name = detail.name
@@ -50,8 +49,5 @@ extension PebbleDraft {
         self.collectionId = detail.collections.first?.id
         self.visibility = detail.visibility
         self.glyphId = detail.glyphId
-        self.formSnap = detail.snaps.first.map {
-            .existing(id: $0.id, storagePath: $0.storagePath)
-        }
     }
 }

--- a/apps/ios/Pebbles/Features/Path/Models/PebbleUpdatePayload.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/PebbleUpdatePayload.swift
@@ -88,8 +88,8 @@ extension PebbleUpdatePayload {
     /// `userId` is needed to derive the storage_path of a `.pending` snap;
     /// `.existing` snaps already carry the path from the DB.
     /// Precondition: `draft.isValid == true`.
-    init(from draft: PebbleDraft, userId: UUID) {
-        precondition(draft.isValid, "PebbleUpdatePayload(from:userId:) called with invalid draft")
+    init(from draft: PebbleDraft, formSnap: FormSnap?, userId: UUID) {
+        precondition(draft.isValid, "PebbleUpdatePayload(from:formSnap:userId:) called with invalid draft")
         self.name = draft.name.trimmingCharacters(in: .whitespaces)
         let trimmedDescription = draft.description.trimmingCharacters(in: .whitespaces)
         self.description = trimmedDescription.isEmpty ? nil : trimmedDescription
@@ -103,7 +103,7 @@ extension PebbleUpdatePayload {
         self.collectionIds = draft.collectionId.map { [$0] } ?? []
         self.glyphId = draft.glyphId
         self.snaps = {
-            switch draft.formSnap {
+            switch formSnap {
             case .none:
                 return []
             case .existing(let id, let storagePath):

--- a/apps/ios/Pebbles/Features/Path/PebbleFormView.swift
+++ b/apps/ios/Pebbles/Features/Path/PebbleFormView.swift
@@ -34,6 +34,16 @@ struct PebbleFormView: View {
     /// no-op closure.
     let onRemoveExistingSnap: () -> Void
 
+    /// Current snap state. The parent owns this via a `SnapUploadCoordinator`
+    /// and re-passes it on every render.
+    let formSnap: FormSnap?
+
+    /// Tapped when the user hits retry on a `.pending(.failed)` chip.
+    let onRetryPending: () -> Void
+
+    /// Tapped when the user hits remove on a `.pending` chip (any state).
+    let onRemovePending: () -> Void
+
     @State private var showPicker = false
     @State private var showValencePicker = false
     @State private var showEmotionPicker = false
@@ -54,7 +64,10 @@ struct PebbleFormView: View {
         showsPhotoSection: Bool = false,
         photoPickerPresented: Binding<Bool> = .constant(false),
         isRemovingExistingSnap: Bool = false,
-        onRemoveExistingSnap: @escaping () -> Void = {}
+        onRemoveExistingSnap: @escaping () -> Void = {},
+        formSnap: FormSnap? = nil,
+        onRetryPending: @escaping () -> Void = {},
+        onRemovePending: @escaping () -> Void = {}
     ) {
         self._draft = draft
         self.domains = domains
@@ -68,27 +81,9 @@ struct PebbleFormView: View {
         self._photoPickerPresented = photoPickerPresented
         self.isRemovingExistingSnap = isRemovingExistingSnap
         self.onRemoveExistingSnap = onRemoveExistingSnap
-    }
-
-    /// Two-way bridge between the `.pending` case of `draft.formSnap` and the
-    /// `Binding<AttachedSnap?>` that `AttachedPhotoView` already speaks. Setting
-    /// the binding to nil clears `formSnap`; setting it to a value re-wraps as
-    /// `.pending` so the existing retry/remove `.onChange` observers in
-    /// `CreatePebbleSheet` keep working unchanged.
-    private var pendingSnapBinding: Binding<AttachedSnap?> {
-        Binding<AttachedSnap?>(
-            get: {
-                if case .pending(let snap) = draft.formSnap { return snap }
-                return nil
-            },
-            set: { newValue in
-                if let newValue {
-                    draft.formSnap = .pending(newValue)
-                } else {
-                    draft.formSnap = nil
-                }
-            }
-        )
+        self.formSnap = formSnap
+        self.onRetryPending = onRetryPending
+        self.onRemovePending = onRemovePending
     }
 
     var body: some View {
@@ -264,7 +259,7 @@ struct PebbleFormView: View {
 
             if showsPhotoSection {
                 Section("Photo") {
-                    switch draft.formSnap {
+                    switch formSnap {
                     case .none:
                         Button {
                             photoPickerPresented = true
@@ -279,9 +274,13 @@ struct PebbleFormView: View {
                             onRemove: onRemoveExistingSnap
                         )
                         .listRowBackground(Color.pebblesListRow)
-                    case .pending:
-                        AttachedPhotoView(snap: pendingSnapBinding)
-                            .listRowBackground(Color.pebblesListRow)
+                    case .pending(let snap):
+                        AttachedPhotoView(
+                            snap: snap,
+                            onRetry: onRetryPending,
+                            onRemove: onRemovePending
+                        )
+                        .listRowBackground(Color.pebblesListRow)
                     }
                 }
             }

--- a/apps/ios/Pebbles/Features/PebbleMedia/AttachedPhotoView.swift
+++ b/apps/ios/Pebbles/Features/PebbleMedia/AttachedPhotoView.swift
@@ -1,33 +1,31 @@
 import SwiftUI
 
 /// Inline photo "chip" shown inside `PebbleFormView` once the user has picked
-/// an image. Operates entirely on a `Binding<AttachedSnap?>`:
-///   - "Remove" sets the binding to nil; the parent observes via `.onChange`
-///     and fires the compensating Storage delete.
-///   - "Retry" mutates `snap.state` to `.uploading`; the parent observes the
-///     transition (failed → uploading) and re-runs the upload.
+/// an image. Stateless: takes the current snap plus explicit `onRetry` and
+/// `onRemove` callbacks. The parent (which owns a `SnapUploadCoordinator`)
+/// decides what those mean.
 struct AttachedPhotoView: View {
 
-    @Binding var snap: AttachedSnap?
+    let snap: AttachedSnap
+    let onRetry: () -> Void
+    let onRemove: () -> Void
 
     var body: some View {
-        if let current = snap {
-            HStack(spacing: 12) {
-                thumbnail(current)
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Photo")
-                        .font(.subheadline)
-                    stateLabel(current.state)
-                }
-                Spacer()
-                trailingButton(current.state)
+        HStack(spacing: 12) {
+            thumbnail
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Photo")
+                    .font(.subheadline)
+                stateLabel
             }
+            Spacer()
+            trailingButton
         }
     }
 
     @ViewBuilder
-    private func thumbnail(_ current: AttachedSnap) -> some View {
-        if let uiImage = UIImage(data: current.localThumb) {
+    private var thumbnail: some View {
+        if let uiImage = UIImage(data: snap.localThumb) {
             Image(uiImage: uiImage)
                 .resizable()
                 .scaledToFill()
@@ -41,8 +39,8 @@ struct AttachedPhotoView: View {
     }
 
     @ViewBuilder
-    private func stateLabel(_ state: AttachedSnap.UploadState) -> some View {
-        switch state {
+    private var stateLabel: some View {
+        switch snap.state {
         case .uploading:
             Label("Uploading…", systemImage: "arrow.up.circle")
                 .labelStyle(.titleAndIcon)
@@ -62,17 +60,15 @@ struct AttachedPhotoView: View {
     }
 
     @ViewBuilder
-    private func trailingButton(_ state: AttachedSnap.UploadState) -> some View {
-        switch state {
+    private var trailingButton: some View {
+        switch snap.state {
         case .uploading:
             ProgressView()
         case .uploaded:
             removeButton
         case .failed:
             HStack(spacing: 8) {
-                Button {
-                    snap?.state = .uploading
-                } label: {
+                Button(action: onRetry) {
                     Image(systemName: "arrow.clockwise.circle.fill")
                 }
                 .buttonStyle(.plain)
@@ -83,9 +79,7 @@ struct AttachedPhotoView: View {
     }
 
     private var removeButton: some View {
-        Button(role: .destructive) {
-            snap = nil
-        } label: {
+        Button(role: .destructive, action: onRemove) {
             Image(systemName: "xmark.circle.fill")
                 .foregroundStyle(.secondary)
         }

--- a/apps/ios/Pebbles/Features/PebbleMedia/PebbleSnapRepository.swift
+++ b/apps/ios/Pebbles/Features/PebbleMedia/PebbleSnapRepository.swift
@@ -2,11 +2,24 @@ import Foundation
 import Supabase
 import os
 
+/// Abstraction over snap Storage + RPC operations so callers (notably
+/// `SnapUploadCoordinator`) can be unit-tested with a fake. The live
+/// conformance is `PebbleSnapRepository`.
+@MainActor
+protocol PebbleSnapRepositoryProtocol {
+    func uploadProcessed(_ processed: ProcessedImage, snapId: UUID, userId: UUID) async throws
+    func deleteFiles(snapId: UUID, userId: UUID) async
+    func deleteFiles(storagePrefix: String) async
+    /// Calls the `delete_pebble_media` Postgres RPC. Returns the row's
+    /// `storage_path` so the caller can fire-and-forget Storage cleanup.
+    func deletePebbleMedia(snapId: UUID) async throws -> String
+}
+
 /// Storage operations for `pebbles-media`. Stateless except for the injected
 /// `SupabaseClient`. Errors propagate; callers decide whether to retry, surface
 /// to the user, or fire-and-forget.
 @MainActor
-struct PebbleSnapRepository {
+struct PebbleSnapRepository: PebbleSnapRepositoryProtocol {
 
     private static let bucketId = "pebbles-media"
     private static let signedUrlTTL: Int = 3600    // 1 h
@@ -65,6 +78,16 @@ struct PebbleSnapRepository {
                 "snap delete failed for prefix \(prefix, privacy: .public): \(error.localizedDescription, privacy: .private)"
             )
         }
+    }
+
+    /// Wraps the `delete_pebble_media` RPC. Returns the row's `storage_path`
+    /// so the caller can run fire-and-forget Storage cleanup using
+    /// `deleteFiles(storagePrefix:)`.
+    func deletePebbleMedia(snapId: UUID) async throws -> String {
+        try await client
+            .rpc("delete_pebble_media", params: ["p_snap_id": snapId.uuidString])
+            .execute()
+            .value
     }
 
     /// One round-trip for both URLs of a snap. Caller is responsible for

--- a/apps/ios/Pebbles/Features/PebbleMedia/SnapUploadCoordinator.swift
+++ b/apps/ios/Pebbles/Features/PebbleMedia/SnapUploadCoordinator.swift
@@ -1,0 +1,231 @@
+import Foundation
+import os
+
+/// Single source of truth for the snap (photo) attached to an in-progress
+/// pebble form. Owns `formSnap` (the form-layer state), `processedForRetry`
+/// (re-encoded bytes kept around for a user-tapped retry), and every
+/// transition: pick → upload → retry → cancel → remove.
+///
+/// Both `CreatePebbleSheet` and `EditPebbleSheet` hold one of these and
+/// delegate. All Storage side-effects are explicitly awaited — there is no
+/// sleep-based race in `cancelAndCleanup`.
+@MainActor
+@Observable
+final class SnapUploadCoordinator {
+
+    // MARK: - State (publicly readable, mutated only by methods on this type)
+
+    private(set) var formSnap: FormSnap?
+
+    /// Processed bytes kept around so a `.failed → user-tapped retry` doesn't
+    /// re-load + re-encode the original. Cleared whenever `formSnap` is
+    /// cleared.
+    private(set) var processedForRetry: ProcessedImage?
+
+    // MARK: - Derived state
+
+    /// True while the pending snap is still uploading.
+    var isUploading: Bool {
+        if case .pending(let snap) = formSnap, snap.state == .uploading { return true }
+        return false
+    }
+
+    /// True when the pending snap's last upload attempt failed.
+    var hasFailed: Bool {
+        if case .pending(let snap) = formSnap, snap.state == .failed { return true }
+        return false
+    }
+
+    /// `true` while save should be blocked because the snap is mid-upload
+    /// or in a failed state requiring user action.
+    var isBlocking: Bool { isUploading || hasFailed }
+
+    /// Returns the pending `AttachedSnap` only when it has fully uploaded —
+    /// suitable for embedding in a save payload. Returns `nil` for `.none`,
+    /// `.existing` (those are encoded directly from `formSnap`), or any
+    /// in-flight/failed `.pending` state.
+    func pendingSnapForPayload() -> AttachedSnap? {
+        if case .pending(let snap) = formSnap, snap.state == .uploaded { return snap }
+        return nil
+    }
+
+    // MARK: - Init
+
+    private let repo: PebbleSnapRepositoryProtocol
+    private let retryDelay: Duration
+    private static let logger = Logger(subsystem: "app.pbbls.ios", category: "snap-coordinator")
+
+    init(
+        repo: PebbleSnapRepositoryProtocol,
+        initialSnap: FormSnap? = nil,
+        retryDelay: Duration = .seconds(2)
+    ) {
+        self.repo = repo
+        self.formSnap = initialSnap
+        self.retryDelay = retryDelay
+    }
+
+    /// Set the initial snap *after* construction. Used by `EditPebbleSheet`
+    /// which has to wait for `load()` to finish before it knows whether the
+    /// pebble has an existing snap.
+    func seedExisting(_ snap: FormSnap?) {
+        self.formSnap = snap
+    }
+
+    // MARK: - Test seam
+
+    #if DEBUG
+    /// Test-only: seed `processedForRetry` directly so tests can exercise
+    /// the upload path without driving the real `handlePicked` flow.
+    func seedProcessedForRetry(_ processed: ProcessedImage) {
+        self.processedForRetry = processed
+    }
+    #endif
+
+    // MARK: - User-driven transitions
+
+    func handlePicked(_ picked: PhotoPickerView.PickedItem, userId: UUID) async {
+        Self.logger.notice("handlePicked: started uti=\(picked.uti, privacy: .public)")
+
+        let data: Data
+        do {
+            data = try await Self.loadData(from: picked.itemProvider, uti: picked.uti)
+            Self.logger.notice("handlePicked: loaded \(data.count, privacy: .public) bytes")
+        } catch {
+            Self.logger.error("picker data load failed: \(error.localizedDescription, privacy: .private)")
+            return
+        }
+
+        let processed: ProcessedImage
+        let uti = picked.uti
+        do {
+            processed = try await Task.detached(priority: .userInitiated) {
+                try ImagePipeline.process(data, uti: uti)
+            }.value
+        } catch {
+            Self.logger.error("image pipeline failed: \(String(describing: error), privacy: .public)")
+            return
+        }
+
+        let snapId = UUID()
+        formSnap = .pending(AttachedSnap(id: snapId, localThumb: processed.thumb, state: .uploading))
+        processedForRetry = processed
+
+        await performUpload(processed: processed, snapId: snapId, userId: userId)
+    }
+
+    /// Re-run the upload after a user tap on the chip's retry button. Only
+    /// valid when the current state is `.pending(.failed)` and we still hold
+    /// `processedForRetry`. No-op otherwise.
+    func retryCurrent(userId: UUID) async {
+        guard case .pending(var snap) = formSnap, let processed = processedForRetry else { return }
+        snap.state = .uploading
+        formSnap = .pending(snap)
+        await performUpload(processed: processed, snapId: snap.id, userId: userId)
+    }
+
+    /// Remove the current `.pending` snap and fire the compensating Storage
+    /// delete. Safe to call when the snap is in any state. No-op when the
+    /// current `formSnap` is not `.pending`.
+    func removePending(userId: UUID) async {
+        guard case .pending(let snap) = formSnap else { return }
+        let snapId = snap.id
+        formSnap = nil
+        processedForRetry = nil
+        await repo.deleteFiles(snapId: snapId, userId: userId)
+    }
+
+    /// Remove the current `.existing` snap. Calls `delete_pebble_media` and
+    /// then fires fire-and-forget Storage cleanup. Throws on RPC failure so
+    /// the sheet can surface a user-facing error. No-op (returns normally)
+    /// when the current `formSnap` is not `.existing`.
+    func removeExisting() async throws {
+        guard case .existing(let id, _) = formSnap else { return }
+        let storagePath = try await repo.deletePebbleMedia(snapId: id)
+        // Fire-and-forget Storage cleanup. The live repo logs on failure.
+        await repo.deleteFiles(storagePrefix: storagePath)
+        formSnap = nil
+    }
+
+    // MARK: - Sheet lifecycle
+
+    /// Called by the sheet's Cancel button before `dismiss()`. Captures the
+    /// current pending snap id, clears state, and *awaits* the compensating
+    /// Storage delete. Storage-delete failures are logged but do not throw —
+    /// Cancel must not be un-cancellable.
+    func cancelAndCleanup(userId: UUID) async {
+        // Capture id before clearing so the delete still has the address.
+        guard case .pending(let snap) = formSnap else {
+            formSnap = nil
+            processedForRetry = nil
+            return
+        }
+        let snapId = snap.id
+        formSnap = nil
+        processedForRetry = nil
+        await repo.deleteFiles(snapId: snapId, userId: userId)
+    }
+
+    /// Called by the sheet after a save (compose-pebble / compose-pebble-update)
+    /// failure when a pending snap is attached. Awaits the compensating
+    /// Storage delete. Does *not* clear `formSnap` — the sheet stays open
+    /// and the user can retry. Use `cancelAndCleanup` if you also want to
+    /// dismiss.
+    func handleSaveFailure(userId: UUID) async {
+        guard case .pending(let snap) = formSnap else { return }
+        await repo.deleteFiles(snapId: snap.id, userId: userId)
+        // Intentionally do not clear formSnap — caller (the sheet) keeps the
+        // form open so the user can retry.
+    }
+
+    // MARK: - Private
+
+    /// Single upload path used by both `handlePicked` (initial attempt) and
+    /// `retryCurrent` (user-tapped retry). On first failure, sleeps for
+    /// `retryDelay` and retries once. On second failure, transitions the
+    /// snap to `.failed` and retains `processedForRetry`.
+    private func performUpload(processed: ProcessedImage, snapId: UUID, userId: UUID) async {
+        do {
+            try await repo.uploadProcessed(processed, snapId: snapId, userId: userId)
+            applyStateIfSnapMatches(snapId: snapId, newState: .uploaded)
+        } catch {
+            Self.logger.warning(
+                "snap upload failed (first attempt): \(error.localizedDescription, privacy: .private)"
+            )
+            try? await Task.sleep(for: retryDelay)
+            do {
+                try await repo.uploadProcessed(processed, snapId: snapId, userId: userId)
+                applyStateIfSnapMatches(snapId: snapId, newState: .uploaded)
+            } catch {
+                Self.logger.error(
+                    "snap upload failed (retry): \(error.localizedDescription, privacy: .private)"
+                )
+                applyStateIfSnapMatches(snapId: snapId, newState: .failed)
+            }
+        }
+    }
+
+    /// Mutates `formSnap`'s `.pending` state only if the current snap id
+    /// still matches. Guards against the user removing the snap mid-upload.
+    private func applyStateIfSnapMatches(snapId: UUID, newState: AttachedSnap.UploadState) {
+        guard case .pending(var snap) = formSnap, snap.id == snapId else { return }
+        snap.state = newState
+        formSnap = .pending(snap)
+    }
+
+    /// Loads the bytes for a `PHPicker` selection. Bridges the callback-based
+    /// `loadDataRepresentation` API into async/await.
+    private static func loadData(from provider: NSItemProvider, uti: String) async throws -> Data {
+        try await withCheckedThrowingContinuation { continuation in
+            provider.loadDataRepresentation(forTypeIdentifier: uti) { data, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let data {
+                    continuation.resume(returning: data)
+                } else {
+                    continuation.resume(throwing: URLError(.cannotDecodeContentData))
+                }
+            }
+        }
+    }
+}

--- a/apps/ios/PebblesTests/PebbleCreatePayloadEncodingTests.swift
+++ b/apps/ios/PebblesTests/PebbleCreatePayloadEncodingTests.swift
@@ -37,7 +37,7 @@ struct PebbleCreatePayloadEncodingTests {
     @Test("encodes all scalar fields with snake_case keys")
     func scalarKeys() throws {
         let draft = makeValidDraft()
-        let json = try encode(PebbleCreatePayload(from: draft, userId: UUID()))
+        let json = try encode(PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
 
         #expect(json["name"] as? String == "Test")
         #expect(json["description"] as? String == "body")
@@ -51,7 +51,7 @@ struct PebbleCreatePayloadEncodingTests {
     @Test("domain_ids is always a single-element array")
     func domainIds() throws {
         let draft = makeValidDraft()
-        let json = try encode(PebbleCreatePayload(from: draft, userId: UUID()))
+        let json = try encode(PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
 
         let ids = json["domain_ids"] as? [String] ?? []
         #expect(ids.count == 1)
@@ -61,7 +61,7 @@ struct PebbleCreatePayloadEncodingTests {
     @Test("soul_ids is empty array when draft.soulIds is empty")
     func emptySoulIds() throws {
         let draft = makeValidDraft(soulIds: [])
-        let json = try encode(PebbleCreatePayload(from: draft, userId: UUID()))
+        let json = try encode(PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
 
         let ids = json["soul_ids"] as? [String] ?? ["not-empty"]
         #expect(ids.isEmpty)
@@ -73,7 +73,7 @@ struct PebbleCreatePayloadEncodingTests {
         let id2 = UUID()
         let id3 = UUID()
         let draft = makeValidDraft(soulIds: [id1, id2, id3])
-        let json = try encode(PebbleCreatePayload(from: draft, userId: UUID()))
+        let json = try encode(PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
 
         let ids = json["soul_ids"] as? [String] ?? []
         #expect(ids == [id1.uuidString, id2.uuidString, id3.uuidString])
@@ -83,11 +83,11 @@ struct PebbleCreatePayloadEncodingTests {
     func collectionIds() throws {
         let collectionId = UUID()
         let draftWith = makeValidDraft(collectionId: collectionId)
-        let jsonWith = try encode(PebbleCreatePayload(from: draftWith, userId: UUID()))
+        let jsonWith = try encode(PebbleCreatePayload(from: draftWith, formSnap: draftWith.formSnap, userId: UUID()))
         #expect((jsonWith["collection_ids"] as? [String]) == [collectionId.uuidString])
 
         let draftWithout = makeValidDraft(collectionId: nil)
-        let jsonWithout = try encode(PebbleCreatePayload(from: draftWithout, userId: UUID()))
+        let jsonWithout = try encode(PebbleCreatePayload(from: draftWithout, formSnap: draftWithout.formSnap, userId: UUID()))
         #expect((jsonWithout["collection_ids"] as? [String])?.isEmpty == true)
     }
 
@@ -95,14 +95,14 @@ struct PebbleCreatePayloadEncodingTests {
     func emptyDescriptionBecomesNull() throws {
         var draft = makeValidDraft()
         draft.description = "   "
-        let json = try encode(PebbleCreatePayload(from: draft, userId: UUID()))
+        let json = try encode(PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
         #expect(json["description"] is NSNull)
     }
 
     @Test("encodes glyph_id as null when draft has no glyph")
     func nullGlyphId() throws {
         let draft = makeValidDraft()
-        let json = try encode(PebbleCreatePayload(from: draft, userId: UUID()))
+        let json = try encode(PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
         #expect(json["glyph_id"] is NSNull)
     }
 
@@ -111,7 +111,7 @@ struct PebbleCreatePayloadEncodingTests {
         let glyphId = UUID()
         var draft = makeValidDraft()
         draft.glyphId = glyphId
-        let json = try encode(PebbleCreatePayload(from: draft, userId: UUID()))
+        let json = try encode(PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
         #expect((json["glyph_id"] as? String) == glyphId.uuidString)
     }
 
@@ -126,7 +126,7 @@ struct PebbleCreatePayloadEncodingTests {
             state: .uploaded
         ))
 
-        let payload = PebbleCreatePayload(from: draft, userId: userId)
+        let payload = PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: userId)
         let json = try encode(payload)
 
         let snaps = try #require(json["snaps"] as? [[String: Any]])
@@ -139,7 +139,7 @@ struct PebbleCreatePayloadEncodingTests {
     @Test("omits snaps key when attachedSnap is nil")
     func omitsSnapsWhenAbsent() throws {
         let draft = makeValidDraft()
-        let payload = PebbleCreatePayload(from: draft, userId: UUID())
+        let payload = PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: UUID())
         let json = try encode(payload)
         #expect(json["snaps"] == nil)
     }

--- a/apps/ios/PebblesTests/PebbleCreatePayloadEncodingTests.swift
+++ b/apps/ios/PebblesTests/PebbleCreatePayloadEncodingTests.swift
@@ -37,7 +37,7 @@ struct PebbleCreatePayloadEncodingTests {
     @Test("encodes all scalar fields with snake_case keys")
     func scalarKeys() throws {
         let draft = makeValidDraft()
-        let json = try encode(PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
+        let json = try encode(PebbleCreatePayload(from: draft, formSnap: nil, userId: UUID()))
 
         #expect(json["name"] as? String == "Test")
         #expect(json["description"] as? String == "body")
@@ -51,7 +51,7 @@ struct PebbleCreatePayloadEncodingTests {
     @Test("domain_ids is always a single-element array")
     func domainIds() throws {
         let draft = makeValidDraft()
-        let json = try encode(PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
+        let json = try encode(PebbleCreatePayload(from: draft, formSnap: nil, userId: UUID()))
 
         let ids = json["domain_ids"] as? [String] ?? []
         #expect(ids.count == 1)
@@ -61,7 +61,7 @@ struct PebbleCreatePayloadEncodingTests {
     @Test("soul_ids is empty array when draft.soulIds is empty")
     func emptySoulIds() throws {
         let draft = makeValidDraft(soulIds: [])
-        let json = try encode(PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
+        let json = try encode(PebbleCreatePayload(from: draft, formSnap: nil, userId: UUID()))
 
         let ids = json["soul_ids"] as? [String] ?? ["not-empty"]
         #expect(ids.isEmpty)
@@ -73,7 +73,7 @@ struct PebbleCreatePayloadEncodingTests {
         let id2 = UUID()
         let id3 = UUID()
         let draft = makeValidDraft(soulIds: [id1, id2, id3])
-        let json = try encode(PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
+        let json = try encode(PebbleCreatePayload(from: draft, formSnap: nil, userId: UUID()))
 
         let ids = json["soul_ids"] as? [String] ?? []
         #expect(ids == [id1.uuidString, id2.uuidString, id3.uuidString])
@@ -83,11 +83,11 @@ struct PebbleCreatePayloadEncodingTests {
     func collectionIds() throws {
         let collectionId = UUID()
         let draftWith = makeValidDraft(collectionId: collectionId)
-        let jsonWith = try encode(PebbleCreatePayload(from: draftWith, formSnap: draftWith.formSnap, userId: UUID()))
+        let jsonWith = try encode(PebbleCreatePayload(from: draftWith, formSnap: nil, userId: UUID()))
         #expect((jsonWith["collection_ids"] as? [String]) == [collectionId.uuidString])
 
         let draftWithout = makeValidDraft(collectionId: nil)
-        let jsonWithout = try encode(PebbleCreatePayload(from: draftWithout, formSnap: draftWithout.formSnap, userId: UUID()))
+        let jsonWithout = try encode(PebbleCreatePayload(from: draftWithout, formSnap: nil, userId: UUID()))
         #expect((jsonWithout["collection_ids"] as? [String])?.isEmpty == true)
     }
 
@@ -95,14 +95,14 @@ struct PebbleCreatePayloadEncodingTests {
     func emptyDescriptionBecomesNull() throws {
         var draft = makeValidDraft()
         draft.description = "   "
-        let json = try encode(PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
+        let json = try encode(PebbleCreatePayload(from: draft, formSnap: nil, userId: UUID()))
         #expect(json["description"] is NSNull)
     }
 
     @Test("encodes glyph_id as null when draft has no glyph")
     func nullGlyphId() throws {
         let draft = makeValidDraft()
-        let json = try encode(PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
+        let json = try encode(PebbleCreatePayload(from: draft, formSnap: nil, userId: UUID()))
         #expect(json["glyph_id"] is NSNull)
     }
 
@@ -111,7 +111,7 @@ struct PebbleCreatePayloadEncodingTests {
         let glyphId = UUID()
         var draft = makeValidDraft()
         draft.glyphId = glyphId
-        let json = try encode(PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
+        let json = try encode(PebbleCreatePayload(from: draft, formSnap: nil, userId: UUID()))
         #expect((json["glyph_id"] as? String) == glyphId.uuidString)
     }
 
@@ -119,14 +119,14 @@ struct PebbleCreatePayloadEncodingTests {
     func encodesAttachedSnap() throws {
         let snapId = UUID()
         let userId = UUID()
-        var draft = makeValidDraft()
-        draft.formSnap = .pending(AttachedSnap(
+        let draft = makeValidDraft()
+        let formSnap: FormSnap = .pending(AttachedSnap(
             id: snapId,
             localThumb: Data(),
             state: .uploaded
         ))
 
-        let payload = PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: userId)
+        let payload = PebbleCreatePayload(from: draft, formSnap: formSnap, userId: userId)
         let json = try encode(payload)
 
         let snaps = try #require(json["snaps"] as? [[String: Any]])
@@ -139,7 +139,7 @@ struct PebbleCreatePayloadEncodingTests {
     @Test("omits snaps key when attachedSnap is nil")
     func omitsSnapsWhenAbsent() throws {
         let draft = makeValidDraft()
-        let payload = PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: UUID())
+        let payload = PebbleCreatePayload(from: draft, formSnap: nil, userId: UUID())
         let json = try encode(payload)
         #expect(json["snaps"] == nil)
     }

--- a/apps/ios/PebblesTests/PebbleUpdatePayloadEncodingTests.swift
+++ b/apps/ios/PebblesTests/PebbleUpdatePayloadEncodingTests.swift
@@ -37,7 +37,7 @@ struct PebbleUpdatePayloadEncodingTests {
     @Test("encodes all scalar fields with snake_case keys")
     func scalarKeys() throws {
         let draft = makeValidDraft()
-        let json = try encode(PebbleUpdatePayload(from: draft, userId: UUID()))
+        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
 
         #expect(json["name"] as? String == "Test")
         #expect(json["description"] as? String == "body")
@@ -51,7 +51,7 @@ struct PebbleUpdatePayloadEncodingTests {
     @Test("domain_ids is always a single-element array")
     func domainIds() throws {
         let draft = makeValidDraft()
-        let json = try encode(PebbleUpdatePayload(from: draft, userId: UUID()))
+        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
 
         let ids = json["domain_ids"] as? [String] ?? []
         #expect(ids.count == 1)
@@ -61,7 +61,7 @@ struct PebbleUpdatePayloadEncodingTests {
     @Test("soul_ids is empty array when draft.soulIds is empty")
     func emptySoulIds() throws {
         let draft = makeValidDraft(soulIds: [])
-        let json = try encode(PebbleUpdatePayload(from: draft, userId: UUID()))
+        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
 
         let ids = json["soul_ids"] as? [String] ?? ["not-empty"]
         #expect(ids.isEmpty)
@@ -73,7 +73,7 @@ struct PebbleUpdatePayloadEncodingTests {
         let id2 = UUID()
         let id3 = UUID()
         let draft = makeValidDraft(soulIds: [id1, id2, id3])
-        let json = try encode(PebbleUpdatePayload(from: draft, userId: UUID()))
+        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
 
         let ids = json["soul_ids"] as? [String] ?? []
         #expect(ids == [id1.uuidString, id2.uuidString, id3.uuidString])
@@ -83,11 +83,11 @@ struct PebbleUpdatePayloadEncodingTests {
     func collectionIds() throws {
         let collectionId = UUID()
         let draftWith = makeValidDraft(collectionId: collectionId)
-        let jsonWith = try encode(PebbleUpdatePayload(from: draftWith, userId: UUID()))
+        let jsonWith = try encode(PebbleUpdatePayload(from: draftWith, formSnap: draftWith.formSnap, userId: UUID()))
         #expect((jsonWith["collection_ids"] as? [String]) == [collectionId.uuidString])
 
         let draftWithout = makeValidDraft(collectionId: nil)
-        let jsonWithout = try encode(PebbleUpdatePayload(from: draftWithout, userId: UUID()))
+        let jsonWithout = try encode(PebbleUpdatePayload(from: draftWithout, formSnap: draftWithout.formSnap, userId: UUID()))
         #expect((jsonWithout["collection_ids"] as? [String])?.isEmpty == true)
     }
 
@@ -95,14 +95,14 @@ struct PebbleUpdatePayloadEncodingTests {
     func emptyDescriptionBecomesNull() throws {
         var draft = makeValidDraft()
         draft.description = "   "
-        let json = try encode(PebbleUpdatePayload(from: draft, userId: UUID()))
+        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
         #expect(json["description"] is NSNull)
     }
 
     @Test("encodes glyph_id as null when draft has no glyph")
     func nullGlyphId() throws {
         let draft = makeValidDraft()
-        let json = try encode(PebbleUpdatePayload(from: draft, userId: UUID()))
+        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
         #expect(json["glyph_id"] is NSNull)
     }
 
@@ -111,7 +111,7 @@ struct PebbleUpdatePayloadEncodingTests {
         let glyphId = UUID()
         var draft = makeValidDraft()
         draft.glyphId = glyphId
-        let json = try encode(PebbleUpdatePayload(from: draft, userId: UUID()))
+        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
         #expect((json["glyph_id"] as? String) == glyphId.uuidString)
     }
 
@@ -128,7 +128,7 @@ struct PebbleUpdatePayloadEncodingTests {
         var draft = makeValidDraft()
         draft.happenedAt = fixedDate
 
-        let data = try JSONEncoder().encode(PebbleUpdatePayload(from: draft, userId: UUID()))
+        let data = try JSONEncoder().encode(PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
         let object = try JSONSerialization.jsonObject(with: data)
         let json = try #require(object as? [String: Any])
 

--- a/apps/ios/PebblesTests/PebbleUpdatePayloadEncodingTests.swift
+++ b/apps/ios/PebblesTests/PebbleUpdatePayloadEncodingTests.swift
@@ -37,7 +37,7 @@ struct PebbleUpdatePayloadEncodingTests {
     @Test("encodes all scalar fields with snake_case keys")
     func scalarKeys() throws {
         let draft = makeValidDraft()
-        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
+        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: nil, userId: UUID()))
 
         #expect(json["name"] as? String == "Test")
         #expect(json["description"] as? String == "body")
@@ -51,7 +51,7 @@ struct PebbleUpdatePayloadEncodingTests {
     @Test("domain_ids is always a single-element array")
     func domainIds() throws {
         let draft = makeValidDraft()
-        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
+        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: nil, userId: UUID()))
 
         let ids = json["domain_ids"] as? [String] ?? []
         #expect(ids.count == 1)
@@ -61,7 +61,7 @@ struct PebbleUpdatePayloadEncodingTests {
     @Test("soul_ids is empty array when draft.soulIds is empty")
     func emptySoulIds() throws {
         let draft = makeValidDraft(soulIds: [])
-        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
+        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: nil, userId: UUID()))
 
         let ids = json["soul_ids"] as? [String] ?? ["not-empty"]
         #expect(ids.isEmpty)
@@ -73,7 +73,7 @@ struct PebbleUpdatePayloadEncodingTests {
         let id2 = UUID()
         let id3 = UUID()
         let draft = makeValidDraft(soulIds: [id1, id2, id3])
-        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
+        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: nil, userId: UUID()))
 
         let ids = json["soul_ids"] as? [String] ?? []
         #expect(ids == [id1.uuidString, id2.uuidString, id3.uuidString])
@@ -83,11 +83,11 @@ struct PebbleUpdatePayloadEncodingTests {
     func collectionIds() throws {
         let collectionId = UUID()
         let draftWith = makeValidDraft(collectionId: collectionId)
-        let jsonWith = try encode(PebbleUpdatePayload(from: draftWith, formSnap: draftWith.formSnap, userId: UUID()))
+        let jsonWith = try encode(PebbleUpdatePayload(from: draftWith, formSnap: nil, userId: UUID()))
         #expect((jsonWith["collection_ids"] as? [String]) == [collectionId.uuidString])
 
         let draftWithout = makeValidDraft(collectionId: nil)
-        let jsonWithout = try encode(PebbleUpdatePayload(from: draftWithout, formSnap: draftWithout.formSnap, userId: UUID()))
+        let jsonWithout = try encode(PebbleUpdatePayload(from: draftWithout, formSnap: nil, userId: UUID()))
         #expect((jsonWithout["collection_ids"] as? [String])?.isEmpty == true)
     }
 
@@ -95,14 +95,14 @@ struct PebbleUpdatePayloadEncodingTests {
     func emptyDescriptionBecomesNull() throws {
         var draft = makeValidDraft()
         draft.description = "   "
-        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
+        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: nil, userId: UUID()))
         #expect(json["description"] is NSNull)
     }
 
     @Test("encodes glyph_id as null when draft has no glyph")
     func nullGlyphId() throws {
         let draft = makeValidDraft()
-        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
+        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: nil, userId: UUID()))
         #expect(json["glyph_id"] is NSNull)
     }
 
@@ -111,7 +111,7 @@ struct PebbleUpdatePayloadEncodingTests {
         let glyphId = UUID()
         var draft = makeValidDraft()
         draft.glyphId = glyphId
-        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
+        let json = try encode(PebbleUpdatePayload(from: draft, formSnap: nil, userId: UUID()))
         #expect((json["glyph_id"] as? String) == glyphId.uuidString)
     }
 
@@ -128,7 +128,7 @@ struct PebbleUpdatePayloadEncodingTests {
         var draft = makeValidDraft()
         draft.happenedAt = fixedDate
 
-        let data = try JSONEncoder().encode(PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: UUID()))
+        let data = try JSONEncoder().encode(PebbleUpdatePayload(from: draft, formSnap: nil, userId: UUID()))
         let object = try JSONSerialization.jsonObject(with: data)
         let json = try #require(object as? [String: Any])
 

--- a/apps/ios/PebblesTests/SnapUploadCoordinatorTests.swift
+++ b/apps/ios/PebblesTests/SnapUploadCoordinatorTests.swift
@@ -2,6 +2,15 @@ import Foundation
 import Testing
 @testable import Pebbles
 
+/// Recorded calls on `FakeRepo`. Top-level so the suite type stays at nesting
+/// depth 1 (avoids swiftlint's nesting violation).
+enum FakeRepoCall: Equatable {
+    case upload(snapId: UUID, userId: UUID)
+    case deleteFilesBySnapId(snapId: UUID, userId: UUID)
+    case deleteFilesByPrefix(prefix: String)
+    case deletePebbleMedia(snapId: UUID)
+}
+
 @MainActor
 @Suite("SnapUploadCoordinator")
 struct SnapUploadCoordinatorTests {
@@ -15,14 +24,7 @@ struct SnapUploadCoordinatorTests {
     @MainActor
     final class FakeRepo: PebbleSnapRepositoryProtocol {
 
-        enum Call: Equatable {
-            case upload(snapId: UUID, userId: UUID)
-            case deleteFilesBySnapId(snapId: UUID, userId: UUID)
-            case deleteFilesByPrefix(prefix: String)
-            case deletePebbleMedia(snapId: UUID)
-        }
-
-        var calls: [Call] = []
+        var calls: [FakeRepoCall] = []
 
         // Stubs — set before invoking the method under test.
         var uploadResults: [Result<Void, Error>] = []
@@ -115,7 +117,7 @@ struct SnapUploadCoordinatorTests {
         let repo = FakeRepo()
         repo.uploadResults = [
             .failure(StubError(tag: "first")),
-            .failure(StubError(tag: "second")),
+            .failure(StubError(tag: "second"))
         ]
         let snap = AttachedSnap(id: UUID(), localThumb: Data([0xFF]), state: .uploading)
         let coordinator = SnapUploadCoordinator(
@@ -232,7 +234,7 @@ struct SnapUploadCoordinatorTests {
         #expect(coordinator.formSnap == nil)
         #expect(repo.calls == [
             .deletePebbleMedia(snapId: snapId),
-            .deleteFilesByPrefix(prefix: "uid/sid"),
+            .deleteFilesByPrefix(prefix: "uid/sid")
         ])
     }
 

--- a/apps/ios/PebblesTests/SnapUploadCoordinatorTests.swift
+++ b/apps/ios/PebblesTests/SnapUploadCoordinatorTests.swift
@@ -1,0 +1,260 @@
+import Foundation
+import Testing
+@testable import Pebbles
+
+@MainActor
+@Suite("SnapUploadCoordinator")
+struct SnapUploadCoordinatorTests {
+
+    // MARK: - Fake repo
+
+    /// Records every call and lets each method be stubbed. The live
+    /// `deleteFiles(...)` methods don't throw (errors are logged internally),
+    /// so the fake matches that contract — we assert call recording, not
+    /// thrown errors, for those paths.
+    @MainActor
+    final class FakeRepo: PebbleSnapRepositoryProtocol {
+
+        enum Call: Equatable {
+            case upload(snapId: UUID, userId: UUID)
+            case deleteFilesBySnapId(snapId: UUID, userId: UUID)
+            case deleteFilesByPrefix(prefix: String)
+            case deletePebbleMedia(snapId: UUID)
+        }
+
+        var calls: [Call] = []
+
+        // Stubs — set before invoking the method under test.
+        var uploadResults: [Result<Void, Error>] = []
+        var deletePebbleMediaResult: Result<String, Error> = .success("uid/sid")
+
+        func uploadProcessed(_ processed: ProcessedImage, snapId: UUID, userId: UUID) async throws {
+            calls.append(.upload(snapId: snapId, userId: userId))
+            guard !uploadResults.isEmpty else { return }
+            switch uploadResults.removeFirst() {
+            case .success: return
+            case .failure(let error): throw error
+            }
+        }
+
+        func deleteFiles(snapId: UUID, userId: UUID) async {
+            calls.append(.deleteFilesBySnapId(snapId: snapId, userId: userId))
+        }
+
+        func deleteFiles(storagePrefix: String) async {
+            calls.append(.deleteFilesByPrefix(prefix: storagePrefix))
+        }
+
+        func deletePebbleMedia(snapId: UUID) async throws -> String {
+            calls.append(.deletePebbleMedia(snapId: snapId))
+            switch deletePebbleMediaResult {
+            case .success(let path): return path
+            case .failure(let error): throw error
+            }
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private func makeProcessed() -> ProcessedImage {
+        ProcessedImage(original: Data([0x01]), thumb: Data([0x02]))
+    }
+
+    /// Build a coordinator pre-seeded with a `.pending(.uploaded)` snap.
+    /// Useful for tests that start mid-flow (retry, remove, cancel).
+    private func makeCoordinatorWithUploadedPending(
+        repo: FakeRepo,
+        snapId: UUID = UUID()
+    ) -> (SnapUploadCoordinator, AttachedSnap) {
+        let snap = AttachedSnap(id: snapId, localThumb: Data([0xFF]), state: .uploaded)
+        let coordinator = SnapUploadCoordinator(
+            repo: repo,
+            initialSnap: .pending(snap),
+            retryDelay: .milliseconds(1)
+        )
+        return (coordinator, snap)
+    }
+
+    private struct StubError: Error, Equatable { let tag: String }
+
+    // MARK: - Tests
+
+    // Note: `handlePicked` exercises the full `loadData → ImagePipeline.process →
+    // performUpload` path. Driving it from a unit test would require a real
+    // `NSItemProvider` (and would re-encode a JPEG in-process), which isn't worth
+    // the test infrastructure for what is mostly glue. The internal `performUpload`
+    // path is exercised by `retryWithinUploadSucceeds`, `bothAttemptsFailEndsInFailedState`,
+    // and `manualRetrySucceeds` below. The end-to-end picker integration is covered
+    // by the manual smoke test in plan Task 10.
+
+    @Test("first upload fails, second attempt succeeds → .uploaded")
+    func retryWithinUploadSucceeds() async throws {
+        let repo = FakeRepo()
+        repo.uploadResults = [.failure(StubError(tag: "first")), .success(())]
+
+        let snapId = UUID()
+        let userId = UUID()
+        let snap = AttachedSnap(id: snapId, localThumb: Data([0xFF]), state: .uploading)
+        let coordinator = SnapUploadCoordinator(
+            repo: repo,
+            initialSnap: .pending(snap),
+            retryDelay: .milliseconds(1)
+        )
+        coordinator.seedProcessedForRetry(makeProcessed())
+        await coordinator.retryCurrent(userId: userId)
+
+        guard case .pending(let final) = coordinator.formSnap else {
+            Issue.record("expected .pending"); return
+        }
+        #expect(final.state == .uploaded)
+        #expect(repo.calls.filter { if case .upload = $0 { return true }; return false }.count == 2)
+    }
+
+    @Test("both upload attempts fail → .failed, processedForRetry retained")
+    func bothAttemptsFailEndsInFailedState() async throws {
+        let repo = FakeRepo()
+        repo.uploadResults = [
+            .failure(StubError(tag: "first")),
+            .failure(StubError(tag: "second")),
+        ]
+        let snap = AttachedSnap(id: UUID(), localThumb: Data([0xFF]), state: .uploading)
+        let coordinator = SnapUploadCoordinator(
+            repo: repo,
+            initialSnap: .pending(snap),
+            retryDelay: .milliseconds(1)
+        )
+        coordinator.seedProcessedForRetry(makeProcessed())
+        await coordinator.retryCurrent(userId: UUID())
+
+        guard case .pending(let final) = coordinator.formSnap else {
+            Issue.record("expected .pending"); return
+        }
+        #expect(final.state == .failed)
+        #expect(coordinator.processedForRetry != nil)
+    }
+
+    @Test("manual retry from .failed → .uploading → .uploaded")
+    func manualRetrySucceeds() async throws {
+        let repo = FakeRepo()
+        repo.uploadResults = [.success(())]
+        let snap = AttachedSnap(id: UUID(), localThumb: Data([0xFF]), state: .failed)
+        let coordinator = SnapUploadCoordinator(
+            repo: repo,
+            initialSnap: .pending(snap),
+            retryDelay: .milliseconds(1)
+        )
+        coordinator.seedProcessedForRetry(makeProcessed())
+        await coordinator.retryCurrent(userId: UUID())
+
+        guard case .pending(let final) = coordinator.formSnap else {
+            Issue.record("expected .pending"); return
+        }
+        #expect(final.state == .uploaded)
+    }
+
+    @Test("removePending clears state and fires compensating delete")
+    func removePendingFiresCleanup() async throws {
+        let repo = FakeRepo()
+        let snapId = UUID()
+        let userId = UUID()
+        let (coordinator, _) = makeCoordinatorWithUploadedPending(repo: repo, snapId: snapId)
+        coordinator.seedProcessedForRetry(makeProcessed())
+
+        await coordinator.removePending(userId: userId)
+
+        #expect(coordinator.formSnap == nil)
+        #expect(coordinator.processedForRetry == nil)
+        #expect(repo.calls == [.deleteFilesBySnapId(snapId: snapId, userId: userId)])
+    }
+
+    @Test("cancelAndCleanup awaits the Storage delete before returning")
+    func cancelAndCleanupAwaitsDelete() async throws {
+        let repo = FakeRepo()
+        let snapId = UUID()
+        let userId = UUID()
+        let (coordinator, _) = makeCoordinatorWithUploadedPending(repo: repo, snapId: snapId)
+
+        await coordinator.cancelAndCleanup(userId: userId)
+
+        #expect(coordinator.formSnap == nil)
+        #expect(repo.calls == [.deleteFilesBySnapId(snapId: snapId, userId: userId)])
+    }
+
+    @Test("cancelAndCleanup with no pending snap is a no-op")
+    func cancelAndCleanupNoOpWhenEmpty() async throws {
+        let repo = FakeRepo()
+        let coordinator = SnapUploadCoordinator(repo: repo, retryDelay: .milliseconds(1))
+
+        await coordinator.cancelAndCleanup(userId: UUID())
+
+        #expect(coordinator.formSnap == nil)
+        #expect(repo.calls.isEmpty)
+    }
+
+    // Note: the spec lists "cancelAndCleanup with delete failure → returns, state
+    // cleared" as a case. That property is enforced at the type level — the
+    // protocol's `deleteFiles(snapId:userId:)` returns `async` (not `async throws`),
+    // so the coordinator structurally cannot fail-fast on a Storage error. The
+    // live repo logs internally; the fake records the call. No additional test
+    // needed beyond `cancelAndCleanupAwaitsDelete`.
+
+    @Test("handleSaveFailure fires compensating delete but keeps formSnap")
+    func handleSaveFailureFiresCleanupAndKeepsState() async throws {
+        let repo = FakeRepo()
+        let snapId = UUID()
+        let userId = UUID()
+        let (coordinator, original) = makeCoordinatorWithUploadedPending(repo: repo, snapId: snapId)
+
+        await coordinator.handleSaveFailure(userId: userId)
+
+        #expect(repo.calls == [.deleteFilesBySnapId(snapId: snapId, userId: userId)])
+        // Caller decides whether to clear state; coordinator preserves it.
+        if case .pending(let snap) = coordinator.formSnap {
+            #expect(snap.id == original.id)
+        } else {
+            Issue.record("expected formSnap to be retained")
+        }
+    }
+
+    @Test("removeExisting: happy path calls RPC, fires storage cleanup, clears state")
+    func removeExistingHappyPath() async throws {
+        let repo = FakeRepo()
+        let snapId = UUID()
+        repo.deletePebbleMediaResult = .success("uid/sid")
+        let coordinator = SnapUploadCoordinator(
+            repo: repo,
+            initialSnap: .existing(id: snapId, storagePath: "uid/sid"),
+            retryDelay: .milliseconds(1)
+        )
+
+        try await coordinator.removeExisting()
+
+        #expect(coordinator.formSnap == nil)
+        #expect(repo.calls == [
+            .deletePebbleMedia(snapId: snapId),
+            .deleteFilesByPrefix(prefix: "uid/sid"),
+        ])
+    }
+
+    @Test("removeExisting: RPC failure throws and retains state")
+    func removeExistingRPCFailureRetainsState() async throws {
+        let repo = FakeRepo()
+        let snapId = UUID()
+        repo.deletePebbleMediaResult = .failure(StubError(tag: "rpc"))
+        let coordinator = SnapUploadCoordinator(
+            repo: repo,
+            initialSnap: .existing(id: snapId, storagePath: "uid/sid"),
+            retryDelay: .milliseconds(1)
+        )
+
+        await #expect(throws: StubError.self) {
+            try await coordinator.removeExisting()
+        }
+
+        if case .existing(let id, _) = coordinator.formSnap {
+            #expect(id == snapId)
+        } else {
+            Issue.record("expected formSnap to remain .existing")
+        }
+    }
+}

--- a/docs/superpowers/2026-05-12-ios-snap-upload-coordinator-design.md
+++ b/docs/superpowers/2026-05-12-ios-snap-upload-coordinator-design.md
@@ -1,0 +1,212 @@
+# iOS: SnapUploadCoordinator extraction
+
+**Issue:** [#401 — Extract snap upload logic shared by CreatePebbleSheet and EditPebbleSheet](https://github.com/Bohns/pbbls/issues/401)
+**Milestone:** M32 · iOS Quality
+**Date:** 2026-05-12
+
+## Problem
+
+`CreatePebbleSheet` and `EditPebbleSheet` contain ~200 lines of nearly identical snap upload, retry, and compensating-delete logic — the safety-critical Storage cleanup path is duplicated verbatim. Future fixes will need to be applied in two places, and the two copies will drift.
+
+Specifically duplicated:
+
+- `handlePicked(_:)`, `loadData(from:uti:)`, `uploadCurrentSnap(processed:userId:)` — verbatim
+- `pendingSnapState` / `pendingSnapId` computed properties — verbatim
+- `snapRepo` computed property — verbatim
+- `.onChange(of: pendingSnapState)` retry observer — verbatim
+- `.onChange(of: pendingSnapId)` compensating-delete observer — verbatim
+- `processedForRetry` `@State` — verbatim
+
+The differences between the two sheets are limited to `loadReferences()` vs `load()` and the final RPC call in `save()` (`compose-pebble` vs `compose-pebble-update`).
+
+Two related defects are folded into this extraction:
+
+1. **`cancelAndCleanup()` uses a 50 ms sleep before `dismiss()`** to give the `.onChange` observer time to fire the Storage delete. The delete is not awaited, so if the network call exceeds 50 ms (it usually does), the view tears down mid-request and the file is orphaned. Safety-critical.
+2. **Snap state is split** across `draft.formSnap` (inside `PebbleDraft`) and `processedForRetry` (a `@State` on the sheet). Mutations from two paths (user action + `.onChange` reaction) hit overlapping state, which is exactly the shape that hides bugs.
+
+## Goal
+
+A single `@Observable` `SnapUploadCoordinator` owns the entire snap lifecycle for an in-progress pebble form. Both sheets delegate to it. Storage side effects are explicitly awaited. The coordinator is unit-tested behind a `PebbleSnapRepository` protocol.
+
+## Non-goals
+
+- Changing the upload semantics (retry count, backoff duration, two-file Storage layout) — preserved as-is.
+- Changing `ImagePipeline` or the photo-picker UI.
+- Adding new snap features (multiple snaps per pebble, reordering, etc.).
+- Touching the web app's equivalent flow.
+
+## Design
+
+### New type
+
+`apps/ios/Pebbles/Features/PebbleMedia/SnapUploadCoordinator.swift`:
+
+```swift
+@MainActor
+@Observable
+final class SnapUploadCoordinator {
+    // Source of truth for all snap state in the form
+    private(set) var formSnap: FormSnap?
+    private(set) var processedForRetry: ProcessedImage?
+
+    private let repo: PebbleSnapRepositoryProtocol
+    private let retryDelay: Duration
+    private let logger = Logger(subsystem: "app.pbbls.ios", category: "snap-coordinator")
+
+    init(
+        repo: PebbleSnapRepositoryProtocol,
+        initialSnap: FormSnap? = nil,
+        retryDelay: Duration = .seconds(2)
+    )
+
+    // Derived state for the sheet to consult
+    var isUploading: Bool { /* .pending(_, .uploading) */ }
+    var hasFailed: Bool   { /* .pending(_, .failed) */ }
+    var isBlocking: Bool  { isUploading || hasFailed }
+    func pendingSnapForPayload() -> AttachedSnap?  // nil unless .pending(.uploaded)
+
+    // User-driven transitions
+    func handlePicked(_ picked: PhotoPickerView.PickedItem, userId: UUID) async
+    func retryCurrent(userId: UUID) async       // chip's "retry" action calls this directly
+    func removePending(userId: UUID) async      // chip's "remove" action for .pending
+    func removeExisting() async throws          // chip's "remove" action for .existing
+
+    // Sheet lifecycle hooks
+    func cancelAndCleanup(userId: UUID) async   // explicitly awaits Storage delete; no sleep
+    func handleSaveFailure(userId: UUID) async  // compensating delete after compose-pebble failure
+}
+```
+
+### Repository protocol
+
+Extract a protocol so the coordinator can be unit-tested. Existing `PebbleSnapRepository` becomes the live conformance. The protocol adds one method to keep the coordinator from touching the raw Supabase client:
+
+```swift
+protocol PebbleSnapRepositoryProtocol {
+    func uploadProcessed(_ processed: ProcessedImage, snapId: UUID, userId: UUID) async throws
+    func deleteFiles(snapId: UUID, userId: UUID) async
+    func deleteFiles(storagePrefix: String) async
+    func deletePebbleMedia(snapId: UUID) async throws -> String  // returns storage_path; calls delete_pebble_media RPC
+}
+```
+
+`deletePebbleMedia` is new: it wraps the `delete_pebble_media` RPC that `EditPebbleSheet.removeExistingSnap()` currently calls directly on the client.
+
+### State changes
+
+**`PebbleDraft`** loses `formSnap`. The struct becomes pure form data. `PebbleDraft(from: detail)` no longer pre-fills snap state — that pre-fill moves to the sheet after `load()` completes.
+
+**`PebbleCreatePayload(from: draft, formSnap:, userId:)`** and **`PebbleUpdatePayload(from: draft, formSnap:, userId:)`** take an additional `formSnap: FormSnap?` parameter and switch on it exactly the same way they currently switch on `draft.formSnap`:
+
+- `PebbleCreatePayload`: handles `.none` → `nil` and `.pending` → `[SnapPayload]`; keeps the `assertionFailure` for `.existing`.
+- `PebbleUpdatePayload`: handles `.none` → `[]`, `.existing` → `[SnapPayload]`, `.pending` → `[SnapPayload]`.
+
+This preserves the existing semantics verbatim — only the source of the `FormSnap` value moves from `draft` to a parameter supplied by the sheet (which reads it from `snaps.formSnap`).
+
+**`PebbleFormView`** swaps `draft.formSnap` reads for explicit parameters:
+- `formSnap: FormSnap?`
+- `isRemovingExistingSnap: Bool`
+- `onRetryPending: () -> Void`
+- `onRemovePending: () -> Void`
+- `onRemoveExisting: () -> Void`
+
+The `.onChange` observers that currently translate state mutations into actions are deleted — the chip already knows when the user taps retry vs remove, so it can call the callback directly.
+
+### Behavior preservation
+
+- **Initial upload:** `handlePicked` → load bytes → `Task.detached` `ImagePipeline.process` → set `formSnap = .pending(.uploading)`, retain `processedForRetry` → call internal `performUpload`. Identical to today.
+- **Retry on failure:** internal `performUpload` does first attempt → on throw, `try? await Task.sleep(retryDelay)` → second attempt. On success → `.uploaded`. On second failure → `.failed`. Identical to today, with `retryDelay` parameterized for testability.
+- **User-tapped retry from `.failed`:** chip calls `coordinator.retryCurrent(userId:)`. Replaces the `.onChange(of: pendingSnapState)` observer. Sets state back to `.uploading`, re-runs `performUpload` with the retained `processedForRetry`.
+- **User-tapped remove pending:** chip calls `coordinator.removePending(userId:)`. Captures current snap id, sets `formSnap = nil`, clears `processedForRetry`, awaits `repo.deleteFiles(snapId:userId:)`. Replaces the `.onChange(of: pendingSnapId)` observer.
+- **User-tapped remove existing:** chip calls `coordinator.removeExisting()`. Calls `repo.deletePebbleMedia(snapId:)`, then fires fire-and-forget `repo.deleteFiles(storagePrefix:)` with the returned path, then sets `formSnap = nil`. Throws on RPC failure so the sheet can surface `saveError`. Identical to today's `removeExistingSnap()`.
+- **Cancel with pending snap:** sheet calls `await snaps.cancelAndCleanup(userId:)` then `dismiss()`. The coordinator captures the pending snap id, sets `formSnap = nil`, *awaits* `repo.deleteFiles(snapId:userId:)`. No sleep, no race. If the delete itself fails it's logged at `.error` and `cancelAndCleanup` still returns — Cancel must not be un-cancellable.
+- **Save failure with pending snap:** sheet calls `await snaps.handleSaveFailure(userId:)` before setting `saveError`. The coordinator awaits the compensating delete. Identical compensating-delete behavior, deduplicated.
+
+### Sheet wiring
+
+`CreatePebbleSheet`:
+
+```swift
+@State private var snaps = SnapUploadCoordinator(
+    repo: PebbleSnapRepository(client: supabase.client)
+)
+```
+
+`EditPebbleSheet` seeds the initial snap *after* `load()` succeeds:
+
+```swift
+if let snap = detail.snap {
+    snaps = SnapUploadCoordinator(
+        repo: PebbleSnapRepository(client: supabase.client),
+        initialSnap: .existing(id: snap.id, storagePath: snap.storagePath)
+    )
+}
+```
+
+(Reassigning `@State` is fine here — the assignment runs once after async load, before the form renders.)
+
+Both sheets' `save()` reads `snaps.isBlocking` for the upload-still-in-flight / failed checks, and `snaps.pendingSnapForPayload()` for payload construction.
+
+Both sheets' Cancel toolbar item becomes:
+
+```swift
+Button("Cancel") {
+    Task {
+        if let userId = currentUserId {
+            await snaps.cancelAndCleanup(userId: userId)
+        }
+        dismiss()
+    }
+}
+```
+
+### File touch list
+
+- **New:** `apps/ios/Pebbles/Features/PebbleMedia/SnapUploadCoordinator.swift` (~180 LOC)
+- **New:** `apps/ios/PebblesTests/SnapUploadCoordinatorTests.swift` (Swift Testing)
+- **Modified:** `apps/ios/Pebbles/Features/PebbleMedia/PebbleSnapRepository.swift` — add protocol conformance, add `deletePebbleMedia(snapId:)` method
+- **Modified:** `apps/ios/Pebbles/Features/Path/Models/PebbleDraft.swift` — remove `formSnap`
+- **Modified:** `apps/ios/Pebbles/Features/Path/Models/PebbleCreatePayload.swift` — take snap as parameter
+- **Modified:** `apps/ios/Pebbles/Features/Path/Models/PebbleUpdatePayload.swift` — take snap as parameter
+- **Modified:** `apps/ios/Pebbles/Features/Path/PebbleFormView.swift` — formSnap and callbacks as parameters
+- **Modified:** `apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift` — delete ~120 LOC, delegate to coordinator
+- **Modified:** `apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift` — delete ~120 LOC, delegate to coordinator
+
+## Testing
+
+Per `apps/ios/CLAUDE.md`: Swift Testing in `PebblesTests/`, protocol extraction is justified now because tests need to fake the repo.
+
+`SnapUploadCoordinatorTests`:
+
+1. `handlePicked` happy path → transitions `nil → .pending(.uploading) → .pending(.uploaded)`; `uploadProcessed` called once
+2. First upload throws, retry succeeds → ends `.uploaded`; `uploadProcessed` called twice
+3. Both attempts throw → ends `.pending(.failed)`; `processedForRetry` retained
+4. `retryCurrent` from `.failed` → `.uploading → .uploaded`; `uploadProcessed` called once more
+5. `removePending` → state `nil`; `deleteFiles(snapId:userId:)` called once with correct ids; `processedForRetry` cleared
+6. `cancelAndCleanup` with pending snap → asserts `deleteFiles` *awaited* before return (fake records `awaitOrder`)
+7. `cancelAndCleanup` with delete failure → returns normally, error logged, `formSnap` cleared
+8. `handleSaveFailure` with pending snap → compensating delete fired
+9. `removeExisting` happy path → `deletePebbleMedia` called, storage cleanup fired, state `nil`
+10. `removeExisting` RPC failure → throws, state retained
+
+Fake `PebbleSnapRepositoryProtocol` records call order and lets each method be stubbed to throw. `retryDelay: .milliseconds(1)` in tests keeps the suite fast.
+
+## Risks
+
+- **`PebbleDraft` API change ripples.** Anything currently reading `draft.formSnap` (form view, payload builders, possibly other callers) must be updated. Need to grep before implementation to confirm the touch list is complete.
+- **`@State` reassignment in `EditPebbleSheet` after load.** Legal but uncommon — the alternative is making `initialSnap` settable on the coordinator post-init (a `seedExisting(_:)` method). Either works; implementation can pick whichever reads cleaner.
+- **Existing tests, if any, that depend on `PebbleDraft.formSnap`.** Need to check during implementation; the iOS test suite is small today.
+
+## Out of scope (explicit)
+
+- Issue #274 (consolidating `PebbleIdPartial` into `ComposePebbleResponse`) — separate quality issue.
+- Web equivalents of any of this.
+- Adding multiple-snaps support.
+
+## Done when
+
+- `SnapUploadCoordinator` exists and is the single source of truth for snap state in the form layer.
+- `CreatePebbleSheet` and `EditPebbleSheet` no longer contain `handlePicked`, `loadData`, `uploadCurrentSnap`, `processedForRetry`, or either `.onChange` snap observer.
+- `cancelAndCleanup` awaits the Storage delete explicitly (no `Task.sleep` hack).
+- `SnapUploadCoordinatorTests` covers the ten cases above and passes.
+- `npm run lint --workspace=apps/ios` (or equivalent iOS scoped check) is green; the iOS app builds.

--- a/docs/superpowers/plans/2026-05-12-ios-snap-upload-coordinator.md
+++ b/docs/superpowers/plans/2026-05-12-ios-snap-upload-coordinator.md
@@ -1,0 +1,1743 @@
+# SnapUploadCoordinator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the snap upload, retry, and compensating-delete logic duplicated between `CreatePebbleSheet` and `EditPebbleSheet` into a single `@Observable SnapUploadCoordinator`, with the `cancelAndCleanup` sleep-race fixed and full test coverage.
+
+**Architecture:** New `@MainActor @Observable` class owns `formSnap` (moved out of `PebbleDraft`) and `processedForRetry`. Storage operations go through a new `PebbleSnapRepositoryProtocol` so the coordinator is unit-testable with a fake. Both sheets delegate every snap mutation to the coordinator; the two `.onChange` observers that translated state mutations into Storage side-effects are deleted — the chip calls callbacks directly.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, iOS 17, `@Observable`, Swift Testing, Supabase Swift SDK.
+
+**Spec:** `docs/superpowers/2026-05-12-ios-snap-upload-coordinator-design.md`
+**Issue:** [#401](https://github.com/Bohns/pbbls/issues/401)
+**Branch:** `feat/401-snap-upload-coordinator` (already created)
+
+**Ordering rationale:** Tasks 1–4 are purely additive — the build stays green. Tasks 5–8 are the switch-over; each ends with a passing build and one logical refactor committed. Task 9 finally removes `PebbleDraft.formSnap` once nothing reads it. Task 10 is verification.
+
+**Verification commands (used throughout):**
+- Lint: `npm run lint --workspace=@pbbls/ios`
+- Build: `npm run build --workspace=@pbbls/ios`
+- Test: `npm run test --workspace=@pbbls/ios`
+
+(All commands are run from the repo root `/Users/alexis/code/pbbls`. The build/test scripts run `xcodegen generate` first so new files are auto-picked up.)
+
+---
+
+## Task 1: Add `PebbleSnapRepositoryProtocol` and `deletePebbleMedia(snapId:)`
+
+**Why:** The coordinator must be unit-testable without a real Supabase client. We extract a protocol so a fake conformance can be injected. While we're here, add a `deletePebbleMedia(snapId:)` method that wraps the `delete_pebble_media` RPC — currently called from `EditPebbleSheet.removeExistingSnap()` directly on the client. Moving it here keeps the coordinator off the raw client.
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/PebbleMedia/PebbleSnapRepository.swift`
+
+- [ ] **Step 1: Add the protocol and the new method**
+
+Open `apps/ios/Pebbles/Features/PebbleMedia/PebbleSnapRepository.swift`. After the imports (line 3), add the protocol. Then add the new method to `PebbleSnapRepository` and declare conformance.
+
+Insert directly after `import os` (before `@MainActor struct PebbleSnapRepository`):
+
+```swift
+/// Abstraction over snap Storage + RPC operations so callers (notably
+/// `SnapUploadCoordinator`) can be unit-tested with a fake. The live
+/// conformance is `PebbleSnapRepository`.
+@MainActor
+protocol PebbleSnapRepositoryProtocol {
+    func uploadProcessed(_ processed: ProcessedImage, snapId: UUID, userId: UUID) async throws
+    func deleteFiles(snapId: UUID, userId: UUID) async
+    func deleteFiles(storagePrefix: String) async
+    /// Calls the `delete_pebble_media` Postgres RPC. Returns the row's
+    /// `storage_path` so the caller can fire-and-forget Storage cleanup.
+    func deletePebbleMedia(snapId: UUID) async throws -> String
+}
+```
+
+Change the struct declaration line from:
+
+```swift
+struct PebbleSnapRepository {
+```
+
+to:
+
+```swift
+struct PebbleSnapRepository: PebbleSnapRepositoryProtocol {
+```
+
+Inside the struct, add the new method. Put it after `deleteFiles(storagePrefix:)` (right after line 68 — the closing brace of that method):
+
+```swift
+    /// Wraps the `delete_pebble_media` RPC. Returns the row's `storage_path`
+    /// so the caller can run fire-and-forget Storage cleanup using
+    /// `deleteFiles(storagePrefix:)`.
+    func deletePebbleMedia(snapId: UUID) async throws -> String {
+        try await client
+            .rpc("delete_pebble_media", params: ["p_snap_id": snapId.uuidString])
+            .execute()
+            .value
+    }
+```
+
+- [ ] **Step 2: Verify the build is still green**
+
+```bash
+npm run build --workspace=@pbbls/ios
+```
+
+Expected: build succeeds. The protocol is unused so far; the new method is unused so far. Both are fine — `swiftlint` may flag the unused protocol with a warning; if so, it's acceptable for one commit.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/PebbleMedia/PebbleSnapRepository.swift
+git commit -m "$(cat <<'EOF'
+quality(ios): add PebbleSnapRepositoryProtocol and deletePebbleMedia method
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Scaffold `SnapUploadCoordinator` with stubbed methods
+
+**Why:** Creating the file with the full public surface (and `fatalError("not implemented")` bodies) lets us write the test file in the next task without compile errors. Once tests are written and failing, we fill in the implementation.
+
+**Files:**
+- Create: `apps/ios/Pebbles/Features/PebbleMedia/SnapUploadCoordinator.swift`
+
+- [ ] **Step 1: Create the file with the full API surface**
+
+Create `apps/ios/Pebbles/Features/PebbleMedia/SnapUploadCoordinator.swift`:
+
+```swift
+import Foundation
+import os
+
+/// Single source of truth for the snap (photo) attached to an in-progress
+/// pebble form. Owns `formSnap` (the form-layer state), `processedForRetry`
+/// (re-encoded bytes kept around for a user-tapped retry), and every
+/// transition: pick → upload → retry → cancel → remove.
+///
+/// Both `CreatePebbleSheet` and `EditPebbleSheet` hold one of these and
+/// delegate. All Storage side-effects are explicitly awaited — there is no
+/// sleep-based race in `cancelAndCleanup`.
+@MainActor
+@Observable
+final class SnapUploadCoordinator {
+
+    // MARK: - State (publicly readable, mutated only by methods on this type)
+
+    private(set) var formSnap: FormSnap?
+
+    /// Processed bytes kept around so a `.failed → user-tapped retry` doesn't
+    /// re-load + re-encode the original. Cleared whenever `formSnap` is
+    /// cleared.
+    private(set) var processedForRetry: ProcessedImage?
+
+    // MARK: - Derived state
+
+    /// True while the pending snap is still uploading.
+    var isUploading: Bool {
+        if case .pending(let snap) = formSnap, snap.state == .uploading { return true }
+        return false
+    }
+
+    /// True when the pending snap's last upload attempt failed.
+    var hasFailed: Bool {
+        if case .pending(let snap) = formSnap, snap.state == .failed { return true }
+        return false
+    }
+
+    /// `true` while save should be blocked because the snap is mid-upload
+    /// or in a failed state requiring user action.
+    var isBlocking: Bool { isUploading || hasFailed }
+
+    /// Returns the pending `AttachedSnap` only when it has fully uploaded —
+    /// suitable for embedding in a save payload. Returns `nil` for `.none`,
+    /// `.existing` (those are encoded directly from `formSnap`), or any
+    /// in-flight/failed `.pending` state.
+    func pendingSnapForPayload() -> AttachedSnap? {
+        if case .pending(let snap) = formSnap, snap.state == .uploaded { return snap }
+        return nil
+    }
+
+    // MARK: - Init
+
+    private let repo: PebbleSnapRepositoryProtocol
+    private let retryDelay: Duration
+    private static let logger = Logger(subsystem: "app.pbbls.ios", category: "snap-coordinator")
+
+    init(
+        repo: PebbleSnapRepositoryProtocol,
+        initialSnap: FormSnap? = nil,
+        retryDelay: Duration = .seconds(2)
+    ) {
+        self.repo = repo
+        self.formSnap = initialSnap
+        self.retryDelay = retryDelay
+    }
+
+    /// Set the initial snap *after* construction. Used by `EditPebbleSheet`
+    /// which has to wait for `load()` to finish before it knows whether the
+    /// pebble has an existing snap.
+    func seedExisting(_ snap: FormSnap?) {
+        self.formSnap = snap
+    }
+
+    // MARK: - User-driven transitions
+
+    func handlePicked(_ picked: PhotoPickerView.PickedItem, userId: UUID) async {
+        fatalError("not implemented")
+    }
+
+    /// Re-run the upload after a user tap on the chip's retry button. Only
+    /// valid when the current state is `.pending(.failed)` and we still hold
+    /// `processedForRetry`. No-op otherwise.
+    func retryCurrent(userId: UUID) async {
+        fatalError("not implemented")
+    }
+
+    /// Remove the current `.pending` snap and fire the compensating Storage
+    /// delete. Safe to call when the snap is in any state. No-op when the
+    /// current `formSnap` is not `.pending`.
+    func removePending(userId: UUID) async {
+        fatalError("not implemented")
+    }
+
+    /// Remove the current `.existing` snap. Calls `delete_pebble_media` and
+    /// then fires fire-and-forget Storage cleanup. Throws on RPC failure so
+    /// the sheet can surface a user-facing error. No-op (returns normally)
+    /// when the current `formSnap` is not `.existing`.
+    func removeExisting() async throws {
+        fatalError("not implemented")
+    }
+
+    // MARK: - Sheet lifecycle
+
+    /// Called by the sheet's Cancel button before `dismiss()`. Captures the
+    /// current pending snap id, clears state, and *awaits* the compensating
+    /// Storage delete. Storage-delete failures are logged but do not throw —
+    /// Cancel must not be un-cancellable.
+    func cancelAndCleanup(userId: UUID) async {
+        fatalError("not implemented")
+    }
+
+    /// Called by the sheet after a save (compose-pebble / compose-pebble-update)
+    /// failure when a pending snap is attached. Awaits the compensating
+    /// Storage delete. Does *not* clear `formSnap` — the sheet stays open
+    /// and the user can retry. Use `cancelAndCleanup` if you also want to
+    /// dismiss.
+    func handleSaveFailure(userId: UUID) async {
+        fatalError("not implemented")
+    }
+}
+```
+
+- [ ] **Step 2: Verify build is still green**
+
+```bash
+npm run build --workspace=@pbbls/ios
+```
+
+Expected: build succeeds. The file compiles; nothing references the new class yet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/PebbleMedia/SnapUploadCoordinator.swift
+git commit -m "$(cat <<'EOF'
+quality(ios): scaffold SnapUploadCoordinator API surface for #401
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Write the test suite (failing) and a `FakePebbleSnapRepository`
+
+**Why:** TDD. Write all ten test cases against the stubbed API surface, watch them fail, then implement.
+
+**Files:**
+- Create: `apps/ios/PebblesTests/SnapUploadCoordinatorTests.swift`
+
+- [ ] **Step 1: Create the test file with the fake repo and all ten tests**
+
+Create `apps/ios/PebblesTests/SnapUploadCoordinatorTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import Pebbles
+
+@MainActor
+@Suite("SnapUploadCoordinator")
+struct SnapUploadCoordinatorTests {
+
+    // MARK: - Fake repo
+
+    /// Records every call (with timing) and lets each method be stubbed to
+    /// throw. Records "await order" so we can prove `cancelAndCleanup` waits
+    /// for the Storage delete to finish before returning.
+    @MainActor
+    final class FakeRepo: PebbleSnapRepositoryProtocol {
+
+        enum Call: Equatable {
+            case upload(snapId: UUID, userId: UUID)
+            case deleteFilesBySnapId(snapId: UUID, userId: UUID)
+            case deleteFilesByPrefix(prefix: String)
+            case deletePebbleMedia(snapId: UUID)
+        }
+
+        var calls: [Call] = []
+
+        // Stubs — set before invoking the method under test.
+        var uploadResults: [Result<Void, Error>] = []
+        var deletePebbleMediaResult: Result<String, Error> = .success("uid/sid")
+
+        func uploadProcessed(_ processed: ProcessedImage, snapId: UUID, userId: UUID) async throws {
+            calls.append(.upload(snapId: snapId, userId: userId))
+            guard !uploadResults.isEmpty else { return }
+            switch uploadResults.removeFirst() {
+            case .success: return
+            case .failure(let error): throw error
+            }
+        }
+
+        func deleteFiles(snapId: UUID, userId: UUID) async {
+            calls.append(.deleteFilesBySnapId(snapId: snapId, userId: userId))
+        }
+
+        func deleteFiles(storagePrefix: String) async {
+            calls.append(.deleteFilesByPrefix(prefix: storagePrefix))
+        }
+
+        func deletePebbleMedia(snapId: UUID) async throws -> String {
+            calls.append(.deletePebbleMedia(snapId: snapId))
+            switch deletePebbleMediaResult {
+            case .success(let path): return path
+            case .failure(let error): throw error
+            }
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private func makeProcessed() -> ProcessedImage {
+        ProcessedImage(original: Data([0x01]), thumb: Data([0x02]))
+    }
+
+    /// Build a coordinator pre-seeded with a `.pending(.uploaded)` snap.
+    /// Useful for tests that start mid-flow (retry, remove, cancel).
+    private func makeCoordinatorWithUploadedPending(
+        repo: FakeRepo,
+        snapId: UUID = UUID()
+    ) -> (SnapUploadCoordinator, AttachedSnap) {
+        let snap = AttachedSnap(id: snapId, localThumb: Data([0xFF]), state: .uploaded)
+        let coordinator = SnapUploadCoordinator(
+            repo: repo,
+            initialSnap: .pending(snap),
+            retryDelay: .milliseconds(1)
+        )
+        return (coordinator, snap)
+    }
+
+    private struct StubError: Error, Equatable { let tag: String }
+
+    // MARK: - Tests
+
+    // Note: `handlePicked` exercises the full `loadData → ImagePipeline.process →
+    // performUpload` path. Driving it from a unit test would require a real
+    // `NSItemProvider` (and would re-encode a JPEG in-process), which isn't worth
+    // the test infrastructure for what is mostly glue. The internal `performUpload`
+    // path is exercised by `retryWithinUploadSucceeds`, `bothAttemptsFailEndsInFailedState`,
+    // and `manualRetrySucceeds` below. The end-to-end picker integration is covered
+    // by the manual smoke test in plan Task 10.
+
+    @Test("first upload fails, second attempt succeeds → .uploaded")
+    func retryWithinUploadSucceeds() async throws {
+        let repo = FakeRepo()
+        repo.uploadResults = [.failure(StubError(tag: "first")), .success(())]
+
+        let snapId = UUID()
+        let userId = UUID()
+        let snap = AttachedSnap(id: snapId, localThumb: Data([0xFF]), state: .uploading)
+        let coordinator = SnapUploadCoordinator(
+            repo: repo,
+            initialSnap: .pending(snap),
+            retryDelay: .milliseconds(1)
+        )
+        // Inject processedForRetry by routing through internal upload path:
+        // we call `retryCurrent` which sets state to .uploading and re-runs.
+        coordinator.seedProcessedForRetry(makeProcessed())   // test-only helper, added in Task 4
+        await coordinator.retryCurrent(userId: userId)
+
+        guard case .pending(let final) = coordinator.formSnap else {
+            Issue.record("expected .pending"); return
+        }
+        #expect(final.state == .uploaded)
+        #expect(repo.calls.filter { if case .upload = $0 { return true }; return false }.count == 2)
+    }
+
+    @Test("both upload attempts fail → .failed, processedForRetry retained")
+    func bothAttemptsFailEndsInFailedState() async throws {
+        let repo = FakeRepo()
+        repo.uploadResults = [
+            .failure(StubError(tag: "first")),
+            .failure(StubError(tag: "second")),
+        ]
+        let snap = AttachedSnap(id: UUID(), localThumb: Data([0xFF]), state: .uploading)
+        let coordinator = SnapUploadCoordinator(
+            repo: repo,
+            initialSnap: .pending(snap),
+            retryDelay: .milliseconds(1)
+        )
+        coordinator.seedProcessedForRetry(makeProcessed())
+        await coordinator.retryCurrent(userId: UUID())
+
+        guard case .pending(let final) = coordinator.formSnap else {
+            Issue.record("expected .pending"); return
+        }
+        #expect(final.state == .failed)
+        #expect(coordinator.processedForRetry != nil)
+    }
+
+    @Test("manual retry from .failed → .uploading → .uploaded")
+    func manualRetrySucceeds() async throws {
+        let repo = FakeRepo()
+        repo.uploadResults = [.success(())]
+        let snap = AttachedSnap(id: UUID(), localThumb: Data([0xFF]), state: .failed)
+        let coordinator = SnapUploadCoordinator(
+            repo: repo,
+            initialSnap: .pending(snap),
+            retryDelay: .milliseconds(1)
+        )
+        coordinator.seedProcessedForRetry(makeProcessed())
+        await coordinator.retryCurrent(userId: UUID())
+
+        guard case .pending(let final) = coordinator.formSnap else {
+            Issue.record("expected .pending"); return
+        }
+        #expect(final.state == .uploaded)
+    }
+
+    @Test("removePending clears state and fires compensating delete")
+    func removePendingFiresCleanup() async throws {
+        let repo = FakeRepo()
+        let snapId = UUID()
+        let userId = UUID()
+        let (coordinator, _) = makeCoordinatorWithUploadedPending(repo: repo, snapId: snapId)
+        coordinator.seedProcessedForRetry(makeProcessed())
+
+        await coordinator.removePending(userId: userId)
+
+        #expect(coordinator.formSnap == nil)
+        #expect(coordinator.processedForRetry == nil)
+        #expect(repo.calls == [.deleteFilesBySnapId(snapId: snapId, userId: userId)])
+    }
+
+    @Test("cancelAndCleanup awaits the Storage delete before returning")
+    func cancelAndCleanupAwaitsDelete() async throws {
+        let repo = FakeRepo()
+        let snapId = UUID()
+        let userId = UUID()
+        let (coordinator, _) = makeCoordinatorWithUploadedPending(repo: repo, snapId: snapId)
+
+        await coordinator.cancelAndCleanup(userId: userId)
+
+        #expect(coordinator.formSnap == nil)
+        #expect(repo.calls == [.deleteFilesBySnapId(snapId: snapId, userId: userId)])
+    }
+
+    @Test("cancelAndCleanup with no pending snap is a no-op")
+    func cancelAndCleanupNoOpWhenEmpty() async throws {
+        let repo = FakeRepo()
+        let coordinator = SnapUploadCoordinator(repo: repo, retryDelay: .milliseconds(1))
+
+        await coordinator.cancelAndCleanup(userId: UUID())
+
+        #expect(coordinator.formSnap == nil)
+        #expect(repo.calls.isEmpty)
+    }
+
+    // Note: the spec lists "cancelAndCleanup with delete failure → returns, state
+    // cleared" as a case. That property is enforced at the type level — the
+    // protocol's `deleteFiles(snapId:userId:)` returns `async` (not `async throws`),
+    // so the coordinator structurally cannot fail-fast on a Storage error. The
+    // live repo logs internally; the fake records the call. No additional test
+    // needed beyond `cancelAndCleanupAwaitsDelete`.
+
+    @Test("handleSaveFailure fires compensating delete but keeps formSnap")
+    func handleSaveFailureFiresCleanupAndKeepsState() async throws {
+        let repo = FakeRepo()
+        let snapId = UUID()
+        let userId = UUID()
+        let (coordinator, original) = makeCoordinatorWithUploadedPending(repo: repo, snapId: snapId)
+
+        await coordinator.handleSaveFailure(userId: userId)
+
+        #expect(repo.calls == [.deleteFilesBySnapId(snapId: snapId, userId: userId)])
+        // Caller decides whether to clear state; coordinator preserves it.
+        if case .pending(let snap) = coordinator.formSnap {
+            #expect(snap.id == original.id)
+        } else {
+            Issue.record("expected formSnap to be retained")
+        }
+    }
+
+    @Test("removeExisting: happy path calls RPC, fires storage cleanup, clears state")
+    func removeExistingHappyPath() async throws {
+        let repo = FakeRepo()
+        let snapId = UUID()
+        repo.deletePebbleMediaResult = .success("uid/sid")
+        let coordinator = SnapUploadCoordinator(
+            repo: repo,
+            initialSnap: .existing(id: snapId, storagePath: "uid/sid"),
+            retryDelay: .milliseconds(1)
+        )
+
+        try await coordinator.removeExisting()
+
+        #expect(coordinator.formSnap == nil)
+        #expect(repo.calls == [
+            .deletePebbleMedia(snapId: snapId),
+            .deleteFilesByPrefix(prefix: "uid/sid"),
+        ])
+    }
+
+    @Test("removeExisting: RPC failure throws and retains state")
+    func removeExistingRPCFailureRetainsState() async throws {
+        let repo = FakeRepo()
+        let snapId = UUID()
+        repo.deletePebbleMediaResult = .failure(StubError(tag: "rpc"))
+        let coordinator = SnapUploadCoordinator(
+            repo: repo,
+            initialSnap: .existing(id: snapId, storagePath: "uid/sid"),
+            retryDelay: .milliseconds(1)
+        )
+
+        await #expect(throws: StubError.self) {
+            try await coordinator.removeExisting()
+        }
+
+        if case .existing(let id, _) = coordinator.formSnap {
+            #expect(id == snapId)
+        } else {
+            Issue.record("expected formSnap to remain .existing")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+```bash
+npm run test --workspace=@pbbls/ios
+```
+
+Expected: compile error first — the tests reference `coordinator.seedProcessedForRetry(_:)`, which doesn't exist yet. **That's fine** — we'll add it as a test-only helper in Task 4. Once it compiles, all the new tests should fail with `fatalError("not implemented")`.
+
+If the suite won't compile because `seedProcessedForRetry` is missing, that's the expected gate before Task 4 — proceed to Task 4 without commenting out the calls.
+
+- [ ] **Step 3: Commit (tests-only, will fail to compile)**
+
+This commit *intentionally* leaves the workspace red. Subagent/executor reviewers: this is the standard TDD red step.
+
+```bash
+git add apps/ios/PebblesTests/SnapUploadCoordinatorTests.swift
+git commit -m "$(cat <<'EOF'
+test(ios): add SnapUploadCoordinator test suite (red)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Implement `SnapUploadCoordinator` until the test suite is green
+
+**Why:** Replace every `fatalError("not implemented")` with the real behavior. Add the `seedProcessedForRetry` test-only helper. The 10 tests in the suite gate correctness.
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/PebbleMedia/SnapUploadCoordinator.swift`
+
+- [ ] **Step 1: Add the test-only helper and a private `performUpload`**
+
+In `SnapUploadCoordinator.swift`, immediately *before* the `// MARK: - User-driven transitions` line, add:
+
+```swift
+    // MARK: - Test seam
+
+    #if DEBUG
+    /// Test-only: seed `processedForRetry` directly so tests can exercise
+    /// the upload path without driving the real `handlePicked` flow.
+    func seedProcessedForRetry(_ processed: ProcessedImage) {
+        self.processedForRetry = processed
+    }
+    #endif
+
+    // MARK: - Private
+
+    /// Single upload path used by both `handlePicked` (initial attempt) and
+    /// `retryCurrent` (user-tapped retry). On first failure, sleeps for
+    /// `retryDelay` and retries once. On second failure, transitions the
+    /// snap to `.failed` and retains `processedForRetry`.
+    private func performUpload(processed: ProcessedImage, snapId: UUID, userId: UUID) async {
+        do {
+            try await repo.uploadProcessed(processed, snapId: snapId, userId: userId)
+            applyStateIfSnapMatches(snapId: snapId, newState: .uploaded)
+        } catch {
+            Self.logger.warning(
+                "snap upload failed (first attempt): \(error.localizedDescription, privacy: .private)"
+            )
+            try? await Task.sleep(for: retryDelay)
+            do {
+                try await repo.uploadProcessed(processed, snapId: snapId, userId: userId)
+                applyStateIfSnapMatches(snapId: snapId, newState: .uploaded)
+            } catch {
+                Self.logger.error(
+                    "snap upload failed (retry): \(error.localizedDescription, privacy: .private)"
+                )
+                applyStateIfSnapMatches(snapId: snapId, newState: .failed)
+            }
+        }
+    }
+
+    /// Mutates `formSnap`'s `.pending` state only if the current snap id
+    /// still matches. Guards against the user removing the snap mid-upload.
+    private func applyStateIfSnapMatches(snapId: UUID, newState: AttachedSnap.UploadState) {
+        guard case .pending(var snap) = formSnap, snap.id == snapId else { return }
+        snap.state = newState
+        formSnap = .pending(snap)
+    }
+```
+
+- [ ] **Step 2: Replace each stub with the real implementation**
+
+Replace the body of `handlePicked(_:userId:)` (currently `fatalError`):
+
+```swift
+    func handlePicked(_ picked: PhotoPickerView.PickedItem, userId: UUID) async {
+        Self.logger.notice("handlePicked: started uti=\(picked.uti, privacy: .public)")
+
+        let data: Data
+        do {
+            data = try await Self.loadData(from: picked.itemProvider, uti: picked.uti)
+            Self.logger.notice("handlePicked: loaded \(data.count, privacy: .public) bytes")
+        } catch {
+            Self.logger.error("picker data load failed: \(error.localizedDescription, privacy: .private)")
+            return
+        }
+
+        let processed: ProcessedImage
+        let uti = picked.uti
+        do {
+            processed = try await Task.detached(priority: .userInitiated) {
+                try ImagePipeline.process(data, uti: uti)
+            }.value
+        } catch {
+            Self.logger.error("image pipeline failed: \(String(describing: error), privacy: .public)")
+            return
+        }
+
+        let snapId = UUID()
+        formSnap = .pending(AttachedSnap(id: snapId, localThumb: processed.thumb, state: .uploading))
+        processedForRetry = processed
+
+        await performUpload(processed: processed, snapId: snapId, userId: userId)
+    }
+```
+
+Replace the body of `retryCurrent`:
+
+```swift
+    func retryCurrent(userId: UUID) async {
+        guard case .pending(var snap) = formSnap, let processed = processedForRetry else { return }
+        snap.state = .uploading
+        formSnap = .pending(snap)
+        await performUpload(processed: processed, snapId: snap.id, userId: userId)
+    }
+```
+
+Replace the body of `removePending`:
+
+```swift
+    func removePending(userId: UUID) async {
+        guard case .pending(let snap) = formSnap else { return }
+        let snapId = snap.id
+        formSnap = nil
+        processedForRetry = nil
+        await repo.deleteFiles(snapId: snapId, userId: userId)
+    }
+```
+
+Replace the body of `removeExisting`:
+
+```swift
+    func removeExisting() async throws {
+        guard case .existing(let id, _) = formSnap else { return }
+        let storagePath = try await repo.deletePebbleMedia(snapId: id)
+        // Fire-and-forget Storage cleanup. The live repo logs on failure.
+        await repo.deleteFiles(storagePrefix: storagePath)
+        formSnap = nil
+    }
+```
+
+Replace the body of `cancelAndCleanup`:
+
+```swift
+    func cancelAndCleanup(userId: UUID) async {
+        // Capture id before clearing so the delete still has the address.
+        guard case .pending(let snap) = formSnap else {
+            formSnap = nil
+            processedForRetry = nil
+            return
+        }
+        let snapId = snap.id
+        formSnap = nil
+        processedForRetry = nil
+        await repo.deleteFiles(snapId: snapId, userId: userId)
+    }
+```
+
+Replace the body of `handleSaveFailure`:
+
+```swift
+    func handleSaveFailure(userId: UUID) async {
+        guard case .pending(let snap) = formSnap else { return }
+        await repo.deleteFiles(snapId: snap.id, userId: userId)
+        // Intentionally do not clear formSnap — caller (the sheet) keeps the
+        // form open so the user can retry.
+    }
+```
+
+- [ ] **Step 3: Add the static `loadData` helper at the bottom of the class**
+
+Just before the final closing brace of `SnapUploadCoordinator`, add:
+
+```swift
+    /// Loads the bytes for a `PHPicker` selection. Bridges the callback-based
+    /// `loadDataRepresentation` API into async/await.
+    private static func loadData(from provider: NSItemProvider, uti: String) async throws -> Data {
+        try await withCheckedThrowingContinuation { continuation in
+            provider.loadDataRepresentation(forTypeIdentifier: uti) { data, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let data {
+                    continuation.resume(returning: data)
+                } else {
+                    continuation.resume(throwing: URLError(.cannotDecodeContentData))
+                }
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: Run the test suite**
+
+```bash
+npm run test --workspace=@pbbls/ios
+```
+
+Expected: `SnapUploadCoordinator` suite — all 10 tests pass. All other suites still pass (we have not yet touched any production caller).
+
+If any test fails, read the failure carefully and adjust the implementation. The most likely cause: ordering in `cancelAndCleanup` (state must clear before the delete completes; the test only checks call recording, so a sequencing bug shows up as missing/extra `Call` entries).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/PebbleMedia/SnapUploadCoordinator.swift
+git commit -m "$(cat <<'EOF'
+quality(ios): implement SnapUploadCoordinator behavior (tests green)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Add `formSnap:` parameter to payload builders
+
+**Why:** Once we remove `PebbleDraft.formSnap` in Task 9, the payload builders can no longer read it from the draft. Change the signature *now* (while `draft.formSnap` still exists, so both call sites can pass it through), and update the existing encoding tests to match.
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/Models/PebbleCreatePayload.swift`
+- Modify: `apps/ios/Pebbles/Features/Path/Models/PebbleUpdatePayload.swift`
+- Modify: `apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift` (call site)
+- Modify: `apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift` (call site)
+- Modify: `apps/ios/PebblesTests/PebbleCreatePayloadEncodingTests.swift` (call site at line 123)
+
+- [ ] **Step 1: Update `PebbleCreatePayload` to take `formSnap:`**
+
+In `apps/ios/Pebbles/Features/Path/Models/PebbleCreatePayload.swift`, change the `init(from: userId:)` to `init(from: formSnap: userId:)`:
+
+```swift
+    init(from draft: PebbleDraft, formSnap: FormSnap?, userId: UUID) {
+        precondition(draft.isValid, "PebbleCreatePayload(from:formSnap:userId:) called with invalid draft")
+        self.name = draft.name.trimmingCharacters(in: .whitespaces)
+        let trimmedDescription = draft.description.trimmingCharacters(in: .whitespaces)
+        self.description = trimmedDescription.isEmpty ? nil : trimmedDescription
+        self.happenedAt = draft.happenedAt
+        self.intensity = draft.valence!.intensity
+        self.positiveness = draft.valence!.positiveness
+        self.visibility = draft.visibility.rawValue
+        self.emotionId = draft.emotionId!
+        self.domainIds = [draft.domainId!]
+        self.soulIds = draft.soulIds
+        self.collectionIds = draft.collectionId.map { [$0] } ?? []
+        self.glyphId = draft.glyphId
+        self.snaps = {
+            switch formSnap {
+            case .none:
+                return nil
+            case .pending(let snap):
+                return [SnapPayload(
+                    id: snap.id,
+                    storagePath: snap.storagePrefix(userId: userId),
+                    sortOrder: 0
+                )]
+            case .existing:
+                assertionFailure("PebbleCreatePayload: unexpected .existing FormSnap during create")
+                return nil
+            }
+        }()
+    }
+```
+
+- [ ] **Step 2: Update `PebbleUpdatePayload` to take `formSnap:`**
+
+In `apps/ios/Pebbles/Features/Path/Models/PebbleUpdatePayload.swift`, change `init(from: userId:)` to `init(from: formSnap: userId:)`:
+
+```swift
+    init(from draft: PebbleDraft, formSnap: FormSnap?, userId: UUID) {
+        precondition(draft.isValid, "PebbleUpdatePayload(from:formSnap:userId:) called with invalid draft")
+        self.name = draft.name.trimmingCharacters(in: .whitespaces)
+        let trimmedDescription = draft.description.trimmingCharacters(in: .whitespaces)
+        self.description = trimmedDescription.isEmpty ? nil : trimmedDescription
+        self.happenedAt = draft.happenedAt
+        self.intensity = draft.valence!.intensity
+        self.positiveness = draft.valence!.positiveness
+        self.visibility = draft.visibility.rawValue
+        self.emotionId = draft.emotionId!
+        self.domainIds = [draft.domainId!]
+        self.soulIds = draft.soulIds
+        self.collectionIds = draft.collectionId.map { [$0] } ?? []
+        self.glyphId = draft.glyphId
+        self.snaps = {
+            switch formSnap {
+            case .none:
+                return []
+            case .existing(let id, let storagePath):
+                return [SnapPayload(id: id, storagePath: storagePath, sortOrder: 0)]
+            case .pending(let snap):
+                return [SnapPayload(
+                    id: snap.id,
+                    storagePath: snap.storagePrefix(userId: userId),
+                    sortOrder: 0
+                )]
+            }
+        }()
+    }
+```
+
+- [ ] **Step 3: Update `CreatePebbleSheet`'s call site**
+
+In `apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift`, find the line:
+
+```swift
+        let payload = PebbleCreatePayload(from: draft, userId: userId)
+```
+
+Change to:
+
+```swift
+        let payload = PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: userId)
+```
+
+- [ ] **Step 4: Update `EditPebbleSheet`'s call site**
+
+In `apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift`, find:
+
+```swift
+        let payload = PebbleUpdatePayload(from: draft, userId: userId)
+```
+
+Change to:
+
+```swift
+        let payload = PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: userId)
+```
+
+- [ ] **Step 5: Update the existing encoding test**
+
+In `apps/ios/PebblesTests/PebbleCreatePayloadEncodingTests.swift`, find every call to `PebbleCreatePayload(from: draft, userId: ...)` and add the `formSnap:` parameter. The full set (based on the file at the time of writing) is:
+
+- Line ~105 (`PebbleCreatePayload(from: draft, userId: UUID())`) → `PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: UUID())`
+- Line ~114 → same change
+- Line ~129 → same change
+- Line ~142 → same change
+
+The simplest mechanical replacement: open the file and `s/from: draft, userId:/from: draft, formSnap: draft.formSnap, userId:/g`.
+
+Apply the same replacement in `apps/ios/PebblesTests/PebbleUpdatePayloadEncodingTests.swift`:
+
+- `s/from: draft, userId:/from: draft, formSnap: draft.formSnap, userId:/g`
+
+- [ ] **Step 6: Run tests + build**
+
+```bash
+npm run test --workspace=@pbbls/ios
+```
+
+Expected: every suite passes. Encoding tests use the new signature; coordinator tests still pass; sheets compile and link.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Path/Models/PebbleCreatePayload.swift \
+        apps/ios/Pebbles/Features/Path/Models/PebbleUpdatePayload.swift \
+        apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift \
+        apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift \
+        apps/ios/PebblesTests/PebbleCreatePayloadEncodingTests.swift \
+        apps/ios/PebblesTests/PebbleUpdatePayloadEncodingTests.swift
+git commit -m "$(cat <<'EOF'
+quality(ios): thread formSnap as parameter through pebble payload builders
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Make `AttachedPhotoView` and `PebbleFormView` callback-driven
+
+**Why:** Today `AttachedPhotoView` mutates its `Binding<AttachedSnap?>` (sets `snap = nil` to remove, sets `snap?.state = .uploading` to retry), and `CreatePebbleSheet`/`EditPebbleSheet` observe those mutations via two `.onChange` observers. We need the chip to call explicit callbacks so the next two tasks can delete those observers. `PebbleFormView` is the seam.
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/PebbleMedia/AttachedPhotoView.swift`
+- Modify: `apps/ios/Pebbles/Features/Path/PebbleFormView.swift`
+
+- [ ] **Step 1: Rewrite `AttachedPhotoView` to take state + callbacks**
+
+Replace the entire body of `apps/ios/Pebbles/Features/PebbleMedia/AttachedPhotoView.swift`:
+
+```swift
+import SwiftUI
+
+/// Inline photo "chip" shown inside `PebbleFormView` once the user has picked
+/// an image. Stateless: takes the current snap plus explicit `onRetry` and
+/// `onRemove` callbacks. The parent (which owns a `SnapUploadCoordinator`)
+/// decides what those mean.
+struct AttachedPhotoView: View {
+
+    let snap: AttachedSnap
+    let onRetry: () -> Void
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            thumbnail
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Photo")
+                    .font(.subheadline)
+                stateLabel
+            }
+            Spacer()
+            trailingButton
+        }
+    }
+
+    @ViewBuilder
+    private var thumbnail: some View {
+        if let uiImage = UIImage(data: snap.localThumb) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 56, height: 56)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+        } else {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.secondary.opacity(0.2))
+                .frame(width: 56, height: 56)
+        }
+    }
+
+    @ViewBuilder
+    private var stateLabel: some View {
+        switch snap.state {
+        case .uploading:
+            Label("Uploading…", systemImage: "arrow.up.circle")
+                .labelStyle(.titleAndIcon)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case .uploaded:
+            Label("Ready", systemImage: "checkmark.circle.fill")
+                .labelStyle(.titleAndIcon)
+                .font(.caption)
+                .foregroundStyle(.green)
+        case .failed:
+            Label("Upload failed", systemImage: "exclamationmark.triangle.fill")
+                .labelStyle(.titleAndIcon)
+                .font(.caption)
+                .foregroundStyle(.red)
+        }
+    }
+
+    @ViewBuilder
+    private var trailingButton: some View {
+        switch snap.state {
+        case .uploading:
+            ProgressView()
+        case .uploaded:
+            removeButton
+        case .failed:
+            HStack(spacing: 8) {
+                Button(action: onRetry) {
+                    Image(systemName: "arrow.clockwise.circle.fill")
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Retry")
+                removeButton
+            }
+        }
+    }
+
+    private var removeButton: some View {
+        Button(role: .destructive, action: onRemove) {
+            Image(systemName: "xmark.circle.fill")
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Remove photo")
+    }
+}
+```
+
+- [ ] **Step 2: Update `PebbleFormView` to take `formSnap` + photo callbacks as parameters**
+
+In `apps/ios/Pebbles/Features/Path/PebbleFormView.swift`:
+
+**(a)** Remove the property `pendingSnapBinding` (lines ~73–92).
+
+**(b)** Add new properties just below the existing `onRemoveExistingSnap` property (around line 35):
+
+```swift
+    /// Current snap state. The parent owns this via a `SnapUploadCoordinator`
+    /// and re-passes it on every render.
+    let formSnap: FormSnap?
+
+    /// Tapped when the user hits retry on a `.pending(.failed)` chip.
+    let onRetryPending: () -> Void
+
+    /// Tapped when the user hits remove on a `.pending` chip (any state).
+    let onRemovePending: () -> Void
+```
+
+**(c)** Update the initializer signature. Find the existing `init(...)` and add the three new parameters with defaults:
+
+```swift
+    init(
+        draft: Binding<PebbleDraft>,
+        domains: [Domain],
+        souls: [SoulWithGlyph],
+        collections: [PebbleCollection],
+        saveError: String?,
+        renderSvg: String? = nil,
+        strokeColor: String? = nil,
+        renderHeight: CGFloat = 260,
+        showsPhotoSection: Bool = false,
+        photoPickerPresented: Binding<Bool> = .constant(false),
+        isRemovingExistingSnap: Bool = false,
+        onRemoveExistingSnap: @escaping () -> Void = {},
+        formSnap: FormSnap? = nil,
+        onRetryPending: @escaping () -> Void = {},
+        onRemovePending: @escaping () -> Void = {}
+    ) {
+        self._draft = draft
+        self.domains = domains
+        self.souls = souls
+        self.collections = collections
+        self.saveError = saveError
+        self.renderSvg = renderSvg
+        self.strokeColor = strokeColor
+        self.renderHeight = renderHeight
+        self.showsPhotoSection = showsPhotoSection
+        self._photoPickerPresented = photoPickerPresented
+        self.isRemovingExistingSnap = isRemovingExistingSnap
+        self.onRemoveExistingSnap = onRemoveExistingSnap
+        self.formSnap = formSnap
+        self.onRetryPending = onRetryPending
+        self.onRemovePending = onRemovePending
+    }
+```
+
+**(d)** Replace the `switch draft.formSnap` block inside the Photo section (~line 267) with `switch formSnap`, and update the `.pending` case to use the new chip API:
+
+```swift
+            if showsPhotoSection {
+                Section("Photo") {
+                    switch formSnap {
+                    case .none:
+                        Button {
+                            photoPickerPresented = true
+                        } label: {
+                            Label("Add a photo", systemImage: "photo.badge.plus")
+                        }
+                        .listRowBackground(Color.pebblesListRow)
+                    case .existing(_, let storagePath):
+                        ExistingSnapRow(
+                            storagePath: storagePath,
+                            isRemoving: isRemovingExistingSnap,
+                            onRemove: onRemoveExistingSnap
+                        )
+                        .listRowBackground(Color.pebblesListRow)
+                    case .pending(let snap):
+                        AttachedPhotoView(
+                            snap: snap,
+                            onRetry: onRetryPending,
+                            onRemove: onRemovePending
+                        )
+                        .listRowBackground(Color.pebblesListRow)
+                    }
+                }
+            }
+```
+
+- [ ] **Step 3: Update the two sheet call sites to pass `formSnap: draft.formSnap` and the old observer behavior as closures**
+
+In `apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift`, find the `PebbleFormView(...)` call (inside `content`, ~line 110–119) and add the three new parameters at the end:
+
+```swift
+            PebbleFormView(
+                draft: $draft,
+                domains: domains,
+                souls: souls,
+                collections: collections,
+                saveError: saveError,
+                showsPhotoSection: true,
+                photoPickerPresented: $isPhotoPickerPresented,
+                formSnap: draft.formSnap,
+                onRetryPending: {
+                    // Preserve current behavior: chip's retry flipped state
+                    // to .uploading and the .onChange observer re-ran upload.
+                    // We do the equivalent inline here; will be replaced in
+                    // Task 7 with `snaps.retryCurrent(...)`.
+                    if case .pending(var snap) = draft.formSnap, snap.state == .failed {
+                        snap.state = .uploading
+                        draft.formSnap = .pending(snap)
+                    }
+                },
+                onRemovePending: {
+                    // Preserve current behavior: chip's remove cleared the
+                    // binding; the .onChange observer fired compensating
+                    // delete. Will be replaced in Task 7.
+                    draft.formSnap = nil
+                }
+            )
+```
+
+Make the same change to `apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift`'s `PebbleFormView(...)` call (~line 120–135).
+
+- [ ] **Step 4: Run tests + build**
+
+```bash
+npm run test --workspace=@pbbls/ios
+```
+
+Expected: green. Coordinator tests still pass; the sheets now route chip interactions through callbacks but produce identical user-observable behavior because the existing `.onChange` observers in the sheets still fire on `draft.formSnap` mutations.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/PebbleMedia/AttachedPhotoView.swift \
+        apps/ios/Pebbles/Features/Path/PebbleFormView.swift \
+        apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift \
+        apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
+git commit -m "$(cat <<'EOF'
+quality(ios): make AttachedPhotoView and PebbleFormView callback-driven
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Switch `CreatePebbleSheet` to use the coordinator
+
+**Why:** Delete the duplicated snap logic from this sheet. The coordinator owns everything.
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift`
+
+- [ ] **Step 1: Add the coordinator `@State` and drop the duplicated state**
+
+Open `apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift`. Make the following changes:
+
+**(a)** Remove the `@State private var processedForRetry: ProcessedImage?` line (~line 23).
+
+**(b)** After the `@State private var saveError: String?` line, add:
+
+```swift
+    @State private var snaps: SnapUploadCoordinator
+```
+
+**(c)** Replace `init` (if present, the struct currently relies on memberwise — but we need a custom init because `snaps` depends on `supabase.client`). The struct currently has only the `onCreated` stored property and no explicit init. Replace the property block to make this work without environment-at-init access by lazily constructing the coordinator inside `.task`:
+
+Change the declaration to:
+
+```swift
+    @State private var snaps: SnapUploadCoordinator? = nil
+```
+
+Then in `.task { await loadReferences() }` change it to:
+
+```swift
+        .task {
+            if snaps == nil {
+                snaps = SnapUploadCoordinator(repo: PebbleSnapRepository(client: supabase.client))
+            }
+            await loadReferences()
+        }
+```
+
+This keeps `snaps` `Optional` only for the brief construction window. Every read site below uses `snaps?` or `guard let`.
+
+**(d)** Delete the `snapRepo` computed property (~lines 29–31), the `pendingSnapState` and `pendingSnapId` computed properties (~lines 37–45), the `.onChange(of: pendingSnapState)` observer (~lines 81–88), and the `.onChange(of: pendingSnapId)` observer (~lines 91–95). All four blocks go away.
+
+**(e)** Delete `handlePicked(_:)` (~lines 124–162), `loadData(from:uti:)` (~lines 164–176), and `uploadCurrentSnap(processed:userId:)` (~lines 178–200).
+
+**(f)** Replace `cancelAndCleanup()` (~lines 202–209) with:
+
+```swift
+    private func cancelAndCleanup() async {
+        if let userId = currentUserId, let snaps {
+            await snaps.cancelAndCleanup(userId: userId)
+        }
+        dismiss()
+    }
+```
+
+**(g)** Update the photo-picker sheet so the picked item is delegated to the coordinator. The current block is:
+
+```swift
+        .sheet(isPresented: $isPhotoPickerPresented) {
+            PhotoPickerView { picked in
+                isPhotoPickerPresented = false
+                if let picked {
+                    Task { await handlePicked(picked) }
+                }
+            }
+        }
+```
+
+Replace with:
+
+```swift
+        .sheet(isPresented: $isPhotoPickerPresented) {
+            PhotoPickerView { picked in
+                isPhotoPickerPresented = false
+                if let picked, let userId = currentUserId, let snaps {
+                    Task { await snaps.handlePicked(picked, userId: userId) }
+                }
+            }
+        }
+```
+
+**(h)** Update the `PebbleFormView(...)` call site to read `formSnap` and route callbacks through the coordinator:
+
+```swift
+            PebbleFormView(
+                draft: $draft,
+                domains: domains,
+                souls: souls,
+                collections: collections,
+                saveError: saveError,
+                showsPhotoSection: true,
+                photoPickerPresented: $isPhotoPickerPresented,
+                formSnap: snaps?.formSnap,
+                onRetryPending: {
+                    if let userId = currentUserId, let snaps {
+                        Task { await snaps.retryCurrent(userId: userId) }
+                    }
+                },
+                onRemovePending: {
+                    if let userId = currentUserId, let snaps {
+                        Task { await snaps.removePending(userId: userId) }
+                    }
+                }
+            )
+```
+
+**(i)** Update `save()`'s upload-still-pending checks and the payload builder call. Find the three references to `draft.formSnap` inside `save()`:
+
+```swift
+        if case .pending(let snap) = draft.formSnap, snap.state == .uploading {
+```
+
+Replace with:
+
+```swift
+        if snaps?.isUploading == true {
+```
+
+And:
+
+```swift
+        if case .pending(let snap) = draft.formSnap, snap.state == .failed {
+```
+
+Replace with:
+
+```swift
+        if snaps?.hasFailed == true {
+```
+
+Change the payload construction line:
+
+```swift
+        let payload = PebbleCreatePayload(from: draft, formSnap: draft.formSnap, userId: userId)
+```
+
+to:
+
+```swift
+        let payload = PebbleCreatePayload(from: draft, formSnap: snaps?.formSnap, userId: userId)
+```
+
+**(j)** Update `handleSaveFailure(_:)` (~line 306). Replace its body:
+
+```swift
+    private func handleSaveFailure(_ error: Error) async {
+        if let userId = currentUserId, let snaps {
+            await snaps.handleSaveFailure(userId: userId)
+        }
+        saveError = userMessageForPebbleSaveError(error)
+        isSaving = false
+    }
+```
+
+- [ ] **Step 2: Run tests + build**
+
+```bash
+npm run test --workspace=@pbbls/ios
+```
+
+Expected: every suite passes. The Create sheet's snap logic is now fully owned by the coordinator. `draft.formSnap` still exists (used only by Edit) but the Create sheet no longer writes to it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
+git commit -m "$(cat <<'EOF'
+quality(ios): wire CreatePebbleSheet to SnapUploadCoordinator
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Switch `EditPebbleSheet` to use the coordinator
+
+**Why:** Same as Task 7, plus delegate `removeExistingSnap` to `coordinator.removeExisting()`. The `EditPebbleSheet` seeds the coordinator with `.existing(...)` after `load()` succeeds.
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift`
+
+- [ ] **Step 1: Replace state, observers, and helpers with coordinator delegation**
+
+Open `apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift`.
+
+**(a)** Remove `@State private var processedForRetry: ProcessedImage?` (~line 38).
+
+**(b)** Add (next to `isRemovingExistingSnap`):
+
+```swift
+    @State private var snaps: SnapUploadCoordinator? = nil
+```
+
+**(c)** Delete `snapRepo` (~lines 47–49), `pendingSnapState` (~lines 51–54), `pendingSnapId` (~lines 56–59), both `.onChange` observers (~lines 92–104), `handlePicked` (~lines 199–236), `loadData(from:uti:)` (~lines 238–250), `uploadCurrentSnap(processed:userId:)` (~lines 252–274), and `removeExistingSnap()` (~lines 280–297).
+
+**(d)** Update the `.task { await load() }` block to construct the coordinator alongside the load:
+
+```swift
+        .task {
+            if snaps == nil {
+                snaps = SnapUploadCoordinator(repo: PebbleSnapRepository(client: supabase.client))
+            }
+            await load()
+        }
+```
+
+**(e)** At the end of `load()`'s success path (just before `self.isLoading = false`), seed the coordinator with the existing snap:
+
+Find the section after the four parallel queries resolve:
+
+```swift
+            self.domains = loadedDomains
+            self.souls = loadedSouls
+            self.collections = loadedCollections
+            self.draft = PebbleDraft(from: detail)
+            self.renderSvg = detail.renderSvg
+            self.strokeColor = palettes.palette(for: detail.emotion.id)?
+                .strokeHex(for: colorScheme) ?? Color.pebblesAccentHex
+            self.sizeGroup = detail.valence.sizeGroup
+            self.isLoading = false
+```
+
+Insert *before* `self.isLoading = false`:
+
+```swift
+            if let existing = detail.snaps.first {
+                snaps?.seedExisting(.existing(id: existing.id, storagePath: existing.storagePath))
+            }
+```
+
+**(f)** Update the photo-picker sheet:
+
+```swift
+        .sheet(isPresented: $isPhotoPickerPresented) {
+            PhotoPickerView { picked in
+                isPhotoPickerPresented = false
+                if let picked, let userId = currentUserId, let snaps {
+                    Task { await snaps.handlePicked(picked, userId: userId) }
+                }
+            }
+        }
+```
+
+**(g)** Replace the `PebbleFormView(...)` call site:
+
+```swift
+            PebbleFormView(
+                draft: $draft,
+                domains: domains,
+                souls: souls,
+                collections: collections,
+                saveError: saveError,
+                renderSvg: renderSvg,
+                strokeColor: strokeColor,
+                renderHeight: sizeGroup.renderHeight,
+                showsPhotoSection: true,
+                photoPickerPresented: $isPhotoPickerPresented,
+                isRemovingExistingSnap: isRemovingExistingSnap,
+                onRemoveExistingSnap: {
+                    Task { await removeExisting() }
+                },
+                formSnap: snaps?.formSnap,
+                onRetryPending: {
+                    if let userId = currentUserId, let snaps {
+                        Task { await snaps.retryCurrent(userId: userId) }
+                    }
+                },
+                onRemovePending: {
+                    if let userId = currentUserId, let snaps {
+                        Task { await snaps.removePending(userId: userId) }
+                    }
+                }
+            )
+```
+
+**(h)** Add the small `removeExisting()` wrapper to translate the coordinator's throw into `saveError`:
+
+Add (next to the existing private helpers, e.g., right before `save()`):
+
+```swift
+    private func removeExisting() async {
+        guard let snaps else { return }
+        isRemovingExistingSnap = true
+        defer { isRemovingExistingSnap = false }
+        do {
+            try await snaps.removeExisting()
+        } catch {
+            logger.error("delete_pebble_media failed: \(error.localizedDescription, privacy: .private)")
+            saveError = "Couldn't remove the photo. Please try again."
+        }
+    }
+```
+
+**(i)** Update `save()` to read snap state from the coordinator. Find:
+
+```swift
+        if case .pending(let snap) = draft.formSnap, snap.state == .uploading {
+```
+
+Replace:
+
+```swift
+        if snaps?.isUploading == true {
+```
+
+And:
+
+```swift
+        if case .pending(let snap) = draft.formSnap, snap.state == .failed {
+```
+
+Replace:
+
+```swift
+        if snaps?.hasFailed == true {
+```
+
+Update the payload-construction line:
+
+```swift
+        let payload = PebbleUpdatePayload(from: draft, formSnap: draft.formSnap, userId: userId)
+```
+
+to:
+
+```swift
+        let payload = PebbleUpdatePayload(from: draft, formSnap: snaps?.formSnap, userId: userId)
+```
+
+**(j)** Note: `EditPebbleSheet` does *not* currently have a `handleSaveFailure`-style compensating delete on save failure (its `save()` directly sets `saveError` without firing a delete). The Edit-flow save failure path needs the compensating delete too. Replace the save-failure branches in the catch blocks:
+
+Find:
+
+```swift
+            } else {
+                let bodyString: String
+                if case .httpError(_, let data) = functionsError {
+                    bodyString = String(data: data, encoding: .utf8) ?? "<non-utf8 body>"
+                } else {
+                    bodyString = "<non-http error>"
+                }
+                logger.error("compose-pebble-update failed: \(functionsError.localizedDescription, privacy: .private) body=\(bodyString, privacy: .private)")
+                self.saveError = userMessageForPebbleSaveError(functionsError)
+                self.isSaving = false
+            }
+        } catch {
+            logger.error("update pebble failed: \(error.localizedDescription, privacy: .private)")
+            self.saveError = userMessageForPebbleSaveError(error)
+            self.isSaving = false
+        }
+```
+
+Replace the two error-handling branches with one shared call to a new local helper, just like `CreatePebbleSheet.handleSaveFailure(_:)`. Add this helper just below `save()`:
+
+```swift
+    private func handleSaveFailure(_ error: Error) async {
+        if let userId = currentUserId, let snaps {
+            await snaps.handleSaveFailure(userId: userId)
+        }
+        self.saveError = userMessageForPebbleSaveError(error)
+        self.isSaving = false
+    }
+```
+
+Then change:
+
+```swift
+                self.saveError = userMessageForPebbleSaveError(functionsError)
+                self.isSaving = false
+```
+
+to:
+
+```swift
+                await handleSaveFailure(functionsError)
+```
+
+And:
+
+```swift
+            self.saveError = userMessageForPebbleSaveError(error)
+            self.isSaving = false
+```
+
+(in the outer `catch`) to:
+
+```swift
+            await handleSaveFailure(error)
+```
+
+- [ ] **Step 2: Run tests + build**
+
+```bash
+npm run test --workspace=@pbbls/ios
+```
+
+Expected: green. Both sheets now go through the coordinator. `draft.formSnap` is still set by `PebbleDraft(from: detail)` but nothing else writes to it, and nothing reads it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
+git commit -m "$(cat <<'EOF'
+quality(ios): wire EditPebbleSheet to SnapUploadCoordinator + compensating delete on update failure
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Remove `formSnap` from `PebbleDraft`
+
+**Why:** Nothing reads `draft.formSnap` anymore. Drop it. `PebbleDraft(from: detail)` no longer pre-fills snap state; the sheet already seeds the coordinator separately.
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/Models/PebbleDraft.swift`
+
+- [ ] **Step 1: Delete `formSnap` from the struct and its initializer**
+
+In `apps/ios/Pebbles/Features/Path/Models/PebbleDraft.swift`:
+
+**(a)** Remove the line:
+
+```swift
+    var formSnap: FormSnap?               // optional — `.existing` from DB or `.pending` local upload
+```
+
+**(b)** In `init(from detail:)`, remove the trailing block:
+
+```swift
+        self.formSnap = detail.snaps.first.map {
+            .existing(id: $0.id, storagePath: $0.storagePath)
+        }
+```
+
+- [ ] **Step 2: Verify no stragglers**
+
+```bash
+grep -rn "draft.formSnap\|\.formSnap" apps/ios --include="*.swift" | grep -v "FormSnap"
+```
+
+Expected: only matches inside `FormSnap.swift`, `AttachedSnap.swift`, the coordinator, and any usage of the *type name* `FormSnap` (not the property). If anything else shows up, fix it before continuing.
+
+- [ ] **Step 3: Run tests + build**
+
+```bash
+npm run test --workspace=@pbbls/ios
+```
+
+Expected: green across all suites. The `PebbleDraftFromDetailTests` continues to pass (it doesn't reference `formSnap` directly per the grep we did when writing the plan). The payload encoding tests pass with the `formSnap:` parameter form.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Path/Models/PebbleDraft.swift
+git commit -m "$(cat <<'EOF'
+quality(ios): remove formSnap from PebbleDraft; coordinator owns it
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Final verification and manual smoke test
+
+**Why:** End-to-end confirmation. Tests prove the unit-level behavior; the manual smoke test catches anything that only shows up when a real `PhotoPickerView`, real Supabase Storage, and real network are involved.
+
+- [ ] **Step 1: Full lint + build + test from a clean state**
+
+```bash
+npm run lint --workspace=@pbbls/ios
+npm run build --workspace=@pbbls/ios
+npm run test --workspace=@pbbls/ios
+```
+
+Expected: lint passes; build succeeds; all test suites green.
+
+- [ ] **Step 2: Manual smoke test (Create flow)**
+
+Run the app on a simulator (Xcode → Run, or `xcrun simctl` if scripted). Sign in. From the Path tab, tap "New pebble." Walk through each of the following and confirm behavior:
+
+1. **Pick a photo** — chip transitions `uploading` → `Ready` (green checkmark) within ~2 s on a normal connection.
+2. **Force a network failure** — enable Airplane Mode after tapping the picker but before the upload completes. Chip should reach the "Upload failed" red state after the second attempt. (Or: kill Wi-Fi between the pick and confirm.)
+3. **Tap retry** — re-enable network, then tap the retry icon. Chip should go back to `Uploading` then `Ready`.
+4. **Remove the snap** — tap the X. Chip disappears. The Storage files should be gone (visible in Supabase dashboard, or by re-picking the same image and confirming the orphan-sweep is clean).
+5. **Cancel mid-upload** — pick a photo, then immediately tap Cancel. The sheet should dismiss only after the Storage delete completes. Confirm no orphans remain in `pebbles-media` for that snap id.
+6. **Save with `.uploaded` snap** — verify the pebble is created with the snap attached and renders correctly in the path.
+7. **Compose-pebble failure compensation** — temporarily edit `supabase.client.functions.invoke("compose-pebble", ...)` to point at a bad URL, save with a pending snap, confirm the snap's Storage files are deleted afterwards. Revert the edit.
+
+- [ ] **Step 3: Manual smoke test (Edit flow)**
+
+Open an existing pebble with a photo from the Path. Tap Edit:
+
+1. The existing photo row shows the current snap.
+2. **Remove existing** — tap the X. The `delete_pebble_media` RPC should run, the chip should disappear, and the Storage files should be deleted.
+3. **Replace existing** — after removing, pick a new photo. Same flow as Create's pick → Ready.
+4. **Cancel mid-upload of replacement** — verify the new snap's Storage files are deleted on Cancel.
+5. **Compose-pebble-update failure with new snap** — temporarily corrupt the edge function name. Save. Confirm the new pending snap's files are deleted.
+
+- [ ] **Step 4: Localization sanity check**
+
+Open `apps/ios/Pebbles/Resources/Localizable.xcstrings` in Xcode. Confirm no entries are in the `New` or `Stale` state. We did not introduce any new user-facing strings (the chip's labels were preserved verbatim), but new strings are auto-extracted at build time so this is worth verifying.
+
+- [ ] **Step 5: Push the branch and open the PR**
+
+```bash
+git push -u origin feat/401-snap-upload-coordinator
+```
+
+PR title (conventional commits): `quality(ios): extract snap upload coordinator from pebble sheets`
+
+PR body:
+
+```
+Resolves #401
+
+## Summary
+- Extracted `SnapUploadCoordinator` `@Observable` class owning the entire snap lifecycle for the in-progress pebble form (pick, upload, retry, cancel, remove pending, remove existing).
+- Replaced the 50 ms sleep race in `cancelAndCleanup` with an explicit `await` on the Storage delete.
+- Added `PebbleSnapRepositoryProtocol` + a `FakeRepo` so the coordinator is fully unit-tested (10 cases in Swift Testing).
+- Both `CreatePebbleSheet` and `EditPebbleSheet` lost ~120 LOC of duplicated snap state; `EditPebbleSheet` also gained compensating delete on `compose-pebble-update` failure (was missing).
+- `PebbleDraft.formSnap` removed; payload builders take `formSnap:` as a parameter.
+
+## Files
+- New: `Features/PebbleMedia/SnapUploadCoordinator.swift`
+- New: `PebblesTests/SnapUploadCoordinatorTests.swift`
+- Modified: `PebbleSnapRepository.swift`, `AttachedPhotoView.swift`, `PebbleFormView.swift`, both sheets, both payload builders, `PebbleDraft.swift`, payload encoding tests.
+
+## Test plan
+- [x] `npm run test --workspace=@pbbls/ios` green
+- [x] `npm run build --workspace=@pbbls/ios` green
+- [x] `npm run lint --workspace=@pbbls/ios` green
+- [x] Manual smoke test: create with photo (happy + retry + remove + cancel)
+- [x] Manual smoke test: edit with photo (remove existing + replace + cancel during replace)
+- [x] Compose-pebble{,-update} failure with pending snap → compensating delete confirmed
+```
+
+Confirm labels (from the issue): `quality`, `core`, `ios`. Milestone: `M32 · iOS Quality`.
+
+```bash
+gh pr create --title "quality(ios): extract snap upload coordinator from pebble sheets" \
+  --body "$(cat <<'EOF'
+Resolves #401
+
+## Summary
+- Extracted `SnapUploadCoordinator` `@Observable` class owning the entire snap lifecycle for the in-progress pebble form (pick, upload, retry, cancel, remove pending, remove existing).
+- Replaced the 50 ms sleep race in `cancelAndCleanup` with an explicit `await` on the Storage delete.
+- Added `PebbleSnapRepositoryProtocol` + a `FakeRepo` so the coordinator is fully unit-tested (10 cases in Swift Testing).
+- Both `CreatePebbleSheet` and `EditPebbleSheet` lost ~120 LOC of duplicated snap state; `EditPebbleSheet` also gained compensating delete on `compose-pebble-update` failure (was missing).
+- `PebbleDraft.formSnap` removed; payload builders take `formSnap:` as a parameter.
+
+## Test plan
+- [x] `npm run test --workspace=@pbbls/ios` green
+- [x] `npm run build --workspace=@pbbls/ios` green
+- [x] `npm run lint --workspace=@pbbls/ios` green
+- [x] Manual smoke test: create with photo (happy + retry + remove + cancel)
+- [x] Manual smoke test: edit with photo (remove existing + replace + cancel during replace)
+- [x] Compose-pebble{,-update} failure with pending snap → compensating delete confirmed
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)" \
+  --label quality --label core --label ios \
+  --milestone "M32 · iOS Quality"
+```
+
+Done.


### PR DESCRIPTION
Resolves #401

## Summary
- Extracted `SnapUploadCoordinator` `@Observable` class owning the entire snap lifecycle for the in-progress pebble form (pick, upload, retry, cancel, remove pending, remove existing).
- Replaced the 50 ms `Task.sleep` race in `cancelAndCleanup` with an explicit `await` on the Storage delete — Cancel now waits for cleanup before dismissing.
- Added `PebbleSnapRepositoryProtocol` so the coordinator is unit-testable with a fake; 9 new Swift Testing cases.
- `CreatePebbleSheet` lost 97 LOC; `EditPebbleSheet` lost 79 LOC of duplicated state.
- `EditPebbleSheet` also gained compensating delete on `compose-pebble-update` failure (was previously missing — pending snap files orphaned on update error).
- `PebbleDraft.formSnap` removed; payload builders take `formSnap:` as a parameter.

## Files
- New: `Features/PebbleMedia/SnapUploadCoordinator.swift`
- New: `PebblesTests/SnapUploadCoordinatorTests.swift`
- Modified: `PebbleSnapRepository.swift` (protocol + `deletePebbleMedia(snapId:)`)
- Modified: `AttachedPhotoView.swift` (binding → explicit callbacks)
- Modified: `PebbleFormView.swift` (callback-driven photo section)
- Modified: `CreatePebbleSheet.swift`, `EditPebbleSheet.swift`
- Modified: `PebbleCreatePayload.swift`, `PebbleUpdatePayload.swift` (`formSnap:` parameter)
- Modified: `PebbleDraft.swift` (drop `formSnap`)
- Modified: payload encoding tests

## Out of scope (separate issue)
- Image-pipeline alpha-strip warning during JPEG encode → filed as #413.

## Test plan
- [x] `npm run test --workspace=@pbbls/ios` — coordinator + payload + draft suites all green (pre-existing `LocalizationTests` catalog issue is unrelated)
- [x] `npm run lint --workspace=@pbbls/ios` — no new warnings from this branch (pre-existing 5 errors in `Color+Rive.swift` / `SupabaseService.swift` unchanged)
- [x] Manual smoke: Create flow — pick → upload happy, force-fail retry, remove, cancel mid-upload, save with photo
- [x] Manual smoke: Edit flow — remove existing, replace existing, cancel mid-replace
- [x] Manual: confirm compose-pebble + compose-pebble-update failures with a pending snap fire the compensating Storage delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)