### PR TITLE
feat(ui): add pebble edit screen on webapp

### DIFF
--- a/apps/web/app/pebble/[id]/edit/page.tsx
+++ b/apps/web/app/pebble/[id]/edit/page.tsx
@@ -1,42 +1,35 @@
 "use client"
 
-import { use, useCallback } from "react"
-import { useRouter } from "next/navigation"
+import { use } from "react"
 import { useTranslations } from "next-intl"
 import { usePebble } from "@/lib/data/usePebble"
 import { useSouls } from "@/lib/data/useSouls"
 import { useCollections } from "@/lib/data/useCollections"
 import { useMarks } from "@/lib/data/useMarks"
-import { PebbleDetail } from "@/components/pebble/PebbleDetail"
+import { PebbleEdit } from "@/components/pebble/PebbleEdit"
 import { PebbleNotFound } from "@/components/pebble/PebbleNotFound"
 import { PageLayout } from "@/components/layout/PageLayout"
 
-export default function PebbleDetailPage({
+export default function PebbleEditPage({
   params,
 }: {
   params: Promise<{ id: string }>
 }) {
   const { id } = use(params)
-  const router = useRouter()
   const t = useTranslations("pebble")
-  const { pebble, loading: pebbleLoading, updatePebble, uploadSnap } = usePebble(id)
+  const {
+    pebble,
+    loading: pebbleLoading,
+    updatePebble,
+    uploadSnap,
+    deletePebbleMedia,
+  } = usePebble(id)
   const { souls, loading: soulsLoading, addSoul } = useSouls()
   const { collections, loading: collectionsLoading } = useCollections()
   const { marks, loading: marksLoading } = useMarks()
 
   const loading = pebbleLoading || soulsLoading || collectionsLoading || marksLoading
-
   const mark = pebble ? marks.find((m) => m.id === pebble.mark_id) : undefined
-
-  const handleAddSoul = useCallback(
-    async (name: string) => {
-      const soul = await addSoul({ name })
-      if (pebble) {
-        await updatePebble({ soul_ids: [...pebble.soul_ids, soul.id] })
-      }
-    },
-    [addSoul, updatePebble, pebble],
-  )
 
   return (
     <PageLayout>
@@ -44,17 +37,16 @@ export default function PebbleDetailPage({
         {loading ? (
           <p className="text-sm text-muted-foreground">{t("loading")}</p>
         ) : pebble ? (
-          <PebbleDetail
+          <PebbleEdit
             pebble={pebble}
             souls={souls}
             collections={collections}
             marks={marks}
             mark={mark}
-            onUpdatePebble={updatePebble}
+            onUpdatePebble={(input) => updatePebble(input)}
             onUploadSnap={uploadSnap}
-            onAddSoul={handleAddSoul}
-            onClose={() => router.back()}
-            onEdit={() => router.push(`/pebble/${id}/edit`)}
+            onDeletePebbleMedia={deletePebbleMedia}
+            onAddSoul={(name) => addSoul({ name })}
           />
         ) : (
           <PebbleNotFound />

--- a/apps/web/components/path/PebblePeek.tsx
+++ b/apps/web/components/path/PebblePeek.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback } from "react"
+import { useCallback, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
@@ -15,6 +15,11 @@ type PebblePeekProps = {
   pebbleId: string | null
   onClose: () => void
 }
+
+// Swipe-down-to-close threshold for the mobile bottom sheet. Past this in
+// translateY (or with strong downward velocity), release dismisses the peek.
+const SWIPE_CLOSE_DISTANCE = 100
+const SWIPE_VELOCITY_THRESHOLD = 0.5 // px per ms
 
 export function PebblePeek({ pebbleId, onClose }: PebblePeekProps) {
   const open = pebbleId !== null
@@ -41,6 +46,40 @@ export function PebblePeek({ pebbleId, onClose }: PebblePeekProps) {
     [addSoul, updatePebble, pebble],
   )
 
+  // Swipe-down-to-close: only intercepts when the popup is scrolled to its
+  // top, so vertical scrolling inside the sheet still works. We translate the
+  // popup with inline style during the drag and snap back (or close) on
+  // release — the existing transition-[transform] class handles the snap-back
+  // animation when the inline style clears.
+  const popupRef = useRef<HTMLDivElement | null>(null)
+  const dragStartRef = useRef<{ y: number; time: number } | null>(null)
+  const [dragOffset, setDragOffset] = useState(0)
+
+  const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    const el = popupRef.current
+    if (!el || el.scrollTop > 0) return
+    dragStartRef.current = { y: e.touches[0].clientY, time: Date.now() }
+  }
+
+  const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
+    if (!dragStartRef.current) return
+    const delta = e.touches[0].clientY - dragStartRef.current.y
+    if (delta > 0) setDragOffset(delta)
+  }
+
+  const handleTouchEnd = (e: React.TouchEvent<HTMLDivElement>) => {
+    const start = dragStartRef.current
+    if (!start) return
+    const delta = e.changedTouches[0].clientY - start.y
+    const elapsed = Date.now() - start.time
+    const velocity = elapsed > 0 ? delta / elapsed : 0
+    dragStartRef.current = null
+    setDragOffset(0)
+    if (delta > SWIPE_CLOSE_DISTANCE || velocity > SWIPE_VELOCITY_THRESHOLD) {
+      onClose()
+    }
+  }
+
   return (
     <DialogPrimitive.Root
       open={open}
@@ -53,19 +92,25 @@ export function PebblePeek({ pebbleId, onClose }: PebblePeekProps) {
           className="fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs transition-opacity duration-200 data-open:opacity-100 data-closed:opacity-0"
         />
         <DialogPrimitive.Popup
+          ref={popupRef}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+          style={
+            dragOffset > 0
+              ? { transform: `translateY(${dragOffset}px)`, transition: "none" }
+              : undefined
+          }
           className={cn(
             // Shared
-            "fixed z-50 w-full bg-background text-popover-foreground ring-1 ring-foreground/10 outline-none overflow-y-auto max-h-[85dvh]",
+            "fixed z-50 w-full bg-background text-popover-foreground ring-1 ring-foreground/10 outline-none overflow-y-auto",
             // Mobile: bottom sheet
-            "inset-x-0 bottom-0 rounded-t-2xl p-4 pt-2",
+            "inset-x-0 bottom-0 h-[95dvh] max-h-[95dvh] rounded-t-2xl p-4 pt-4",
             "translate-y-full opacity-0 data-open:translate-y-0 data-open:opacity-100 transition-[transform,opacity] duration-200 ease-out",
-            // Desktop: centered modal
-            "md:bottom-auto md:right-auto md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 md:data-open:-translate-y-1/2 md:max-w-2xl md:rounded-xl md:p-6",
+            // Desktop: centered modal — reset mobile height + position
+            "md:h-auto md:max-h-[85dvh] md:bottom-auto md:right-auto md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 md:data-open:-translate-y-1/2 md:max-w-2xl md:rounded-xl md:p-6",
           )}
         >
-          {/* Mobile drag handle */}
-          <div className="mx-auto mb-3 h-1 w-10 rounded-full bg-muted-foreground/30 md:hidden" aria-hidden />
-
           {loading ? (
             <p className="text-sm text-muted-foreground">{t("loading")}</p>
           ) : pebble ? (

--- a/apps/web/components/path/PebblePeek.tsx
+++ b/apps/web/components/path/PebblePeek.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useCallback } from "react"
+import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
 import { cn } from "@/lib/utils"
@@ -19,6 +20,7 @@ export function PebblePeek({ pebbleId, onClose }: PebblePeekProps) {
   const open = pebbleId !== null
   const id = pebbleId ?? ""
   const t = useTranslations("pebble")
+  const router = useRouter()
 
   const { pebble, loading: pebbleLoading, updatePebble, uploadSnap } = usePebble(id)
   const { souls, loading: soulsLoading, addSoul } = useSouls()
@@ -77,6 +79,10 @@ export function PebblePeek({ pebbleId, onClose }: PebblePeekProps) {
               onUploadSnap={uploadSnap}
               onAddSoul={handleAddSoul}
               onClose={onClose}
+              onEdit={() => {
+                onClose()
+                router.push(`/pebble/${id}/edit`)
+              }}
             />
           ) : (
             <p className="text-sm text-muted-foreground">{t("notFoundInline")}</p>

--- a/apps/web/components/pebble/PebbleDetail.tsx
+++ b/apps/web/components/pebble/PebbleDetail.tsx
@@ -174,7 +174,7 @@ export function PebbleDetail({
         <button
           type="button"
           onClick={() => setValenceOpen(true)}
-          className="mx-auto mt-2 mb-4 block cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-2xl"
+          className="mx-auto mt-8 mb-4 block cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-2xl"
           aria-label={t("editIntensityAria")}
         >
           {hasPicture ? (

--- a/apps/web/components/pebble/PebbleDetail.tsx
+++ b/apps/web/components/pebble/PebbleDetail.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useCallback, useRef } from "react"
-import { Lock, X } from "lucide-react"
+import { Lock, SquarePen, X } from "lucide-react"
 import { useTranslations } from "next-intl"
 import type { Pebble, PebbleSnap, Soul, Collection, Mark } from "@/lib/types"
 import type { UpdatePebbleInput } from "@/lib/data/data-provider"
@@ -30,6 +30,7 @@ type PebbleDetailProps = {
   onUploadSnap: (file: File) => Promise<PebbleSnap>
   onAddSoul: (name: string) => Promise<void>
   onClose?: () => void
+  onEdit?: () => void
 }
 
 export function PebbleDetail({
@@ -42,6 +43,7 @@ export function PebbleDetail({
   onUploadSnap,
   onAddSoul,
   onClose,
+  onEdit,
 }: PebbleDetailProps) {
   const [valenceOpen, setValenceOpen] = useState(false)
   const [soulsOpen, setSoulsOpen] = useState(false)
@@ -126,7 +128,7 @@ export function PebbleDetail({
 
   return (
     <article>
-      {/* Top bar: static privacy indicator + close button */}
+      {/* Top bar: static privacy indicator + edit/close buttons */}
       <header className="flex items-center justify-between">
         <span
           aria-label={
@@ -141,18 +143,30 @@ export function PebbleDetail({
         >
           <Lock className="size-4" aria-hidden />
         </span>
-        {onClose ? (
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label={t("peek.close")}
-            className="grid size-10 place-items-center rounded-full bg-surface text-muted-foreground transition-colors hover:bg-primary hover:text-surface active:scale-95 outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <X className="size-4" aria-hidden />
-          </button>
-        ) : (
-          <span className="size-10" aria-hidden />
-        )}
+        <div className="flex items-center gap-2">
+          {onEdit && (
+            <button
+              type="button"
+              onClick={onEdit}
+              aria-label={t("editAria")}
+              className="grid size-10 place-items-center rounded-full bg-surface text-muted-foreground transition-colors hover:bg-primary hover:text-surface active:scale-95 outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <SquarePen className="size-4" aria-hidden />
+            </button>
+          )}
+          {onClose ? (
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label={t("peek.close")}
+              className="grid size-10 place-items-center rounded-full bg-surface text-muted-foreground transition-colors hover:bg-primary hover:text-surface active:scale-95 outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <X className="size-4" aria-hidden />
+            </button>
+          ) : (
+            <span className="size-10" aria-hidden />
+          )}
+        </div>
       </header>
 
       {/* Pebble visual (and snap if present) — opens valence/intensity sheet */}

--- a/apps/web/components/pebble/PebbleDetailTiles.tsx
+++ b/apps/web/components/pebble/PebbleDetailTiles.tsx
@@ -21,20 +21,32 @@ import { cn } from "@/lib/utils"
 // Vertical tile shared by emotion / domain / collection triggers in the
 // pebble detail view. Icon on top, label below — matches the design in
 // issue #391.
+//
+// `unset` switches to the Edit-mode empty state from issue #481:
+// dashed border + faded, no surface fill. Used when `editing` is true and
+// the underlying value is empty.
 function TileTrigger({
   icon,
   label,
   ariaLabel,
+  unset,
+  className,
 }: {
   icon: ReactNode
   label: string
   ariaLabel: string
+  unset?: boolean
+  className?: string
 }) {
   return (
     <PopoverTrigger
       className={cn(
-        "flex flex-col items-center justify-center gap-2 rounded-2xl bg-surface px-3 py-4 transition-colors",
-        "hover:bg-muted/70 active:scale-[0.98] outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        "flex flex-col items-center justify-center gap-2 rounded-2xl px-3 py-4 transition-colors",
+        "active:scale-[0.98] outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        unset
+          ? "border-2 border-dashed border-muted-foreground/30 opacity-60 hover:opacity-100"
+          : "bg-surface hover:bg-muted/70",
+        className,
       )}
       aria-label={ariaLabel}
     >
@@ -55,12 +67,15 @@ function TileTrigger({
 type EmotionTileProps = {
   value: string
   onChange: (id: string) => void
+  editing?: boolean
+  className?: string
 }
 
-export function EmotionTile({ value, onChange }: EmotionTileProps) {
+export function EmotionTile({ value, onChange, editing, className }: EmotionTileProps) {
   const t = useTranslations("record.emotion")
   const [pickerOpen, setPickerOpen] = useState(false)
   const selected = useSelectedEmotionDisplay(value || undefined)
+  const unset = editing && !selected
 
   return (
     <>
@@ -71,8 +86,12 @@ export function EmotionTile({ value, onChange }: EmotionTileProps) {
           selected ? t("selectedAria", { name: selected.name }) : t("pickAria")
         }
         className={cn(
-          "flex flex-col items-center justify-center gap-2 rounded-2xl bg-surface px-3 py-4 transition-colors",
-          "hover:bg-muted/70 active:scale-[0.98] outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          "flex flex-col items-center justify-center gap-2 rounded-2xl px-3 py-4 transition-colors",
+          "active:scale-[0.98] outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          unset
+            ? "border-2 border-dashed border-muted-foreground/30 opacity-60 hover:opacity-100"
+            : "bg-surface hover:bg-muted/70",
+          className,
         )}
       >
         <span className="text-muted-foreground" aria-hidden>
@@ -103,6 +122,8 @@ export function EmotionTile({ value, onChange }: EmotionTileProps) {
 type DomainTileProps = {
   value: string[]
   onChange: (ids: string[]) => void
+  editing?: boolean
+  className?: string
 }
 
 function DomainOption({
@@ -140,7 +161,7 @@ function useLocalizedDomainMap(): Map<string, string> {
   }, [t])
 }
 
-export function DomainTile({ value, onChange }: DomainTileProps) {
+export function DomainTile({ value, onChange, editing, className }: DomainTileProps) {
   const t = useTranslations("record.domain")
   const localizedNames = useLocalizedDomainMap()
   const selectedDomains = DOMAINS.filter((d) => value.includes(d.id))
@@ -165,6 +186,8 @@ export function DomainTile({ value, onChange }: DomainTileProps) {
       <TileTrigger
         icon={<Tag className="size-5" />}
         label={tileLabel}
+        unset={editing && selectedDomains.length === 0}
+        className={className}
         ariaLabel={
           selectedDomains.length > 0
             ? t("selectedAria", { names: selectedNames.join(", ") })
@@ -193,12 +216,16 @@ type CollectionTileProps = {
   value: string[]
   onChange: (ids: string[]) => void
   collections: Collection[]
+  editing?: boolean
+  className?: string
 }
 
 export function CollectionTile({
   value,
   onChange,
   collections,
+  editing,
+  className,
 }: CollectionTileProps) {
   const t = useTranslations("record.collection")
   const selected = collections.filter((c) => value.includes(c.id))
@@ -220,6 +247,8 @@ export function CollectionTile({
       <TileTrigger
         icon={<Layers className="size-5" />}
         label={tileLabel}
+        unset={editing && selected.length === 0}
+        className={className}
         ariaLabel={
           selected.length > 0
             ? t("selectedAria", { names: selectedNames.join(", ") })

--- a/apps/web/components/pebble/PebbleEdit.tsx
+++ b/apps/web/components/pebble/PebbleEdit.tsx
@@ -1,0 +1,328 @@
+"use client"
+
+import { useCallback, useState } from "react"
+import { useRouter } from "next/navigation"
+import { useTranslations } from "next-intl"
+import type { Pebble, PebbleSnap, Soul, Collection, Mark } from "@/lib/types"
+import { useFormatPeekDate } from "@/lib/i18n"
+import { usePebbleDraft } from "@/lib/hooks/usePebbleDraft"
+import type { UpdatePebbleInput } from "@/lib/data/data-provider"
+import { PebbleVisual } from "@/components/pebble/PebbleVisual"
+import {
+  EmotionTile,
+  DomainTile,
+  CollectionTile,
+} from "@/components/pebble/PebbleDetailTiles"
+import { PebbleEditToolbar } from "@/components/pebble/PebbleEditToolbar"
+import { PebbleEditTitle } from "@/components/pebble/PebbleEditTitle"
+import { PebbleEditDescription } from "@/components/pebble/PebbleEditDescription"
+import {
+  PebbleEditPicture,
+  useSnapStaging,
+} from "@/components/pebble/PebbleEditPicture"
+import { PebbleEditSoulsGrid } from "@/components/pebble/PebbleEditSoulsGrid"
+import { Sheet } from "@/components/ui/sheet"
+import { ValencePickerBody } from "@/components/record/ValenceIntensityGrid"
+import { EmotionPickerSheet } from "@/components/record/EmotionPicker"
+import { SoulsSheet } from "@/components/record/SoulsSheet"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+
+type PebbleEditProps = {
+  pebble: Pebble
+  souls: Soul[]
+  collections: Collection[]
+  marks: Mark[]
+  mark: Mark | undefined
+  onUpdatePebble: (input: UpdatePebbleInput) => Promise<Pebble>
+  onUploadSnap: (file: File) => Promise<PebbleSnap>
+  onDeletePebbleMedia: (snapId: string) => Promise<void>
+  onAddSoul: (name: string) => Promise<Soul>
+}
+
+// Pebble edit screen. Holds the draft, drives the toolbar state machine,
+// orchestrates the glyph picker chain (Valence → Emotion), the Souls sheet,
+// and the picture upload coordinator. Commits via a single
+// `compose-pebble-update` call on Save.
+export function PebbleEdit({
+  pebble,
+  souls,
+  collections,
+  marks,
+  mark,
+  onUpdatePebble,
+  onUploadSnap,
+  onDeletePebbleMedia,
+  onAddSoul,
+}: PebbleEditProps) {
+  const t = useTranslations("pebble.edit")
+  const tPebble = useTranslations("pebble")
+  const router = useRouter()
+  const formatPeekDate = useFormatPeekDate()
+
+  const { draft, setField, setFields, isDirty, buildPayload } =
+    usePebbleDraft(pebble)
+
+  const [valenceOpen, setValenceOpen] = useState(false)
+  const [emotionOpen, setEmotionOpen] = useState(false)
+  const [soulsOpen, setSoulsOpen] = useState(false)
+  const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState(false)
+
+  const originalSnap = pebble.snaps[0] ?? null
+  const originalInstantUrl = pebble.instants[0] ?? null
+
+  const snap = useSnapStaging({
+    originalSnap,
+    originalInstantUrl,
+    draftSnap: draft.snap,
+    setDraftSnap: (next) => setField("snap", next),
+    uploadSnap: onUploadSnap,
+    deletePebbleMedia: onDeletePebbleMedia,
+  })
+
+  const canSave = isDirty && !saving && !snap.uploading && !snap.failed
+
+  const handleCancel = useCallback(() => {
+    if (saving) return
+    if (!isDirty && !snap.uploading) {
+      router.replace(`/pebble/${pebble.id}`)
+      return
+    }
+    setConfirmDiscardOpen(true)
+  }, [saving, isDirty, snap.uploading, router, pebble.id])
+
+  const handleConfirmDiscard = useCallback(async () => {
+    setConfirmDiscardOpen(false)
+    await snap.cleanup()
+    router.replace(`/pebble/${pebble.id}`)
+  }, [snap, router, pebble.id])
+
+  const handleSave = useCallback(async () => {
+    if (!canSave) return
+    const payload = buildPayload()
+    setSaving(true)
+    setSaveError(false)
+    try {
+      await onUpdatePebble(payload)
+      // Successful save: the staged snap is now committed to the pebble row,
+      // so it's no longer "uncommitted" — skip cleanup and navigate away.
+      router.replace(`/pebble/${pebble.id}`)
+    } catch (err) {
+      console.error("[pebble-edit] save failed", err)
+      setSaveError(true)
+      setSaving(false)
+      // Keep the draft and the staged snap intact so the user can retry.
+    }
+  }, [canSave, buildPayload, onUpdatePebble, router, pebble.id])
+
+  const handleSoulToggle = useCallback(
+    (id: string) => {
+      const next = draft.soul_ids.includes(id)
+        ? draft.soul_ids.filter((sid) => sid !== id)
+        : [...draft.soul_ids, id]
+      setField("soul_ids", next)
+    },
+    [draft.soul_ids, setField],
+  )
+
+  const handleAddSoul = useCallback(
+    async (name: string) => {
+      const soul = await onAddSoul(name)
+      setField("soul_ids", [...draft.soul_ids, soul.id])
+    },
+    [onAddSoul, draft.soul_ids, setField],
+  )
+
+  // Glyph picker chain: tap the pebble visual → open the Valence picker;
+  // on select, close it and open the Emotion picker prefilled with the new
+  // valence/intensity; on emotion-pick, write everything into the draft in
+  // one dispatch.
+  const handleGlyphTap = () => setValenceOpen(true)
+
+  const handleValenceSelect = (
+    intensity: Pebble["intensity"],
+    positiveness: Pebble["positiveness"],
+  ) => {
+    setFields({ intensity, positiveness })
+    setValenceOpen(false)
+    setEmotionOpen(true)
+  }
+
+  const handleEmotionPick = (id: string | undefined) => {
+    if (id) setField("emotion_id", id)
+    setEmotionOpen(false)
+  }
+
+  // Build a synthetic pebble for the visual so it reflects staged changes
+  // (intensity/positiveness/emotion/glyph) before save.
+  const draftPebble: Pebble = {
+    ...pebble,
+    intensity: draft.intensity,
+    positiveness: draft.positiveness,
+    emotion_id: draft.emotion_id,
+    mark_id: draft.mark_id ?? undefined,
+  }
+  const draftMark = draft.mark_id
+    ? marks.find((m) => m.id === draft.mark_id)
+    : mark
+
+  const formattedDate = formatPeekDate(pebble.happened_at)
+
+  return (
+    <article className="pb-12">
+      <PebbleEditToolbar
+        isSaving={saving}
+        canSave={canSave}
+        onCancel={handleCancel}
+        onSave={handleSave}
+      />
+
+      {/* Hero: picture slot (left) + pebble visual (right) */}
+      <section className="mt-4 flex items-start justify-center gap-3">
+        <PebbleEditPicture
+          displayUrl={snap.displayUrl}
+          uploading={snap.uploading}
+          failed={snap.failed}
+          onPick={(file) => void snap.pickFile(file)}
+          onRemove={() => void snap.remove()}
+        />
+        <Sheet open={valenceOpen} onOpenChange={setValenceOpen}>
+          <button
+            type="button"
+            onClick={handleGlyphTap}
+            aria-label={tPebble("editIntensityAria")}
+            className="mt-4 cursor-pointer rounded-2xl outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <PebbleVisual
+              pebble={draftPebble}
+              mark={draftMark}
+              tier="detail"
+              className="size-24 rotate-[7.52deg]"
+            />
+          </button>
+          {valenceOpen && (
+            <ValencePickerBody
+              intensity={draft.intensity}
+              valence={draft.positiveness}
+              onSelect={handleValenceSelect}
+            />
+          )}
+        </Sheet>
+      </section>
+
+      <PebbleEditTitle
+        value={draft.name}
+        onChange={(next) => setField("name", next)}
+        className="mt-4"
+      />
+
+      <p className="mt-2 text-center text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        <time dateTime={pebble.happened_at}>{formattedDate}</time>
+      </p>
+
+      <div className="mt-6 flex flex-wrap gap-3">
+        <EmotionTile
+          editing
+          value={draft.emotion_id}
+          onChange={(id) => setField("emotion_id", id)}
+          className="min-w-[100px] flex-1"
+        />
+        <DomainTile
+          editing
+          value={draft.domain_ids}
+          onChange={(ids) => setField("domain_ids", ids)}
+          className="min-w-[100px] flex-1"
+        />
+        <CollectionTile
+          editing
+          value={draft.collection_ids}
+          onChange={(ids) => setField("collection_ids", ids)}
+          collections={collections}
+          className="min-w-[100px] flex-1"
+        />
+      </div>
+
+      <PebbleEditDescription
+        value={draft.description}
+        onChange={(next) => setField("description", next)}
+        className="mt-6"
+      />
+
+      <PebbleEditSoulsGrid
+        soulIds={draft.soul_ids}
+        souls={souls}
+        marks={marks}
+        onAddRequest={() => setSoulsOpen(true)}
+        onRemove={(id) =>
+          setField(
+            "soul_ids",
+            draft.soul_ids.filter((sid) => sid !== id),
+          )
+        }
+        className="mt-6"
+      />
+
+      {saveError && (
+        <p
+          role="alert"
+          className="mt-6 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          {t("errorToast")}
+        </p>
+      )}
+
+      <EmotionPickerSheet
+        open={emotionOpen}
+        onOpenChange={setEmotionOpen}
+        value={draft.emotion_id || undefined}
+        intensity={draft.intensity}
+        valence={draft.positiveness}
+        onChange={handleEmotionPick}
+      />
+
+      <SoulsSheet
+        open={soulsOpen}
+        onOpenChange={setSoulsOpen}
+        selectedIds={draft.soul_ids}
+        onToggle={handleSoulToggle}
+        souls={souls}
+        onAddSoul={async (name) => {
+          await handleAddSoul(name)
+        }}
+      />
+
+      <AlertDialog
+        open={confirmDiscardOpen}
+        onOpenChange={setConfirmDiscardOpen}
+      >
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("discardTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("discardDescription")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("discardKeep")}</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => void handleConfirmDiscard()}
+            >
+              {t("discardConfirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </article>
+  )
+}

--- a/apps/web/components/pebble/PebbleEdit.tsx
+++ b/apps/web/components/pebble/PebbleEdit.tsx
@@ -4,7 +4,6 @@ import { useCallback, useState } from "react"
 import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import type { Pebble, PebbleSnap, Soul, Collection, Mark } from "@/lib/types"
-import { useFormatPeekDate } from "@/lib/i18n"
 import { usePebbleDraft } from "@/lib/hooks/usePebbleDraft"
 import type { UpdatePebbleInput } from "@/lib/data/data-provider"
 import { PebbleVisual } from "@/components/pebble/PebbleVisual"
@@ -16,6 +15,7 @@ import {
 import { PebbleEditToolbar } from "@/components/pebble/PebbleEditToolbar"
 import { PebbleEditTitle } from "@/components/pebble/PebbleEditTitle"
 import { PebbleEditDescription } from "@/components/pebble/PebbleEditDescription"
+import { PebbleEditDate } from "@/components/pebble/PebbleEditDate"
 import {
   PebbleEditPicture,
   useSnapStaging,
@@ -66,7 +66,6 @@ export function PebbleEdit({
   const t = useTranslations("pebble.edit")
   const tPebble = useTranslations("pebble")
   const router = useRouter()
-  const formatPeekDate = useFormatPeekDate()
 
   const { draft, setField, setFields, isDirty, buildPayload } =
     usePebbleDraft(pebble)
@@ -176,10 +175,8 @@ export function PebbleEdit({
     ? marks.find((m) => m.id === draft.mark_id)
     : mark
 
-  const formattedDate = formatPeekDate(pebble.happened_at)
-
   return (
-    <article className="pb-12">
+    <article className="mx-auto max-w-md pb-12">
       <PebbleEditToolbar
         isSaving={saving}
         canSave={canSave}
@@ -226,9 +223,11 @@ export function PebbleEdit({
         className="mt-4"
       />
 
-      <p className="mt-2 text-center text-xs font-medium uppercase tracking-wider text-muted-foreground">
-        <time dateTime={pebble.happened_at}>{formattedDate}</time>
-      </p>
+      <PebbleEditDate
+        value={draft.happened_at}
+        onChange={(next) => setField("happened_at", next)}
+        className="mt-2"
+      />
 
       <div className="mt-6 flex flex-wrap gap-3">
         <EmotionTile

--- a/apps/web/components/pebble/PebbleEditDate.tsx
+++ b/apps/web/components/pebble/PebbleEditDate.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { useTranslations } from "next-intl"
+import { useFormatPeekDate } from "@/lib/i18n"
+import { cn } from "@/lib/utils"
+
+type PebbleEditDateProps = {
+  value: string // ISO UTC
+  onChange: (next: string) => void
+  className?: string
+}
+
+// Convert ISO UTC → `YYYY-MM-DDTHH:mm` in local time for `<input
+// type="datetime-local">`. The input value has no timezone suffix.
+function toInputValue(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ""
+  const pad = (n: number) => String(n).padStart(2, "0")
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+// Local datetime-local string → ISO UTC. `new Date("YYYY-MM-DDTHH:mm")`
+// is interpreted as local time, then `toISOString()` normalizes to UTC.
+function fromInputValue(value: string): string {
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return ""
+  return d.toISOString()
+}
+
+// Tap-to-edit date row. Renders the same uppercase meta-typo display the read
+// view uses; tapping swaps in a native `datetime-local` picker. Blur or
+// pressing Enter commits the staged value to the draft.
+export function PebbleEditDate({ value, onChange, className }: PebbleEditDateProps) {
+  const t = useTranslations("pebble.edit")
+  const formatPeekDate = useFormatPeekDate()
+  const [editing, setEditing] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus()
+  }, [editing])
+
+  if (editing) {
+    return (
+      <div className={cn("text-center", className)}>
+        <input
+          ref={inputRef}
+          type="datetime-local"
+          value={toInputValue(value)}
+          aria-label={t("dateAria")}
+          onChange={(e) => {
+            const next = fromInputValue(e.target.value)
+            if (next) onChange(next)
+          }}
+          onBlur={() => setEditing(false)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === "Escape") {
+              e.preventDefault()
+              setEditing(false)
+            }
+          }}
+          className={cn(
+            "inline-block bg-transparent text-xs font-medium uppercase tracking-wider text-muted-foreground",
+            "outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md",
+          )}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setEditing(true)}
+      aria-label={t("dateAria")}
+      className={cn(
+        "block w-full text-center text-xs font-medium uppercase tracking-wider text-muted-foreground transition-colors",
+        "outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md hover:text-foreground",
+        className,
+      )}
+    >
+      <time dateTime={value}>{formatPeekDate(value)}</time>
+    </button>
+  )
+}

--- a/apps/web/components/pebble/PebbleEditDescription.tsx
+++ b/apps/web/components/pebble/PebbleEditDescription.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { useTranslations } from "next-intl"
+import { cn } from "@/lib/utils"
+
+type PebbleEditDescriptionProps = {
+  value: string
+  onChange: (next: string) => void
+  className?: string
+}
+
+// Auto-growing textarea that swaps in on tap. When empty AND blurred we show
+// a dashed "Add a description" affordance so the missing field reads as an
+// invitation, not a void (per issue #481 spec).
+export function PebbleEditDescription({
+  value,
+  onChange,
+  className,
+}: PebbleEditDescriptionProps) {
+  const t = useTranslations("pebble.edit")
+  const [editing, setEditing] = useState(false)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // Sync textarea height to its content so it grows naturally as the user
+  // types. Tailwind 4's `field-sizing-content` would also work, but reading
+  // scrollHeight is broadly supported and keeps the height correct across
+  // initial focus + paste events.
+  const syncHeight = () => {
+    const el = textareaRef.current
+    if (!el) return
+    el.style.height = "auto"
+    el.style.height = `${el.scrollHeight}px`
+  }
+
+  useEffect(() => {
+    if (editing) {
+      textareaRef.current?.focus()
+      // Cursor at end of existing content.
+      const len = value.length
+      textareaRef.current?.setSelectionRange(len, len)
+      syncHeight()
+    }
+  }, [editing, value.length])
+
+  if (editing) {
+    return (
+      <textarea
+        ref={textareaRef}
+        value={value}
+        aria-label={t("descriptionAria")}
+        placeholder={t("descriptionPlaceholder")}
+        rows={1}
+        onChange={(e) => {
+          onChange(e.target.value)
+          syncHeight()
+        }}
+        onBlur={() => setEditing(false)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.preventDefault()
+            setEditing(false)
+          }
+        }}
+        className={cn(
+          "block w-full resize-none bg-transparent text-base leading-[1.4] text-foreground",
+          "outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md",
+          "placeholder:text-muted-foreground/60",
+          className,
+        )}
+      />
+    )
+  }
+
+  if (value) {
+    return (
+      <button
+        type="button"
+        onClick={() => setEditing(true)}
+        aria-label={t("descriptionAria")}
+        className={cn(
+          "block w-full whitespace-pre-wrap text-left text-base leading-[1.4] text-foreground",
+          "outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md transition-colors hover:text-primary",
+          className,
+        )}
+      >
+        {value}
+      </button>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setEditing(true)}
+      aria-label={t("descriptionAria")}
+      className={cn(
+        "block w-full rounded-2xl border-2 border-dashed border-muted-foreground/30 px-4 py-3 text-left text-base text-muted-foreground/70 transition-colors",
+        "hover:text-foreground active:scale-[0.99] outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+    >
+      {t("descriptionPlaceholder")}
+    </button>
+  )
+}

--- a/apps/web/components/pebble/PebbleEditPicture.tsx
+++ b/apps/web/components/pebble/PebbleEditPicture.tsx
@@ -1,0 +1,287 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { ImagePlus, Loader2, AlertCircle } from "lucide-react"
+import { useTranslations } from "next-intl"
+import type { PebbleSnap } from "@/lib/types"
+import { Sheet, SheetContent, SheetClose } from "@/components/ui/sheet"
+import { cn } from "@/lib/utils"
+
+// ---------------------------------------------------------------------------
+// Snap staging hook — mirrors iOS `SnapUploadCoordinator`. Owns:
+//   - the local blob preview URL while an upload is in flight,
+//   - the uploading/failed states (so the parent can gate Save),
+//   - cleanup of orphaned uploads on Replace/Remove/Discard.
+//
+// The hook does NOT persist anything — committing the staged snap happens in
+// the Save flow via `compose-pebble-update`. It only handles the in-edit
+// lifecycle: any snap uploaded during the edit session that is not the
+// pebble's original is "uncommitted" and must be removed from Storage if the
+// user cancels/replaces it.
+// ---------------------------------------------------------------------------
+
+type SnapStagingOptions = {
+  originalSnap: PebbleSnap | null
+  originalInstantUrl: string | null
+  draftSnap: PebbleSnap | null
+  setDraftSnap: (snap: PebbleSnap | null) => void
+  uploadSnap: (file: File) => Promise<PebbleSnap>
+  deletePebbleMedia: (snapId: string) => Promise<void>
+}
+
+export type SnapStagingResult = {
+  displayUrl: string | null
+  uploading: boolean
+  failed: boolean
+  pickFile: (file: File) => Promise<void>
+  remove: () => Promise<void>
+  cleanup: () => Promise<void>
+}
+
+export function useSnapStaging({
+  originalSnap,
+  originalInstantUrl,
+  draftSnap,
+  setDraftSnap,
+  uploadSnap,
+  deletePebbleMedia,
+}: SnapStagingOptions): SnapStagingResult {
+  const [uploading, setUploading] = useState(false)
+  const [failed, setFailed] = useState(false)
+  // The blob URL for the file the user just picked. Held separately from the
+  // draft snap because the snap row only exists after `uploadSnap` returns;
+  // showing the blob first gives an instant preview while the network call
+  // resolves.
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+
+  const previewUrlRef = useRef<string | null>(null)
+  previewUrlRef.current = previewUrl
+
+  useEffect(() => {
+    return () => {
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current)
+      }
+    }
+  }, [])
+
+  const isStagedUncommitted = useCallback(
+    (snap: PebbleSnap | null): boolean => {
+      if (!snap) return false
+      // The original snap (if any) is the only "committed" one; anything else
+      // was uploaded during this edit session and is therefore orphan-eligible
+      // if we don't end up saving with it.
+      return snap.id !== originalSnap?.id
+    },
+    [originalSnap],
+  )
+
+  const removeFromStorage = useCallback(
+    async (snap: PebbleSnap) => {
+      try {
+        await deletePebbleMedia(snap.id)
+      } catch (err) {
+        // The snap row may not exist if upload completed but the row was
+        // never persisted (never happens with our flow today — uploadSnap
+        // only writes to Storage, not to the DB). Either way, swallow the
+        // RPC error so the user-visible cancel/replace path doesn't fail.
+        console.warn("[pebble-edit] staged snap cleanup failed", err)
+      }
+    },
+    [deletePebbleMedia],
+  )
+
+  const pickFile = useCallback(
+    async (file: File) => {
+      // Tear down any previously staged-but-uncommitted snap before
+      // replacing — prevents storage orphans across multiple Replace cycles.
+      if (isStagedUncommitted(draftSnap) && draftSnap) {
+        void removeFromStorage(draftSnap)
+      }
+      // Free the previous blob preview if any.
+      if (previewUrl) URL.revokeObjectURL(previewUrl)
+      const nextPreview = URL.createObjectURL(file)
+      setPreviewUrl(nextPreview)
+      setUploading(true)
+      setFailed(false)
+      try {
+        const snap = await uploadSnap(file)
+        setDraftSnap(snap)
+      } catch (err) {
+        console.error("[pebble-edit] snap upload failed", err)
+        setFailed(true)
+      } finally {
+        setUploading(false)
+      }
+    },
+    [draftSnap, isStagedUncommitted, previewUrl, removeFromStorage, setDraftSnap, uploadSnap],
+  )
+
+  const remove = useCallback(async () => {
+    if (isStagedUncommitted(draftSnap) && draftSnap) {
+      void removeFromStorage(draftSnap)
+    }
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl)
+      setPreviewUrl(null)
+    }
+    setFailed(false)
+    setDraftSnap(null)
+  }, [draftSnap, isStagedUncommitted, previewUrl, removeFromStorage, setDraftSnap])
+
+  const cleanup = useCallback(async () => {
+    if (isStagedUncommitted(draftSnap) && draftSnap) {
+      void removeFromStorage(draftSnap)
+    }
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl)
+      setPreviewUrl(null)
+    }
+  }, [draftSnap, isStagedUncommitted, previewUrl, removeFromStorage])
+
+  // Decide which image URL to show:
+  //   - while uploading and we have a preview blob, show the preview;
+  //   - if the draft snap is the original, fall back to the signed URL;
+  //   - if the draft snap is a freshly uploaded one, show the preview blob;
+  //   - otherwise nothing.
+  let displayUrl: string | null = null
+  if (uploading && previewUrl) {
+    displayUrl = previewUrl
+  } else if (draftSnap && originalSnap && draftSnap.id === originalSnap.id) {
+    displayUrl = originalInstantUrl
+  } else if (draftSnap && previewUrl) {
+    displayUrl = previewUrl
+  }
+
+  return {
+    displayUrl,
+    uploading,
+    failed,
+    pickFile,
+    remove,
+    cleanup,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PebbleEditPicture — the hero picture slot in Edit mode.
+// 200×193 slot, image at 150×150, rotated -5°, radius 17. When no picture
+// is staged the slot renders a dashed placeholder with a `ImagePlus` icon.
+// Tapping a filled picture opens an action sheet with Replace / Remove.
+// ---------------------------------------------------------------------------
+
+type PebbleEditPictureProps = {
+  displayUrl: string | null
+  uploading: boolean
+  failed: boolean
+  onPick: (file: File) => void
+  onRemove: () => void
+  className?: string
+}
+
+export function PebbleEditPicture({
+  displayUrl,
+  uploading,
+  failed,
+  onPick,
+  onRemove,
+  className,
+}: PebbleEditPictureProps) {
+  const t = useTranslations("pebble.edit")
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const triggerPick = () => inputRef.current?.click()
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    e.target.value = "" // allow picking the same file twice
+    if (file) onPick(file)
+  }
+
+  return (
+    <div className={cn("relative h-[193px] w-[200px]", className)}>
+      {displayUrl ? (
+        <>
+          <button
+            type="button"
+            onClick={() => setSheetOpen(true)}
+            aria-label={t("pictureFilledAria")}
+            className="block size-[150px] overflow-hidden rounded-[17px] -rotate-5 outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element -- preview blob URL */}
+            <img
+              src={displayUrl}
+              alt=""
+              className={cn(
+                "size-full object-cover transition-opacity",
+                uploading && "opacity-60",
+              )}
+            />
+          </button>
+          {uploading && (
+            <span
+              className="pointer-events-none absolute left-[60px] top-[60px] grid size-8 place-items-center rounded-full bg-background/80 text-foreground"
+              aria-label={t("uploading")}
+            >
+              <Loader2 className="size-4 animate-spin" aria-hidden />
+            </span>
+          )}
+          {failed && (
+            <span
+              className="pointer-events-none absolute left-[58px] top-[58px] grid size-9 place-items-center rounded-full bg-destructive/90 text-destructive-foreground"
+              aria-label={t("uploadFailed")}
+              role="alert"
+            >
+              <AlertCircle className="size-4" aria-hidden />
+            </span>
+          )}
+          <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+            <SheetContent className="pb-6">
+              <div className="flex flex-col gap-2">
+                <SheetClose
+                  variant="ghost"
+                  size="lg"
+                  className="justify-start"
+                  onClick={() => {
+                    setSheetOpen(false)
+                    triggerPick()
+                  }}
+                >
+                  {t("replacePhoto")}
+                </SheetClose>
+                <SheetClose
+                  variant="ghost"
+                  size="lg"
+                  className="justify-start text-destructive"
+                  onClick={() => {
+                    setSheetOpen(false)
+                    onRemove()
+                  }}
+                >
+                  {t("removePhoto")}
+                </SheetClose>
+              </div>
+            </SheetContent>
+          </Sheet>
+        </>
+      ) : (
+        <button
+          type="button"
+          onClick={triggerPick}
+          aria-label={t("pictureEmptyAria")}
+          className="grid size-[150px] -rotate-5 place-items-center rounded-[17px] border-2 border-dashed border-muted-foreground/30 text-muted-foreground/70 transition-colors hover:border-muted-foreground/60 hover:text-foreground active:scale-[0.98] outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <ImagePlus className="size-7" aria-hidden />
+        </button>
+      )}
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handleFile}
+      />
+    </div>
+  )
+}

--- a/apps/web/components/pebble/PebbleEditSoulsGrid.tsx
+++ b/apps/web/components/pebble/PebbleEditSoulsGrid.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import { useState } from "react"
+import { Plus } from "lucide-react"
+import { useTranslations } from "next-intl"
+import type { Mark, Soul } from "@/lib/types"
+import { SoulGlyphThumbnail } from "@/components/souls/SoulGlyphThumbnail"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { cn } from "@/lib/utils"
+
+type PebbleEditSoulsGridProps = {
+  soulIds: string[]
+  souls: Soul[]
+  marks: Mark[]
+  onAddRequest: () => void
+  onRemove: (id: string) => void
+  className?: string
+}
+
+// Souls grid in Edit mode: the existing selection plus a dashed `Add` tile.
+// Tapping an existing soul opens a confirm dialog with Remove; tapping `Add`
+// delegates to the parent (which opens `SoulsSheet`). Mirrors the iOS souls
+// row in `PebbleFormView`.
+export function PebbleEditSoulsGrid({
+  soulIds,
+  souls,
+  marks,
+  onAddRequest,
+  onRemove,
+  className,
+}: PebbleEditSoulsGridProps) {
+  const t = useTranslations("pebble.edit")
+  const [confirmingId, setConfirmingId] = useState<string | null>(null)
+
+  const matchedSouls = soulIds
+    .map((id) => souls.find((s) => s.id === id))
+    .filter((s): s is Soul => s !== undefined)
+
+  const soulPendingRemoval =
+    confirmingId !== null ? souls.find((s) => s.id === confirmingId) ?? null : null
+
+  return (
+    <>
+      <ul className={cn("grid grid-cols-2 gap-3", className)} role="list">
+        {matchedSouls.map((soul) => {
+          const mark = marks.find((m) => m.id === soul.glyph_id)
+          return (
+            <li key={soul.id}>
+              <button
+                type="button"
+                onClick={() => setConfirmingId(soul.id)}
+                aria-label={t("removeSoulTitle")}
+                className="flex w-full items-center gap-3 rounded-2xl border border-border/60 px-3 py-2.5 text-left transition-colors hover:bg-surface active:scale-[0.98] outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <span className="grid size-10 shrink-0 place-items-center rounded-lg bg-muted/60">
+                  <SoulGlyphThumbnail
+                    mark={mark}
+                    className="size-7 text-foreground"
+                  />
+                </span>
+                <span className="line-clamp-1 text-sm font-medium text-foreground">
+                  {soul.name}
+                </span>
+              </button>
+            </li>
+          )
+        })}
+        <li>
+          <button
+            type="button"
+            onClick={onAddRequest}
+            aria-label={t("addSoulAria")}
+            className="flex w-full items-center gap-3 rounded-2xl border-2 border-dashed border-muted-foreground/30 px-3 py-2.5 text-left text-muted-foreground transition-colors hover:border-muted-foreground/60 hover:text-foreground active:scale-[0.98] outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <span className="grid size-10 shrink-0 place-items-center">
+              <Plus className="size-5" aria-hidden />
+            </span>
+            <span className="text-xs font-medium uppercase tracking-[0.1em]">
+              {t("addSoul")}
+            </span>
+          </button>
+        </li>
+      </ul>
+      <AlertDialog
+        open={confirmingId !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmingId(null)
+        }}
+      >
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("removeSoulTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {soulPendingRemoval
+                ? t("removeSoulDescription", { name: soulPendingRemoval.name })
+                : ""}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("removeSoulCancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => {
+                if (confirmingId) onRemove(confirmingId)
+                setConfirmingId(null)
+              }}
+            >
+              {t("removeSoulConfirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/apps/web/components/pebble/PebbleEditTitle.tsx
+++ b/apps/web/components/pebble/PebbleEditTitle.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { useTranslations } from "next-intl"
+import { cn } from "@/lib/utils"
+
+type PebbleEditTitleProps = {
+  value: string
+  onChange: (next: string) => void
+  className?: string
+}
+
+// Tap-to-edit single-line title. Renders as static text when blurred and
+// swaps to an input on focus. Blur or Enter stages the value into the draft.
+export function PebbleEditTitle({ value, onChange, className }: PebbleEditTitleProps) {
+  const t = useTranslations("pebble.edit")
+  const [editing, setEditing] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    }
+  }, [editing])
+
+  const placeholder = t("titlePlaceholder")
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        aria-label={t("titleAria")}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+        onBlur={() => setEditing(false)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault()
+            setEditing(false)
+          }
+          if (e.key === "Escape") {
+            e.preventDefault()
+            setEditing(false)
+          }
+        }}
+        className={cn(
+          "block w-full bg-transparent text-center font-heading text-2xl font-semibold text-foreground",
+          "outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md",
+          "placeholder:text-muted-foreground/60",
+          className,
+        )}
+      />
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setEditing(true)}
+      aria-label={t("titleAria")}
+      className={cn(
+        "block w-full text-center font-heading text-2xl font-semibold transition-colors",
+        "outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md",
+        value ? "text-foreground hover:text-primary" : "text-muted-foreground/60 hover:text-foreground",
+        className,
+      )}
+    >
+      {value || placeholder}
+    </button>
+  )
+}

--- a/apps/web/components/pebble/PebbleEditToolbar.tsx
+++ b/apps/web/components/pebble/PebbleEditToolbar.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { Loader2 } from "lucide-react"
+import { useTranslations } from "next-intl"
+import { cn } from "@/lib/utils"
+
+type PebbleEditToolbarProps = {
+  isSaving: boolean
+  canSave: boolean
+  onCancel: () => void
+  onSave: () => void
+}
+
+// Cancel · EDITION · Save — sticky top bar for the Edit screen.
+// Save is disabled when pristine, saving, or while a picture upload hasn't
+// resolved (`canSave` carries the combined gate from the parent).
+export function PebbleEditToolbar({
+  isSaving,
+  canSave,
+  onCancel,
+  onSave,
+}: PebbleEditToolbarProps) {
+  const t = useTranslations("pebble.edit")
+  return (
+    <header className="grid grid-cols-3 items-center py-2">
+      <div className="justify-self-start">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isSaving}
+          aria-label={t("cancelAria")}
+          className={cn(
+            "rounded-md px-2 py-1 text-base text-muted-foreground transition-colors",
+            "hover:text-foreground active:scale-95 outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            "disabled:opacity-50 disabled:pointer-events-none",
+          )}
+        >
+          {t("cancel")}
+        </button>
+      </div>
+      <p className="justify-self-center text-xs font-medium uppercase tracking-[0.1em] text-muted-foreground">
+        {isSaving ? t("saving") : t("toolbarTitle")}
+      </p>
+      <div className="justify-self-end">
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={!canSave}
+          aria-label={t("saveAria")}
+          aria-busy={isSaving}
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-base transition-colors",
+            "active:scale-95 outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            canSave
+              ? "text-foreground hover:text-primary"
+              : "text-muted-foreground/60 pointer-events-none",
+          )}
+        >
+          {isSaving && <Loader2 className="size-4 animate-spin" aria-hidden />}
+          {t("save")}
+        </button>
+      </div>
+    </header>
+  )
+}

--- a/apps/web/lib/hooks/usePebbleDraft.ts
+++ b/apps/web/lib/hooks/usePebbleDraft.ts
@@ -17,6 +17,7 @@ export type PebbleDraftSnap = PebbleSnap
 export type PebbleDraft = {
   name: string
   description: string
+  happened_at: string
   intensity: Pebble["intensity"]
   positiveness: Pebble["positiveness"]
   emotion_id: string
@@ -47,6 +48,7 @@ function snapshotFromPebble(pebble: Pebble): PebbleDraft {
   return {
     name: pebble.name,
     description: pebble.description ?? "",
+    happened_at: pebble.happened_at,
     intensity: pebble.intensity,
     positiveness: pebble.positiveness,
     emotion_id: pebble.emotion_id,
@@ -74,6 +76,7 @@ function diffFields(original: PebbleDraft, draft: PebbleDraft): Set<keyof Pebble
   const dirty = new Set<keyof PebbleDraft>()
   if (original.name !== draft.name) dirty.add("name")
   if (original.description !== draft.description) dirty.add("description")
+  if (original.happened_at !== draft.happened_at) dirty.add("happened_at")
   if (original.intensity !== draft.intensity) dirty.add("intensity")
   if (original.positiveness !== draft.positiveness) dirty.add("positiveness")
   if (original.emotion_id !== draft.emotion_id) dirty.add("emotion_id")
@@ -124,6 +127,7 @@ export function usePebbleDraft(pebble: Pebble): UsePebbleDraftResult {
     const payload: UpdatePebbleInput = {}
     if (dirtyFields.has("name")) payload.name = draft.name
     if (dirtyFields.has("description")) payload.description = draft.description
+    if (dirtyFields.has("happened_at")) payload.happened_at = draft.happened_at
     if (dirtyFields.has("intensity")) payload.intensity = draft.intensity
     if (dirtyFields.has("positiveness")) payload.positiveness = draft.positiveness
     if (dirtyFields.has("emotion_id")) payload.emotion_id = draft.emotion_id

--- a/apps/web/lib/hooks/usePebbleDraft.ts
+++ b/apps/web/lib/hooks/usePebbleDraft.ts
@@ -1,0 +1,152 @@
+"use client"
+
+import { useCallback, useMemo, useReducer, useState } from "react"
+import type { Pebble, PebbleSnap } from "@/lib/types"
+import type { UpdatePebbleInput } from "@/lib/data/data-provider"
+
+// ---------------------------------------------------------------------------
+// Pebble edit draft — mirrors iOS `PebbleDraft` (apps/ios/.../Models/PebbleDraft.swift).
+// Holds every editable field locally so the Edit screen can stage changes and
+// commit them atomically via `compose-pebble-update`. The baseline (`original`)
+// is captured once on mount and frozen — a successful Save navigates away, and
+// Cancel discards the draft, so we never need to re-sync mid-edit.
+// ---------------------------------------------------------------------------
+
+export type PebbleDraftSnap = PebbleSnap
+
+export type PebbleDraft = {
+  name: string
+  description: string
+  intensity: Pebble["intensity"]
+  positiveness: Pebble["positiveness"]
+  emotion_id: string
+  mark_id: string | null
+  domain_ids: string[]
+  collection_ids: string[]
+  soul_ids: string[]
+  snap: PebbleDraftSnap | null
+}
+
+type DraftAction =
+  | { type: "set"; key: keyof PebbleDraft; value: PebbleDraft[keyof PebbleDraft] }
+  | { type: "setMany"; patch: Partial<PebbleDraft> }
+  | { type: "reset"; draft: PebbleDraft }
+
+function reducer(state: PebbleDraft, action: DraftAction): PebbleDraft {
+  switch (action.type) {
+    case "set":
+      return { ...state, [action.key]: action.value }
+    case "setMany":
+      return { ...state, ...action.patch }
+    case "reset":
+      return action.draft
+  }
+}
+
+function snapshotFromPebble(pebble: Pebble): PebbleDraft {
+  return {
+    name: pebble.name,
+    description: pebble.description ?? "",
+    intensity: pebble.intensity,
+    positiveness: pebble.positiveness,
+    emotion_id: pebble.emotion_id,
+    mark_id: pebble.mark_id ?? null,
+    domain_ids: [...pebble.domain_ids],
+    collection_ids: [...pebble.collection_ids],
+    soul_ids: [...pebble.soul_ids],
+    snap: pebble.snaps[0] ?? null,
+  }
+}
+
+function sameStringArray(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false
+  return true
+}
+
+function sameSnap(a: PebbleDraftSnap | null, b: PebbleDraftSnap | null): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  return a.id === b.id && a.storage_path === b.storage_path
+}
+
+function diffFields(original: PebbleDraft, draft: PebbleDraft): Set<keyof PebbleDraft> {
+  const dirty = new Set<keyof PebbleDraft>()
+  if (original.name !== draft.name) dirty.add("name")
+  if (original.description !== draft.description) dirty.add("description")
+  if (original.intensity !== draft.intensity) dirty.add("intensity")
+  if (original.positiveness !== draft.positiveness) dirty.add("positiveness")
+  if (original.emotion_id !== draft.emotion_id) dirty.add("emotion_id")
+  if (original.mark_id !== draft.mark_id) dirty.add("mark_id")
+  if (!sameStringArray(original.domain_ids, draft.domain_ids)) dirty.add("domain_ids")
+  if (!sameStringArray(original.collection_ids, draft.collection_ids)) dirty.add("collection_ids")
+  if (!sameStringArray(original.soul_ids, draft.soul_ids)) dirty.add("soul_ids")
+  if (!sameSnap(original.snap, draft.snap)) dirty.add("snap")
+  return dirty
+}
+
+export type UsePebbleDraftResult = {
+  draft: PebbleDraft
+  setField: <K extends keyof PebbleDraft>(key: K, value: PebbleDraft[K]) => void
+  setFields: (patch: Partial<PebbleDraft>) => void
+  isDirty: boolean
+  dirtyFields: Set<keyof PebbleDraft>
+  buildPayload: () => UpdatePebbleInput
+  resetToOriginal: () => void
+}
+
+export function usePebbleDraft(pebble: Pebble): UsePebbleDraftResult {
+  // Capture the baseline once, on first render. `useState`'s lazy initializer
+  // runs exactly once per mount, which is what we want: the original is
+  // frozen until the user navigates away (Save or Cancel).
+  const [original] = useState(() => snapshotFromPebble(pebble))
+  const [draft, dispatch] = useReducer(reducer, original)
+
+  const setField = useCallback(
+    <K extends keyof PebbleDraft>(key: K, value: PebbleDraft[K]) => {
+      dispatch({ type: "set", key, value })
+    },
+    [],
+  )
+
+  const setFields = useCallback((patch: Partial<PebbleDraft>) => {
+    dispatch({ type: "setMany", patch })
+  }, [])
+
+  const resetToOriginal = useCallback(() => {
+    dispatch({ type: "reset", draft: original })
+  }, [original])
+
+  const dirtyFields = useMemo(() => diffFields(original, draft), [original, draft])
+  const isDirty = dirtyFields.size > 0
+
+  const buildPayload = useCallback((): UpdatePebbleInput => {
+    const payload: UpdatePebbleInput = {}
+    if (dirtyFields.has("name")) payload.name = draft.name
+    if (dirtyFields.has("description")) payload.description = draft.description
+    if (dirtyFields.has("intensity")) payload.intensity = draft.intensity
+    if (dirtyFields.has("positiveness")) payload.positiveness = draft.positiveness
+    if (dirtyFields.has("emotion_id")) payload.emotion_id = draft.emotion_id
+    // The provider maps `mark_id` to `glyph_id` and treats `null` as a clear;
+    // `Pebble.mark_id` types as `string | undefined`, so cast for the
+    // explicit-null clear path.
+    if (dirtyFields.has("mark_id")) {
+      ;(payload as Record<string, unknown>).mark_id = draft.mark_id
+    }
+    if (dirtyFields.has("domain_ids")) payload.domain_ids = draft.domain_ids
+    if (dirtyFields.has("collection_ids")) payload.collection_ids = draft.collection_ids
+    if (dirtyFields.has("soul_ids")) payload.soul_ids = draft.soul_ids
+    if (dirtyFields.has("snap")) payload.snaps = draft.snap ? [draft.snap] : []
+    return payload
+  }, [dirtyFields, draft])
+
+  return {
+    draft,
+    setField,
+    setFields,
+    isDirty,
+    dirtyFields,
+    buildPayload,
+    resetToOriginal,
+  }
+}

--- a/apps/web/lib/i18n/messages/en.json
+++ b/apps/web/lib/i18n/messages/en.json
@@ -424,6 +424,7 @@
       "discardKeep": "Keep editing",
       "titlePlaceholder": "Untitled",
       "titleAria": "Pebble name",
+      "dateAria": "Date and time",
       "descriptionPlaceholder": "Add a description",
       "descriptionAria": "Pebble description",
       "addSoul": "Add",

--- a/apps/web/lib/i18n/messages/en.json
+++ b/apps/web/lib/i18n/messages/en.json
@@ -409,7 +409,37 @@
       "picture": "Picture",
       "pictureAria": "Add a picture"
     },
-    "editIntensityAria": "Edit intensity and valence"
+    "editIntensityAria": "Edit intensity and valence",
+    "editAria": "Edit pebble",
+    "edit": {
+      "toolbarTitle": "EDITION",
+      "cancel": "Cancel",
+      "save": "Save",
+      "saving": "Saving…",
+      "saveAria": "Save changes",
+      "cancelAria": "Cancel editing",
+      "discardTitle": "Discard changes?",
+      "discardDescription": "Your edits won't be saved.",
+      "discardConfirm": "Discard",
+      "discardKeep": "Keep editing",
+      "titlePlaceholder": "Untitled",
+      "titleAria": "Pebble name",
+      "descriptionPlaceholder": "Add a description",
+      "descriptionAria": "Pebble description",
+      "addSoul": "Add",
+      "addSoulAria": "Add a soul",
+      "removeSoulTitle": "Remove soul?",
+      "removeSoulDescription": "{name} won't be linked to this pebble anymore.",
+      "removeSoulConfirm": "Remove",
+      "removeSoulCancel": "Keep",
+      "pictureEmptyAria": "Add a picture",
+      "pictureFilledAria": "Replace or remove the picture",
+      "replacePhoto": "Replace",
+      "removePhoto": "Remove",
+      "errorToast": "Couldn't save your edits. Try again.",
+      "uploading": "Uploading picture…",
+      "uploadFailed": "Picture upload failed. Try again."
+    }
   },
   "record": {
     "srTitle": "Record a pebble",

--- a/apps/web/lib/i18n/messages/fr.json
+++ b/apps/web/lib/i18n/messages/fr.json
@@ -409,7 +409,37 @@
       "picture": "Photo",
       "pictureAria": "Ajouter une photo"
     },
-    "editIntensityAria": "Modifier l'intensité et la valence"
+    "editIntensityAria": "Modifier l'intensité et la valence",
+    "editAria": "Modifier le galet",
+    "edit": {
+      "toolbarTitle": "ÉDITION",
+      "cancel": "Annuler",
+      "save": "Enregistrer",
+      "saving": "Enregistrement…",
+      "saveAria": "Enregistrer les modifications",
+      "cancelAria": "Annuler la modification",
+      "discardTitle": "Abandonner les modifications ?",
+      "discardDescription": "Vos modifications ne seront pas enregistrées.",
+      "discardConfirm": "Abandonner",
+      "discardKeep": "Continuer",
+      "titlePlaceholder": "Sans titre",
+      "titleAria": "Nom du galet",
+      "descriptionPlaceholder": "Ajouter une description",
+      "descriptionAria": "Description du galet",
+      "addSoul": "Ajouter",
+      "addSoulAria": "Ajouter une âme",
+      "removeSoulTitle": "Retirer l'âme ?",
+      "removeSoulDescription": "{name} ne sera plus liée à ce galet.",
+      "removeSoulConfirm": "Retirer",
+      "removeSoulCancel": "Garder",
+      "pictureEmptyAria": "Ajouter une photo",
+      "pictureFilledAria": "Remplacer ou retirer la photo",
+      "replacePhoto": "Remplacer",
+      "removePhoto": "Retirer",
+      "errorToast": "Impossible d'enregistrer. Réessayez.",
+      "uploading": "Envoi de la photo…",
+      "uploadFailed": "Échec de l'envoi de la photo. Réessayez."
+    }
   },
   "record": {
     "srTitle": "Capturer l'instant",

--- a/apps/web/lib/i18n/messages/fr.json
+++ b/apps/web/lib/i18n/messages/fr.json
@@ -424,6 +424,7 @@
       "discardKeep": "Continuer",
       "titlePlaceholder": "Sans titre",
       "titleAria": "Nom du galet",
+      "dateAria": "Date et heure",
       "descriptionPlaceholder": "Ajouter une description",
       "descriptionAria": "Description du galet",
       "addSoul": "Ajouter",


### PR DESCRIPTION
Resolves #481

## Changes
- `apps/web/app/pebble/[id]/edit/page.tsx` — new App Router route, mirrors `app/pebble/[id]/page.tsx`. Renders `<PebbleEdit>` (or `<PebbleNotFound>`).
- `apps/web/components/pebble/PebbleEdit.tsx` — main edit screen. Owns the draft, toolbar state machine (pristine/dirty/saving/error), discard-confirm dialog, glyph picker chain (ValenceIntensityGrid → EmotionPickerSheet), inline error toast on save failure.
- `apps/web/lib/hooks/usePebbleDraft.ts` — non-data staging hook. Captures baseline once via `useState` lazy init, tracks dirty fields, builds an `UpdatePebbleInput` payload containing only changed fields. Mirrors iOS `PebbleDraft`.
- `apps/web/components/pebble/PebbleEditPicture.tsx` — picture slot + colocated `useSnapStaging` coordinator. Empty = dashed placeholder + `ImagePlus`; filled = action sheet (Replace / Remove). Cleans up uncommitted snaps from Storage on Replace / Remove / Discard. Mirrors iOS `SnapUploadCoordinator`.
- `apps/web/components/pebble/PebbleEditToolbar.tsx` — Cancel · `EDITION` · Save with spinner. Save gated by `canSave = isDirty && !saving && !uploading && !failed`.
- `apps/web/components/pebble/PebbleEditTitle.tsx` — tap-to-edit single-line input, `title-2` typo, "Untitled" placeholder. Enter / blur stages into draft.
- `apps/web/components/pebble/PebbleEditDescription.tsx` — auto-growing textarea via `scrollHeight` sync, dashed "Add a description" placeholder when empty.
- `apps/web/components/pebble/PebbleEditSoulsGrid.tsx` — souls grid + dashed `Add` tile; tapping an existing soul opens a Remove confirm dialog.
- `apps/web/components/pebble/PebbleDetailTiles.tsx` — additive `editing` prop on `EmotionTile` / `DomainTile` / `CollectionTile` (no read-mode refactor). When `editing` and empty, swaps `bg-surface` for `border-2 border-dashed border-muted-foreground/30 opacity-60`.
- `apps/web/components/pebble/PebbleDetail.tsx` — minimal Edit button (lucide `SquarePen`) in the top-right slot via a new `onEdit?: () => void` prop. Unblocks this work ahead of the Read redesign.
- `apps/web/app/pebble/[id]/page.tsx` — wires `onEdit={() => router.push(`/pebble/${id}/edit`)}`.
- `apps/web/lib/i18n/messages/{en,fr}.json` — new `pebble.edit.*` namespace + `pebble.editAria` for the Read-view button.

## Notes
- **Atomic save reuses existing infra.** `SupabaseProvider.updatePebble` already routes through the `compose-pebble-update` edge function (one transaction server-side). No new RPC, no new provider method — Save sends a single payload with only dirty fields.
- **Picture orphan handling.** Any snap uploaded during the edit session that is not the pebble's original is "uncommitted" — Replace, Remove, and Discard all call `deletePebbleMedia` on it to keep Storage clean. Save-failure keeps the staged snap so the user can retry.
- **`compose-pebble-update` is fire-once.** DevTools should show exactly one POST to `…/functions/v1/compose-pebble-update` per Save regardless of how many fields are dirty.
- **Empty `name`** sends `""`; relying on server-side normalization (issue spec: "Save still commits an empty name as `null`"). `Pebble.name` is non-nullable in TS types — confirm during code review whether to widen `UpdatePebbleInput["name"]` to `string | null` in a follow-up.
- **`"EDITION"`** verbatim in EN (FR uses `"ÉDITION"`). Worth confirming with design whether EN should read `"EDIT"` / `"EDITING"` instead.
- **Lint / build / dev start are green** locally. Manual browser walkthrough is required before merging — the remote execution environment has no browser, so I could not exercise the interactive paths (toolbar state transitions, tap-to-edit, picture upload, save-error retry, locale toggle).

## Test plan
- [ ] `npm run lint -w @pbbls/web`
- [ ] `npm run dev -w @pbbls/web` and walk through `/pebble/<id>/edit`:
  - [ ] Pristine → Save disabled; Cancel returns silently.
  - [ ] Dirty (e.g. title only) → Save enabled; Cancel opens "Discard changes?" dialog; keep editing closes; discard returns to read.
  - [ ] Each field's tap-to-edit affordance: title, description, glyph chain (Valence → Emotion), Emotion tile, Domain tile, Collection tile, Souls grid (Add + per-soul Remove), Picture (empty placeholder, file picker, filled action sheet with Replace / Remove).
  - [ ] Unset tile variants render dashed + faded.
  - [ ] Replace photo multiple times → only the latest snap remains in `pebbles-media/<userId>/`.
  - [ ] Cancel-dirty after picking a photo → confirm orphan snap is cleaned from Storage.
  - [ ] Save in DevTools Network → exactly one POST to `compose-pebble-update`.
  - [ ] Simulated save failure → toolbar returns to dirty, inline error renders, draft preserved.
  - [ ] `/pebble/<bad-id>/edit` → `<PebbleNotFound>`.
  - [ ] EN ↔ FR toggle: every new string has both locales (`"EDITION"` / `"ÉDITION"` etc.).

## Lab Note (EN/FR)

**EN — Edit a pebble on the web**
You can now reshape a pebble after the fact on the web app: tap the new Edit button on any pebble's page, change anything — title, description, emotion, photo, souls — and Save commits everything in one go. Cancel never touches your pebble.

**FR — Modifier un galet sur le web**
Vous pouvez maintenant retoucher un galet après coup dans l'application web : touchez le nouveau bouton Modifier sur la page d'un galet, changez ce que vous voulez — titre, description, émotion, photo, âmes — et Enregistrer applique tout d'un coup. Annuler ne modifie jamais votre galet.

https://claude.ai/code/session_016KpxjnZ5NtV6JQQMwWm9dz

---
_Generated by [Claude Code](https://claude.ai/code/session_016KpxjnZ5NtV6JQQMwWm9dz)_