### PR TITLE
docs: promote learnings into CLAUDE.md only on hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,17 @@ Keep CLAUDE.md short. Read these when relevant — don't pre-load:
 - **Data layer / Supabase / async** → `docs/agents/data-and-async.md` (DataProvider, auth deadlock, withTimeout, error logging)
 - **Product architecture map** → `arkaik` skill (see `.claude/skills/arkaik/`)
 
+## Editing CLAUDE.md / AGENTS.md
+
+These files load into every agent context, so they are the most token-precious docs in the repo — they must hold only durable, action-guiding rules, not a junk drawer of observations.
+
+Treat learnings as living wisdom captured in plans' "Lessons learned" sections. Promote a learning into a CLAUDE.md/AGENTS.md rule **only when it hardens** — i.e. clears both bars:
+
+- **Durable** — the constraint will outlive the next refactor, not a quirk of one feature.
+- **Action-guiding** — it tells a future agent what to do or avoid, not a passive observation.
+
+Cadence: promote during the periodic monorepo-audit grooming pass at **milestone boundaries** (folded into the audit's "Doc accuracy" domain — see `docs/superpowers/specs/2026-04-11-monorepo-audit-design.md`). **Never edit CLAUDE.md per-PR for learnings.** Land each promoted rule at the right scope: root `CLAUDE.md` / `AGENTS.md` for cross-cutting rules; workspace `CLAUDE.md` (`apps/web`, `apps/ios`, `apps/admin`, `packages/supabase`) for surface-specific ones.
+
 ## Code conventions
 
 - TypeScript strict. No `any`. No type assertions unless absolutely necessary.

--- a/docs/decisions/log.md
+++ b/docs/decisions/log.md
@@ -70,3 +70,14 @@ Append-only ledger of **significant** product/engineering decisions. One terse e
 - **Consequences:** Routine choices, style nits, and anything obvious from the code stay out of the log. GitHub Issues remain the place for discussion; the log captures the outcome. If the log grows unwieldy, we'll revisit splitting it by scope — not yet.
 - **Supersedes / Superseded-by:** —
 - **Refs:** #477, #482, `CLAUDE.md` (PR checklist step 6).
+
+## 2026-05-26 — Promote learnings into CLAUDE.md only on hardening, via a milestone grooming pass
+
+- **Status:** taken
+- **Scope:** docs
+- **Context:** Learnings are living wisdom, captured cheaply in plans' "Lessons learned" sections. `CLAUDE.md`/`AGENTS.md` load into *every* agent context, so they are the most token-precious files in the repo and must hold only durable, action-guiding rules — not a junk drawer of observations. Per-PR CLAUDE.md edits for learnings bloat the file and dilute its signal.
+- **Decision:** We will promote a learning into a CLAUDE.md/AGENTS.md rule only when it clears both bars — **durable** (outlives the next refactor) and **action-guiding** (tells a future agent what to do or avoid). Cadence is the periodic monorepo-audit grooming pass at **milestone boundaries**, folded into the audit's existing "Doc accuracy" domain. Never a per-PR CLAUDE.md edit for learnings. Promoted rules land at the right scope: root `CLAUDE.md`/`AGENTS.md` for cross-cutting, workspace `CLAUDE.md` for surface-specific.
+- **Why:** Two-stage pipe — cheap capture, expensive promotion — keeps CLAUDE.md small and high-signal while losing nothing. Milestone cadence groups grooming with the audit work that already touches the same files, so there is no separate ritual to remember. Precedent: the "never await Supabase inside `onAuthStateChange`" rail is a learning that hardened into a rule exactly this way.
+- **Consequences:** Agents do not edit CLAUDE.md to record per-PR learnings; they leave them in the plan's "Lessons learned". Reviewers can push back on CLAUDE.md edits that fail the durable + action-guiding bars. The monorepo-audit checklist now explicitly includes a grooming sweep; expect rules to be **demoted or deleted** during the same pass when they have gone stale.
+- **Supersedes / Superseded-by:** —
+- **Refs:** #479, `CLAUDE.md` ("Editing CLAUDE.md / AGENTS.md"), `docs/superpowers/specs/2026-04-11-monorepo-audit-design.md` (per-domain checklist item 6).

--- a/docs/superpowers/specs/2026-04-11-monorepo-audit-design.md
+++ b/docs/superpowers/specs/2026-04-11-monorepo-audit-design.md
@@ -28,7 +28,7 @@ Each domain is checked against these 6 categories:
 3. **Build integrity** — build/lint pass cleanly, unused deps, mismatched versions, workspace wiring
 4. **Pattern consistency** — adherence to CLAUDE.md conventions (naming, structure, separation of concerns)
 5. **Redundancy** — duplicated logic, components, or configs across workspaces
-6. **Doc accuracy** — do instructions match reality, stale references to old structure
+6. **Doc accuracy** — do instructions match reality, stale references to old structure; **learnings grooming pass** — review recent plans' "Lessons learned" sections and promote any that have hardened (durable + action-guiding, per the bar in root `CLAUDE.md`) into the right-scope CLAUDE.md/AGENTS.md. Conversely, demote or delete rules that have gone stale.
 
 ## Findings format
 


### PR DESCRIPTION
Resolves #479

## Summary
- Adds a new **Editing CLAUDE.md / AGENTS.md** section to root `CLAUDE.md` documenting the promotion bar (durable + action-guiding) and the milestone cadence for the grooming pass, with explicit "never per-PR" guidance and scope routing (root vs workspace `CLAUDE.md`).
- Folds the learnings-promotion pass into the existing monorepo-audit **Doc accuracy** checklist item in `docs/superpowers/specs/2026-04-11-monorepo-audit-design.md`. The same pass is also the place to demote/delete stale rules.
- Records the choice as a new entry in `docs/decisions/log.md` (2026-05-26).

## Key files
- `CLAUDE.md` — new section between *Topical references* and *Code conventions*.
- `docs/superpowers/specs/2026-04-11-monorepo-audit-design.md` — checklist item 6 extended.
- `docs/decisions/log.md` — appended entry.

## Notes
- No code changes; docs-only PR. No lint/build required per the task-size triage.
- Not user-facing (no `feat` label, no Arkaik view node touched), so no Lab Note section.