### PR TITLE
fix(auth): tighten ios email validation and normalize input

### DIFF
--- a/apps/ios/Pebbles/Features/Auth/AuthView.swift
+++ b/apps/ios/Pebbles/Features/Auth/AuthView.swift
@@ -28,6 +28,7 @@ struct AuthView: View {
     @State private var privacyAccepted = false
     @State private var presentedLegalDoc: LegalDoc?
     @State private var authError: String?
+    @State private var emailError: LocalizedStringResource?
 
     init(initialMode: Mode = .login) {
         _mode = State(initialValue: initialMode)
@@ -39,14 +40,24 @@ struct AuthView: View {
                 .padding(.top, 24)
 
             VStack(spacing: 12) {
-                PebblesTextInput(
-                    placeholder: "Email",
-                    text: $email,
-                    contentType: .emailAddress,
-                    keyboard: .emailAddress,
-                    autocapitalization: .never,
-                    autocorrection: false
-                )
+                VStack(alignment: .leading, spacing: 4) {
+                    PebblesTextInput(
+                        placeholder: "Email",
+                        text: $email,
+                        contentType: .emailAddress,
+                        keyboard: .emailAddress,
+                        autocapitalization: .never,
+                        autocorrection: false
+                    )
+
+                    if let emailError {
+                        Text(emailError)
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                            .multilineTextAlignment(.leading)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
 
                 PebblesTextInput(
                     placeholder: "Password",
@@ -118,8 +129,25 @@ struct AuthView: View {
                 privacyAccepted = false
             }
         }
-        .onChange(of: email) { _, _ in
+        .onChange(of: email) { oldValue, newValue in
+            // Writing `email = normalized` below re-enters this closure with
+            // the normalized string. Detect that and skip so we don't undo
+            // the emailError we just set when stripping a '+'.
+            if oldValue != newValue, Self.normalizeEmailInput(oldValue) == newValue {
+                return
+            }
             if authError != nil { authError = nil }
+            // Stripping '+' is the only normalization that requires an inline
+            // explanation — lowercasing is silent on purpose.
+            if newValue.contains("+") {
+                emailError = "The '+' character is not allowed in email addresses."
+            } else if emailError != nil {
+                emailError = nil
+            }
+            let normalized = Self.normalizeEmailInput(newValue)
+            if normalized != newValue {
+                email = normalized
+            }
         }
         .onChange(of: password) { _, _ in
             if authError != nil { authError = nil }
@@ -147,8 +175,12 @@ struct AuthView: View {
         privacyAccepted: Bool,
         isSubmitting: Bool
     ) -> Bool {
+        let trimmed = email.trimmingCharacters(in: .whitespaces)
         guard !isSubmitting,
-              email.contains("@"),
+              !trimmed.isEmpty,
+              trimmed.contains("@"),
+              trimmed.contains("."),
+              !trimmed.contains("+"),
               password.count >= 6
         else { return false }
 
@@ -158,16 +190,26 @@ struct AuthView: View {
         return true
     }
 
+    /// Lowercases and strips disallowed characters from raw email input.
+    /// Real-time scrubbing keeps the visible field, the submitted value, and
+    /// the server's view of the address in sync.
+    static func normalizeEmailInput(_ raw: String) -> String {
+        var result = raw.lowercased()
+        result.removeAll { $0 == "+" }
+        return result
+    }
+
     private func submit() {
         isSubmitting = true
         authError = nil
+        let submittedEmail = email.trimmingCharacters(in: .whitespaces)
         Task {
             do {
                 switch mode {
                 case .login:
-                    try await supabase.signIn(email: email, password: password)
+                    try await supabase.signIn(email: submittedEmail, password: password)
                 case .signup:
-                    try await supabase.signUp(email: email, password: password)
+                    try await supabase.signUp(email: submittedEmail, password: password)
                 }
             } catch {
                 authError = error.localizedDescription

--- a/apps/ios/Pebbles/Resources/Localizable.xcstrings
+++ b/apps/ios/Pebbles/Resources/Localizable.xcstrings
@@ -3952,6 +3952,23 @@
         }
       }
     },
+    "The '+' character is not allowed in email addresses." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The '+' character is not allowed in email addresses."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le caractère « + » n’est pas autorisé dans les adresses e-mail."
+          }
+        }
+      }
+    },
     "This can't be undone." : {
       "extractionState" : "manual",
       "localizations" : {

--- a/apps/ios/PebblesTests/Features/Auth/AuthViewLogicTests.swift
+++ b/apps/ios/PebblesTests/Features/Auth/AuthViewLogicTests.swift
@@ -74,4 +74,51 @@ struct AuthViewLogicTests {
             termsAccepted: true, privacyAccepted: true, isSubmitting: true
         ) == false)
     }
+
+    @Test("login: email missing dot returns false")
+    func loginEmailMissingDot() {
+        #expect(AuthView.canSubmit(
+            mode: .login, email: "hello@bohns", password: "abcdef",
+            termsAccepted: false, privacyAccepted: false, isSubmitting: false
+        ) == false)
+    }
+
+    @Test("login: email with '+' returns false")
+    func loginEmailWithPlus() {
+        #expect(AuthView.canSubmit(
+            mode: .login, email: "hello+work@bohns.design", password: "abcdef",
+            termsAccepted: false, privacyAccepted: false, isSubmitting: false
+        ) == false)
+    }
+
+    @Test("login: whitespace-only email returns false")
+    func loginWhitespaceEmail() {
+        #expect(AuthView.canSubmit(
+            mode: .login, email: "   ", password: "abcdef",
+            termsAccepted: false, privacyAccepted: false, isSubmitting: false
+        ) == false)
+    }
+
+    @Test("login: email with surrounding whitespace is accepted")
+    func loginEmailTrimmed() {
+        #expect(AuthView.canSubmit(
+            mode: .login, email: "  hello@bohns.design  ", password: "abcdef",
+            termsAccepted: false, privacyAccepted: false, isSubmitting: false
+        ) == true)
+    }
+
+    @Test("normalizeEmailInput lowercases uppercase characters")
+    func normalizeLowercases() {
+        #expect(AuthView.normalizeEmailInput("Hello@Bohns.Design") == "hello@bohns.design")
+    }
+
+    @Test("normalizeEmailInput strips '+' characters")
+    func normalizeStripsPlus() {
+        #expect(AuthView.normalizeEmailInput("hello+work@bohns.design") == "hellowork@bohns.design")
+    }
+
+    @Test("normalizeEmailInput is idempotent on a clean address")
+    func normalizeIdempotent() {
+        #expect(AuthView.normalizeEmailInput("hello@bohns.design") == "hello@bohns.design")
+    }
 }


### PR DESCRIPTION
Resolves #409

## Summary
- Replace the weak `email.contains("@")` guard in `AuthView.canSubmit` with a stronger check: trim whitespace, require `@` and `.`, forbid `+`, and reject empty/whitespace-only input.
- Add real-time email normalization in `.onChange(of: email)` — lowercases every keystroke/paste and strips any `+` character. A re-entry guard prevents the closure's own write from clearing the inline error.
- Render a localized inline error directly under the email field when the user types a `+`. Cleared as soon as the offending character is gone.
- `submit()` sends the trimmed email so trailing whitespace doesn't reach Supabase.
- The `PebblesTextInput` config (email keyboard, no autocorrect, no autocapitalize, `.emailAddress` content type for autofill) was already correct — no changes needed there.

## Files
- `apps/ios/Pebbles/Features/Auth/AuthView.swift` — `canSubmit`, new `normalizeEmailInput`, `.onChange` rewrite, inline `emailError` rendering.
- `apps/ios/Pebbles/Resources/Localizable.xcstrings` — new key for the inline error (en + fr, both `translated`).
- `apps/ios/PebblesTests/Features/Auth/AuthViewLogicTests.swift` — 7 new Swift Testing cases covering `.`, `+`, whitespace, and the normalizer.

## Notes
- The `+` ban is intentional even though RFC 5322 allows it — per product decision to prevent Gmail-alias multi-account abuse. Inline error explains it to the user.
- Server remains the authority on email format; client now agrees with Supabase instead of passing strings the server will reject.

## Test plan
- [ ] Open `Localizable.xcstrings` in Xcode and confirm the new entry has values in both `en` and `fr` columns and is not in `New`/`Stale` state.
- [ ] Manually test on a simulator: type `Hello+World@Example.com`, confirm it normalizes to `helloworld@example.com` and shows the inline `+` error.
- [ ] Confirm the inline error disappears once the user removes the `+` character.
- [ ] Confirm Supabase autofill from a saved credential still works (the email field still declares `.emailAddress` content type).
- [ ] `npm run test --workspace=@pbbls/ios` — all 16 `AuthView.canSubmit` tests pass (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)