### PR TITLE
quality(ios): polish glyph carve sheet input and canvas border

### DIFF
--- a/apps/ios/Pebbles/Features/Glyph/Views/GlyphCanvasView.swift
+++ b/apps/ios/Pebbles/Features/Glyph/Views/GlyphCanvasView.swift
@@ -56,7 +56,7 @@ struct GlyphCanvasView: View {
         }
         .frame(width: side, height: side)
         .background(Color.white)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(RoundedRectangle(cornerRadius: Spacing.xxl, style: .continuous))
         .gesture(
             DragGesture(minimumDistance: 0, coordinateSpace: .local)
                 .onChanged { value in

--- a/apps/ios/Pebbles/Features/Glyph/Views/GlyphCarveSheet.swift
+++ b/apps/ios/Pebbles/Features/Glyph/Views/GlyphCarveSheet.swift
@@ -61,18 +61,28 @@ struct GlyphCarveSheet: View {
         VStack(spacing: 24) {
             Spacer(minLength: 0)
 
-            TextField("Name (optional)", text: $name)
-                .textFieldStyle(.roundedBorder)
-                .textInputAutocapitalization(.words)
-                .submitLabel(.done)
-                .focused($nameFieldFocused)
-                .onSubmit { nameFieldFocused = false }
-                .accessibilityLabel("Glyph name")
+            TextField(
+                "",
+                text: $name,
+                prompt: Text("Name (optional)").foregroundStyle(Color.system.muted)
+            )
+            .pebblesFont(.title)
+            .foregroundStyle(Color.system.foreground)
+            .multilineTextAlignment(.center)
+            .textInputAutocapitalization(.words)
+            .submitLabel(.done)
+            .focused($nameFieldFocused)
+            .onSubmit { nameFieldFocused = false }
+            .accessibilityLabel("Glyph name")
 
             GlyphCanvasView(
                 committedStrokes: strokes,
                 onStrokeCommit: { stroke in strokes.append(stroke) },
                 strokeColor: Color.accent.primary
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Spacing.xxl, style: .continuous)
+                    .stroke(Color.system.muted, lineWidth: 1)
             )
 
             if let saveError {


### PR DESCRIPTION
Resolves #457

## Summary
- Replace the bordered `TextField` in `GlyphCarveSheet` with a transparent, title-styled inline input — `PebblesFont.title`, `system.muted` placeholder (via styled `prompt:`), `system.foreground` when filled, centered.
- Add a 1pt `system.muted` border around the carving zone using the system-wide 2XL radius (`Spacing.xxl`, continuous), matching `GlyphView`.
- Bump `GlyphCanvasView`'s clip from `cornerRadius: 12` to the same `Spacing.xxl` so committed and in-progress strokes near the corners are clipped to the visible zone.

## Key files
- `apps/ios/Pebbles/Features/Glyph/Views/GlyphCarveSheet.swift` — input restyle + canvas overlay border.
- `apps/ios/Pebbles/Features/Glyph/Views/GlyphCanvasView.swift` — clip radius bumped to `Spacing.xxl`. Only caller is the carve sheet.

## Test plan
- [x] Open the carve sheet from `GlyphPickerSheet` (pebble record/edit) — placeholder reads "Name (optional)" in `system.muted`, switches to `system.foreground` once typed.
- [x] Carve zone shows a 1pt `system.muted` rounded-rect border in both light and dark mode.
- [x] Draw strokes that hug the corners — confirm they're clipped to the rounded shape (no bleed past the border).
- [x] Open the carve sheet from `GlyphsListView` (profile) — same behavior.
- [x] Save flow + cancel-with-strokes discard alert still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)