### PR TITLE
fix(ios): isolate lab feed failures so partial loads still render

### DIFF
--- a/apps/ios/Pebbles/Features/Lab/LabView.swift
+++ b/apps/ios/Pebbles/Features/Lab/LabView.swift
@@ -118,24 +118,45 @@ struct LabView: View {
     // MARK: - Data
 
     private func load() async {
-        do {
-            async let announcementsResult: [Log] = service.announcements()
-            async let changelogResult: [Log] = service.changelog(limit: Self.feedLimit)
-            async let initiativesResult: [Log] = service.initiatives()
-            async let backlogResult: [Log] = service.backlog(limit: Self.feedLimit)
-            async let reactionsResult: Set<UUID> = service.myReactions()
+        async let announcementsResult: [Log] = service.announcements()
+        async let changelogResult: [Log] = service.changelog(limit: Self.feedLimit)
+        async let initiativesResult: [Log] = service.initiatives()
+        async let backlogResult: [Log] = service.backlog(limit: Self.feedLimit)
+        async let reactionsResult: Set<UUID> = service.myReactions()
 
-            self.announcements = try await announcementsResult
-            self.changelog = try await changelogResult
-            self.initiatives = try await initiativesResult
-            self.backlog = try await backlogResult
-            self.reactedIds = try await reactionsResult
-            self.isLoading = false
-        } catch {
-            logger.error("lab fetch failed: \(error.localizedDescription, privacy: .private)")
+        // Each feed loads independently so a single transient failure (e.g.
+        // reactions) doesn't blank out the whole Lab. The fullscreen error
+        // is reserved for the case where every content feed fails.
+        var announcements: [Log]?
+        var changelog: [Log]?
+        var initiatives: [Log]?
+        var backlog: [Log]?
+        var reactedIds: Set<UUID>?
+
+        do { announcements = try await announcementsResult } catch { logFetchFailure(error, "announcements") }
+        do { changelog = try await changelogResult } catch { logFetchFailure(error, "changelog") }
+        do { initiatives = try await initiativesResult } catch { logFetchFailure(error, "initiatives") }
+        do { backlog = try await backlogResult } catch { logFetchFailure(error, "backlog") }
+        do { reactedIds = try await reactionsResult } catch { logFetchFailure(error, "reactions") }
+
+        self.announcements = announcements ?? []
+        self.changelog = changelog ?? []
+        self.initiatives = initiatives ?? []
+        self.backlog = backlog ?? []
+        self.reactedIds = reactedIds ?? []
+
+        let allContentFailed = announcements == nil
+            && changelog == nil
+            && initiatives == nil
+            && backlog == nil
+        if allContentFailed {
             self.loadError = "Couldn't load the Lab."
-            self.isLoading = false
         }
+        self.isLoading = false
+    }
+
+    private func logFetchFailure(_ error: Error, _ label: String) {
+        logger.error("lab \(label) fetch failed: \(error.localizedDescription, privacy: .private)")
     }
 
     private func toggle(_ log: Log) async {


### PR DESCRIPTION
Resolves #406

## Summary
- `LabView.load()` previously awaited five queries with `try await` inside a single `do/catch`, so any one failure (most commonly `myReactions`) blanked the whole Lab to a fullscreen error.
- Each feed now loads independently via inline `do/catch`. The fullscreen error is reserved for the case where every content feed fails simultaneously.
- All failures still surface through `os.Logger` (no silent catches), matching the iOS error-handling rule in `apps/ios/CLAUDE.md`.

## Key files
- `apps/ios/Pebbles/Features/Lab/LabView.swift` — restructured `load()`, added `logFetchFailure` helper.

## Test plan
- [x] `xcodebuild -scheme Pebbles -destination 'generic/platform=iOS Simulator' build` — succeeds.
- [x] Manual: open Lab with reactions endpoint failing (e.g. signed-out edge case) — content feeds render, no blank error screen.
- [x] Manual: open Lab with all content endpoints failing — fullscreen "Couldn't load the Lab." still appears.