### PR TITLE
fix(ios): cache reference data via ReferenceDataService

### DIFF
--- a/apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
@@ -6,16 +6,12 @@ struct CreatePebbleSheet: View {
     let onCreated: (UUID) -> Void
 
     @Environment(SupabaseService.self) private var supabase
+    @Environment(ReferenceDataService.self) private var refs
     @Environment(\.dismiss) private var dismiss
 
     @State private var draft = PebbleDraft()
-    @State private var domains: [Domain] = []
-    @State private var souls: [SoulWithGlyph] = []
-    @State private var collections: [PebbleCollection] = []
     @State private var selectedGlyph: Glyph?
 
-    @State private var isLoadingReferences = true
-    @State private var loadError: String?
     @State private var isSaving = false
     @State private var saveError: String?
 
@@ -59,7 +55,6 @@ struct CreatePebbleSheet: View {
             if snaps == nil {
                 snaps = SnapUploadCoordinator(repo: PebbleSnapRepository(client: supabase.client))
             }
-            await loadReferences()
         }
         .sheet(isPresented: $isPhotoPickerPresented) {
             PhotoPickerView { picked in
@@ -73,41 +68,30 @@ struct CreatePebbleSheet: View {
 
     @ViewBuilder
     private var content: some View {
-        if isLoadingReferences {
-            ProgressView()
-        } else if let loadError {
-            VStack(spacing: 12) {
-                Text(loadError).foregroundStyle(.secondary)
-                Button("Retry") {
-                    Task { await loadReferences() }
+        PebbleFormView(
+            draft: $draft,
+            domains: refs.domains,
+            souls: refs.souls,
+            collections: refs.collections,
+            saveError: saveError,
+            selectedGlyph: selectedGlyph,
+            onGlyphPicked: { picked in selectedGlyph = picked },
+            showsPhotoSection: true,
+            photoPickerPresented: $isPhotoPickerPresented,
+            formSnap: snaps?.formSnap,
+            onRetryPending: {
+                if let userId = currentUserId, let snaps {
+                    Task { await snaps.retryCurrent(userId: userId) }
+                }
+            },
+            onRemovePending: {
+                if let userId = currentUserId, let snaps {
+                    Task { await snaps.removePending(userId: userId) }
                 }
             }
-        } else {
-            PebbleFormView(
-                draft: $draft,
-                domains: domains,
-                souls: souls,
-                collections: collections,
-                saveError: saveError,
-                selectedGlyph: selectedGlyph,
-                onGlyphPicked: { picked in selectedGlyph = picked },
-                showsPhotoSection: true,
-                photoPickerPresented: $isPhotoPickerPresented,
-                formSnap: snaps?.formSnap,
-                onRetryPending: {
-                    if let userId = currentUserId, let snaps {
-                        Task { await snaps.retryCurrent(userId: userId) }
-                    }
-                },
-                onRemovePending: {
-                    if let userId = currentUserId, let snaps {
-                        Task { await snaps.removePending(userId: userId) }
-                    }
-                }
-            )
-            .onChange(of: draft.glyphId) { _, newValue in
-                if newValue == nil { selectedGlyph = nil }
-            }
+        )
+        .onChange(of: draft.glyphId) { _, newValue in
+            if newValue == nil { selectedGlyph = nil }
         }
     }
 
@@ -116,45 +100,6 @@ struct CreatePebbleSheet: View {
             await snaps.cancelAndCleanup(userId: userId)
         }
         dismiss()
-    }
-
-    // MARK: - load references
-
-    private func loadReferences() async {
-        isLoadingReferences = true
-        loadError = nil
-        do {
-            async let domainsQuery: [Domain] = supabase.client
-                .from("domains")
-                .select()
-                .order("name")
-                .execute()
-                .value
-            async let soulsQuery: [SoulWithGlyph] = supabase.client
-                .from("souls")
-                .select("id, name, glyph_id, glyphs(id, name, strokes, view_box)")
-                .order("name")
-                .execute()
-                .value
-            async let collectionsQuery: [PebbleCollection] = supabase.client
-                .from("collections")
-                .select("id, name")
-                .order("name")
-                .execute()
-                .value
-
-            let (loadedDomains, loadedSouls, loadedCollections) =
-                try await (domainsQuery, soulsQuery, collectionsQuery)
-
-            self.domains = loadedDomains
-            self.souls = loadedSouls
-            self.collections = loadedCollections
-            self.isLoadingReferences = false
-        } catch {
-            logger.error("reference load failed: \(error.localizedDescription, privacy: .private)")
-            self.loadError = "Couldn't load the form data."
-            self.isLoadingReferences = false
-        }
     }
 
     // MARK: - save
@@ -242,8 +187,10 @@ private struct PebbleIdPartial: Decodable {
 }
 
 #Preview {
-    CreatePebbleSheet(onCreated: { _ in })
-        .environment(SupabaseService())
+    let supabase = SupabaseService()
+    return CreatePebbleSheet(onCreated: { _ in })
+        .environment(supabase)
+        .environment(ReferenceDataService(client: supabase.client))
 }
 
 /// Maps a thrown error to a user-facing localized string. Module-private so

--- a/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
@@ -17,13 +17,11 @@ struct EditPebbleSheet: View {
 
     @Environment(SupabaseService.self) private var supabase
     @Environment(EmotionPaletteService.self) private var palettes
+    @Environment(ReferenceDataService.self) private var refs
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.dismiss) private var dismiss
 
     @State private var draft = PebbleDraft()
-    @State private var domains: [Domain] = []
-    @State private var souls: [SoulWithGlyph] = []
-    @State private var collections: [PebbleCollection] = []
     @State private var renderSvg: String?
     @State private var strokeColor: String?
     @State private var sizeGroup: ValenceSizeGroup = .medium
@@ -102,9 +100,9 @@ struct EditPebbleSheet: View {
         } else {
             PebbleFormView(
                 draft: $draft,
-                domains: domains,
-                souls: souls,
-                collections: collections,
+                domains: refs.domains,
+                souls: refs.souls,
+                collections: refs.collections,
                 saveError: saveError,
                 renderSvg: renderSvg,
                 strokeColor: strokeColor,
@@ -154,13 +152,11 @@ struct EditPebbleSheet: View {
         }
     }
 
-    // Five parallel queries (detail + four reference lists) push this just past the default limit.
-    // swiftlint:disable:next function_body_length
     private func load() async {
         isLoading = true
         loadError = nil
         do {
-            async let detailQuery: PebbleDetail = supabase.client
+            let detail: PebbleDetail = try await supabase.client
                 .from("pebbles")
                 .select("""
                     id, name, description, happened_at, intensity, positiveness, visibility,
@@ -177,31 +173,6 @@ struct EditPebbleSheet: View {
                 .execute()
                 .value
 
-            async let domainsQuery: [Domain] = supabase.client
-                .from("domains")
-                .select()
-                .order("name")
-                .execute()
-                .value
-            async let soulsQuery: [SoulWithGlyph] = supabase.client
-                .from("souls")
-                .select("id, name, glyph_id, glyphs(id, name, strokes, view_box)")
-                .order("name")
-                .execute()
-                .value
-            async let collectionsQuery: [PebbleCollection] = supabase.client
-                .from("collections")
-                .select("id, name")
-                .order("name")
-                .execute()
-                .value
-
-            let (detail, loadedDomains, loadedSouls, loadedCollections) =
-                try await (detailQuery, domainsQuery, soulsQuery, collectionsQuery)
-
-            self.domains = loadedDomains
-            self.souls = loadedSouls
-            self.collections = loadedCollections
             self.draft = PebbleDraft(from: detail)
             self.selectedGlyph = detail.glyph
             self.renderSvg = detail.renderSvg
@@ -305,6 +276,8 @@ private struct ComposePebbleUpdateRequest: Encodable {
 }
 
 #Preview {
-    EditPebbleSheet(pebbleId: UUID(), onSaved: {})
-        .environment(SupabaseService())
+    let supabase = SupabaseService()
+    return EditPebbleSheet(pebbleId: UUID(), onSaved: {})
+        .environment(supabase)
+        .environment(ReferenceDataService(client: supabase.client))
 }

--- a/apps/ios/Pebbles/Features/Profile/Lists/CollectionsListView.swift
+++ b/apps/ios/Pebbles/Features/Profile/Lists/CollectionsListView.swift
@@ -3,6 +3,7 @@ import os
 
 struct CollectionsListView: View {
     @Environment(SupabaseService.self) private var supabase
+    @Environment(ReferenceDataService.self) private var refs
     @State private var items: [Collection] = []
     @State private var isLoading = true
     @State private var loadError: String?
@@ -29,7 +30,10 @@ struct CollectionsListView: View {
             .task { await load() }
             .sheet(isPresented: $isPresentingCreate) {
                 CreateCollectionSheet(onCreated: {
-                    Task { await load() }
+                    Task {
+                        await load()
+                        await refs.refreshCollections()
+                    }
                 })
             }
             .refreshable { await load() }
@@ -88,7 +92,10 @@ struct CollectionsListView: View {
                 ForEach(items) { collection in
                     NavigationLink {
                         CollectionDetailView(collection: collection, onChanged: {
-                            Task { await load() }
+                            Task {
+                                await load()
+                                await refs.refreshCollections()
+                            }
                         })
                     } label: {
                         CollectionRow(collection: collection)
@@ -134,6 +141,7 @@ struct CollectionsListView: View {
                 .eq("id", value: collection.id)
                 .execute()
             await load()
+            await refs.refreshCollections()
         } catch {
             logger.error("delete collection failed: \(error.localizedDescription, privacy: .private)")
             deleteError = "Something went wrong. Please try again."
@@ -172,8 +180,10 @@ private struct CollectionRow: View {
 }
 
 #Preview {
-    NavigationStack {
+    let supabase = SupabaseService()
+    return NavigationStack {
         CollectionsListView()
-            .environment(SupabaseService())
+            .environment(supabase)
+            .environment(ReferenceDataService(client: supabase.client))
     }
 }

--- a/apps/ios/Pebbles/Features/Profile/Lists/SoulsListView.swift
+++ b/apps/ios/Pebbles/Features/Profile/Lists/SoulsListView.swift
@@ -3,6 +3,7 @@ import os
 
 struct SoulsListView: View {
     @Environment(SupabaseService.self) private var supabase
+    @Environment(ReferenceDataService.self) private var refs
     @State private var items: [SoulWithGlyph] = []
     @State private var isLoading = true
     @State private var loadError: String?
@@ -31,7 +32,10 @@ struct SoulsListView: View {
             .task { await load() }
             .sheet(isPresented: $isPresentingCreate) {
                 CreateSoulSheet(onCreated: { _ in
-                    Task { await load() }
+                    Task {
+                        await load()
+                        await refs.refreshSouls()
+                    }
                 })
             }
             .confirmationDialog(
@@ -90,7 +94,10 @@ struct SoulsListView: View {
                     ForEach(items) { item in
                         NavigationLink {
                             SoulDetailView(initial: item, onChanged: {
-                                Task { await load() }
+                                Task {
+                                    await load()
+                                    await refs.refreshSouls()
+                                }
                             })
                         } label: {
                             SoulGridCell(soul: item)
@@ -137,6 +144,7 @@ struct SoulsListView: View {
                 .eq("id", value: soul.id)
                 .execute()
             await load()
+            await refs.refreshSouls()
         } catch {
             logger.error("delete soul failed: \(error.localizedDescription, privacy: .private)")
             deleteError = "Something went wrong. Please try again."
@@ -145,8 +153,10 @@ struct SoulsListView: View {
 }
 
 #Preview {
-    NavigationStack {
+    let supabase = SupabaseService()
+    return NavigationStack {
         SoulsListView()
-            .environment(SupabaseService())
+            .environment(supabase)
+            .environment(ReferenceDataService(client: supabase.client))
     }
 }

--- a/apps/ios/Pebbles/PebblesApp.swift
+++ b/apps/ios/Pebbles/PebblesApp.swift
@@ -5,6 +5,7 @@ import UIKit
 struct PebblesApp: App {
     @State private var supabase: SupabaseService
     @State private var palettes: EmotionPaletteService
+    @State private var refs: ReferenceDataService
     @State private var stats: PathStatsService
     @State private var snapURLs: SnapURLCache
 
@@ -12,6 +13,7 @@ struct PebblesApp: App {
         let supabase = SupabaseService()
         self._supabase = State(initialValue: supabase)
         self._palettes = State(initialValue: EmotionPaletteService(client: supabase.client))
+        self._refs     = State(initialValue: ReferenceDataService(client: supabase.client))
         self._stats    = State(initialValue: PathStatsService(supabase: supabase))
         self._snapURLs = State(initialValue: SnapURLCache(client: supabase.client))
         Self.configureSegmentedControlAppearance()
@@ -22,6 +24,7 @@ struct PebblesApp: App {
             RootView()
                 .environment(supabase)
                 .environment(palettes)
+                .environment(refs)
                 .environment(stats)
                 .environment(snapURLs)
         }

--- a/apps/ios/Pebbles/RootView.swift
+++ b/apps/ios/Pebbles/RootView.swift
@@ -17,6 +17,7 @@ import SwiftUI
 struct RootView: View {
     @Environment(SupabaseService.self) private var supabase
     @Environment(EmotionPaletteService.self) private var palettes
+    @Environment(ReferenceDataService.self) private var refs
     @Environment(SnapURLCache.self) private var snapURLs
     @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
     @State private var isPresentingOnboarding = false
@@ -80,6 +81,7 @@ struct RootView: View {
             minSplashDone = true
         }
         .task { await palettes.load() }
+        .task { await refs.load() }
         // Relies on supabase.start() being kicked off in .task above.
         // session?.user.id is nil when this observer is registered, so the
         // first authStateChanges event delivers a real nil→id transition
@@ -102,5 +104,6 @@ struct RootView: View {
     return RootView()
         .environment(supabase)
         .environment(EmotionPaletteService(client: supabase.client))
+        .environment(ReferenceDataService(client: supabase.client))
         .environment(SnapURLCache(client: supabase.client))
 }

--- a/apps/ios/Pebbles/Services/ReferenceDataService.swift
+++ b/apps/ios/Pebbles/Services/ReferenceDataService.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Observation
+import Supabase
+import os
+
+/// Caches the three reference lists used by `CreatePebbleSheet` and
+/// `EditPebbleSheet` (`domains`, `souls`, `collections`) for the session.
+///
+/// Loaded once from `RootView.task` alongside `EmotionPaletteService`, hidden
+/// behind the splash. Subsequent sheet opens read directly from the cached
+/// arrays — no per-open round-trips. `domains` is seed data and never refreshes
+/// at runtime; `souls` and `collections` are refreshed via `refreshSouls()` /
+/// `refreshCollections()` after the matching Profile mutations succeed.
+///
+/// No retry on failure: a failed `load()` leaves the arrays empty and pickers
+/// render empty, matching the UX of an offline launch. State recovers on the
+/// next app launch.
+@Observable
+@MainActor
+final class ReferenceDataService {
+    private(set) var domains: [Domain] = []
+    private(set) var souls: [SoulWithGlyph] = []
+    private(set) var collections: [PebbleCollection] = []
+    private(set) var hasLoaded: Bool = false
+
+    private let client: SupabaseClient
+    private let logger = Logger(subsystem: "app.pbbls.ios", category: "reference-data")
+
+    init(client: SupabaseClient) {
+        self.client = client
+    }
+
+    /// Fetch all three lists in parallel and populate the cache. Idempotent —
+    /// the splash-driven call site only fires once, but safe to call again
+    /// (e.g. for retry after a transient launch-time failure).
+    func load() async {
+        do {
+            async let domainsQuery: [Domain] = client
+                .from("domains")
+                .select()
+                .order("name")
+                .execute()
+                .value
+            async let soulsQuery: [SoulWithGlyph] = client
+                .from("souls")
+                .select("id, name, glyph_id, glyphs(id, name, strokes, view_box)")
+                .order("name")
+                .execute()
+                .value
+            async let collectionsQuery: [PebbleCollection] = client
+                .from("collections")
+                .select("id, name")
+                .order("name")
+                .execute()
+                .value
+
+            let (loadedDomains, loadedSouls, loadedCollections) =
+                try await (domainsQuery, soulsQuery, collectionsQuery)
+
+            self.domains = loadedDomains
+            self.souls = loadedSouls
+            self.collections = loadedCollections
+            self.hasLoaded = true
+            logger.info("""
+                loaded \(loadedDomains.count, privacy: .public) domains, \
+                \(loadedSouls.count, privacy: .public) souls, \
+                \(loadedCollections.count, privacy: .public) collections
+                """)
+        } catch {
+            logger.error("reference data load failed: \(error.localizedDescription, privacy: .private)")
+        }
+    }
+
+    /// Re-fetch souls only. Called from `SoulsListView` after create/edit/delete
+    /// completes, so the pebble sheets see the new list on next open.
+    func refreshSouls() async {
+        do {
+            let rows: [SoulWithGlyph] = try await client
+                .from("souls")
+                .select("id, name, glyph_id, glyphs(id, name, strokes, view_box)")
+                .order("name")
+                .execute()
+                .value
+            self.souls = rows
+        } catch {
+            logger.error("souls refresh failed: \(error.localizedDescription, privacy: .private)")
+        }
+    }
+
+    /// Re-fetch collections only. Called from `CollectionsListView` after
+    /// create/edit/delete completes.
+    func refreshCollections() async {
+        do {
+            let rows: [PebbleCollection] = try await client
+                .from("collections")
+                .select("id, name")
+                .order("name")
+                .execute()
+                .value
+            self.collections = rows
+        } catch {
+            logger.error("collections refresh failed: \(error.localizedDescription, privacy: .private)")
+        }
+    }
+}


### PR DESCRIPTION
Resolves #404

## Summary
- Adds `ReferenceDataService` (`@Observable @MainActor`) holding `domains`, `souls`, `collections`. `load()` fires once from `RootView.task` alongside `EmotionPaletteService` during the 2.5s splash.
- `CreatePebbleSheet` and `EditPebbleSheet` now read directly from the cached arrays — no per-open queries, no loading spinner. `CreatePebbleSheet` loses ~85 lines of state/branches.
- `EditPebbleSheet.load()` drops the three reference queries (keeps the pebble detail query) and the `swiftlint:disable function_body_length` it required.
- `SoulsListView` / `CollectionsListView` call `refreshSouls()` / `refreshCollections()` after their existing `load()` in create / detail-onChanged / delete paths, so cached lists stay in sync with Profile mutations.

A user creating 5 pebbles now fires 3 reference queries total (during splash), not 15.

## Key files
- `apps/ios/Pebbles/Services/ReferenceDataService.swift` — new cache, mirrors `EmotionPaletteService` shape
- `apps/ios/Pebbles/PebblesApp.swift`, `apps/ios/Pebbles/RootView.swift` — construct, inject, kick off load
- `apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift`, `EditPebbleSheet.swift` — consume the cache
- `apps/ios/Pebbles/Features/Profile/Lists/SoulsListView.swift`, `CollectionsListView.swift` — refresh hooks

## Implementation notes
- No retry on `load()` failure: cache stays empty, pickers render empty (same UX as offline launch). State recovers on next launch — matches `EmotionPaletteService`.
- Two separate refresh methods (`refreshSouls()` / `refreshCollections()`) rather than a `Kind` enum — clearer at call sites, mutation paths are single-kind by construction.
- Refresh hooks land in the two list views (3 sites each), not in the 4 mutation sheets + 2 detail views — all mutation paths already funnel through the list views via existing `onCreated` / `onChanged` callbacks.
- Domains are seed data and never refresh at runtime.

## Test plan
- [ ] Cold launch → splash plays → open Create Pebble: domain/soul/collection pickers populated, no spinner
- [ ] Open Create Pebble 5 times in a row: no network traffic for reference lists
- [ ] Open Edit Pebble: pebble detail still loads (spinner shows briefly), reference pickers populated immediately
- [ ] Profile → create a new soul → open Create Pebble → new soul appears in the picker
- [ ] Profile → edit a soul name → open Create Pebble → renamed soul appears
- [ ] Profile → delete a soul → open Create Pebble → deleted soul gone
- [ ] Same three checks for collections
- [ ] Offline cold launch: pickers render empty, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)