### PR TITLE
quality(ios): restore PebbleFormView "Pure UI" contract

### DIFF
--- a/apps/ios/Pebbles/Features/Glyph/Views/GlyphPickerSheet.swift
+++ b/apps/ios/Pebbles/Features/Glyph/Views/GlyphPickerSheet.swift
@@ -5,7 +5,7 @@ import os
 /// Presented from `PebbleFormView`'s "Glyph" row.
 struct GlyphPickerSheet: View {
     let currentGlyphId: UUID?
-    let onSelected: (UUID?) -> Void
+    let onSelected: (Glyph) -> Void
 
     @Environment(SupabaseService.self) private var supabase
     @Environment(\.dismiss) private var dismiss
@@ -35,7 +35,7 @@ struct GlyphPickerSheet: View {
                 .fullScreenCover(isPresented: $showCarveSheet) {
                     GlyphCarveSheet(onSaved: { glyph in
                         glyphs.insert(glyph, at: 0)
-                        onSelected(glyph.id)
+                        onSelected(glyph)
                         dismiss()
                     })
                 }
@@ -69,7 +69,7 @@ struct GlyphPickerSheet: View {
                         LazyVGrid(columns: columns, spacing: 12) {
                             ForEach(glyphs) { glyph in
                                 Button {
-                                    onSelected(glyph.id)
+                                    onSelected(glyph)
                                     dismiss()
                                 } label: {
                                     GlyphThumbnail(

--- a/apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
@@ -12,6 +12,7 @@ struct CreatePebbleSheet: View {
     @State private var domains: [Domain] = []
     @State private var souls: [SoulWithGlyph] = []
     @State private var collections: [PebbleCollection] = []
+    @State private var selectedGlyph: Glyph?
 
     @State private var isLoadingReferences = true
     @State private var loadError: String?
@@ -88,6 +89,8 @@ struct CreatePebbleSheet: View {
                 souls: souls,
                 collections: collections,
                 saveError: saveError,
+                selectedGlyph: selectedGlyph,
+                onGlyphPicked: { picked in selectedGlyph = picked },
                 showsPhotoSection: true,
                 photoPickerPresented: $isPhotoPickerPresented,
                 formSnap: snaps?.formSnap,
@@ -102,6 +105,9 @@ struct CreatePebbleSheet: View {
                     }
                 }
             )
+            .onChange(of: draft.glyphId) { _, newValue in
+                if newValue == nil { selectedGlyph = nil }
+            }
         }
     }
 

--- a/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
@@ -27,6 +27,7 @@ struct EditPebbleSheet: View {
     @State private var renderSvg: String?
     @State private var strokeColor: String?
     @State private var sizeGroup: ValenceSizeGroup = .medium
+    @State private var selectedGlyph: Glyph?
 
     @State private var isLoading = true
     @State private var loadError: String?
@@ -108,6 +109,8 @@ struct EditPebbleSheet: View {
                 renderSvg: renderSvg,
                 strokeColor: strokeColor,
                 renderHeight: sizeGroup.renderHeight,
+                selectedGlyph: selectedGlyph,
+                onGlyphPicked: { picked in selectedGlyph = picked },
                 showsPhotoSection: true,
                 photoPickerPresented: $isPhotoPickerPresented,
                 isRemovingExistingSnap: isRemovingExistingSnap,
@@ -126,6 +129,9 @@ struct EditPebbleSheet: View {
                     }
                 }
             )
+            .onChange(of: draft.glyphId) { _, newValue in
+                if newValue == nil { selectedGlyph = nil }
+            }
         }
     }
 
@@ -159,6 +165,7 @@ struct EditPebbleSheet: View {
                 .select("""
                     id, name, description, happened_at, intensity, positiveness, visibility,
                     render_svg, render_version, glyph_id,
+                    glyph:glyphs(id, name, strokes, view_box),
                     emotion:emotions(id, slug, name),
                     pebble_domains(domain:domains(id, slug, name)),
                     pebble_souls(soul:souls(id, name, glyph_id, glyphs(id, name, strokes, view_box))),
@@ -196,6 +203,7 @@ struct EditPebbleSheet: View {
             self.souls = loadedSouls
             self.collections = loadedCollections
             self.draft = PebbleDraft(from: detail)
+            self.selectedGlyph = detail.glyph
             self.renderSvg = detail.renderSvg
             self.strokeColor = palettes.palette(for: detail.emotion.id)?
                 .strokeHex(for: colorScheme) ?? Color.pebblesAccentHex

--- a/apps/ios/Pebbles/Features/Path/Models/PebbleDetail.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/PebbleDetail.swift
@@ -46,6 +46,10 @@ struct PebbleDetail: Identifiable, Decodable, Hashable {
     let renderSvg: String?
     let renderVersion: String?
     let glyphId: UUID?
+    /// Full glyph row when the detail SELECT includes
+    /// `glyph:glyphs(id, name, strokes, view_box)`. `nil` when the pebble has
+    /// no glyph or the caller didn't ask for it.
+    let glyph: Glyph?
 
     /// Lightweight read-model row for `public.snaps`. The detail SELECT
     /// projects `snaps(id, storage_path, sort_order)` ordered by `sort_order`.
@@ -105,6 +109,7 @@ struct PebbleDetail: Identifiable, Decodable, Hashable {
         case renderSvg = "render_svg"
         case renderVersion = "render_version"
         case glyphId = "glyph_id"
+        case glyph
     }
 
     private struct DomainWrapper: Decodable { let domain: DomainRef }
@@ -138,5 +143,6 @@ struct PebbleDetail: Identifiable, Decodable, Hashable {
         self.renderSvg = try container.decodeIfPresent(String.self, forKey: .renderSvg)
         self.renderVersion = try container.decodeIfPresent(String.self, forKey: .renderVersion)
         self.glyphId = try container.decodeIfPresent(UUID.self, forKey: .glyphId)
+        self.glyph = try container.decodeIfPresent(Glyph.self, forKey: .glyph)
     }
 }

--- a/apps/ios/Pebbles/Features/Path/PebbleFormView.swift
+++ b/apps/ios/Pebbles/Features/Path/PebbleFormView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import os
 
 /// The pebble `Form` body, shared by `CreatePebbleSheet` and `EditPebbleSheet`.
 ///
@@ -17,6 +16,17 @@ struct PebbleFormView: View {
     var renderSvg: String?
     var strokeColor: String?
     var renderHeight: CGFloat = 260
+
+    /// Full glyph row for the currently-selected `draft.glyphId`. Owned by
+    /// the parent sheet (loaded from the detail SELECT on edit, or set from
+    /// `onGlyphPicked` after the user picks one). The form renders a
+    /// thumbnail + name from it but never fetches.
+    let selectedGlyph: Glyph?
+
+    /// Fired when the user picks a glyph from `GlyphPickerSheet`. The parent
+    /// is responsible for updating both `selectedGlyph` and `draft.glyphId`
+    /// (the form sets `draft.glyphId` via the binding before calling back).
+    let onGlyphPicked: (Glyph) -> Void
 
     /// When true, render the Photo section. Off by default so callers that
     /// don't yet support photo flows opt out explicitly.
@@ -47,9 +57,7 @@ struct PebbleFormView: View {
     @State private var showPicker = false
     @State private var showValencePicker = false
     @State private var showEmotionPicker = false
-    @State private var selectedGlyph: Glyph?
 
-    @Environment(SupabaseService.self) private var supabase
     @Environment(EmotionPaletteService.self) private var palettes
 
     init(
@@ -61,6 +69,8 @@ struct PebbleFormView: View {
         renderSvg: String? = nil,
         strokeColor: String? = nil,
         renderHeight: CGFloat = 260,
+        selectedGlyph: Glyph? = nil,
+        onGlyphPicked: @escaping (Glyph) -> Void = { _ in },
         showsPhotoSection: Bool = false,
         photoPickerPresented: Binding<Bool> = .constant(false),
         isRemovingExistingSnap: Bool = false,
@@ -77,6 +87,8 @@ struct PebbleFormView: View {
         self.renderSvg = renderSvg
         self.strokeColor = strokeColor
         self.renderHeight = renderHeight
+        self.selectedGlyph = selectedGlyph
+        self.onGlyphPicked = onGlyphPicked
         self.showsPhotoSection = showsPhotoSection
         self._photoPickerPresented = photoPickerPresented
         self.isRemovingExistingSnap = isRemovingExistingSnap
@@ -229,7 +241,6 @@ struct PebbleFormView: View {
                     if draft.glyphId != nil {
                         Button(role: .destructive) {
                             draft.glyphId = nil
-                            selectedGlyph = nil
                         } label: {
                             Label("Remove glyph", systemImage: "trash")
                         }
@@ -297,7 +308,10 @@ struct PebbleFormView: View {
         .sheet(isPresented: $showPicker) {
             GlyphPickerSheet(
                 currentGlyphId: draft.glyphId,
-                onSelected: { glyphId in draft.glyphId = glyphId }
+                onSelected: { picked in
+                    draft.glyphId = picked.id
+                    onGlyphPicked(picked)
+                }
             )
         }
         .sheet(isPresented: $showValencePicker) {
@@ -313,7 +327,6 @@ struct PebbleFormView: View {
                 onSelected: { picked in draft.emotionId = picked }
             )
         }
-        .task(id: draft.glyphId) { await loadSelectedGlyph() }
     }
 
     /// Right-hand label on the Emotion row. Returns a `Text` (not a string)
@@ -330,27 +343,5 @@ struct PebbleFormView: View {
         if draft.glyphId == nil { return "Carve or pick a glyph" }
         if let name = selectedGlyph?.name { return name }
         return "Untitled glyph"
-    }
-
-    private func loadSelectedGlyph() async {
-        guard let id = draft.glyphId else {
-            selectedGlyph = nil
-            return
-        }
-        if selectedGlyph?.id == id { return }
-        do {
-            let fetched: Glyph = try await supabase.client
-                .from("glyphs")
-                .select("id, name, strokes, view_box")
-                .eq("id", value: id)
-                .single()
-                .execute()
-                .value
-            self.selectedGlyph = fetched
-        } catch {
-            // Non-fatal: the row renders without a thumbnail until the refetch works.
-            Logger(subsystem: "app.pbbls.ios", category: "pebble-form")
-                .warning("glyph fetch for preview failed: \(error.localizedDescription, privacy: .private)")
-        }
     }
 }

--- a/apps/ios/Pebbles/Features/Profile/Sheets/CreateSoulSheet.swift
+++ b/apps/ios/Pebbles/Features/Profile/Sheets/CreateSoulSheet.swift
@@ -63,13 +63,12 @@ struct CreateSoulSheet: View {
                 GlyphPickerSheet(
                     currentGlyphId: draft.glyphId,
                     onSelected: { selected in
-                        // Picker returns the chosen glyph's id. Update draft
-                        // and refetch the glyph so the row's thumbnail
-                        // re-renders without waiting for a list reload.
-                        if let selected {
-                            draft.glyphId = selected
-                            Task { await loadGlyph(id: selected) }
-                        }
+                        // Picker hands us the full Glyph; we still refetch via
+                        // `loadGlyph` so the row's thumbnail re-renders from
+                        // shared state. Eliminating the refetch is tracked
+                        // separately.
+                        draft.glyphId = selected.id
+                        Task { await loadGlyph(id: selected.id) }
                     }
                 )
             }

--- a/apps/ios/Pebbles/Features/Profile/Sheets/EditSoulSheet.swift
+++ b/apps/ios/Pebbles/Features/Profile/Sheets/EditSoulSheet.swift
@@ -75,10 +75,8 @@ struct EditSoulSheet: View {
                 GlyphPickerSheet(
                     currentGlyphId: draft.glyphId,
                     onSelected: { selected in
-                        if let selected {
-                            draft.glyphId = selected
-                            Task { await loadGlyph(id: selected) }
-                        }
+                        draft.glyphId = selected.id
+                        Task { await loadGlyph(id: selected.id) }
                     }
                 )
             }


### PR DESCRIPTION
Resolves #402

## Summary

- Drops `@Environment(SupabaseService.self)` and the `.task(id: draft.glyphId)` + `loadSelectedGlyph()` pair from `PebbleFormView`. It now takes `selectedGlyph: Glyph?` and an `onGlyphPicked: (Glyph) -> Void` callback — the docstring's "Pure UI" claim finally holds.
- `GlyphPickerSheet.onSelected` is now `(Glyph) -> Void` (was `(UUID?) -> Void`). Callers already had the full `Glyph` in scope.
- `CreatePebbleSheet` and `EditPebbleSheet` own `@State private var selectedGlyph: Glyph?` and clear it via `.onChange(of: draft.glyphId)` when the in-form context-menu removes the glyph.
- `EditPebbleSheet.load()` SELECT now joins `glyph:glyphs(id, name, strokes, view_box)` so the initial render gets the glyph without an extra fetch. `PebbleDetail` decodes the new optional `glyph: Glyph?` via `decodeIfPresent` so existing fixtures are unaffected.
- `CreateSoulSheet` and `EditSoulSheet` get the minimum signature fix only (`selected.id` instead of `selected`); the existing `loadGlyph(id:)` refetch is preserved. Follow-up cleanup tracked in #415.

## Key files

- `apps/ios/Pebbles/Features/Path/PebbleFormView.swift`
- `apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift`
- `apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift`
- `apps/ios/Pebbles/Features/Path/Models/PebbleDetail.swift`
- `apps/ios/Pebbles/Features/Glyph/Views/GlyphPickerSheet.swift`
- `apps/ios/Pebbles/Features/Profile/Sheets/{Create,Edit}SoulSheet.swift`

## Test plan

- [x] `xcodebuild ... build` succeeds
- [x] `PebbleDetailDecodingTests`, `PebbleDetailSoulGlyphDecodingTests`, `PebbleDraftFromDetailTests` pass — fixtures continue to decode without the new `glyph` key
- [x] SwiftLint introduces no new warnings on changed files
- [x] Manual: open create-pebble sheet, tap glyph row, pick an existing glyph → row thumbnail + name update immediately, no network call on dismiss
- [x] Manual: open create-pebble sheet, tap glyph row, carve a fresh glyph → thumbnail updates immediately on dismiss
- [x] Manual: open edit-pebble sheet for a pebble with a glyph → thumbnail renders without a separate fetch (single detail query)
- [x] Manual: from the edit sheet, long-press glyph row → "Remove glyph" → row clears and Save persists the removal