### PR TITLE
quality(ios): move authError into view-local state

### DIFF
--- a/apps/ios/Pebbles/Features/Auth/AuthView.swift
+++ b/apps/ios/Pebbles/Features/Auth/AuthView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 /// Email + password auth screen. Switcher toggles between Login and Signup
-/// modes. Signup mode adds two consent checkboxes. State lives view-locally
-/// except for `authError`, which is read from `SupabaseService` so failures
-/// from `signIn` / `signUp` surface inline.
+/// modes. Signup mode adds two consent checkboxes. All state lives view-locally,
+/// including `authError` — the auth service throws on failure and this view
+/// catches and renders the message inline.
 struct AuthView: View {
     enum Mode: String, CaseIterable, Identifiable {
         case login
@@ -27,6 +27,7 @@ struct AuthView: View {
     @State private var termsAccepted = false
     @State private var privacyAccepted = false
     @State private var presentedLegalDoc: LegalDoc?
+    @State private var authError: String?
 
     init(initialMode: Mode = .login) {
         _mode = State(initialValue: initialMode)
@@ -74,7 +75,7 @@ struct AuthView: View {
                 }
             }
 
-            if let error = supabase.authError {
+            if let error = authError {
                 Text(error)
                     .font(.footnote)
                     .foregroundStyle(.red)
@@ -111,17 +112,17 @@ struct AuthView: View {
                 .ignoresSafeArea()
         }
         .onChange(of: mode) { _, newMode in
-            supabase.authError = nil
+            authError = nil
             if newMode == .login {
                 termsAccepted = false
                 privacyAccepted = false
             }
         }
         .onChange(of: email) { _, _ in
-            if supabase.authError != nil { supabase.authError = nil }
+            if authError != nil { authError = nil }
         }
         .onChange(of: password) { _, _ in
-            if supabase.authError != nil { supabase.authError = nil }
+            if authError != nil { authError = nil }
         }
         .pebblesScreen()
     }
@@ -159,12 +160,17 @@ struct AuthView: View {
 
     private func submit() {
         isSubmitting = true
+        authError = nil
         Task {
-            switch mode {
-            case .login:
-                await supabase.signIn(email: email, password: password)
-            case .signup:
-                await supabase.signUp(email: email, password: password)
+            do {
+                switch mode {
+                case .login:
+                    try await supabase.signIn(email: email, password: password)
+                case .signup:
+                    try await supabase.signUp(email: email, password: password)
+                }
+            } catch {
+                authError = error.localizedDescription
             }
             isSubmitting = false
         }
@@ -173,14 +179,24 @@ struct AuthView: View {
     private func runApple() async {
         guard !isSubmitting else { return }
         isSubmitting = true
-        await supabase.signInWithApple()
+        authError = nil
+        do {
+            try await supabase.signInWithApple()
+        } catch {
+            authError = error.localizedDescription
+        }
         isSubmitting = false
     }
 
     private func runGoogle() async {
         guard !isSubmitting else { return }
         isSubmitting = true
-        await supabase.signInWithGoogle()
+        authError = nil
+        do {
+            try await supabase.signInWithGoogle()
+        } catch {
+            authError = error.localizedDescription
+        }
         isSubmitting = false
     }
 }

--- a/apps/ios/Pebbles/Features/Welcome/WelcomeView.swift
+++ b/apps/ios/Pebbles/Features/Welcome/WelcomeView.swift
@@ -26,6 +26,7 @@ struct WelcomeView: View {
     @State private var isSubmitting: Bool = false
     @State private var presentedLegalDoc: LegalDoc?
     @State private var revealStep: Int = 0
+    @State private var authError: String?
     @State private var logoViewModel = RiveViewModel(fileName: "pbbls-logo-appear_idle")
 
     /// Reveal cadence (seconds from the moment `contentRevealed` flips
@@ -150,7 +151,7 @@ struct WelcomeView: View {
                     .disabled(isSubmitting)
                     .opacity(revealStep >= 6 ? 1 : 0)
 
-                if let error = supabase.authError {
+                if let error = authError {
                     Text(error)
                         .font(.footnote)
                         .foregroundStyle(.red)
@@ -197,14 +198,24 @@ struct WelcomeView: View {
     private func runApple() async {
         guard !isSubmitting else { return }
         isSubmitting = true
-        await supabase.signInWithApple()
+        authError = nil
+        do {
+            try await supabase.signInWithApple()
+        } catch {
+            authError = error.localizedDescription
+        }
         isSubmitting = false
     }
 
     private func runGoogle() async {
         guard !isSubmitting else { return }
         isSubmitting = true
-        await supabase.signInWithGoogle()
+        authError = nil
+        do {
+            try await supabase.signInWithGoogle()
+        } catch {
+            authError = error.localizedDescription
+        }
         isSubmitting = false
     }
 }

--- a/apps/ios/Pebbles/Services/SupabaseService.swift
+++ b/apps/ios/Pebbles/Services/SupabaseService.swift
@@ -25,10 +25,6 @@ final class SupabaseService {
     /// AuthView flash before the tab bar.
     var isInitializing: Bool = true
 
-    /// Last signIn/signUp error, displayed inline under the auth form.
-    /// Cleared on successful auth, on mode toggle, and as the user edits the form.
-    var authError: String?
-
     private let logger = Logger(subsystem: "app.pbbls.ios", category: "auth")
 
     init() {
@@ -49,25 +45,21 @@ final class SupabaseService {
     /// awaiting a Supabase call from inside the callback deadlocks the
     /// client. Mutate state synchronously only.
     func start() async {
-        for await (event, session) in client.auth.authStateChanges {
+        for await (_, session) in client.auth.authStateChanges {
             self.session = session
             self.isInitializing = false
-            if event == .signedIn {
-                self.authError = nil
-            }
         }
         logger.error("authStateChanges stream ended unexpectedly")
     }
 
     /// Sign in with email + password. On success, the `.signedIn` event flows
     /// through `authStateChanges` and `session` becomes non-nil.
-    func signIn(email: String, password: String) async {
-        self.authError = nil
+    func signIn(email: String, password: String) async throws {
         do {
             try await client.auth.signIn(email: email, password: password)
         } catch {
             logger.error("signIn failed: \(error.localizedDescription, privacy: .private)")
-            self.authError = error.localizedDescription
+            throw error
         }
     }
 
@@ -75,8 +67,7 @@ final class SupabaseService {
     /// passed through `auth.users.raw_user_meta_data`. Note: the current
     /// `handle_new_user` DB trigger does not copy them into `public.profiles`
     /// — this mirrors web behavior and will be fixed in a separate `fix(db)` issue.
-    func signUp(email: String, password: String) async {
-        self.authError = nil
+    func signUp(email: String, password: String) async throws {
         let now = ISO8601DateFormatter().string(from: Date())
         do {
             try await client.auth.signUp(
@@ -89,7 +80,7 @@ final class SupabaseService {
             )
         } catch {
             logger.error("signUp failed: \(error.localizedDescription, privacy: .private)")
-            self.authError = error.localizedDescription
+            throw error
         }
     }
 
@@ -98,8 +89,7 @@ final class SupabaseService {
     /// On the user's first authorization, Apple returns their `fullName` —
     /// we use it to overwrite the trigger-seeded `'Pebbler'` display name.
     /// Subsequent sign-ins return no name, so the patch is a no-op.
-    func signInWithApple() async {
-        self.authError = nil
+    func signInWithApple() async throws {
         do {
             let result = try await AppleSignInService.authorize()
             try await client.auth.signInWithIdToken(
@@ -116,7 +106,7 @@ final class SupabaseService {
             // User dismissed the sheet — silent.
         } catch {
             logger.error("signInWithApple failed: \(error.localizedDescription, privacy: .private)")
-            self.authError = error.localizedDescription
+            throw error
         }
     }
 
@@ -132,8 +122,7 @@ final class SupabaseService {
     /// available native Google SDK (GoogleSignIn-iOS 7.1) injects a nonce
     /// via AppAuth that it never exposes — Supabase rejects the exchange
     /// because the id_token's nonce claim has no matching parameter.
-    func signInWithGoogle() async {
-        self.authError = nil
+    func signInWithGoogle() async throws {
         do {
             let session = try await client.auth.signInWithOAuth(
                 provider: .google,
@@ -147,7 +136,7 @@ final class SupabaseService {
             // User dismissed the sheet — silent.
         } catch {
             logger.error("signInWithGoogle failed: \(error.localizedDescription, privacy: .private)")
-            self.authError = error.localizedDescription
+            throw error
         }
     }
 

--- a/apps/ios/PebblesTests/SupabaseServiceTests.swift
+++ b/apps/ios/PebblesTests/SupabaseServiceTests.swift
@@ -4,11 +4,10 @@ import Testing
 @Suite("SupabaseService auth state")
 @MainActor
 struct SupabaseServiceTests {
-    @Test("Service initializes with no session, initializing true, no error")
+    @Test("Service initializes with no session and initializing true")
     func initialStateIsInitializingWithNoSession() {
         let service = SupabaseService()
         #expect(service.session == nil)
         #expect(service.isInitializing == true)
-        #expect(service.authError == nil)
     }
 }

--- a/docs/superpowers/specs/2026-05-14-issue-408-authview-mutates-service-state-design.md
+++ b/docs/superpowers/specs/2026-05-14-issue-408-authview-mutates-service-state-design.md
@@ -1,0 +1,154 @@
+# Issue #408 — AuthView mutates SupabaseService state from the View layer
+
+## Problem
+
+`AuthView` assigns `supabase.authError = nil` directly from `.onChange` handlers and from the form's `submit` paths. `SupabaseService` is a shared `@Observable` service, not a screen-scoped ViewModel, so any view holding a reference can silently clear another view's error state. `authError` is transient UI state belonging to one screen; it should not live on a shared service.
+
+## Goal
+
+Remove `authError` from `SupabaseService` entirely. Move it into `AuthView` as local `@State`. Have the service's auth methods throw on failure; the view catches and renders.
+
+## Non-goals
+
+- No changes to error logging discipline — the service still logs every error path with `os.Logger` before rethrowing.
+- No new `AuthViewModel`. `AuthView`'s existing `@State` fields are sufficient.
+- No changes to Apple / Google cancel handling (still silent).
+
+## Design
+
+### `SupabaseService` (`apps/ios/Pebbles/Services/SupabaseService.swift`)
+
+Delete:
+
+- `var authError: String?` property.
+- The `if event == .signedIn { self.authError = nil }` branch inside `start()`.
+
+Change signatures from `async` to `async throws`:
+
+- `signIn(email:password:)`
+- `signUp(email:password:)`
+- `signInWithApple()`
+- `signInWithGoogle()`
+
+`signIn` / `signUp`: drop `self.authError = nil` at the top and `self.authError = error.localizedDescription` in the catch. Keep `logger.error(...)` then `throw error`.
+
+`signInWithApple`: keep the existing `catch AppleSignInService.Failure.canceled { /* silent */ }` clause (returns normally). Other errors: log then rethrow.
+
+`signInWithGoogle`: keep the existing `catch let error as ASWebAuthenticationSessionError where error.code == .canceledLogin { /* silent */ }` clause (returns normally). Other errors: log then rethrow.
+
+`signOut()` is unchanged — failures stay logged-only.
+
+### `AuthView` (`apps/ios/Pebbles/Features/Auth/AuthView.swift`)
+
+Add `@State private var authError: String?`.
+
+Update the error display:
+
+```swift
+if let error = authError {
+    Text(error)
+        // …unchanged…
+}
+```
+
+Update the three `.onChange` handlers to clear local state:
+
+```swift
+.onChange(of: mode) { _, newMode in
+    authError = nil
+    if newMode == .login {
+        termsAccepted = false
+        privacyAccepted = false
+    }
+}
+.onChange(of: email) { _, _ in
+    if authError != nil { authError = nil }
+}
+.onChange(of: password) { _, _ in
+    if authError != nil { authError = nil }
+}
+```
+
+Update each action to clear the local error, call the throwing service method, and catch:
+
+```swift
+private func submit() {
+    isSubmitting = true
+    authError = nil
+    Task {
+        do {
+            switch mode {
+            case .login:
+                try await supabase.signIn(email: email, password: password)
+            case .signup:
+                try await supabase.signUp(email: email, password: password)
+            }
+        } catch {
+            authError = error.localizedDescription
+        }
+        isSubmitting = false
+    }
+}
+
+private func runApple() async {
+    guard !isSubmitting else { return }
+    isSubmitting = true
+    authError = nil
+    do {
+        try await supabase.signInWithApple()
+    } catch {
+        authError = error.localizedDescription
+    }
+    isSubmitting = false
+}
+
+private func runGoogle() async {
+    guard !isSubmitting else { return }
+    isSubmitting = true
+    authError = nil
+    do {
+        try await supabase.signInWithGoogle()
+    } catch {
+        authError = error.localizedDescription
+    }
+    isSubmitting = false
+}
+```
+
+The doc comment at the top of `AuthView` currently mentions reading `authError` from `SupabaseService`; update it to reflect that the error is now view-local.
+
+## Behavioral notes
+
+- On successful sign-in, `client.auth.authStateChanges` emits `.signedIn`, `session` becomes non-nil, and the root view swaps `AuthView` out of the tree. The view's `authError` is destroyed with it. No explicit "clear on success" is needed.
+- The Apple / Google cancel paths still return normally from the service, so the view's `do` block falls through without entering `catch`. `authError` stays `nil` — same UX as today.
+
+## Why not the other approaches considered
+
+- **`clearAuthError()` method on the service.** Encapsulates the assignment but not the ownership — any other view could still call it and clear `AuthView`'s state. Doesn't address the root cause.
+- **`AuthViewModel`.** Heavier than needed. `AuthView` has no cross-cutting state to coordinate beyond the existing `@State` fields. Introducing a ViewModel for one screen would add indirection without buying anything.
+
+## Test plan
+
+No unit tests exist for `AuthView` or `SupabaseService` and none are added here (no `SupabaseServicing` protocol yet — per `apps/ios/CLAUDE.md`, that's introduced only when a test actually needs it).
+
+Manual verification on a device or simulator after the change:
+
+1. Email login with a wrong password → red error appears under the form.
+2. Edit the email field → error clears.
+3. Edit the password field → error clears.
+4. Toggle the Login/Signup switcher → error clears, signup checkboxes reset when switching to Login.
+5. Tap Connect again with the right password → sign-in succeeds, view swaps to the tab bar.
+6. Sign out, return to AuthView → no stale error.
+7. Tap Sign in with Apple, dismiss the system sheet → no error shown (cancel is silent).
+8. Tap Sign in with Google, dismiss the in-app Safari sheet → no error shown (cancel is silent).
+
+## Out of scope
+
+- Renaming or reorganizing the auth surface beyond what this fix requires.
+- Adding a `SupabaseServicing` protocol for testability.
+- Any change to web-app auth handling.
+
+## Files touched
+
+- `apps/ios/Pebbles/Services/SupabaseService.swift`
+- `apps/ios/Pebbles/Features/Auth/AuthView.swift`

--- a/docs/superpowers/specs/2026-05-14-issue-408-authview-mutates-service-state-design.md
+++ b/docs/superpowers/specs/2026-05-14-issue-408-authview-mutates-service-state-design.md
@@ -152,3 +152,4 @@ Manual verification on a device or simulator after the change:
 
 - `apps/ios/Pebbles/Services/SupabaseService.swift`
 - `apps/ios/Pebbles/Features/Auth/AuthView.swift`
+- `apps/ios/Pebbles/Features/Welcome/WelcomeView.swift` — also read `supabase.authError` and called `signInWithApple` / `signInWithGoogle`; gets the same view-local `authError` + `do/catch` treatment.


### PR DESCRIPTION
Resolves #408

## Summary

- Removes `authError` from `SupabaseService` — it was transient UI state on a shared `@Observable`, which let any view silently clear another view's error.
- `signIn`, `signUp`, `signInWithApple`, `signInWithGoogle` now `throw` instead of stashing errors on the service. Apple/Google cancel paths still return silently (the existing `catch AppleSignInService.Failure.canceled` / `ASWebAuthenticationSessionError.canceledLogin` clauses are preserved).
- `AuthView` and `WelcomeView` each hold their own `@State private var authError: String?` and wrap service calls in `do/catch`.
- `start()` no longer special-cases `.signedIn` to clear `authError` — the view tree swaps out on sign-in, so view-local state is destroyed naturally.

## Key files

- `apps/ios/Pebbles/Services/SupabaseService.swift` — drops `authError`, methods throw, drops the `.signedIn` clear branch.
- `apps/ios/Pebbles/Features/Auth/AuthView.swift` — view-local `authError`, `.onChange` clears it, actions wrap in `do/catch`.
- `apps/ios/Pebbles/Features/Welcome/WelcomeView.swift` — same treatment for the Apple/Google buttons on the splash.
- `apps/ios/PebblesTests/SupabaseServiceTests.swift` — drops the assertion on the removed property.
- `docs/superpowers/specs/2026-05-14-issue-408-authview-mutates-service-state-design.md` — design doc.

## Test plan

- [x] `xcodebuild build` succeeds.
- [x] `SupabaseServiceTests` passes; `LocalizationTests` failure is a pre-existing flake on `main` (unrelated to this change).
- [x] Email login with wrong password → red error appears under the form.
- [x] Edit email or password → error clears.
- [x] Toggle Login/Signup switcher → error clears, signup checkboxes reset when switching to Login.
- [x] Tap Connect again with correct password → sign-in succeeds, view swaps to tab bar.
- [x] Tap Sign in with Apple, dismiss the system sheet → no error shown.
- [x] Tap Sign in with Google, dismiss the in-app Safari sheet → no error shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)