### PR TITLE
feat(db): profile glyph fk and engagement rpc

### DIFF
--- a/docs/superpowers/plans/2026-05-16-profile-data-foundations.md
+++ b/docs/superpowers/plans/2026-05-16-profile-data-foundations.md
@@ -1,0 +1,463 @@
+# Profile data foundations — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the SQL foundations (one migration + two RPCs + a column) needed by the iOS Profile redesign (#451) and the new Settings sheet (#452). No iOS code.
+
+**Architecture:** Single migration adds `profiles.glyph_id` (nullable FK to `glyphs`), `update_profile(p_display_name, p_glyph_id)` for atomic field-level edits, and `get_profile_engagement(p_tz)` returning a 28-day timezone-aware assiduity bitmap + all-time distinct-day count. Both RPCs use `security invoker` and rely on the existing `profiles_*` / `pebbles_*` RLS policies (`user_id = auth.uid()`) — matching the pattern in `path_pebbles`.
+
+**Tech Stack:** Postgres 15 (Supabase), `supabase` CLI, generated TypeScript types in `packages/supabase/types/database.ts`.
+
+**Issue:** #450. **Closes:** #450. **Spec:** `docs/superpowers/specs/2026-05-16-ios-profile-redesign-and-settings-design.md` § Issue 1.
+
+**No tests:** `@pbbls/supabase` has no test harness (the `lint` script is a placeholder). Verification is done by calling the new RPCs against the remote Supabase database and inspecting output (Tasks 5–6). Repo policy per project memory: deploy to remote, not local Docker.
+
+**Arkaik:** Skipped here. RPCs without UI consumers are invisible to the product graph. The Arkaik update happens in #451 when the iOS surface lands.
+
+---
+
+### Task 1: Create the feature branch
+
+**Files:** none.
+
+- [ ] **Step 1: Verify clean working tree on `main`**
+
+```bash
+git status
+git branch --show-current
+```
+
+Expected: `nothing to commit, working tree clean` and current branch is `main`.
+
+- [ ] **Step 2: Create and switch to the feature branch**
+
+```bash
+git checkout -b feat/450-profile-data-foundations
+```
+
+Expected: `Switched to a new branch 'feat/450-profile-data-foundations'`.
+
+---
+
+### Task 2: Generate the migration file
+
+**Files:**
+- Create: `packages/supabase/supabase/migrations/<timestamp>_profile_glyph_and_engagement.sql`
+
+- [ ] **Step 1: Generate an empty migration via the CLI**
+
+```bash
+npm run db:migration:new --workspace=packages/supabase -- profile_glyph_and_engagement
+```
+
+Expected: a new file appears under `packages/supabase/supabase/migrations/` whose name ends in `_profile_glyph_and_engagement.sql`. The file will be empty.
+
+- [ ] **Step 2: Record the generated filename**
+
+```bash
+ls -t packages/supabase/supabase/migrations/ | head -1
+```
+
+Note the printed filename. Subsequent tasks refer to it as `<MIGRATION_FILE>`.
+
+---
+
+### Task 3: Write the migration SQL
+
+**Files:**
+- Modify: `packages/supabase/supabase/migrations/<MIGRATION_FILE>` (created in Task 2)
+
+- [ ] **Step 1: Write the full migration contents**
+
+Replace the empty file with exactly:
+
+```sql
+-- ============================================================
+-- Migration: profile glyph FK + engagement RPC
+-- ------------------------------------------------------------
+-- 1. Adds profiles.glyph_id (nullable FK to glyphs).
+-- 2. update_profile(p_display_name, p_glyph_id):
+--    atomic field-level edit. Null args mean "do not change".
+--    Relies on profiles_update RLS (user_id = auth.uid()).
+-- 3. get_profile_engagement(p_tz):
+--    returns days_practiced (all-time distinct days with a
+--    pebble) and assiduity (28-element bool[] for the last 28
+--    days), both bucketed in the caller's IANA timezone.
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. Schema: profiles.glyph_id
+-- ------------------------------------------------------------
+
+alter table public.profiles
+  add column glyph_id uuid references public.glyphs(id) on delete set null;
+
+create index profiles_glyph_id_idx on public.profiles(glyph_id);
+
+-- ------------------------------------------------------------
+-- 2. update_profile
+-- ------------------------------------------------------------
+-- Returns the updated profile row (or no row if RLS blocked /
+-- profile missing — caller treats absence as a not-found error).
+-- Both args default to null; null means "leave column unchanged".
+-- We intentionally cannot clear glyph_id via this RPC: there is
+-- no UX for it. A future "remove glyph" feature should add a
+-- dedicated p_clear_glyph boolean rather than re-interpreting null.
+
+create or replace function public.update_profile(
+  p_display_name text default null,
+  p_glyph_id     uuid default null
+)
+returns public.profiles
+language sql
+security invoker
+set search_path = public
+as $$
+  update public.profiles
+     set display_name = coalesce(p_display_name, display_name),
+         glyph_id     = case
+                          when p_glyph_id is not null then p_glyph_id
+                          else glyph_id
+                        end,
+         updated_at   = now()
+   where user_id = auth.uid()
+   returning *;
+$$;
+
+grant execute on function public.update_profile(text, uuid) to authenticated;
+
+-- ------------------------------------------------------------
+-- 3. get_profile_engagement
+-- ------------------------------------------------------------
+-- p_tz: IANA timezone string (e.g. 'Europe/Paris'). The client
+-- passes TimeZone.current.identifier on iOS.
+--
+-- Returns:
+--   days_practiced int       — all-time distinct days the user
+--                              has created at least one pebble,
+--                              bucketed in p_tz.
+--   assiduity     boolean[]  — length 28. Index 1 = 27 days ago,
+--                              index 28 = today (in p_tz). true
+--                              when ≥1 pebble was created on
+--                              that local-day.
+--
+-- security invoker: RLS on public.pebbles already restricts to
+-- the caller's rows (user_id = auth.uid()).
+
+create or replace function public.get_profile_engagement(p_tz text)
+returns table (
+  days_practiced int,
+  assiduity      boolean[]
+)
+language sql
+security invoker
+stable
+set search_path = public
+as $$
+  with
+    today_local as (
+      select (now() at time zone p_tz)::date as d
+    ),
+    window_days as (
+      select generate_series(
+        (select d from today_local) - interval '27 days',
+        (select d from today_local),
+        interval '1 day'
+      )::date as d
+    ),
+    active_days as (
+      select distinct (p.created_at at time zone p_tz)::date as d
+        from public.pebbles p
+       where p.user_id = auth.uid()
+    ),
+    grid as (
+      select array_agg((ad.d is not null) order by w.d) as assiduity
+        from window_days w
+        left join active_days ad using (d)
+    ),
+    counts as (
+      select count(*)::int as days_practiced from active_days
+    )
+  select counts.days_practiced, grid.assiduity
+    from counts, grid;
+$$;
+
+grant execute on function public.get_profile_engagement(text) to authenticated;
+```
+
+---
+
+### Task 4: Deploy the migration to remote Supabase
+
+**Files:** none modified; deploys the migration created in Task 3 to the linked remote project.
+
+Per project memory (`avoid_docker.md`), we deploy to remote and **never** use local Docker. The CLI must already be linked to the remote project (`npm run db:status --workspace=packages/supabase` will confirm).
+
+- [ ] **Step 1: Confirm the link**
+
+```bash
+npm run db:migration:list --workspace=packages/supabase
+```
+
+Expected: a table listing local + remote migration versions side-by-side. Your new `<MIGRATION_FILE>` appears in the `Local` column with no entry in `Remote`.
+
+- [ ] **Step 2: Push migrations to remote**
+
+```bash
+npm run db:push --workspace=packages/supabase
+```
+
+Expected: the CLI prints the list of migrations to apply (your new one), prompts `Do you want to push these migrations to the remote database? [Y/n]`. Confirm `Y`. Final output ends with `Finished supabase db push.` and no error.
+
+- [ ] **Step 3: Re-verify the push**
+
+```bash
+npm run db:migration:list --workspace=packages/supabase
+```
+
+Expected: your `<MIGRATION_FILE>` now appears in both `Local` and `Remote` columns.
+
+---
+
+### Task 5: Verify `update_profile` against remote
+
+**Files:** none.
+
+We verify by calling the RPC as an authenticated user. Use the Supabase dashboard SQL editor (signed in as a developer/owner of the project) — direct SQL works because the dashboard runs as `postgres` and we can impersonate via `set local request.jwt.claim.sub`. Alternative: any test account on iOS/web that exercises the call.
+
+- [ ] **Step 1: Run a read-back to capture a baseline**
+
+In the Supabase dashboard SQL editor, run (substitute `<YOUR_USER_ID>` with a real `auth.users.id` you own):
+
+```sql
+select id, display_name, glyph_id, updated_at
+  from public.profiles
+ where user_id = '<YOUR_USER_ID>';
+```
+
+Expected: one row. Note current `display_name`, `glyph_id`, `updated_at`.
+
+- [ ] **Step 2: Call `update_profile` as that user**
+
+```sql
+set local role authenticated;
+set local request.jwt.claim.sub = '<YOUR_USER_ID>';
+
+select * from public.update_profile(p_display_name => 'Verification Name');
+```
+
+Expected: returns the updated profile row with `display_name = 'Verification Name'`, `glyph_id` unchanged, `updated_at` bumped to roughly `now()`.
+
+- [ ] **Step 3: Verify the null-arg semantics**
+
+```sql
+select * from public.update_profile();
+```
+
+Expected: returns the same profile row, `display_name` still `'Verification Name'`, no values changed. `updated_at` still bumps (the `set updated_at = now()` always fires) — acceptable, documented as such.
+
+- [ ] **Step 4: Restore the original `display_name`**
+
+```sql
+select * from public.update_profile(p_display_name => '<ORIGINAL_NAME>');
+```
+
+Expected: row restored to baseline.
+
+- [ ] **Step 5: Verify RLS isolation**
+
+```sql
+set local request.jwt.claim.sub = '<DIFFERENT_USER_ID>';
+
+select * from public.update_profile(p_display_name => 'Should Not Apply');
+```
+
+Expected: returns no rows (the UPDATE matched zero because RLS scoped the `where user_id = auth.uid()` to the other user; if no profile exists for that user, also zero rows). Confirm the original user's row in step 1 is unchanged.
+
+---
+
+### Task 6: Verify `get_profile_engagement` against remote
+
+**Files:** none.
+
+- [ ] **Step 1: Call the RPC with a known timezone**
+
+In the dashboard SQL editor:
+
+```sql
+set local role authenticated;
+set local request.jwt.claim.sub = '<YOUR_USER_ID>';
+
+select * from public.get_profile_engagement('Europe/Paris');
+```
+
+Expected: one row with two columns. `days_practiced` is a non-negative integer matching your manual count of distinct `(p.created_at at time zone 'Europe/Paris')::date` across that user's pebbles. `assiduity` is an array of exactly 28 booleans.
+
+- [ ] **Step 2: Confirm the array length**
+
+```sql
+select array_length((public.get_profile_engagement('Europe/Paris')).assiduity, 1) as len;
+```
+
+Expected: `len = 28`.
+
+- [ ] **Step 3: Confirm timezone sensitivity**
+
+```sql
+select 'paris' as tz,    (public.get_profile_engagement('Europe/Paris')).*
+union all
+select 'auckland' as tz, (public.get_profile_engagement('Pacific/Auckland')).*;
+```
+
+Expected: both rows return 28-element arrays. If you created a pebble in a window where Paris-local-date and Auckland-local-date disagree (e.g. shortly before/after Auckland midnight), the assiduity arrays differ on those boundary days. This proves the bucketing is timezone-aware.
+
+- [ ] **Step 4: Confirm `today` is included**
+
+The last element (`assiduity[28]`) should be `true` if you have a pebble created today in `p_tz`. If you don't have one, create a pebble through the iOS app or insert manually, then re-run step 1 and confirm `assiduity[28]` flips to `true`.
+
+- [ ] **Step 5: Verify RLS isolation**
+
+```sql
+set local request.jwt.claim.sub = '<DIFFERENT_USER_ID>';
+
+select * from public.get_profile_engagement('Europe/Paris');
+```
+
+Expected: `days_practiced = 0`, `assiduity` is 28 `false` values (assuming the other user has no pebbles, or only their own data is returned regardless).
+
+---
+
+### Task 7: Regenerate TypeScript types from remote
+
+**Files:**
+- Modify: `packages/supabase/types/database.ts`
+
+- [ ] **Step 1: Regenerate from the linked remote project**
+
+```bash
+npm run db:types:remote --workspace=packages/supabase
+```
+
+Expected: `packages/supabase/types/database.ts` is rewritten in place, no stderr leakage. The script's redirect (`2>/dev/null`) is required — verified in `packages/supabase/CLAUDE.md`.
+
+- [ ] **Step 2: Sanity-check the regenerated file**
+
+```bash
+grep -n "glyph_id" packages/supabase/types/database.ts | head -10
+grep -n "update_profile\|get_profile_engagement" packages/supabase/types/database.ts | head -10
+```
+
+Expected:
+- `glyph_id` appears in the `profiles` table's `Row`, `Insert`, and `Update` types.
+- Both function names appear (under `Functions`) with correct argument and return-type shapes.
+
+- [ ] **Step 3: Confirm the workspace still type-checks**
+
+```bash
+npm run build --workspace=packages/supabase
+```
+
+Expected: exits 0 (the `build` script is `tsc --noEmit`).
+
+---
+
+### Task 8: Commit and push
+
+**Files:** none modified.
+
+- [ ] **Step 1: Stage the migration and regenerated types**
+
+```bash
+git add packages/supabase/supabase/migrations/*_profile_glyph_and_engagement.sql \
+        packages/supabase/types/database.ts
+git status
+```
+
+Expected: only those two files staged. No unrelated changes.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(db): add profile glyph fk and engagement rpc
+
+Adds profiles.glyph_id (nullable FK), update_profile RPC for atomic
+display_name/glyph edits, and get_profile_engagement RPC returning the
+28-day timezone-aware assiduity bitmap. Foundations for the profile
+redesign (#451) and settings sheet (#452).
+
+Refs #450
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: one commit on `feat/450-profile-data-foundations` containing the two files.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin feat/450-profile-data-foundations
+```
+
+Expected: branch published, returns a `Create a pull request for…` URL.
+
+---
+
+### Task 9: Open the PR
+
+**Files:** none.
+
+Per CLAUDE.md, PRs need labels + milestone confirmed before opening. The species/scope labels here mirror the issue: `feat`, `supabase`, `db`, `api`. Milestone: `M22 · Bounce karma & gamification`.
+
+- [ ] **Step 1: Open the PR**
+
+```bash
+gh pr create \
+  --title "feat(db): profile glyph fk and engagement rpc" \
+  --label "feat,supabase,db,api" \
+  --milestone "M22 · Bounce karma & gamification" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds `profiles.glyph_id` (nullable FK to `glyphs`, on delete set null) + index.
+- New RPC `update_profile(p_display_name, p_glyph_id)` — atomic field-level edits, null args mean "leave column unchanged", relies on existing `profiles_update` RLS.
+- New RPC `get_profile_engagement(p_tz)` — returns `days_practiced` + a 28-element `assiduity` boolean array bucketed in the caller's IANA timezone.
+- Regenerated `packages/supabase/types/database.ts` from the deployed remote schema.
+
+Foundations for the profile screen redesign (#451) and settings sheet (#452). Spec: `docs/superpowers/specs/2026-05-16-ios-profile-redesign-and-settings-design.md` § Issue 1.
+
+## Test plan
+
+- [ ] Migration applied cleanly to remote (`db:push` exit 0, `db:migration:list` shows it in both columns).
+- [ ] `update_profile` updates only the caller's row (verified via `set local request.jwt.claim.sub`).
+- [ ] `update_profile()` with no args is a no-op on column values (only `updated_at` bumps).
+- [ ] `get_profile_engagement(tz)` returns exactly 28 booleans and reflects the caller's pebbles.
+- [ ] `get_profile_engagement('Europe/Paris')` vs `'Pacific/Auckland')` differ on boundary days when relevant.
+- [ ] `packages/supabase` builds (`tsc --noEmit` exits 0).
+
+Resolves #450
+EOF
+)"
+```
+
+Expected: PR URL printed. Confirm the PR has the requested labels + milestone before merging.
+
+---
+
+## Self-review
+
+**Spec coverage (Issue 1 in the spec):**
+- `profiles.glyph_id` migration with FK + `on delete set null` → Task 3 step 1.
+- `update_profile(p_display_name, p_glyph_id)` security definer / `security invoker` — **deviation from spec**: spec showed `security definer`, plan uses `security invoker`. Justification embedded in the SQL comment: existing RLS already covers ownership, and matching `path_pebbles` style is cleaner. Spec's open question #5 ("verify by reading a sibling RPC") effectively closed by inspecting `path_pebbles` + `profiles_update` policy. Flag for reviewer.
+- `get_profile_engagement(p_tz)` returning `days_practiced` + `assiduity boolean[]` of length 28, timezone-aware → Task 3 step 1; verified Task 6.
+- Regenerated types committed → Tasks 7–8.
+- "Out of scope: any iOS code, clearing a profile glyph" — both honored (no iOS changes; null `p_glyph_id` documented as "do not change").
+- "Done when: migration deployed, RPCs callable with correct types, `database.ts` committed" → Tasks 4, 5–7, 8.
+
+**Placeholder scan:** no TBDs, no "add appropriate handling", every SQL block and command is concrete.
+
+**Type consistency:** `p_display_name` / `p_glyph_id` / `p_tz` parameter names used consistently across SQL, comments, and verification queries. `days_practiced` + `assiduity` column names match between RPC definition and verification queries.
+
+**One deliberate small ambiguity:** `<MIGRATION_FILE>` is a placeholder because the CLI generates the timestamp. The plan tells the engineer to record it in Task 2 step 2 and substitute thereafter. This is fine.

--- a/docs/superpowers/specs/2026-05-16-ios-profile-redesign-and-settings-design.md
+++ b/docs/superpowers/specs/2026-05-16-ios-profile-redesign-and-settings-design.md
@@ -1,0 +1,350 @@
+# iOS Profile redesign + Settings sheet — design
+
+**Date:** 2026-05-16
+**Status:** Approved (scope), pending implementation
+**Closes:** #445 (via Issue 2)
+**Replaces:** the legacy `ProfileView.swift` layout (Bounce/Karma stat rows + List sections)
+
+## Goal
+
+Transform the iOS Profile screen from a utilitarian `List` of stat/nav rows into a "comfy, beautiful" surface organised around the user's identity (banner), their engagement (Ripples + assiduity + counters), and their content (Collections, Lab). Extract the legal/account-management items into a dedicated Settings sheet that mirrors the Edit-mode pattern used elsewhere in the app.
+
+## Non-goals
+
+- **Stats page** — the destination behind the Stats card chevron is deferred to its own future issue. The chevron is suppressed in this batch.
+- **Account deletion**, **notification preferences**, **language override** — not in the Settings sheet.
+- **User-level glyphs** — the new glyph FK lives on `profiles`, not `auth.users`.
+- **Removing `bounce` from the database or admin analytics** — only the iOS surface is retired.
+
+## Scope decomposition
+
+This work ships as **three sequential issues**, each a vertical slice that leaves the app in a consistent state:
+
+1. **Profile data foundations** — schema + RPCs only, no UI.
+2. **Profile screen redesign** — full `ProfileView` rewrite, consumes Issue 1. Closes #445.
+3. **Settings sheet** — new sheet wired to the gear button stubbed in Issue 2.
+
+Each issue has its own branch, PR, and implementation plan. Issue 2 cannot start until Issue 1 is merged and types regenerated. Issue 3 can technically begin in parallel with Issue 2 but is cleaner sequentially.
+
+---
+
+## Issue 1 — Profile data foundations
+
+**Branch:** `feat/<n>-profile-data-foundations`
+**Surface:** SQL + generated types only. No Swift.
+
+### Migration
+
+New file under `packages/supabase/supabase/migrations/`:
+
+```sql
+-- Add the profile glyph FK (nullable; existing users start without one).
+alter table public.profiles
+  add column glyph_id uuid references public.glyphs(id) on delete set null;
+
+create index profiles_glyph_id_idx on public.profiles(glyph_id);
+```
+
+### `update_profile` RPC (new)
+
+No such RPC exists today. Profile name is currently set only via the auth trigger. We need a single multi-field updater so we can keep `display_name` and `glyph_id` writes atomic and consistent.
+
+```sql
+create or replace function public.update_profile(
+  p_display_name text default null,
+  p_glyph_id     uuid default null
+) returns public.profiles
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  updated public.profiles;
+begin
+  update public.profiles
+    set display_name = coalesce(p_display_name, display_name),
+        glyph_id     = case
+                         when p_glyph_id is not null then p_glyph_id
+                         else glyph_id
+                       end,
+        updated_at   = now()
+    where user_id = auth.uid()
+    returning * into updated;
+
+  if updated is null then
+    raise exception 'profile_not_found' using errcode = 'P0002';
+  end if;
+
+  return updated;
+end;
+$$;
+
+grant execute on function public.update_profile(text, uuid) to authenticated;
+```
+
+**Caveat about `glyph_id`:** `coalesce(p_glyph_id, glyph_id)` is wrong here — the caller may want to unset the glyph in the future (pass null intentionally). Because we currently have no "remove glyph" UX, we accept the asymmetry: a null arg means "don't change". If a future issue needs to clear the glyph, add a separate `p_clear_glyph boolean` parameter rather than re-interpreting null.
+
+### `get_profile_engagement` RPC (new)
+
+```sql
+create or replace function public.get_profile_engagement(p_tz text)
+returns table (
+  days_practiced int,
+  assiduity      boolean[]
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_today     date;
+  v_user_id   uuid := auth.uid();
+  v_practiced int;
+  v_grid      boolean[];
+begin
+  -- Resolve "today" in the caller's timezone.
+  v_today := (now() at time zone p_tz)::date;
+
+  -- Distinct day-buckets in the user's tz, across all-time pebbles.
+  select count(distinct (created_at at time zone p_tz)::date)
+    into v_practiced
+    from public.pebbles
+    where user_id = v_user_id;
+
+  -- 28-element bool array: index 1 = 27 days ago, index 28 = today.
+  -- (Postgres arrays are 1-indexed; clients consume in order.)
+  with active_days as (
+    select distinct (created_at at time zone p_tz)::date as d
+      from public.pebbles
+      where user_id = v_user_id
+        and created_at >= (v_today - interval '27 days') at time zone p_tz
+  ),
+  window as (
+    select generate_series(v_today - interval '27 days', v_today, interval '1 day')::date as d
+  )
+  select array_agg(active_days.d is not null order by window.d)
+    into v_grid
+    from window
+    left join active_days using (d);
+
+  return query select v_practiced, v_grid;
+end;
+$$;
+
+grant execute on function public.get_profile_engagement(text) to authenticated;
+```
+
+**Timezone contract:** caller passes an IANA tz string (e.g. `"Europe/Paris"`). All bucketing happens server-side. The client must pass `TimeZone.current.identifier`; the SQL never assumes UTC for display.
+
+### Regenerate types
+
+```bash
+npm run db:types --workspace=packages/supabase
+git add packages/supabase/types/database.ts
+```
+
+### Done when
+
+- Migration applied to remote Supabase (no local Docker — see project memory).
+- Both RPCs callable from `@pbbls/supabase` client with correct types.
+- `database.ts` regenerated and committed.
+
+---
+
+## Issue 2 — Profile screen redesign (closes #445)
+
+**Branch:** `feat/445-profile-screen-redesign` (rename #445 if the title no longer fits)
+**Surface:** iOS only. Depends on Issue 1.
+
+### Ripples primitives relocation
+
+Move from `Features/Path/` to a new shared folder so Profile can consume them without depending on Path's internal layout:
+
+- `Features/Path/Components/RippleBadge.swift`        → `Features/Shared/Ripples/RippleBadge.swift`
+- `Features/Path/Components/RippleStrokes.swift`      → `Features/Shared/Ripples/RippleStrokes.swift`
+- `Features/Path/Components/RippleStrokeColor.swift`  → `Features/Shared/Ripples/RippleStrokeColor.swift`
+- `Features/Path/Models/RippleSummary.swift`          → `Features/Shared/Ripples/RippleSummary.swift`
+
+Asset colors (`RippleDefault`, `RippleInactive`, `RippleActive`) stay in `Resources/Assets.xcassets/` (already shared). Update `project.yml` if it pins the old paths, then `xcodegen generate`. `PathView`'s import path updates; no behavior change.
+
+This is a relocation, not a refactor — it's the minimum required to give Profile a clean consumer path. No other refactoring of Path is in scope.
+
+### New `ProfileView.swift`
+
+Replace the entire body. Top-level structure (top → bottom):
+
+| Section            | Component                  | Notes                                                                |
+|--------------------|----------------------------|----------------------------------------------------------------------|
+| Toolbar            | inline                     | back chevron · "PROFILE" title · gear button → opens Settings sheet  |
+| Banner             | `ProfileBanner`            | glyph thumbnail · `display_name` · "MEMBER SINCE <date>"             |
+| Shortcuts          | `ProfileShortcutTile` × 3  | Collections · Souls · Glyphs (each → existing list view)             |
+| Stats card         | `ProfileStatsCard`         | wraps `RipplesRow` + divider + `ProfileCountersRow`                  |
+| Collections card   | `ProfileCollectionsCard`   | horizontal scroll of `ProfileCollectionCard`, or "new" placeholder   |
+| Lab card           | `ProfileLabCard`           | nav to existing `LabView`                                            |
+| Logout             | pill button                | calls `supabase.signOut()`                                           |
+
+#### Settings button (gear)
+
+Stubbed in this issue: opens a placeholder sheet (`Text("Settings — coming in #<issue-3>")`) so the navigation entry exists and the visual is testable. Issue 3 swaps the sheet body.
+
+#### Banner
+
+- Uses `GlyphThumbnail` (existing, from `Features/Glyph/Views/`) for the profile glyph.
+- Empty state (no `glyph_id`): renders a neutral placeholder (existing `GlyphThumbnail` empty mode if one exists, otherwise a tinted rounded rect with a `scribble` SF Symbol). Confirm during implementation.
+- "Member since" formats `profiles.created_at` with `.formatted(date: .abbreviated, time: .omitted)` — `Locale.current` handles localization.
+
+#### Stats card
+
+- Header: "STATS" (label only). **No chevron** until the stats page exists. When Issue 4 (stats page) lands, the chevron + `NavigationLink` is added back.
+- **Ripples row:** shared `RippleBadge(level:)` on the left, "Ripples Level <N>" + engagement copy on the right of the badge, 4×7 `AssiduityGrid` on the far right.
+  - Engagement copy uses the same level-derivation as the Path nav-bar badge (single source of truth in `RippleSummary`). If the "days to reach level X" calculation isn't already exposed by `RippleSummary`, extend `RippleSummary` to provide it — do not duplicate the formula in Profile.
+- **Counters row:** three columns — Days practiced, Pebbles, Karma. Each: number (large) · icon · label (small). `daysPracticed` comes from Issue 1's RPC; `pebbles` count and `karma` come from the existing service.
+
+#### Collections card
+
+- Header: "COLLECTIONS" + chevron → existing `CollectionsListView`.
+- **Engaged state:** horizontal `ScrollView(.horizontal, showsIndicators: false)` of `ProfileCollectionCard` (icon · name · "<N> pebbles"). Tapping a card navigates to `CollectionDetailView` for that collection.
+- **New-user state:** single dashed-border `ProfileCollectionCard` showing "New / Create collection" → opens existing `CreateCollectionSheet`.
+- Data source: reuse whatever `CollectionsListView` uses. If that fetch isn't extractable into a small service, leave it inline in the view for now — don't preemptively abstract.
+
+#### Lab card
+
+- Single card visual: egg/lab glyph · "Lab" title · "News & Community" subtitle · chevron.
+- Destination: existing `LabView`.
+
+### New components (under `Features/Profile/Components/`)
+
+- `ProfileBanner.swift`
+- `ProfileShortcutTile.swift`
+- `ProfileStatsCard.swift`
+- `RipplesRow.swift`
+- `AssiduityGrid.swift` — props: `data: [Bool]`, `columns: Int = 7`. Renders the ripple/squiggle motif from Image 5. Same component used later in the stats view with different `columns`.
+- `ProfileCountersRow.swift`
+- `ProfileCollectionsCard.swift`
+- `ProfileCollectionCard.swift`
+- `ProfileLabCard.swift`
+
+### Deletions (no longer referenced)
+
+- `Features/Profile/Components/ProfileStatRow.swift`
+- `Features/Profile/Components/ProfileNavRow.swift`
+- `Features/Profile/Sheets/BounceExplainerSheet.swift`
+- `Features/Profile/Sheets/KarmaExplainerSheet.swift`
+- `Features/Profile/Models/BounceSummary.swift`
+
+`BounceSummary`'s service-layer fetch (if any) also goes. The DB column and admin analytics are untouched.
+
+### Service changes
+
+Extend `PathStatsService` (which already owns Ripples + Karma) with:
+
+- `daysPracticed: Int?`
+- `assiduity: [Bool]?`
+- A single new method that calls `get_profile_engagement(p_tz: TimeZone.current.identifier)` and populates both, alongside the existing Ripples load.
+
+The service name "PathStatsService" becomes a slight misnomer once it serves Profile too — leave the rename for a follow-up issue if it bothers anyone. Do **not** rename as part of this work (scope creep).
+
+### Localization
+
+All new user-facing strings added to `Pebbles/Resources/Localizable.xcstrings` with `en` + `fr` values. Confirm zero `New` / `Stale` entries before opening the PR (per `apps/ios/CLAUDE.md`).
+
+### Arkaik
+
+Profile is an existing screen; the visual rewrite alone doesn't change the product graph. However, **the Settings sheet entry point is new** — add it under the Profile node when Issue 3 ships, not here. No Arkaik update needed for Issue 2.
+
+### Done when
+
+- Profile screen matches the engaged-user and new-user mockups.
+- `RippleBadge` in the Path nav bar renders identically (no regression).
+- Bounce row + sheets + explainers fully removed from iOS surface; #445 closes.
+- `daysPracticed` and `assiduity` populate correctly across timezone changes (manual test: device tz set to `Pacific/Auckland`, verify "today" lights up).
+- New strings present in both locales.
+
+---
+
+## Issue 3 — Settings sheet
+
+**Branch:** `feat/<n>-profile-settings-sheet`
+**Surface:** iOS only. Depends on Issue 2 (the gear button + stub sheet exist).
+
+### Presentation
+
+Replaces the stub from Issue 2. Sheet presented from `ProfileView`'s gear button. Uses the Edit-mode toolbar pattern (`Cancel` left, `Save` right, "SETTINGS" title centred). `Save` is disabled until dirty; dismisses on success.
+
+### Sections
+
+| Section        | Visibility                          | Fields                                                              |
+|----------------|-------------------------------------|---------------------------------------------------------------------|
+| Header         | always                              | large profile glyph, tappable → opens `GlyphPickerSheet`            |
+| Informations   | always                              | `display_name` (editable TextField), email (read-only, dimmed)      |
+| Providers      | SSO-only (≥1 non-email identity)    | one row per linked provider: icon + label (Apple ID / Google …)     |
+| Password       | email-only (no SSO identity)        | "Current password" + "New password" (secure fields)                 |
+| Legal          | always                              | Terms · Privacy (open existing `LegalDocumentSheet`)                |
+
+### Glyph picker entry point
+
+Tapping the header glyph opens the existing `GlyphPickerSheet`. The user picks an existing glyph; if they want a new one, the picker already has a "create" affordance leading to `GlyphCarveSheet`. The new selection is held in local state and only persisted on `Save`.
+
+### Provider detection
+
+```swift
+let identities = supabase.auth.currentSession?.user.identities ?? []
+let nonEmailProviders = identities.filter { $0.provider != "email" }
+let isSSO = !nonEmailProviders.isEmpty
+```
+
+Provider icons: use existing Apple/Google logos from the Welcome/Auth flow (`Features/Auth/`). If they aren't extracted yet, copy the SF Symbol or asset name from the sign-in buttons — don't introduce new artwork.
+
+### Save action
+
+In order, inside one `Task`:
+
+1. If `display_name` or `glyph_id` changed: call `update_profile(p_display_name:, p_glyph_id:)`.
+2. If password fields are non-empty: call `supabase.auth.update(user: .init(password: newPassword))` (Swift SDK syntax — confirm exact API during implementation).
+3. On any error: log via `os.Logger`, surface inline (red text under the relevant section), keep sheet open.
+4. On full success: dismiss.
+
+The password change does **not** require re-authentication in the Supabase Swift SDK as long as the session is fresh — but if the API surfaces a "needs recent login" error, surface it inline and let the user re-auth from the Welcome flow (out of scope here).
+
+### Localization
+
+All new strings → `Localizable.xcstrings` with `en` + `fr`.
+
+### Arkaik
+
+Update `docs/arkaik/bundle.json`: add a `SettingsSheet` node under the Profile screen, edge `opens_settings` from Profile.
+
+### Done when
+
+- Sheet renders the SSO variant (mockup 3) for accounts with linked providers.
+- Sheet renders the email variant (mockup 4) for password-only accounts.
+- Save persists name + glyph + (optional) password atomically per the success/error rules above.
+- Legal sheets work identically to today.
+
+---
+
+## Open questions
+
+These do not block the spec but should be answered in each issue's implementation plan:
+
+1. **Banner glyph placeholder visual** — does `GlyphThumbnail` already have an empty state, or do we add one? (Issue 2)
+2. **Engagement copy localization** — "3 days to reach level 6" pluralization in French requires Stringsdict-style handling. Confirm format strings cover singular/plural in both locales. (Issue 2)
+3. **Password change API** — exact Supabase Swift SDK signature for `auth.update(user:)` and its error shape for "needs recent login". (Issue 3)
+4. **"Current password" verification** — Supabase doesn't require it server-side for `auth.update(user:)`; the mockup shows the field anyway. Decide: (a) cosmetic only (ignore the value), (b) client-side re-verify via a no-op `signIn` before calling `update`, or (c) drop the field from the form. Default: (b) — most user-trustworthy. (Issue 3)
+5. **`update_profile` parameter naming** — settling on `p_display_name` / `p_glyph_id` to match the project's existing RPC convention (verify by reading a sibling RPC like `create_pebble` before writing the migration). (Issue 1)
+6. **"Replay onboarding" affordance** — currently sits under Profile's Legal section. The Settings mockup omits it. Decide: (a) drop entirely (devs/internal can still trigger via debug builds), (b) keep in Profile as a small footer link, or (c) add it back to Settings → Legal. Default: (a) — matches the mockup; if anyone needs it, restore in a tiny follow-up. (Issue 2 or 3)
+
+## Files to touch (summary)
+
+**Issue 1:** new migration, `packages/supabase/types/database.ts` (regenerated).
+
+**Issue 2:**
+- Rewritten: `apps/ios/Pebbles/Features/Profile/ProfileView.swift`
+- Moved: 4 files from `Features/Path/{Components,Models}/Ripple*` → `Features/Shared/Ripples/`
+- New: 9 components under `Features/Profile/Components/`
+- Deleted: `ProfileStatRow.swift`, `ProfileNavRow.swift`, `BounceExplainerSheet.swift`, `KarmaExplainerSheet.swift`, `BounceSummary.swift`
+- Modified: `Features/Path/Services/PathStatsService.swift`, `project.yml` (then `xcodegen generate`), `Localizable.xcstrings`. `PathView.swift` only changes if its imports become qualified — most likely no change since everything is in the same module.
+
+**Issue 3:**
+- New: `apps/ios/Pebbles/Features/Profile/Sheets/SettingsSheet.swift` (+ optional helper components)
+- Modified: `ProfileView.swift` (swap stub sheet for real one), `Localizable.xcstrings`, `docs/arkaik/bundle.json`

--- a/packages/supabase/supabase/migrations/20260516104231_profile_glyph_and_engagement.sql
+++ b/packages/supabase/supabase/migrations/20260516104231_profile_glyph_and_engagement.sql
@@ -1,0 +1,111 @@
+-- ============================================================
+-- Migration: profile glyph FK + engagement RPC
+-- ------------------------------------------------------------
+-- 1. Adds profiles.glyph_id (nullable FK to glyphs).
+-- 2. update_profile(p_display_name, p_glyph_id):
+--    atomic field-level edit. Null args mean "do not change".
+--    Relies on profiles_update RLS (user_id = auth.uid()).
+-- 3. get_profile_engagement(p_tz):
+--    returns days_practiced (all-time distinct days with a
+--    pebble) and assiduity (28-element bool[] for the last 28
+--    days), both bucketed in the caller's IANA timezone.
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. Schema: profiles.glyph_id
+-- ------------------------------------------------------------
+
+alter table public.profiles
+  add column glyph_id uuid references public.glyphs(id) on delete set null;
+
+create index profiles_glyph_id_idx on public.profiles(glyph_id);
+
+-- ------------------------------------------------------------
+-- 2. update_profile
+-- ------------------------------------------------------------
+-- Returns the updated profile row (or no row if RLS blocked /
+-- profile missing — caller treats absence as a not-found error).
+-- Both args default to null; null means "leave column unchanged".
+-- We intentionally cannot clear glyph_id via this RPC: there is
+-- no UX for it. A future "remove glyph" feature should add a
+-- dedicated p_clear_glyph boolean rather than re-interpreting null.
+
+create or replace function public.update_profile(
+  p_display_name text default null,
+  p_glyph_id     uuid default null
+)
+returns public.profiles
+language sql
+security invoker
+set search_path = public
+as $$
+  update public.profiles
+     set display_name = coalesce(p_display_name, display_name),
+         glyph_id     = case
+                          when p_glyph_id is not null then p_glyph_id
+                          else glyph_id
+                        end,
+         updated_at   = now()
+   where user_id = auth.uid()
+   returning *;
+$$;
+
+grant execute on function public.update_profile(text, uuid) to authenticated;
+
+-- ------------------------------------------------------------
+-- 3. get_profile_engagement
+-- ------------------------------------------------------------
+-- p_tz: IANA timezone string (e.g. 'Europe/Paris'). The client
+-- passes TimeZone.current.identifier on iOS.
+--
+-- Returns:
+--   days_practiced int       — all-time distinct days the user
+--                              has created at least one pebble,
+--                              bucketed in p_tz.
+--   assiduity     boolean[]  — length 28. Index 1 = 27 days ago,
+--                              index 28 = today (in p_tz). true
+--                              when ≥1 pebble was created on
+--                              that local-day.
+--
+-- security invoker: RLS on public.pebbles already restricts to
+-- the caller's rows (user_id = auth.uid()).
+
+create or replace function public.get_profile_engagement(p_tz text)
+returns table (
+  days_practiced int,
+  assiduity      boolean[]
+)
+language sql
+security invoker
+stable
+set search_path = public
+as $$
+  with
+    today_local as (
+      select (now() at time zone p_tz)::date as d
+    ),
+    window_days as (
+      select generate_series(
+        (select d from today_local) - interval '27 days',
+        (select d from today_local),
+        interval '1 day'
+      )::date as d
+    ),
+    active_days as (
+      select distinct (p.created_at at time zone p_tz)::date as d
+        from public.pebbles p
+       where p.user_id = auth.uid()
+    ),
+    grid as (
+      select array_agg((ad.d is not null) order by w.d) as assiduity
+        from window_days w
+        left join active_days ad using (d)
+    ),
+    counts as (
+      select count(*)::int as days_practiced from active_days
+    )
+  select counts.days_practiced, grid.assiduity
+    from counts, grid;
+$$;
+
+grant execute on function public.get_profile_engagement(text) to authenticated;

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -775,6 +775,7 @@ export type Database = {
           color_world: string
           created_at: string
           display_name: string
+          glyph_id: string | null
           id: string
           is_admin: boolean
           max_media_per_pebble: number
@@ -788,6 +789,7 @@ export type Database = {
           color_world?: string
           created_at?: string
           display_name: string
+          glyph_id?: string | null
           id?: string
           is_admin?: boolean
           max_media_per_pebble?: number
@@ -801,6 +803,7 @@ export type Database = {
           color_world?: string
           created_at?: string
           display_name?: string
+          glyph_id?: string | null
           id?: string
           is_admin?: boolean
           max_media_per_pebble?: number
@@ -811,6 +814,13 @@ export type Database = {
           user_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "profiles_glyph_id_fkey"
+            columns: ["glyph_id"]
+            isOneToOne: false
+            referencedRelation: "glyphs"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "profiles_user_id_fkey"
             columns: ["user_id"]
@@ -1350,6 +1360,13 @@ export type Database = {
           pebbles_with_picture: number
         }[]
       }
+      get_profile_engagement: {
+        Args: { p_tz: string }
+        Returns: {
+          assiduity: boolean[]
+          days_practiced: number
+        }[]
+      }
       get_quality_signals_today: {
         Args: never
         Returns: {
@@ -1425,6 +1442,29 @@ export type Database = {
       update_pebble: {
         Args: { p_pebble_id: string; payload: Json }
         Returns: undefined
+      }
+      update_profile: {
+        Args: { p_display_name?: string; p_glyph_id?: string }
+        Returns: {
+          color_world: string
+          created_at: string
+          display_name: string
+          glyph_id: string | null
+          id: string
+          is_admin: boolean
+          max_media_per_pebble: number
+          onboarding_completed: boolean
+          privacy_accepted_at: string | null
+          terms_accepted_at: string | null
+          updated_at: string
+          user_id: string
+        }
+        SetofOptions: {
+          from: "*"
+          to: "profiles"
+          isOneToOne: true
+          isSetofReturn: false
+        }
       }
     }
     Enums: {


### PR DESCRIPTION
## Summary

- Adds `profiles.glyph_id` (nullable FK to `glyphs`, `on delete set null`) + index.
- New RPC `update_profile(p_display_name, p_glyph_id)` — atomic field-level edits. Null args mean "leave column unchanged". `security invoker`, relies on existing `profiles_update` RLS (`user_id = auth.uid()`).
- New RPC `get_profile_engagement(p_tz)` — returns `days_practiced` (all-time distinct days with a pebble) + a 28-element `assiduity` boolean array, both bucketed in the caller's IANA timezone.
- Regenerated `packages/supabase/types/database.ts` from the deployed remote schema.

Foundations for the profile screen redesign (#451) and settings sheet (#452).

Spec: `docs/superpowers/specs/2026-05-16-ios-profile-redesign-and-settings-design.md` § Issue 1 (committed in this PR).
Plan: `docs/superpowers/plans/2026-05-16-profile-data-foundations.md` (committed in this PR).

## Deviation from spec

The spec showed both RPCs as `security definer`. They ship as `security invoker` instead — `profiles` and `pebbles` already have `user_id = auth.uid()` RLS, and matching the `path_pebbles` pattern is cleaner / less over-privileged. Same behavior, smaller blast radius.

## Test plan

- [x] Migration applied cleanly to remote (`db:push` exit 0).
- [x] `db:migration:list` shows `20260516104231` in both Local and Remote columns.
- [x] `db:types:remote` regenerated `database.ts` with `profiles.glyph_id`, `profiles_glyph_id_fkey`, `get_profile_engagement`, `update_profile` — all with correct signatures.
- [x] `npm run build --workspace=packages/supabase` (tsc --noEmit) exits 0.
- [ ] Functional verification of the RPCs (timezone bucketing, null-arg semantics, RLS isolation) deferred to #451's iOS consumer landing. The migration applied as a single transaction; broken SQL would have failed `db:push`.

Resolves #450