### PR TITLE
feat(logs): add released_at field and prioritize in timeline

### DIFF
--- a/apps/web/components/lab/LogTimeline.tsx
+++ b/apps/web/components/lab/LogTimeline.tsx
@@ -35,14 +35,14 @@ export function LogTimeline({ mode, logs, locale, renderTrailing }: LogTimelineP
     <ol className="flex flex-col">
       {logs.map((log, index) => {
         const isLast = index === logs.length - 1
-        const date =
-          showDate && log.published_at
-            ? formatDate(log.published_at, {
-                day: "numeric",
-                month: "long",
-                year: "numeric",
-              })
-            : null
+        const dateSource = showDate ? (log.released_at ?? log.published_at) : null
+        const date = dateSource
+          ? formatDate(dateSource, {
+              day: "numeric",
+              month: "long",
+              year: "numeric",
+            })
+          : null
         const trailing = renderTrailing?.(log)
 
         return (

--- a/apps/web/lib/data/logs-api.ts
+++ b/apps/web/lib/data/logs-api.ts
@@ -22,6 +22,7 @@ type LogRow = {
   external_url: string | null
   published: boolean | null
   published_at: string | null
+  released_at: string | null
   created_at: string | null
   reaction_count: number | null
 }
@@ -46,6 +47,7 @@ function rowToLog(row: LogRow): Log | null {
     external_url: row.external_url,
     published: row.published ?? false,
     published_at: row.published_at,
+    released_at: row.released_at,
     created_at: row.created_at,
     reaction_count: row.reaction_count ?? 0,
   }
@@ -88,6 +90,7 @@ export async function fetchChangelog(
     .eq("status", "shipped")
     .eq("published", true)
     .in("platform", WEB_PLATFORMS as unknown as string[])
+    .order("released_at", { ascending: false, nullsFirst: false })
     .order("published_at", { ascending: false })
   if (options?.limit) query = query.limit(options.limit)
   const { data, error } = await query

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -109,6 +109,7 @@ export type Log = {
   external_url: string | null
   published: boolean
   published_at: string | null
+  released_at: string | null
   created_at: string
   reaction_count: number
 }


### PR DESCRIPTION
Resolves #433

## Changes

- **apps/web/lib/types.ts**: Added `released_at: string | null` field to the `Log` type
- **apps/web/lib/data/logs-api.ts**: 
  - Added `released_at` to `LogRow` type definition
  - Mapped `released_at` from database rows to `Log` objects
  - Updated changelog query to order by `released_at` (descending, nulls last) before `published_at`
- **apps/web/components/lab/LogTimeline.tsx**: Updated date selection logic to prefer `released_at` over `published_at` when displaying log dates

## Notes

The changes introduce a new `released_at` field to distinguish between when a log entry was published (metadata) versus when the actual feature/change was released. The timeline now prioritizes `released_at` for display and sorting, falling back to `published_at` if `released_at` is not available. The database query ordering ensures logs are sorted by release date first, then by publish date as a secondary sort.

## Checklist
- [ ] Branch name follows `type/issueNumber-description`
- [ ] PR title uses conventional commits: `type(scope): description`
- [ ] Labels applied (species + scope)
- [ ] Milestone assigned
- [ ] `npm run build` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_01JJywnNz3bpUt96sxqmB9rs