### PR TITLE
feat(ui): improve admin logs views

### DIFF
--- a/apps/admin/app/(authed)/logs/_components/LogSection.tsx
+++ b/apps/admin/app/(authed)/logs/_components/LogSection.tsx
@@ -87,7 +87,7 @@ const PLATFORM_ICONS: Record<LogPlatform, LucideIcon> = {
 }
 
 const PLATFORM_ICON_BG: Record<LogPlatform, string> = {
-  ios: "#00000022",
+  ios: "#00000011",
   webapp: "#087ea422",
   android: "#2e924922",
   all: "#C07A7A",
@@ -105,13 +105,12 @@ const PLATFORM_ICON_FG: Record<LogPlatform, string> = {
 }
 
 function formatDate(value: string) {
-  return new Date(value).toLocaleString(undefined, {
-    year: "numeric",
+  const date = new Date(value)
+  const monthDay = date.toLocaleString(undefined, {
     month: "short",
     day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
   })
+  return `${monthDay} ${date.getHours()}h`
 }
 
 function getDateValue(log: LogRow, field: DateField): string {
@@ -179,7 +178,7 @@ export function LogSection({
                       </Link>
                     </div>
                   </TableCell>
-                  <TableCell className="text-muted-foreground w-44 rounded-r-md text-sm group-hover:bg-muted/50">
+                  <TableCell className="text-muted-foreground w-28 rounded-r-md text-right text-xs group-hover:bg-muted/50">
                     {formatDate(getDateValue(log, config.dateField))}
                   </TableCell>
                 </TableRow>

--- a/apps/admin/app/(authed)/logs/_components/LogSection.tsx
+++ b/apps/admin/app/(authed)/logs/_components/LogSection.tsx
@@ -1,5 +1,18 @@
 import Link from "next/link"
 import {
+  Apple,
+  Bot,
+  CircleCheckBig,
+  CircleDotDashed,
+  CircleFadingArrowUp,
+  CirclePile,
+  DatabaseZap,
+  Monitor,
+  MonitorSmartphone,
+  Telescope,
+  type LucideIcon,
+} from "lucide-react"
+import {
   Table,
   TableBody,
   TableCell,
@@ -7,7 +20,82 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import type { LogRow } from "@/lib/logs/types"
+import { cn } from "@/lib/utils"
+import { PLATFORM_OPTIONS } from "@/lib/logs/options"
+import type { LogPlatform, LogRow } from "@/lib/logs/types"
+
+export type LogSectionVariant =
+  | "in_progress"
+  | "planned"
+  | "backlog"
+  | "shipped"
+  | "drafts"
+  | "published"
+
+type DateField = "updated_at" | "released_at" | "published_at"
+
+type VariantConfig = {
+  icon: LucideIcon | null
+  iconClass: string
+  dateField: DateField
+  dateLabel: string
+}
+
+const VARIANTS: Record<LogSectionVariant, VariantConfig> = {
+  in_progress: {
+    icon: CircleDotDashed,
+    iconClass: "text-blue-500",
+    dateField: "updated_at",
+    dateLabel: "Updated",
+  },
+  planned: {
+    icon: CircleFadingArrowUp,
+    iconClass: "text-yellow-500",
+    dateField: "updated_at",
+    dateLabel: "Updated",
+  },
+  backlog: {
+    icon: CirclePile,
+    iconClass: "text-muted-foreground",
+    dateField: "updated_at",
+    dateLabel: "Updated",
+  },
+  shipped: {
+    icon: CircleCheckBig,
+    iconClass: "text-green-600",
+    dateField: "released_at",
+    dateLabel: "Released",
+  },
+  drafts: {
+    icon: null,
+    iconClass: "",
+    dateField: "updated_at",
+    dateLabel: "Updated",
+  },
+  published: {
+    icon: null,
+    iconClass: "",
+    dateField: "published_at",
+    dateLabel: "Published",
+  },
+}
+
+const PLATFORM_ICONS: Record<LogPlatform, LucideIcon> = {
+  ios: Apple,
+  webapp: Monitor,
+  android: Bot,
+  all: MonitorSmartphone,
+  infra: DatabaseZap,
+  project: Telescope,
+}
+
+const PLATFORM_LABELS: Record<LogPlatform, string> = PLATFORM_OPTIONS.reduce(
+  (acc, o) => {
+    acc[o.value] = o.label
+    return acc
+  },
+  {} as Record<LogPlatform, string>,
+)
 
 function formatDate(value: string) {
   return new Date(value).toLocaleString(undefined, {
@@ -19,19 +107,35 @@ function formatDate(value: string) {
   })
 }
 
+function getDateValue(log: LogRow, field: DateField): string {
+  const value = log[field]
+  return typeof value === "string" && value.length > 0 ? value : log.updated_at
+}
+
+function isLogPlatform(value: string): value is LogPlatform {
+  return value in PLATFORM_ICONS
+}
+
 export function LogSection({
   title,
   logs,
   emptyLabel,
+  variant,
 }: {
   title: string
   logs: LogRow[]
   emptyLabel: string
+  variant: LogSectionVariant
 }) {
+  const config = VARIANTS[variant]
+  const Icon = config.icon
+
   return (
     <section className="space-y-3">
-      <h2 className="text-base font-semibold">
-        {title} <span className="text-muted-foreground font-normal">· {logs.length}</span>
+      <h2 className="flex items-center gap-2 text-base font-semibold">
+        {Icon && <Icon className={cn("size-5", config.iconClass)} aria-hidden />}
+        <span>{title}</span>
+        <span className="text-muted-foreground font-normal">· {logs.length}</span>
       </h2>
       {logs.length === 0 ? (
         <div className="border-border rounded-md border border-dashed p-8 text-center">
@@ -42,24 +146,43 @@ export function LogSection({
           <TableHeader>
             <TableRow>
               <TableHead>Title</TableHead>
-              <TableHead>Platform</TableHead>
-              <TableHead>Updated</TableHead>
+              <TableHead className="w-44">{config.dateLabel}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
-            {logs.map((log) => (
-              <TableRow key={log.id}>
-                <TableCell className="font-medium">
-                  <Link href={`/logs/${log.id}`} className="hover:underline">
-                    {log.title_en}
-                  </Link>
-                </TableCell>
-                <TableCell>{log.platform}</TableCell>
-                <TableCell className="text-muted-foreground text-sm">
-                  {formatDate(log.updated_at)}
-                </TableCell>
-              </TableRow>
-            ))}
+            {logs.map((log) => {
+              const platform = isLogPlatform(log.platform) ? log.platform : "all"
+              const PlatformIcon = PLATFORM_ICONS[platform]
+              const platformLabel = PLATFORM_LABELS[platform] ?? log.platform
+              return (
+                <TableRow key={log.id}>
+                  <TableCell>
+                    <div className="flex items-center gap-3">
+                      <div
+                        className="bg-muted text-muted-foreground flex size-10 shrink-0 items-center justify-center rounded-md border"
+                        aria-hidden
+                      >
+                        <PlatformIcon className="size-5" />
+                      </div>
+                      <div className="flex flex-col">
+                        <Link
+                          href={`/logs/${log.id}`}
+                          className="font-medium hover:underline"
+                        >
+                          {log.title_en}
+                        </Link>
+                        <span className="text-muted-foreground text-xs">
+                          {platformLabel}
+                        </span>
+                      </div>
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-sm">
+                    {formatDate(getDateValue(log, config.dateField))}
+                  </TableCell>
+                </TableRow>
+              )
+            })}
           </TableBody>
         </Table>
       )}

--- a/apps/admin/app/(authed)/logs/_components/LogSection.tsx
+++ b/apps/admin/app/(authed)/logs/_components/LogSection.tsx
@@ -21,7 +21,6 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { cn } from "@/lib/utils"
-import { PLATFORM_OPTIONS } from "@/lib/logs/options"
 import type { LogPlatform, LogRow } from "@/lib/logs/types"
 
 export type LogSectionVariant =
@@ -98,14 +97,6 @@ const PLATFORM_ICON_BG: Record<LogPlatform, string> = {
   infra: "#722F37",
 }
 
-const PLATFORM_LABELS: Record<LogPlatform, string> = PLATFORM_OPTIONS.reduce(
-  (acc, o) => {
-    acc[o.value] = o.label
-    return acc
-  },
-  {} as Record<LogPlatform, string>,
-)
-
 function formatDate(value: string) {
   return new Date(value).toLocaleString(undefined, {
     year: "numeric",
@@ -162,29 +153,23 @@ export function LogSection({
             {logs.map((log) => {
               const platform = isLogPlatform(log.platform) ? log.platform : "all"
               const PlatformIcon = PLATFORM_ICONS[platform]
-              const platformLabel = PLATFORM_LABELS[platform] ?? log.platform
               return (
                 <TableRow key={log.id}>
                   <TableCell>
                     <div className="flex items-center gap-3">
                       <div
-                        className="flex size-10 shrink-0 items-center justify-center rounded-md text-white"
+                        className="flex size-7 shrink-0 items-center justify-center rounded-md text-white"
                         style={{ backgroundColor: PLATFORM_ICON_BG[platform] }}
                         aria-hidden
                       >
-                        <PlatformIcon className="size-5" />
+                        <PlatformIcon className="size-3" strokeWidth={3} />
                       </div>
-                      <div className="flex flex-col">
-                        <Link
-                          href={`/logs/${log.id}`}
-                          className="font-medium hover:underline"
-                        >
-                          {log.title_en}
-                        </Link>
-                        <span className="text-muted-foreground text-xs">
-                          {platformLabel}
-                        </span>
-                      </div>
+                      <Link
+                        href={`/logs/${log.id}`}
+                        className="font-medium hover:underline"
+                      >
+                        {log.title_en}
+                      </Link>
                     </div>
                   </TableCell>
                   <TableCell className="text-muted-foreground text-sm">

--- a/apps/admin/app/(authed)/logs/_components/LogSection.tsx
+++ b/apps/admin/app/(authed)/logs/_components/LogSection.tsx
@@ -16,8 +16,6 @@ import {
   Table,
   TableBody,
   TableCell,
-  TableHead,
-  TableHeader,
   TableRow,
 } from "@/components/ui/table"
 import { cn } from "@/lib/utils"
@@ -152,19 +150,16 @@ export function LogSection({
         </div>
       ) : (
         <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Title</TableHead>
-              <TableHead className="w-44">{config.dateLabel}</TableHead>
-            </TableRow>
-          </TableHeader>
           <TableBody>
             {logs.map((log) => {
               const platform = isLogPlatform(log.platform) ? log.platform : "all"
               const PlatformIcon = PLATFORM_ICONS[platform]
               return (
-                <TableRow key={log.id}>
-                  <TableCell>
+                <TableRow
+                  key={log.id}
+                  className="group border-b-0 hover:bg-transparent"
+                >
+                  <TableCell className="rounded-l-md group-hover:bg-muted/50">
                     <div className="flex items-center gap-3">
                       <div
                         className="flex size-7 shrink-0 items-center justify-center rounded-md"
@@ -184,7 +179,7 @@ export function LogSection({
                       </Link>
                     </div>
                   </TableCell>
-                  <TableCell className="text-muted-foreground text-sm">
+                  <TableCell className="text-muted-foreground w-44 rounded-r-md text-sm group-hover:bg-muted/50">
                     {formatDate(getDateValue(log, config.dateField))}
                   </TableCell>
                 </TableRow>

--- a/apps/admin/app/(authed)/logs/_components/LogSection.tsx
+++ b/apps/admin/app/(authed)/logs/_components/LogSection.tsx
@@ -89,6 +89,15 @@ const PLATFORM_ICONS: Record<LogPlatform, LucideIcon> = {
   project: Telescope,
 }
 
+const PLATFORM_ICON_BG: Record<LogPlatform, string> = {
+  ios: "#000000",
+  webapp: "#087ea4",
+  android: "#2e9249",
+  all: "#C07A7A",
+  project: "#7A5E64",
+  infra: "#722F37",
+}
+
 const PLATFORM_LABELS: Record<LogPlatform, string> = PLATFORM_OPTIONS.reduce(
   (acc, o) => {
     acc[o.value] = o.label
@@ -159,7 +168,8 @@ export function LogSection({
                   <TableCell>
                     <div className="flex items-center gap-3">
                       <div
-                        className="bg-muted text-muted-foreground flex size-10 shrink-0 items-center justify-center rounded-md border"
+                        className="flex size-10 shrink-0 items-center justify-center rounded-md text-white"
+                        style={{ backgroundColor: PLATFORM_ICON_BG[platform] }}
                         aria-hidden
                       >
                         <PlatformIcon className="size-5" />

--- a/apps/admin/app/(authed)/logs/_components/LogSection.tsx
+++ b/apps/admin/app/(authed)/logs/_components/LogSection.tsx
@@ -89,12 +89,21 @@ const PLATFORM_ICONS: Record<LogPlatform, LucideIcon> = {
 }
 
 const PLATFORM_ICON_BG: Record<LogPlatform, string> = {
+  ios: "#00000022",
+  webapp: "#087ea422",
+  android: "#2e924922",
+  all: "#C07A7A",
+  project: "#C07A7A22",
+  infra: "#AA333322",
+}
+
+const PLATFORM_ICON_FG: Record<LogPlatform, string> = {
   ios: "#000000",
   webapp: "#087ea4",
   android: "#2e9249",
-  all: "#C07A7A",
-  project: "#7A5E64",
-  infra: "#722F37",
+  all: "#FFFFFF",
+  project: "#C07A7A",
+  infra: "#AA3333",
 }
 
 function formatDate(value: string) {
@@ -158,8 +167,11 @@ export function LogSection({
                   <TableCell>
                     <div className="flex items-center gap-3">
                       <div
-                        className="flex size-7 shrink-0 items-center justify-center rounded-md text-white"
-                        style={{ backgroundColor: PLATFORM_ICON_BG[platform] }}
+                        className="flex size-7 shrink-0 items-center justify-center rounded-md"
+                        style={{
+                          backgroundColor: PLATFORM_ICON_BG[platform],
+                          color: PLATFORM_ICON_FG[platform],
+                        }}
                         aria-hidden
                       >
                         <PlatformIcon className="size-3" strokeWidth={3} />

--- a/apps/admin/app/(authed)/logs/announcements/_components/AnnouncementsPublishedSection.tsx
+++ b/apps/admin/app/(authed)/logs/announcements/_components/AnnouncementsPublishedSection.tsx
@@ -18,5 +18,12 @@ export async function AnnouncementsPublishedSection() {
 
   const logs: LogRow[] = data ?? []
 
-  return <LogSection title="Published" logs={logs} emptyLabel="No published announcements." />
+  return (
+    <LogSection
+      title="Published"
+      logs={logs}
+      emptyLabel="No published announcements."
+      variant="published"
+    />
+  )
 }

--- a/apps/admin/app/(authed)/logs/announcements/page.tsx
+++ b/apps/admin/app/(authed)/logs/announcements/page.tsx
@@ -34,7 +34,7 @@ export default async function AnnouncementsPage() {
         </Link>
       </header>
       <div className="space-y-8">
-        <LogSection title="Drafts" logs={drafts} emptyLabel="No drafts." />
+        <LogSection title="Drafts" logs={drafts} emptyLabel="No drafts." variant="drafts" />
         <Suspense fallback={<LogSectionSkeleton title="Published" />}>
           <AnnouncementsPublishedSection />
         </Suspense>

--- a/apps/admin/app/(authed)/logs/features/_components/FeaturesShippedSection.tsx
+++ b/apps/admin/app/(authed)/logs/features/_components/FeaturesShippedSection.tsx
@@ -29,5 +29,12 @@ export async function FeaturesShippedSection({
 
   const logs: LogRow[] = data ?? []
 
-  return <LogSection title="Shipped" logs={logs} emptyLabel="No shipped features." />
+  return (
+    <LogSection
+      title="Shipped"
+      logs={logs}
+      emptyLabel="No shipped features."
+      variant="shipped"
+    />
+  )
 }

--- a/apps/admin/app/(authed)/logs/features/_components/PlatformFilter.tsx
+++ b/apps/admin/app/(authed)/logs/features/_components/PlatformFilter.tsx
@@ -1,21 +1,12 @@
 "use client"
 
-import { useId } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import { Label } from "@/components/ui/label"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { PLATFORM_FILTER_OPTIONS } from "@/lib/logs/options"
 
 const ANY = "any"
 
 export function PlatformFilter() {
-  const id = useId()
   const router = useRouter()
   const params = useSearchParams()
   const current = params.get("platform") ?? ANY
@@ -31,23 +22,15 @@ export function PlatformFilter() {
   }
 
   return (
-    <div className="space-y-1 text-sm">
-      <Label htmlFor={id} className="text-muted-foreground">
-        Platform
-      </Label>
-      <Select value={current} onValueChange={(v) => onChange(v ?? ANY)}>
-        <SelectTrigger id={id} className="w-44">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value={ANY}>Any platform</SelectItem>
-          {PLATFORM_FILTER_OPTIONS.map((o) => (
-            <SelectItem key={o.value} value={o.value}>
-              {o.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
+    <Tabs value={current} onValueChange={(v) => onChange(typeof v === "string" ? v : ANY)}>
+      <TabsList>
+        <TabsTrigger value={ANY}>Any</TabsTrigger>
+        {PLATFORM_FILTER_OPTIONS.map((o) => (
+          <TabsTrigger key={o.value} value={o.value}>
+            {o.label}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
   )
 }

--- a/apps/admin/app/(authed)/logs/features/page.tsx
+++ b/apps/admin/app/(authed)/logs/features/page.tsx
@@ -64,9 +64,20 @@ export default async function FeaturesPage({ searchParams }: { searchParams: Sea
           title="In progress"
           logs={grouped.in_progress}
           emptyLabel="No features in progress."
+          variant="in_progress"
         />
-        <LogSection title="Planned" logs={grouped.planned} emptyLabel="No planned features." />
-        <LogSection title="Backlog" logs={grouped.backlog} emptyLabel="No backlog features." />
+        <LogSection
+          title="Planned"
+          logs={grouped.planned}
+          emptyLabel="No planned features."
+          variant="planned"
+        />
+        <LogSection
+          title="Backlog"
+          logs={grouped.backlog}
+          emptyLabel="No backlog features."
+          variant="backlog"
+        />
         <Suspense fallback={<LogSectionSkeleton title="Shipped" />}>
           <FeaturesShippedSection platform={platform} />
         </Suspense>


### PR DESCRIPTION
Resolves #424

## Summary

- Replace the platform `Select` on `/logs/features` with a shadcn `Tabs` filter (Any / Web app / iOS / Android).
- Redesign `LogSection` tables: each row gets a squared icon box with a Lucide platform icon (`apple`/`monitor`/`bot`/`monitor-smartphone`/`database-zap`/`telescope`), and the title now stacks vertically over a small platform label, replacing the separate Platform column.
- The date column reflects the section: `released_at` (Released) for shipped features, `published_at` (Published) for published announcements, and `updated_at` (Updated) elsewhere, falling back to `updated_at` when the preferred field is null.
- Add colored Lucide section icons via a new `variant` prop on `LogSection`: `circle-dot-dashed` (blue) for In progress, `circle-fading-arrow-up` (yellow) for Planned, `circle-pile` (muted) for Backlog, `circle-check-big` (green) for Shipped. Drafts and Published announcements stay unadorned.

## Key files

- `apps/admin/app/(authed)/logs/features/_components/PlatformFilter.tsx` — Select → Tabs.
- `apps/admin/app/(authed)/logs/_components/LogSection.tsx` — variant config, platform icon box, stacked title/platform, smart date column.
- `apps/admin/app/(authed)/logs/features/page.tsx`, `.../features/_components/FeaturesShippedSection.tsx`, `.../announcements/page.tsx`, `.../announcements/_components/AnnouncementsPublishedSection.tsx` — pass the appropriate `variant`.

## Test plan

- [ ] `/logs/features`: switch platform tabs; verify URL `?platform=` updates and the lists filter accordingly.
- [ ] Each section header shows the correct icon and color.
- [ ] Table rows show the squared platform icon, title stacked over the platform label, and the right date column (Released for Shipped features, Published for Published announcements, Updated elsewhere).
- [ ] `/logs/announcements`: Drafts and Published sections render without a status icon.
- [ ] `npm run lint --workspace=apps/admin` is green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XTjUqNbpaUBSXHztdnJ4d6)_