### PR TITLE
fix(logs): sort shipped features by released_at instead of updated_at

### DIFF
--- a/apps/admin/app/(authed)/logs/features/_components/FeaturesShippedSection.tsx
+++ b/apps/admin/app/(authed)/logs/features/_components/FeaturesShippedSection.tsx
@@ -15,7 +15,7 @@ export async function FeaturesShippedSection({
     .select("*")
     .eq("species", "feature")
     .eq("status", "shipped")
-    .order("updated_at", { ascending: false })
+    .order("released_at", { ascending: false, nullsFirst: false })
 
   if (platform) {
     query = query.in("platform", [platform, "all"])


### PR DESCRIPTION
Resolves #434 

## Changes
- **FeaturesShippedSection.tsx**: Updated the query ordering from `updated_at` (ascending: false) to `released_at` (ascending: false, nullsFirst: false)
  - This ensures shipped features are sorted by their release date rather than last update date
  - Added `nullsFirst: false` to handle any null `released_at` values by placing them at the end

## Notes
- This is a small, single-file change affecting the features shipped log display
- The change prioritizes release date as the canonical sort order for shipped features, which is more semantically correct than update date
- `nullsFirst: false` ensures any features without a release date don't appear first in the list

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_015i7MthEJZe9GpXfCyLiVCk