### PR TITLE
fix(ios): select created_at + intensity in soul + collection detail fetches

### DIFF
--- a/apps/ios/Pebbles/Features/Profile/Views/CollectionDetailView.swift
+++ b/apps/ios/Pebbles/Features/Profile/Views/CollectionDetailView.swift
@@ -157,7 +157,7 @@ struct CollectionDetailView: View {
         do {
             // Inner join on `collection_pebbles` filters parent rows; the extra
             // key is ignored by Pebble's default decoder.
-            let columns = "id, name, happened_at, render_svg"
+            let columns = "id, name, happened_at, created_at, intensity, render_svg"
                 + ", emotion:emotions(id, slug, name)"
                 + ", collection_pebbles!inner(collection_id)"
             let result: [Pebble] = try await supabase.client

--- a/apps/ios/Pebbles/Features/Profile/Views/SoulDetailView.swift
+++ b/apps/ios/Pebbles/Features/Profile/Views/SoulDetailView.swift
@@ -158,7 +158,7 @@ struct SoulDetailView: View {
         isLoading = true
         loadError = nil
         do {
-            let columns = "id, name, happened_at, render_svg"
+            let columns = "id, name, happened_at, created_at, intensity, render_svg"
                 + ", emotion:emotions(id, slug, name)"
                 + ", pebble_souls!inner(soul_id)"
             let result: [Pebble] = try await supabase.client


### PR DESCRIPTION
Resolves #469.

## Root cause

`Pebble` (apps/ios/Pebbles/Features/Path/Models/Pebble.swift:3) grew two non-optional fields over time:

- `intensity: Int` — added in #388 (May 12)
- `createdAt: Date` — added in #443 (May 16)

`SoulDetailView.load()` was written before those additions and its select still listed only `id, name, happened_at, render_svg, emotion(...)`. When iOS tried to decode the response into `[Pebble]`, Swift's `JSONDecoder` raised `keyNotFound` for `created_at`, which Foundation surfaces as the localized message _"The data couldn't be read because it is missing."_ — exactly what the Xcode console showed in the bug report.

`CollectionDetailView.load()` has the identical latent bug (same incomplete select, same model). Fixed in the same PR since it's the same one-line change driven by the same root cause; any collection containing pebbles would surface the same error.

## Changes

- `SoulDetailView.swift` — add `created_at, intensity` to the `pebbles` select.
- `CollectionDetailView.swift` — same.

`first_snap_path` (the third recently-added Pebble field) is optional on the model and is RPC-only (`path_pebbles`), so it doesn't need to appear in the table select.

## Test plan

- [x] Open a soul that has pebbles attached → pebbles list renders, no error banner.
- [x] Open a soul that has zero pebbles → empty state still renders.
- [x] Open a collection that has pebbles attached → pebbles list renders.
- [x] Xcode console clean of `"soul pebbles fetch failed"` / `"collection pebbles fetch failed"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)