### PR TITLE
feat(core): karma wallet — spendable currency rails + wallet page

### DIFF
--- a/apps/web/app/wallet/page.tsx
+++ b/apps/web/app/wallet/page.tsx
@@ -1,0 +1,5 @@
+import { WalletView } from "@/components/wallet/WalletView"
+
+export default function WalletPage() {
+  return <WalletView />
+}

--- a/apps/web/components/path/PathBottomBar.tsx
+++ b/apps/web/components/path/PathBottomBar.tsx
@@ -43,7 +43,7 @@ export function PathBottomBar() {
       </Link>
       <Link
         href="/wallet"
-        aria-label={t("bottomBar.statsAria")}
+        aria-label={t("bottomBar.walletAria")}
         className="flex items-center gap-4"
       >
         <Stat icon={CirclePile} value={bounceLoading ? "—" : bounce} label={t("stats.bounce")} />

--- a/apps/web/components/path/PathBottomBar.tsx
+++ b/apps/web/components/path/PathBottomBar.tsx
@@ -42,7 +42,7 @@ export function PathBottomBar() {
         <CircleUser className="size-7" />
       </Link>
       <Link
-        href="/profile"
+        href="/wallet"
         aria-label={t("bottomBar.statsAria")}
         className="flex items-center gap-4"
       >

--- a/apps/web/components/wallet/WalletHistoryItem.tsx
+++ b/apps/web/components/wallet/WalletHistoryItem.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import { ArrowDownLeft, ArrowUpRight } from "lucide-react"
+import type { KarmaEvent } from "@/lib/types"
+import { signedAmount, direction, reasonKey } from "@/lib/utils/wallet-format"
+
+export function WalletHistoryItem({ event }: { event: KarmaEvent }) {
+  const t = useTranslations("wallet")
+  const dir = direction(event.delta)
+  const Icon = dir === "in" ? ArrowDownLeft : ArrowUpRight
+  const date = new Date(event.created_at).toLocaleDateString()
+
+  return (
+    <li className="flex items-center justify-between gap-3 py-3">
+      <div className="flex items-center gap-3">
+        <Icon className="size-4 text-muted-foreground" aria-hidden />
+        <div>
+          <p className="text-sm font-medium">{t(`reason.${reasonKey(event.reason)}`)}</p>
+          <p className="text-xs text-muted-foreground">{date}</p>
+        </div>
+      </div>
+      <span className="text-sm font-semibold tabular-nums">{signedAmount(event.delta)}</span>
+    </li>
+  )
+}

--- a/apps/web/components/wallet/WalletView.tsx
+++ b/apps/web/components/wallet/WalletView.tsx
@@ -5,6 +5,8 @@ import { Sparkle } from "lucide-react"
 import { useWallet } from "@/lib/data/useWallet"
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
+import { PageLayout } from "@/components/layout/PageLayout"
+import { PageHeader } from "@/components/layout/PageHeader"
 import { WalletHistoryItem } from "./WalletHistoryItem"
 
 export function WalletView() {
@@ -12,8 +14,10 @@ export function WalletView() {
   const { balance, totalEarned, totalSpent, history, hasMore, loadMore, loading } = useWallet()
 
   return (
-    <div className="mx-auto flex w-full max-w-md flex-col gap-6 p-4">
-      <Card className="flex flex-col gap-2 p-6">
+    <PageLayout>
+      <div className="flex flex-col gap-6">
+        <PageHeader title={t("title")} backHref="/path" />
+        <Card className="flex flex-col gap-2 p-6">
         <div className="flex items-center gap-2">
           <Sparkle className="size-5" aria-hidden />
           <span className="text-3xl font-bold tabular-nums">{loading ? "—" : balance}</span>
@@ -42,7 +46,8 @@ export function WalletView() {
             {t("loadMore")}
           </Button>
         )}
-      </section>
-    </div>
+        </section>
+      </div>
+    </PageLayout>
   )
 }

--- a/apps/web/components/wallet/WalletView.tsx
+++ b/apps/web/components/wallet/WalletView.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import { Sparkle } from "lucide-react"
+import { useWallet } from "@/lib/data/useWallet"
+import { Card } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { WalletHistoryItem } from "./WalletHistoryItem"
+
+export function WalletView() {
+  const t = useTranslations("wallet")
+  const { balance, totalEarned, totalSpent, history, hasMore, loadMore, loading } = useWallet()
+
+  return (
+    <div className="mx-auto flex w-full max-w-md flex-col gap-6 p-4">
+      <Card className="flex flex-col gap-2 p-6">
+        <div className="flex items-center gap-2">
+          <Sparkle className="size-5" aria-hidden />
+          <span className="text-3xl font-bold tabular-nums">{loading ? "—" : balance}</span>
+          <span className="text-sm text-muted-foreground">{t("balance")}</span>
+        </div>
+        {balance < 0 && !loading && (
+          <p className="text-sm text-amber-600 dark:text-amber-400">{t("debtHint")}</p>
+        )}
+        <div className="mt-2 flex gap-6 text-sm text-muted-foreground">
+          <span>{t("earned")}: <span className="tabular-nums">{totalEarned}</span></span>
+          <span>{t("spent")}: <span className="tabular-nums">{totalSpent}</span></span>
+        </div>
+      </Card>
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold text-muted-foreground">{t("history")}</h2>
+        {history.length === 0 && !loading ? (
+          <p className="text-sm text-muted-foreground">{t("empty")}</p>
+        ) : (
+          <ul className="divide-y">
+            {history.map((e) => <WalletHistoryItem key={e.id} event={e} />)}
+          </ul>
+        )}
+        {hasMore && (
+          <Button variant="ghost" className="mt-3 w-full" onClick={() => loadMore()}>
+            {t("loadMore")}
+          </Button>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/apps/web/lib/data/data-provider.ts
+++ b/apps/web/lib/data/data-provider.ts
@@ -5,6 +5,7 @@ import type {
   Collection,
   KarmaEvent,
   Mark,
+  WalletSnapshot,
 } from "@/lib/types"
 
 // ---------------------------------------------------------------------------
@@ -70,6 +71,11 @@ export type UpdateMarkInput = Partial<
   Omit<Mark, "id" | "name" | "created_at" | "updated_at">
 > & { name?: string | null }
 
+export type WalletHistoryPage = {
+  events: KarmaEvent[]
+  nextCursor: string | null
+}
+
 // ---------------------------------------------------------------------------
 // DataProvider interface — implemented by SupabaseProvider.
 // All mutation methods return Promises to match async Supabase calls.
@@ -79,6 +85,10 @@ export interface DataProvider {
   getStore(): Store
   loadFromSupabase(): Promise<Store>
   reset(): Promise<Store>
+
+  getWallet(): Promise<WalletSnapshot>
+  getWalletHistory(cursor?: string, limit?: number): Promise<WalletHistoryPage>
+  spendKarma(amount: number, reason: "purchase", refId?: string): Promise<string>
 
   getPebblesCount(): Promise<number>
   getKarma(): Promise<number>

--- a/apps/web/lib/data/supabase-provider.ts
+++ b/apps/web/lib/data/supabase-provider.ts
@@ -11,6 +11,7 @@ import {
   type UpdateCollectionInput,
   type CreateMarkInput,
   type UpdateMarkInput,
+  type WalletHistoryPage,
 } from "@/lib/data/data-provider"
 import type {
   Pebble,
@@ -18,6 +19,8 @@ import type {
   Soul,
   Collection,
   Mark,
+  KarmaEvent,
+  WalletSnapshot,
 } from "@/lib/types"
 import { DEFAULT_GLYPH_ID } from "@/lib/config/glyphs"
 import { processPebbleImage } from "@/lib/utils/process-pebble-image"
@@ -243,6 +246,51 @@ export class SupabaseProvider implements DataProvider {
   async getPebblesCount(): Promise<number> { return this.store.pebbles_count }
   async getKarma(): Promise<number> { return this.store.karma }
   async getBounce(): Promise<number> { return this.store.bounce }
+
+  // ---------------------------------------------------------------------------
+  // Wallet — read summary + on-demand paginated history, and spend via RPC.
+  // ---------------------------------------------------------------------------
+
+  async getWallet(): Promise<WalletSnapshot> {
+    const { data } = await this.supabase
+      .from("v_wallet_summary")
+      .select("*")
+      .eq("user_id", this.userId)
+      .maybeSingle()
+    return {
+      balance: (data?.balance as number) ?? 0,
+      totalEarned: (data?.total_earned as number) ?? 0,
+      totalSpent: (data?.total_spent as number) ?? 0,
+    }
+  }
+
+  async getWalletHistory(cursor?: string, limit = 20): Promise<WalletHistoryPage> {
+    let query = this.supabase
+      .from("karma_events")
+      .select("id, type, delta, reason, ref_id, created_at")
+      .eq("user_id", this.userId)
+      .order("created_at", { ascending: false })
+      .order("id", { ascending: false })
+      .limit(limit + 1)
+    if (cursor) query = query.lt("created_at", cursor)
+    const { data, error } = await query
+    if (error) throw new Error(`getWalletHistory failed: ${error.message}`)
+    const rows = (data ?? []) as KarmaEvent[]
+    const hasMore = rows.length > limit
+    const events = hasMore ? rows.slice(0, limit) : rows
+    const nextCursor = hasMore ? events[events.length - 1].created_at : null
+    return { events, nextCursor }
+  }
+
+  async spendKarma(amount: number, reason: "purchase", refId?: string): Promise<string> {
+    const { data, error } = await this.supabase.rpc("spend_karma", {
+      p_amount: amount,
+      p_reason: reason,
+      p_ref_id: refId ?? null,
+    })
+    if (error) throw new Error(`spend_karma failed: ${error.message}`)
+    return data as string
+  }
   async listPebbles(): Promise<Pebble[]> { return this.store.pebbles }
   async getPebble(id: string): Promise<Pebble | undefined> { return this.store.pebbles.find((p) => p.id === id) }
   async listSouls(): Promise<Soul[]> { return this.store.souls }

--- a/apps/web/lib/data/supabase-provider.ts
+++ b/apps/web/lib/data/supabase-provider.ts
@@ -272,13 +272,24 @@ export class SupabaseProvider implements DataProvider {
       .order("created_at", { ascending: false })
       .order("id", { ascending: false })
       .limit(limit + 1)
-    if (cursor) query = query.lt("created_at", cursor)
+    if (cursor) {
+      // Composite keyset cursor "<created_at>|<id>": fetch rows strictly before
+      // (created_at, id) under the (desc, desc) ordering, so same-timestamp rows
+      // straddling a page boundary are not dropped.
+      const sep = cursor.lastIndexOf("|")
+      const ts = cursor.slice(0, sep)
+      const id = cursor.slice(sep + 1)
+      query = query.or(`created_at.lt.${ts},and(created_at.eq.${ts},id.lt.${id})`)
+    }
     const { data, error } = await query
     if (error) throw new Error(`getWalletHistory failed: ${error.message}`)
+    // `as KarmaEvent[]` is load-bearing: PostgREST types `type`/`reason` as plain
+    // strings; the karma_events CHECK constraints are what make this cast sound.
     const rows = (data ?? []) as KarmaEvent[]
     const hasMore = rows.length > limit
     const events = hasMore ? rows.slice(0, limit) : rows
-    const nextCursor = hasMore ? events[events.length - 1].created_at : null
+    const last = events[events.length - 1]
+    const nextCursor = hasMore && last ? `${last.created_at}|${last.id}` : null
     return { events, nextCursor }
   }
 

--- a/apps/web/lib/data/useWallet.ts
+++ b/apps/web/lib/data/useWallet.ts
@@ -15,6 +15,7 @@ export function useWallet() {
   // Start in the loading state only when a provider is available to load from;
   // without one (unauthenticated) there is nothing to fetch.
   const [loading, setLoading] = useState(() => provider !== null)
+  const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState<Error | null>(null)
 
   useEffect(() => {
@@ -51,11 +52,18 @@ export function useWallet() {
   }, [provider])
 
   const loadMore = useCallback(async () => {
-    if (!cursor || !provider) return
-    const page = await provider.getWalletHistory(cursor)
-    setHistory((prev) => [...prev, ...page.events])
-    setCursor(page.nextCursor)
-  }, [provider, cursor])
+    if (!cursor || !provider || loadingMore) return
+    setLoadingMore(true)
+    try {
+      const page = await provider.getWalletHistory(cursor)
+      setHistory((prev) => [...prev, ...page.events])
+      setCursor(page.nextCursor)
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error("Failed to load more wallet history"))
+    } finally {
+      setLoadingMore(false)
+    }
+  }, [provider, cursor, loadingMore])
 
   return {
     balance: summary.balance,
@@ -64,6 +72,7 @@ export function useWallet() {
     history,
     hasMore: cursor !== null,
     loadMore,
+    loadingMore,
     loading,
     error,
   }

--- a/apps/web/lib/data/useWallet.ts
+++ b/apps/web/lib/data/useWallet.ts
@@ -1,0 +1,70 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { useDataProvider } from "@/lib/data/provider-context"
+import type { KarmaEvent, WalletSnapshot } from "@/lib/types"
+
+const EMPTY: WalletSnapshot = { balance: 0, totalEarned: 0, totalSpent: 0 }
+
+// Wallet history is fetched on demand (not part of the eager global store load).
+export function useWallet() {
+  const { provider } = useDataProvider()
+  const [summary, setSummary] = useState<WalletSnapshot>(EMPTY)
+  const [history, setHistory] = useState<KarmaEvent[]>([])
+  const [cursor, setCursor] = useState<string | null>(null)
+  // Start in the loading state only when a provider is available to load from;
+  // without one (unauthenticated) there is nothing to fetch.
+  const [loading, setLoading] = useState(() => provider !== null)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    if (!provider) return
+    let cancelled = false
+
+    // The `await Promise.resolve()` defers state updates past the synchronous
+    // render boundary (mirrors useLab.ts) to satisfy react-hooks/set-state-in-effect.
+    void (async () => {
+      await Promise.resolve()
+      if (cancelled) return
+      setLoading(true)
+      setError(null)
+      try {
+        const [s, page] = await Promise.all([
+          provider.getWallet(),
+          provider.getWalletHistory(),
+        ])
+        if (cancelled) return
+        setSummary(s)
+        setHistory(page.events)
+        setCursor(page.nextCursor)
+        setLoading(false)
+      } catch (err) {
+        if (cancelled) return
+        setError(err instanceof Error ? err : new Error("Failed to load wallet"))
+        setLoading(false)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [provider])
+
+  const loadMore = useCallback(async () => {
+    if (!cursor || !provider) return
+    const page = await provider.getWalletHistory(cursor)
+    setHistory((prev) => [...prev, ...page.events])
+    setCursor(page.nextCursor)
+  }, [provider, cursor])
+
+  return {
+    balance: summary.balance,
+    totalEarned: summary.totalEarned,
+    totalSpent: summary.totalSpent,
+    history,
+    hasMore: cursor !== null,
+    loadMore,
+    loading,
+    error,
+  }
+}

--- a/apps/web/lib/i18n/messages/en.json
+++ b/apps/web/lib/i18n/messages/en.json
@@ -102,6 +102,24 @@
       "removeUpvoteAria": "Remove upvote"
     }
   },
+  "wallet": {
+    "title": "Wallet",
+    "balance": "Balance",
+    "earned": "Total earned",
+    "spent": "Total spent",
+    "debtHint": "Earn karma to clear your balance before you can shop again.",
+    "history": "History",
+    "empty": "No karma movements yet.",
+    "loadMore": "Load more",
+    "reason": {
+      "pebble_created": "Pebble created",
+      "pebble_enriched": "Pebble enriched",
+      "pebble_deleted": "Pebble deleted",
+      "grant": "Karma granted",
+      "purchase": "Purchase",
+      "refund": "Refund"
+    }
+  },
   "glyphs": {
     "title": "Glyphs",
     "loading": "Loading…",

--- a/apps/web/lib/i18n/messages/en.json
+++ b/apps/web/lib/i18n/messages/en.json
@@ -380,7 +380,8 @@
     "bottomBar": {
       "label": "Profile and stats",
       "profileAria": "Profile",
-      "statsAria": "Profile stats"
+      "statsAria": "Profile stats",
+      "walletAria": "Karma wallet"
     },
     "stats": {
       "bounce": "bounce",

--- a/apps/web/lib/i18n/messages/fr.json
+++ b/apps/web/lib/i18n/messages/fr.json
@@ -380,7 +380,8 @@
     "bottomBar": {
       "label": "Profil et statistiques",
       "profileAria": "Profil",
-      "statsAria": "Statistiques du profil"
+      "statsAria": "Statistiques du profil",
+      "walletAria": "Porte-karma"
     },
     "stats": {
       "bounce": "ricochet",

--- a/apps/web/lib/i18n/messages/fr.json
+++ b/apps/web/lib/i18n/messages/fr.json
@@ -102,6 +102,24 @@
       "removeUpvoteAria": "Ôter mon vote"
     }
   },
+  "wallet": {
+    "title": "Porte-karma",
+    "balance": "Solde",
+    "earned": "Total gagné",
+    "spent": "Total dépensé",
+    "debtHint": "Gagnez du karma pour remettre votre solde à zéro avant de pouvoir acheter à nouveau.",
+    "history": "Historique",
+    "empty": "Aucun mouvement de karma pour l’instant.",
+    "loadMore": "Voir plus",
+    "reason": {
+      "pebble_created": "Caillou créé",
+      "pebble_enriched": "Caillou enrichi",
+      "pebble_deleted": "Caillou supprimé",
+      "grant": "Karma offert",
+      "purchase": "Achat",
+      "refund": "Remboursement"
+    }
+  },
   "glyphs": {
     "title": "Glyphes",
     "loading": "Chargement…",

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -64,11 +64,28 @@ export type Collection = {
   updated_at: string
 }
 
+export type KarmaReason =
+  | "pebble_created"
+  | "pebble_enriched"
+  | "pebble_deleted"
+  | "grant"
+  | "purchase"
+  | "refund"
+
 export type KarmaEvent = {
+  id: string
+  type: "credit" | "withdraw"
   delta: number
-  reason: string
+  reason: KarmaReason
   ref_id?: string
   created_at: string
+}
+
+// Read-only wallet summary projected from v_wallet_summary.
+export type WalletSnapshot = {
+  balance: number
+  totalEarned: number
+  totalSpent: number
 }
 
 export type MarkStroke = {

--- a/apps/web/lib/utils/wallet-format.ts
+++ b/apps/web/lib/utils/wallet-format.ts
@@ -1,0 +1,18 @@
+import type { KarmaEvent } from "@/lib/types"
+
+// i18n key suffix for a movement's reason (consumed under the `wallet.reason` ns).
+// Returns the literal union (not `string`) so next-intl can type-check the
+// resulting `reason.${...}` message key.
+export function reasonKey(reason: KarmaEvent["reason"]): KarmaEvent["reason"] {
+  return reason
+}
+
+// Signed, display-ready amount: "+3" for credits in, "-50" for spends.
+export function signedAmount(delta: number): string {
+  return delta > 0 ? `+${delta}` : `${delta}`
+}
+
+// Direction for non-colour-only cues / icon choice.
+export function direction(delta: number): "in" | "out" {
+  return delta >= 0 ? "in" : "out"
+}

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -6,7 +6,7 @@
     "root_node_id": "V-landing",
     "metadata": { "view_card_variant": "large" },
     "created_at": "2026-04-01T00:00:00.000Z",
-    "updated_at": "2026-05-16T00:00:00.000Z"
+    "updated_at": "2026-06-29T00:00:00.000Z"
   },
   "nodes": [
     {
@@ -1266,6 +1266,60 @@
       "description": "PostgREST select on public.v_emotions_with_palette. RLS open (select using true) — readable by any authenticated user. Returns ~38 rows × 11 columns: id, slug, name, color (legacy), category_id, category_slug, category_name, primary_color, secondary_color, light_color, surface_color. iOS consumes this once on app mount via EmotionPaletteService and caches in memory for the session.",
       "status": "development",
       "platforms": ["web", "ios", "android"]
+    },
+    {
+      "id": "V-wallet",
+      "project_id": "pebbles",
+      "species": "view",
+      "title": "Wallet",
+      "description": "Karma wallet page at /wallet (M36, #494). Shows the user's spendable karma balance, total earned, total spent, a debt hint when the balance is negative, and a paginated credit/withdraw history list (fetched on demand, not part of the eager global load). Reachable from the karma stat in the Path bottom bar; back button returns to /path.",
+      "status": "development",
+      "platforms": ["web"]
+    },
+    {
+      "id": "DM-karma-events",
+      "project_id": "pebbles",
+      "species": "data-model",
+      "title": "karma_events",
+      "description": "Postgres append-only karma ledger. Each row carries a smallint delta plus a type axis (credit = earn-side: pebble_created/pebble_enriched/pebble_deleted/grant; withdraw = spend-side: purchase/refund), making karma a spendable currency. balance = Σ delta; earned = Σ delta where credit; spent = -Σ delta where withdraw. Inserts fire two triggers: apply_karma_event_to_wallet (all events) and apply_karma_event_to_bounce (credit-only, so the bounce snapshot stays earned-karma). Indexed on (user_id, type) and (user_id, created_at desc).",
+      "status": "development",
+      "platforms": ["web"]
+    },
+    {
+      "id": "DM-wallet-balances",
+      "project_id": "pebbles",
+      "species": "data-model",
+      "title": "wallet_balances",
+      "description": "Postgres table: per-user spendable karma balance snapshot. Columns: user_id (PK, FK auth.users), balance (int, default 0; may go transiently negative on earn-side clawbacks — no non-negative CHECK, the overdraw guard lives in spend_karma), updated_at. Maintained atomically by trigger karma_events_apply_to_wallet on every karma_events insert (credit and withdraw). RLS: users read their own row; writes only via the trigger (security definer). Backfilled at migration time from sum(karma_events.delta) per user.",
+      "status": "development",
+      "platforms": ["web"]
+    },
+    {
+      "id": "API-spend-karma",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "spend_karma",
+      "description": "SECURITY DEFINER plpgsql RPC (granted to authenticated). Guarded, race-safe karma debit: takes p_amount (positive), p_reason ('purchase'), optional p_ref_id. Locks the caller's wallet_balances row FOR UPDATE to serialize concurrent spends, raises insufficient_karma (P0001) when balance < amount, otherwise inserts a negative withdraw karma_events row — the trigger updates wallet_balances in the same transaction. Returns the new event id.",
+      "status": "development",
+      "platforms": ["web"]
+    },
+    {
+      "id": "API-refund-karma",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "refund_karma",
+      "description": "SECURITY DEFINER plpgsql RPC, execution restricted to service_role (revoked from authenticated to avoid a client-callable karma mint). Inserts a positive withdraw-side karma_events row reversing a prior spend; the trigger updates wallet_balances. Returns the new event id.",
+      "status": "development",
+      "platforms": ["web"]
+    },
+    {
+      "id": "API-get-wallet-summary",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "select v_wallet_summary",
+      "description": "PostgREST select on public.v_wallet_summary, filtered to auth.uid() and granted to authenticated. Returns one row: balance (from wallet_balances) plus total_earned (Σ credit delta) and total_spent (-Σ withdraw delta) computed from karma_events. Backs the Wallet page summary card in one round-trip.",
+      "status": "development",
+      "platforms": ["web"]
     }
   ],
   "edges": [
@@ -1504,6 +1558,17 @@
     { "id": "e-V-collection-detail-API-get-emotion-palettes", "project_id": "pebbles", "source_id": "V-collection-detail", "target_id": "API-get-emotion-palettes", "edge_type": "calls" },
     { "id": "e-V-collection-detail-DM-emotion-category", "project_id": "pebbles", "source_id": "V-collection-detail", "target_id": "DM-emotion-category", "edge_type": "displays" },
     { "id": "e-V-quick-pebble-editor-API-get-emotion-palettes", "project_id": "pebbles", "source_id": "V-quick-pebble-editor", "target_id": "API-get-emotion-palettes", "edge_type": "calls" },
-    { "id": "e-V-quick-pebble-editor-DM-emotion-category", "project_id": "pebbles", "source_id": "V-quick-pebble-editor", "target_id": "DM-emotion-category", "edge_type": "displays" }
+    { "id": "e-V-quick-pebble-editor-DM-emotion-category", "project_id": "pebbles", "source_id": "V-quick-pebble-editor", "target_id": "DM-emotion-category", "edge_type": "displays" },
+
+    { "id": "e-V-timeline-V-wallet", "project_id": "pebbles", "source_id": "V-timeline", "target_id": "V-wallet", "edge_type": "composes" },
+    { "id": "e-V-wallet-API-get-wallet-summary", "project_id": "pebbles", "source_id": "V-wallet", "target_id": "API-get-wallet-summary", "edge_type": "calls" },
+    { "id": "e-V-wallet-DM-wallet-balances", "project_id": "pebbles", "source_id": "V-wallet", "target_id": "DM-wallet-balances", "edge_type": "displays" },
+    { "id": "e-V-wallet-DM-karma-events", "project_id": "pebbles", "source_id": "V-wallet", "target_id": "DM-karma-events", "edge_type": "displays" },
+    { "id": "e-API-get-wallet-summary-DM-wallet-balances", "project_id": "pebbles", "source_id": "API-get-wallet-summary", "target_id": "DM-wallet-balances", "edge_type": "queries" },
+    { "id": "e-API-get-wallet-summary-DM-karma-events", "project_id": "pebbles", "source_id": "API-get-wallet-summary", "target_id": "DM-karma-events", "edge_type": "queries" },
+    { "id": "e-API-spend-karma-DM-karma-events", "project_id": "pebbles", "source_id": "API-spend-karma", "target_id": "DM-karma-events", "edge_type": "queries" },
+    { "id": "e-API-spend-karma-DM-wallet-balances", "project_id": "pebbles", "source_id": "API-spend-karma", "target_id": "DM-wallet-balances", "edge_type": "queries" },
+    { "id": "e-API-refund-karma-DM-karma-events", "project_id": "pebbles", "source_id": "API-refund-karma", "target_id": "DM-karma-events", "edge_type": "queries" },
+    { "id": "e-API-refund-karma-DM-wallet-balances", "project_id": "pebbles", "source_id": "API-refund-karma", "target_id": "DM-wallet-balances", "edge_type": "queries" }
   ]
 }

--- a/docs/decisions/log.md
+++ b/docs/decisions/log.md
@@ -81,3 +81,14 @@ Append-only ledger of **significant** product/engineering decisions. One terse e
 - **Consequences:** Agents do not edit CLAUDE.md to record per-PR learnings; they leave them in the plan's "Lessons learned". Reviewers can push back on CLAUDE.md edits that fail the durable + action-guiding bars. The monorepo-audit checklist now explicitly includes a grooming sweep; expect rules to be **demoted or deleted** during the same pass when they have gone stale.
 - **Supersedes / Superseded-by:** —
 - **Refs:** #479, `CLAUDE.md` ("Editing CLAUDE.md / AGENTS.md"), `docs/superpowers/specs/2026-04-11-monorepo-audit-design.md` (per-domain checklist item 6).
+
+## 2026-06-29 — Karma wallet: one ledger, debt allowed, refunds server-only
+
+- **Status:** taken
+- **Scope:** db, webapp
+- **Context:** Making karma spendable (M36 Pebblestore, #494) required turning the earn-only `karma_events` ledger into a currency with a balance that can go down — without breaking existing flows (notably pebble deletion, which claws back the karma a pebble earned).
+- **Decision:** We will keep **one ledger** (`karma_events` gains a `type` credit/withdraw axis keyed off movement *category*, not sign) with a single balance = Σ delta, snapshotted in `wallet_balances`. The non-negative rule lives **only in the `spend_karma` RPC** (row-locked `balance ≥ amount` check); there is deliberately **no `CHECK(balance >= 0)`** on the snapshot, so earn-side clawbacks may drive the balance **negative (a debt)** the user clears by re-earning. `refund_karma` is **`service_role`-only**, never callable by `authenticated`.
+- **Why:** Coupling pebble deletion to wallet state would be wrong UX, so clawbacks must always apply even into the negative — a column `CHECK` would roll back a legitimate delete. The purchase guard alone keeps the store safe (a negative balance can't buy anything). An unguarded `refund_karma` granted to `authenticated` is a karma-minting hole (`refund_karma(1_000_000, …)`); refunds are admin/server actions, and the buy flow needs no client refund because a failed grant rolls back the spend in the same transaction.
+- **Consequences:** **Do not add `CHECK(balance >= 0)` to `wallet_balances`** — it would break pebble deletion. New spend-side reasons go through `spend_karma`; new earn-side reasons just insert credit events. The `bounces` admin snapshot trigger now folds **credits only** so "bounce karma distribution" keeps meaning *earned*. `delta` stays `smallint` (widening would force dropping/recreating dependent views on the live DB). Idempotency of a *purchase* is the caller's (sub-project C's) responsibility, enabled by `spend_karma` being callable inside the caller's transaction.
+- **Supersedes / Superseded-by:** —
+- **Refs:** #494, `docs/superpowers/specs/2026-06-29-issue-494-karma-wallet-design.md`, `packages/supabase/supabase/migrations/20260629192621_karma_events_type_axis.sql` … `20260629194621_wallet_summary_and_bounce_credit_only.sql`.

--- a/docs/superpowers/plans/2026-06-29-issue-494-karma-wallet.md
+++ b/docs/superpowers/plans/2026-06-29-issue-494-karma-wallet.md
@@ -1,0 +1,919 @@
+# Karma Wallet Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn karma into a spendable currency: one append-only ledger with a credit/withdraw axis, a balance snapshot that purchases can never overdraw (but earn-side clawbacks may push negative), atomic `spend_karma`/`refund_karma` RPCs, and a read-only `/wallet` page.
+
+**Architecture:** Extend `public.karma_events` with a `type` column and widen `delta` to `integer`. A `public.wallet_balances` snapshot (no non-negative CHECK) is maintained by a trigger and gives O(1) balance reads plus a single row to lock; the overdraw guard lives only in `spend_karma` (`SELECT … FOR UPDATE` + `balance ≥ amount`). The web app gains `getWallet`/`getWalletHistory`/`spendKarma` on the provider, a `useWallet` hook, and a `/wallet` page. No spend UI ships here — sub-project C is the first caller of `spend_karma`.
+
+**Tech Stack:** Supabase (Postgres, plpgsql, RLS), Next.js 16 App Router, React 19, TypeScript strict, next-intl, shadcn/ui.
+
+**Spec:** `docs/superpowers/specs/2026-06-29-issue-494-karma-wallet-design.md` · Issue #494 · Milestone M36.
+
+---
+
+## Project conventions that shape verification
+
+- **No local Docker.** This repo deploys to the **linked remote Supabase**, not a local container (project preference). Apply migrations with `npm run db:push --workspace=packages/supabase`, regenerate types with `npm run db:types:remote --workspace=packages/supabase`, and run SQL verification blocks in the **Supabase SQL editor** (or `psql` against the linked DB). *If you do have local Docker, substitute `db:reset` + `db:types`.*
+- **No test runner exists (V1).** "Verify" means: SQL assertion blocks for DB tasks; `npm run lint --workspace=apps/web` + `npm run build` for TypeScript; manual `npm run dev` check for the page. Pure helpers are written so they *could* be unit-tested later.
+- **Commit cadence:** one logical change per commit, conventional-commits lowercase, scope `core`/`db`/`ui`. Branch is already `docs/494-karma-wallet-spec`; create the implementation branch `feat/494-karma-wallet` off latest `main` before Task 1.
+- After **every** migration: regenerate `packages/supabase/types/database.ts` and `git add` it (AGENTS.md).
+
+---
+
+## File structure
+
+**Create:**
+- `packages/supabase/supabase/migrations/<ts>_karma_events_type_axis.sql` — type column, delta→integer, reason check, indexes.
+- `packages/supabase/supabase/migrations/<ts>_wallet_balances.sql` — snapshot table, trigger, backfill.
+- `packages/supabase/supabase/migrations/<ts>_wallet_rpcs.sql` — `spend_karma`, `refund_karma`.
+- `packages/supabase/supabase/migrations/<ts>_wallet_summary_and_bounce_credit_only.sql` — `v_wallet_summary` view + `bounces` trigger folds credits only.
+- `apps/web/lib/data/useWallet.ts` — wallet hook.
+- `apps/web/app/wallet/page.tsx` — route shell.
+- `apps/web/components/wallet/WalletView.tsx` — page body (balance header + debt hint + history list).
+- `apps/web/components/wallet/WalletHistoryItem.tsx` — one ledger row.
+- `apps/web/lib/utils/wallet-format.ts` — pure helpers (reason→i18n key, signed amount).
+
+**Modify:**
+- `apps/web/lib/types.ts` — extend `KarmaEvent`, add `KarmaReason`, `WalletSnapshot`.
+- `apps/web/lib/data/data-provider.ts` — add `getWallet`/`getWalletHistory`/`spendKarma` to the interface + `WalletPage` result type.
+- `apps/web/lib/data/supabase-provider.ts` — implement the three methods.
+- `apps/web/lib/i18n/messages/en.json` + `fr.json` — `wallet` namespace.
+- `apps/web/components/path/PathBottomBar.tsx` — point the karma stat at `/wallet`.
+- `docs/arkaik/bundle.json` (repo root, via the `arkaik` skill) — new view + data-model/endpoint nodes.
+
+> **Design note (divergence from spec, intentional):** the spec mentioned populating `store.karma_log` on global load. We deliberately **keep wallet history out of the eager global load** (it's paginated and wallet-page-specific; loading it on every app start is wasteful). `store.karma` already equals the balance via `v_karma_summary` (Σ delta), so the bottom bar keeps working unchanged. `useWallet` fetches history on demand.
+
+---
+
+## Task 1: Migration — `karma_events` gains the credit/withdraw axis
+
+**Files:**
+- Create: `packages/supabase/supabase/migrations/<ts>_karma_events_type_axis.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+Run: `npm run db:migration:new --workspace=packages/supabase -- karma_events_type_axis`
+This creates an empty timestamped file. Paste:
+
+```sql
+-- Karma becomes a spendable currency: add a movement category to the ledger.
+-- `type` keys off the CATEGORY of movement, not the sign of `delta`:
+--   credit   = earn-side  (pebble_created, pebble_enriched, pebble_deleted, grant) — may be negative
+--   withdraw = spend-side (purchase negative, refund positive)
+-- Sign stays in `delta`. balance = Σ delta; earned = Σ delta where credit;
+-- spent = -Σ delta where withdraw.
+
+alter table public.karma_events
+  add column type text not null default 'credit'
+    check (type in ('credit','withdraw'));
+
+-- Widen delta: smallint (max 32767) is fine per-event today, but lifetime sums
+-- and future goods (themes/skins) make integer the safe choice.
+alter table public.karma_events
+  alter column delta type integer;
+
+-- Constrain reason now that it spans both sides. Existing rows are all earn-side
+-- and already use the first three reasons, so the default 'credit' covers them.
+alter table public.karma_events
+  add constraint karma_events_reason_check check (reason in (
+    'pebble_created','pebble_enriched','pebble_deleted','grant',  -- credit
+    'purchase','refund'                                           -- withdraw
+  ));
+
+-- Indexes: (user_id, type) powers earned/spent sums; (user_id, created_at desc)
+-- powers the wallet history read.
+create index if not exists karma_events_user_type_idx
+  on public.karma_events (user_id, type);
+create index if not exists karma_events_user_created_idx
+  on public.karma_events (user_id, created_at desc);
+```
+
+- [ ] **Step 2: Apply to the linked Supabase**
+
+Run: `npm run db:push --workspace=packages/supabase`
+Expected: migration applies with no error (the `reason` check passes because all existing rows use `pebble_created`/`pebble_enriched`/`pebble_deleted`).
+
+- [ ] **Step 3: Verify in the Supabase SQL editor**
+
+```sql
+-- All historical rows are now typed 'credit', delta is integer, and the
+-- reason check holds.
+select count(*)                         as total_rows,
+       count(*) filter (where type='credit')   as credit_rows,
+       count(*) filter (where type='withdraw') as withdraw_rows
+from public.karma_events;
+select data_type from information_schema.columns
+where table_name='karma_events' and column_name='delta';   -- expect 'integer'
+```
+Expected: `withdraw_rows = 0`, `credit_rows = total_rows`, `delta` is `integer`.
+
+- [ ] **Step 4: Regenerate types**
+
+Run: `npm run db:types:remote --workspace=packages/supabase`
+Expected: `packages/supabase/types/database.ts` updates (`karma_events.Row` gains `type`, `delta` becomes `number`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/supabase/supabase/migrations packages/supabase/types/database.ts
+git commit -m "feat(db): add credit/withdraw type axis to karma_events"
+```
+
+---
+
+## Task 2: Migration — `wallet_balances` snapshot + trigger + backfill
+
+**Files:**
+- Create: `packages/supabase/supabase/migrations/<ts>_wallet_balances.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+Run: `npm run db:migration:new --workspace=packages/supabase -- wallet_balances`
+Paste:
+
+```sql
+-- O(1) balance reads + a single row to lock for serializing concurrent spends.
+-- NO non-negative CHECK: earn-side clawbacks (pebble deletion) may legally
+-- drive this below zero. The overdraw guard lives in spend_karma, not here.
+create table if not exists public.wallet_balances (
+  user_id    uuid primary key references auth.users(id) on delete cascade,
+  balance    integer not null default 0,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.wallet_balances enable row level security;
+
+drop policy if exists "wallet_balances_select_self" on public.wallet_balances;
+create policy "wallet_balances_select_self" on public.wallet_balances
+  for select using (user_id = auth.uid());
+-- No INSERT/UPDATE/DELETE policies: maintained exclusively by the trigger below.
+
+-- Keep the snapshot in sync with EVERY karma_events insert (credit and withdraw).
+create or replace function public.apply_karma_event_to_wallet()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  insert into public.wallet_balances (user_id, balance, updated_at)
+  values (new.user_id, new.delta, now())
+  on conflict (user_id) do update
+    set balance    = public.wallet_balances.balance + excluded.balance,
+        updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists karma_events_apply_to_wallet on public.karma_events;
+create trigger karma_events_apply_to_wallet
+  after insert on public.karma_events
+  for each row execute function public.apply_karma_event_to_wallet();
+
+-- One-shot backfill from the existing ledger. Idempotent.
+insert into public.wallet_balances (user_id, balance, updated_at)
+select user_id, sum(delta)::int, now()
+from public.karma_events group by user_id
+on conflict (user_id) do update
+  set balance = excluded.balance, updated_at = excluded.updated_at;
+```
+
+- [ ] **Step 2: Apply**
+
+Run: `npm run db:push --workspace=packages/supabase`
+Expected: applies cleanly; backfill populates one row per user that has karma events.
+
+- [ ] **Step 3: Verify the snapshot equals the ledger sum**
+
+```sql
+-- Every snapshot row must equal Σ delta from the ledger. Zero mismatches.
+select count(*) as mismatches
+from public.wallet_balances wb
+join (
+  select user_id, sum(delta)::int as ledger_balance
+  from public.karma_events group by user_id
+) led on led.user_id = wb.user_id
+where wb.balance <> led.ledger_balance;
+```
+Expected: `mismatches = 0`.
+
+- [ ] **Step 4: Regenerate types + commit**
+
+```bash
+npm run db:types:remote --workspace=packages/supabase
+git add packages/supabase/supabase/migrations packages/supabase/types/database.ts
+git commit -m "feat(db): add wallet_balances snapshot maintained by karma_events trigger"
+```
+
+---
+
+## Task 3: Migration — `spend_karma` + `refund_karma` RPCs
+
+**Files:**
+- Create: `packages/supabase/supabase/migrations/<ts>_wallet_rpcs.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+Run: `npm run db:migration:new --workspace=packages/supabase -- wallet_rpcs`
+Paste:
+
+```sql
+-- Spend karma. Guarded + race-safe. Called by C (glyph buy) and future goods.
+-- p_amount is POSITIVE karma to debit; recorded as a negative withdraw delta.
+create or replace function public.spend_karma(
+  p_amount integer,
+  p_reason text,                 -- 'purchase'
+  p_ref_id uuid default null
+) returns uuid
+language plpgsql security definer set search_path = public as $$
+declare
+  v_user_id  uuid := auth.uid();
+  v_balance  integer;
+  v_event_id uuid;
+begin
+  if v_user_id is null then raise exception 'not_authenticated' using errcode='42501'; end if;
+  if p_amount is null or p_amount <= 0 then raise exception 'invalid_amount'; end if;
+  if p_reason not in ('purchase') then raise exception 'invalid_reason'; end if;
+
+  -- Serialize concurrent spends for this user; create the row if first-ever.
+  insert into public.wallet_balances (user_id, balance)
+    values (v_user_id, 0) on conflict (user_id) do nothing;
+  select balance into v_balance
+    from public.wallet_balances where user_id = v_user_id for update;
+
+  if v_balance < p_amount then
+    raise exception 'insufficient_karma' using errcode='P0001',
+      detail = format('balance=%s amount=%s', v_balance, p_amount);
+  end if;
+
+  insert into public.karma_events (user_id, type, delta, reason, ref_id)
+  values (v_user_id, 'withdraw', -p_amount, p_reason, p_ref_id)
+  returning id into v_event_id;   -- trigger updates wallet_balances in this txn
+
+  return v_event_id;
+end;
+$$;
+
+-- Refund. Symmetric reversal (positive withdraw-side delta).
+create or replace function public.refund_karma(
+  p_amount integer,
+  p_ref_id uuid
+) returns uuid
+language plpgsql security definer set search_path = public as $$
+declare
+  v_user_id  uuid := auth.uid();
+  v_event_id uuid;
+begin
+  if v_user_id is null then raise exception 'not_authenticated' using errcode='42501'; end if;
+  if p_amount is null or p_amount <= 0 then raise exception 'invalid_amount'; end if;
+
+  insert into public.karma_events (user_id, type, delta, reason, ref_id)
+  values (v_user_id, 'withdraw', p_amount, 'refund', p_ref_id)
+  returning id into v_event_id;
+  return v_event_id;
+end;
+$$;
+
+revoke all on function public.spend_karma(integer,text,uuid)  from public, anon;
+revoke all on function public.refund_karma(integer,uuid)      from public, anon;
+grant execute on function public.spend_karma(integer,text,uuid)  to authenticated;
+grant execute on function public.refund_karma(integer,uuid)      to authenticated;
+```
+
+- [ ] **Step 2: Apply**
+
+Run: `npm run db:push --workspace=packages/supabase`
+Expected: both functions created.
+
+- [ ] **Step 3: Verify behavior in the SQL editor (as a real authenticated user)**
+
+Run this block **impersonating a test user** (Supabase SQL editor: set the role/JWT, or wrap with `set local role authenticated; set local request.jwt.claim.sub = '<test-user-uuid>';`). Substitute a real `<test-user-uuid>` that has some earned karma.
+
+```sql
+-- A) Read starting balance.
+select balance from public.wallet_balances where user_id = '<test-user-uuid>';
+
+-- B) Successful spend of 1: returns an event id, balance drops by 1.
+select public.spend_karma(1, 'purchase', null);
+select balance from public.wallet_balances where user_id = '<test-user-uuid>';  -- down 1
+
+-- C) Overdraw is rejected: spending more than balance raises insufficient_karma.
+--    Expect ERROR: insufficient_karma (nothing written).
+select public.spend_karma(999999, 'purchase', null);
+
+-- D) Refund of 1 restores the balance.
+select public.refund_karma(1, null);
+select balance from public.wallet_balances where user_id = '<test-user-uuid>';  -- back up 1
+
+-- E) Invalid inputs rejected.
+select public.spend_karma(0, 'purchase', null);     -- ERROR invalid_amount
+select public.spend_karma(1, 'grant', null);        -- ERROR invalid_reason
+```
+Expected: A returns a number; B returns a uuid and balance −1; **C errors `insufficient_karma`**; D restores; E errors as annotated.
+
+- [ ] **Step 4: Verify the debt path (clawback may go negative; purchase then blocked)**
+
+```sql
+-- Drain to a known low balance first via spends, then simulate a pebble-delete
+-- clawback that exceeds the balance to prove negatives are allowed on the
+-- earn-side and that a subsequent purchase is then refused.
+-- Insert a clawback directly (this is what delete_pebble does):
+insert into public.karma_events (user_id, type, delta, reason, ref_id)
+values ('<test-user-uuid>', 'credit', -100000, 'pebble_deleted', null);
+select balance from public.wallet_balances where user_id='<test-user-uuid>'; -- NEGATIVE, allowed
+select public.spend_karma(1, 'purchase', null);  -- ERROR insufficient_karma (in debt)
+-- Cleanup so the test user isn't left in debt:
+insert into public.karma_events (user_id, type, delta, reason, ref_id)
+values ('<test-user-uuid>', 'credit', 100000, 'grant', null);
+```
+Expected: balance goes negative without error; the purchase is refused; cleanup restores it.
+
+- [ ] **Step 5: (Optional) Verify concurrent-spend serialization**
+
+In two separate `psql` sessions against the linked DB, in session 1: `begin; select balance from wallet_balances where user_id='<u>' for update;` (hold). In session 2: `select public.spend_karma(1,'purchase',null);` — it should **block** until session 1 commits/rolls back, proving the row lock serializes spends. Roll back both afterward.
+
+- [ ] **Step 6: Regenerate types + commit**
+
+```bash
+npm run db:types:remote --workspace=packages/supabase
+git add packages/supabase/supabase/migrations packages/supabase/types/database.ts
+git commit -m "feat(db): add guarded spend_karma and refund_karma RPCs"
+```
+
+---
+
+## Task 4: Migration — `v_wallet_summary` view + `bounces` folds credits only
+
+**Files:**
+- Create: `packages/supabase/supabase/migrations/<ts>_wallet_summary_and_bounce_credit_only.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+Run: `npm run db:migration:new --workspace=packages/supabase -- wallet_summary_and_bounce_credit_only`
+Paste:
+
+```sql
+-- 1. One-round-trip wallet summary. Filtered to the caller (mirrors how
+--    v_karma_summary was hardened with an auth.uid() filter).
+drop view if exists public.v_wallet_summary;
+create view public.v_wallet_summary as
+select
+  wb.user_id,
+  wb.balance,
+  coalesce((select sum(ke.delta) from public.karma_events ke
+            where ke.user_id = wb.user_id and ke.type='credit'), 0)::int   as total_earned,
+  coalesce(-(select sum(ke.delta) from public.karma_events ke
+            where ke.user_id = wb.user_id and ke.type='withdraw'), 0)::int as total_spent
+from public.wallet_balances wb
+where wb.user_id = auth.uid();
+
+revoke all on public.v_wallet_summary from public, anon;
+grant select on public.v_wallet_summary to authenticated;
+
+-- 2. Keep the admin "bounce karma distribution" meaning EARNED, not spendable.
+--    Now that withdraw events exist, the bounces snapshot must ignore them or
+--    it silently becomes the spendable balance. Fold only credit-type events.
+create or replace function public.apply_karma_event_to_bounce()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  -- Only earn-side movements contribute to the bounce (earned-karma) snapshot.
+  if new.type <> 'credit' then
+    return new;
+  end if;
+  insert into public.bounces (user_id, score, updated_at)
+  values (new.user_id, new.delta, now())
+  on conflict (user_id) do update
+    set score      = public.bounces.score + excluded.score,
+        updated_at = now();
+  return new;
+end;
+$$;
+-- Trigger definition is unchanged; CREATE OR REPLACE on the function is enough.
+
+-- 3. Realign existing bounces snapshots to credit-only (they currently include
+--    any historical negatives, which are all credit-side today, so this is a
+--    no-op for current data but makes the invariant explicit going forward).
+insert into public.bounces (user_id, score, updated_at)
+select user_id, coalesce(sum(delta) filter (where type='credit'), 0)::int, now()
+from public.karma_events group by user_id
+on conflict (user_id) do update
+  set score = excluded.score, updated_at = excluded.updated_at;
+```
+
+- [ ] **Step 2: Apply**
+
+Run: `npm run db:push --workspace=packages/supabase`
+Expected: view created, function replaced, bounces realigned.
+
+- [ ] **Step 3: Verify the summary math and the bounce/withdraw isolation**
+
+```sql
+-- Summary reconciles: balance = total_earned - total_spent for the caller.
+-- Run impersonating <test-user-uuid> (so auth.uid() resolves):
+select balance, total_earned, total_spent,
+       (total_earned - total_spent) as derived_balance
+from public.v_wallet_summary;   -- expect balance = derived_balance
+
+-- A withdraw must NOT move the bounce snapshot. Capture, spend, compare:
+select score from public.bounces where user_id='<test-user-uuid>';   -- note value
+select public.spend_karma(1,'purchase',null);
+select score from public.bounces where user_id='<test-user-uuid>';   -- UNCHANGED
+select public.refund_karma(1, null);  -- cleanup
+```
+Expected: `balance = derived_balance`; the bounce `score` is identical before and after the spend.
+
+- [ ] **Step 4: Regenerate types + commit**
+
+```bash
+npm run db:types:remote --workspace=packages/supabase
+git add packages/supabase/supabase/migrations packages/supabase/types/database.ts
+git commit -m "feat(db): add v_wallet_summary and fold only credits into bounce snapshot"
+```
+
+---
+
+## Task 5: Web types — extend `KarmaEvent`, add `WalletSnapshot`
+
+**Files:**
+- Modify: `apps/web/lib/types.ts:67-72`
+
+- [ ] **Step 1: Replace the `KarmaEvent` type and add the new types**
+
+Replace lines 67-72 (the current `KarmaEvent`) with:
+
+```ts
+export type KarmaReason =
+  | "pebble_created"
+  | "pebble_enriched"
+  | "pebble_deleted"
+  | "grant"
+  | "purchase"
+  | "refund"
+
+export type KarmaEvent = {
+  id: string
+  type: "credit" | "withdraw"
+  delta: number
+  reason: KarmaReason
+  ref_id?: string
+  created_at: string
+}
+
+// Read-only wallet summary projected from v_wallet_summary.
+export type WalletSnapshot = {
+  balance: number
+  totalEarned: number
+  totalSpent: number
+}
+```
+
+- [ ] **Step 2: Verify it type-checks**
+
+Run: `npm run lint --workspace=apps/web`
+Expected: passes. (No code constructs `KarmaEvent` today, so widening `reason` to a union breaks nothing. `store.karma_log` stays `KarmaEvent[]` and remains empty.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/lib/types.ts
+git commit -m "feat(core): extend KarmaEvent with type/reason union and add WalletSnapshot"
+```
+
+---
+
+## Task 6: Provider — `getWallet`, `getWalletHistory`, `spendKarma`
+
+**Files:**
+- Modify: `apps/web/lib/data/data-provider.ts` (interface + a result type)
+- Modify: `apps/web/lib/data/supabase-provider.ts` (implementation)
+
+- [ ] **Step 1: Add the history page result type + interface methods**
+
+In `apps/web/lib/data/data-provider.ts`, add `WalletSnapshot` to the type import from `@/lib/types` (line 1-8 block) and, just above `getPebblesCount()` (line 83), add:
+
+```ts
+  getWallet(): Promise<WalletSnapshot>
+  getWalletHistory(cursor?: string, limit?: number): Promise<WalletHistoryPage>
+  spendKarma(amount: number, reason: "purchase", refId?: string): Promise<string>
+```
+
+Then add this exported type near the other input types (after line 71):
+
+```ts
+export type WalletHistoryPage = {
+  events: KarmaEvent[]
+  nextCursor: string | null
+}
+```
+(Add `KarmaEvent` and `WalletSnapshot` to the existing `import type { … } from "@/lib/types"` at the top — `KarmaEvent` is already imported; add `WalletSnapshot`.)
+
+- [ ] **Step 2: Implement in `SupabaseProvider`**
+
+In `apps/web/lib/data/supabase-provider.ts`, add these three methods next to `getKarma()` (around line 244). Match the file's existing error-handling style (it reads `.data`/`.error` from the Supabase client; mirror whatever `logError` helper the file already uses — if none, throw on error as other mutating methods do):
+
+```ts
+  async getWallet(): Promise<WalletSnapshot> {
+    const { data } = await this.supabase
+      .from("v_wallet_summary")
+      .select("*")
+      .eq("user_id", this.userId)
+      .maybeSingle()
+    return {
+      balance: (data?.balance as number) ?? 0,
+      totalEarned: (data?.total_earned as number) ?? 0,
+      totalSpent: (data?.total_spent as number) ?? 0,
+    }
+  }
+
+  async getWalletHistory(cursor?: string, limit = 20): Promise<WalletHistoryPage> {
+    let query = this.supabase
+      .from("karma_events")
+      .select("id, type, delta, reason, ref_id, created_at")
+      .eq("user_id", this.userId)
+      .order("created_at", { ascending: false })
+      .order("id", { ascending: false })
+      .limit(limit + 1)
+    if (cursor) query = query.lt("created_at", cursor)
+    const { data, error } = await query
+    if (error) throw error
+    const rows = (data ?? []) as KarmaEvent[]
+    const hasMore = rows.length > limit
+    const events = hasMore ? rows.slice(0, limit) : rows
+    const nextCursor = hasMore ? events[events.length - 1].created_at : null
+    return { events, nextCursor }
+  }
+
+  async spendKarma(amount: number, reason: "purchase", refId?: string): Promise<string> {
+    const { data, error } = await this.supabase.rpc("spend_karma", {
+      p_amount: amount,
+      p_reason: reason,
+      p_ref_id: refId ?? null,
+    })
+    if (error) throw error
+    return data as string
+  }
+```
+
+Add `WalletSnapshot`, `WalletHistoryPage` to the provider's imports (`WalletHistoryPage` from `./data-provider`, `WalletSnapshot` + `KarmaEvent` from `@/lib/types`).
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run lint --workspace=apps/web && npm run build`
+Expected: both pass. The `spend_karma` RPC name resolves against the regenerated `database.ts` from Task 3.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/lib/data/data-provider.ts apps/web/lib/data/supabase-provider.ts
+git commit -m "feat(core): add wallet read + spendKarma provider methods"
+```
+
+---
+
+## Task 7: `useWallet` hook
+
+**Files:**
+- Create: `apps/web/lib/data/useWallet.ts`
+
+- [ ] **Step 1: Write the hook**
+
+```ts
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { useDataProvider } from "@/lib/data/provider-context"
+import type { KarmaEvent, WalletSnapshot } from "@/lib/types"
+
+const EMPTY: WalletSnapshot = { balance: 0, totalEarned: 0, totalSpent: 0 }
+
+// Wallet history is fetched on demand (not part of the eager global store load).
+export function useWallet() {
+  const { provider } = useDataProvider()
+  const [summary, setSummary] = useState<WalletSnapshot>(EMPTY)
+  const [history, setHistory] = useState<KarmaEvent[]>([])
+  const [cursor, setCursor] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    let active = true
+    setLoading(true)
+    Promise.all([provider.getWallet(), provider.getWalletHistory()])
+      .then(([s, page]) => {
+        if (!active) return
+        setSummary(s)
+        setHistory(page.events)
+        setCursor(page.nextCursor)
+      })
+      .catch((e) => active && setError(e as Error))
+      .finally(() => active && setLoading(false))
+    return () => {
+      active = false
+    }
+  }, [provider])
+
+  const loadMore = useCallback(async () => {
+    if (!cursor) return
+    const page = await provider.getWalletHistory(cursor)
+    setHistory((prev) => [...prev, ...page.events])
+    setCursor(page.nextCursor)
+  }, [provider, cursor])
+
+  return {
+    balance: summary.balance,
+    totalEarned: summary.totalEarned,
+    totalSpent: summary.totalSpent,
+    history,
+    hasMore: cursor !== null,
+    loadMore,
+    loading,
+    error,
+  }
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `npm run lint --workspace=apps/web`
+Expected: passes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/lib/data/useWallet.ts
+git commit -m "feat(core): add useWallet hook (on-demand balance + paginated history)"
+```
+
+---
+
+## Task 8: i18n — `wallet` namespace (EN + FR)
+
+**Files:**
+- Modify: `apps/web/lib/i18n/messages/en.json`
+- Modify: `apps/web/lib/i18n/messages/fr.json`
+
+- [ ] **Step 1: Add the `wallet` block to `en.json`**
+
+Add this top-level key (sibling of the existing namespaces):
+
+```json
+"wallet": {
+  "title": "Wallet",
+  "balance": "Balance",
+  "earned": "Total earned",
+  "spent": "Total spent",
+  "debtHint": "Earn karma to clear your balance before you can shop again.",
+  "history": "History",
+  "empty": "No karma movements yet.",
+  "loadMore": "Load more",
+  "reason": {
+    "pebble_created": "Pebble created",
+    "pebble_enriched": "Pebble enriched",
+    "pebble_deleted": "Pebble deleted",
+    "grant": "Karma granted",
+    "purchase": "Purchase",
+    "refund": "Refund"
+  }
+}
+```
+
+- [ ] **Step 2: Add the translated `wallet` block to `fr.json`**
+
+```json
+"wallet": {
+  "title": "Porte-karma",
+  "balance": "Solde",
+  "earned": "Total gagné",
+  "spent": "Total dépensé",
+  "debtHint": "Gagnez du karma pour remettre votre solde à zéro avant de pouvoir acheter à nouveau.",
+  "history": "Historique",
+  "empty": "Aucun mouvement de karma pour l’instant.",
+  "loadMore": "Voir plus",
+  "reason": {
+    "pebble_created": "Caillou créé",
+    "pebble_enriched": "Caillou enrichi",
+    "pebble_deleted": "Caillou supprimé",
+    "grant": "Karma offert",
+    "purchase": "Achat",
+    "refund": "Remboursement"
+  }
+}
+```
+
+- [ ] **Step 3: Verify both files are valid JSON**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('apps/web/lib/i18n/messages/en.json','utf8')); JSON.parse(require('fs').readFileSync('apps/web/lib/i18n/messages/fr.json','utf8')); console.log('ok')"`
+Expected: prints `ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/lib/i18n/messages/en.json apps/web/lib/i18n/messages/fr.json
+git commit -m "feat(ui): add wallet i18n strings (en/fr)"
+```
+
+---
+
+## Task 9: Wallet page + history components + nav link
+
+**Files:**
+- Create: `apps/web/lib/utils/wallet-format.ts`
+- Create: `apps/web/components/wallet/WalletHistoryItem.tsx`
+- Create: `apps/web/components/wallet/WalletView.tsx`
+- Create: `apps/web/app/wallet/page.tsx`
+- Modify: `apps/web/components/path/PathBottomBar.tsx:44-51`
+
+- [ ] **Step 1: Pure format helpers**
+
+Create `apps/web/lib/utils/wallet-format.ts`:
+
+```ts
+import type { KarmaEvent } from "@/lib/types"
+
+// i18n key suffix for a movement's reason (consumed under the `wallet.reason` ns).
+export function reasonKey(reason: KarmaEvent["reason"]): string {
+  return reason
+}
+
+// Signed, display-ready amount: "+3" for credits in, "-50" for spends.
+export function signedAmount(delta: number): string {
+  return delta > 0 ? `+${delta}` : `${delta}`
+}
+
+// Direction for non-colour-only cues / icon choice.
+export function direction(delta: number): "in" | "out" {
+  return delta >= 0 ? "in" : "out"
+}
+```
+
+- [ ] **Step 2: History row component**
+
+Create `apps/web/components/wallet/WalletHistoryItem.tsx`:
+
+```tsx
+"use client"
+
+import { useTranslations } from "next-intl"
+import { ArrowDownLeft, ArrowUpRight } from "lucide-react"
+import type { KarmaEvent } from "@/lib/types"
+import { signedAmount, direction, reasonKey } from "@/lib/utils/wallet-format"
+
+export function WalletHistoryItem({ event }: { event: KarmaEvent }) {
+  const t = useTranslations("wallet")
+  const dir = direction(event.delta)
+  const Icon = dir === "in" ? ArrowDownLeft : ArrowUpRight
+  const date = new Date(event.created_at).toLocaleDateString()
+
+  return (
+    <li className="flex items-center justify-between gap-3 py-3">
+      <div className="flex items-center gap-3">
+        <Icon className="size-4 text-muted-foreground" aria-hidden />
+        <div>
+          <p className="text-sm font-medium">{t(`reason.${reasonKey(event.reason)}`)}</p>
+          <p className="text-xs text-muted-foreground">{date}</p>
+        </div>
+      </div>
+      <span className="text-sm font-semibold tabular-nums">{signedAmount(event.delta)}</span>
+    </li>
+  )
+}
+```
+
+- [ ] **Step 3: Page body**
+
+Create `apps/web/components/wallet/WalletView.tsx`:
+
+```tsx
+"use client"
+
+import { useTranslations } from "next-intl"
+import { Sparkle } from "lucide-react"
+import { useWallet } from "@/lib/data/useWallet"
+import { Card } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { WalletHistoryItem } from "./WalletHistoryItem"
+
+export function WalletView() {
+  const t = useTranslations("wallet")
+  const { balance, totalEarned, totalSpent, history, hasMore, loadMore, loading } = useWallet()
+
+  return (
+    <div className="mx-auto flex w-full max-w-md flex-col gap-6 p-4">
+      <Card className="flex flex-col gap-2 p-6">
+        <div className="flex items-center gap-2">
+          <Sparkle className="size-5" aria-hidden />
+          <span className="text-3xl font-bold tabular-nums">{loading ? "—" : balance}</span>
+          <span className="text-sm text-muted-foreground">{t("balance")}</span>
+        </div>
+        {balance < 0 && !loading && (
+          <p className="text-sm text-amber-600 dark:text-amber-400">{t("debtHint")}</p>
+        )}
+        <div className="mt-2 flex gap-6 text-sm text-muted-foreground">
+          <span>{t("earned")}: <span className="tabular-nums">{totalEarned}</span></span>
+          <span>{t("spent")}: <span className="tabular-nums">{totalSpent}</span></span>
+        </div>
+      </Card>
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold text-muted-foreground">{t("history")}</h2>
+        {history.length === 0 && !loading ? (
+          <p className="text-sm text-muted-foreground">{t("empty")}</p>
+        ) : (
+          <ul className="divide-y">
+            {history.map((e) => <WalletHistoryItem key={e.id} event={e} />)}
+          </ul>
+        )}
+        {hasMore && (
+          <Button variant="ghost" className="mt-3 w-full" onClick={() => loadMore()}>
+            {t("loadMore")}
+          </Button>
+        )}
+      </section>
+    </div>
+  )
+}
+```
+(If `@/components/ui/card` or `button` aren't present yet, add them: `npx shadcn@latest add card button`.)
+
+- [ ] **Step 4: Route shell**
+
+Create `apps/web/app/wallet/page.tsx`:
+
+```tsx
+import { WalletView } from "@/components/wallet/WalletView"
+
+export default function WalletPage() {
+  return <WalletView />
+}
+```
+
+- [ ] **Step 5: Point the karma stat at the wallet**
+
+In `apps/web/components/path/PathBottomBar.tsx`, the karma `Stat` is wrapped in a `<Link href="/profile">` (lines 44-51). Change **that** link's `href` to `/wallet` (leave the profile avatar link above it untouched):
+
+```tsx
+      <Link
+        href="/wallet"
+```
+
+- [ ] **Step 6: Verify build + manual check**
+
+Run: `npm run lint --workspace=apps/web && npm run build`
+Expected: pass.
+Then `npm run dev`, sign in, and visit `/wallet`: balance shows, history lists your earn events, EN/FR both render (toggle locale), and tapping the karma stat in the bottom bar navigates to `/wallet`. With a negative test balance the debt hint appears.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/lib/utils/wallet-format.ts apps/web/components/wallet apps/web/app/wallet apps/web/components/path/PathBottomBar.tsx
+git commit -m "feat(ui): add wallet page with balance, debt hint and paginated history"
+```
+
+---
+
+## Task 10: Arkaik map update
+
+**Files:**
+- Modify: `docs/arkaik/bundle.json` (repo root, via the `arkaik` skill)
+
+- [ ] **Step 1: Invoke the `arkaik` skill** and add:
+  - a **view node** for `/wallet` (status: development),
+  - **data-model** nodes for the wallet ledger (`karma_events` type axis) and `wallet_balances`,
+  - **endpoint** nodes for `spend_karma` / `refund_karma`,
+  - edges: `/wallet` → `v_wallet_summary`/`wallet_balances`; `spend_karma` → `karma_events`/`wallet_balances`.
+
+- [ ] **Step 2: Verify** the bundle still parses (the skill validates) and commit:
+
+```bash
+git add docs/arkaik/bundle.json
+git commit -m "docs(core): map wallet page, ledger and spend RPCs in arkaik"
+```
+
+---
+
+## Wrap-up (PR, not a task step)
+
+When opening the PR for #494:
+- Title: `feat(core): karma wallet — spendable currency rails + wallet page`.
+- Body starts `Resolves #494`; inherit M36 + labels (`feat`, `db`, `core`, `ui`, `web`, `supabase`) — confirm with the user per CLAUDE.md.
+- **Lab Note (EN/FR):** gated in (touches a user-visible Arkaik view node). Draft a short bilingual blurb in the PR body — proposal only.
+- Run `npm run lint --workspace=apps/web` + `npm run build` green before opening.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- Ledger `type` axis + widened `delta` + reason check + indexes → Task 1. ✓
+- `wallet_balances` snapshot + trigger + backfill, no CHECK → Task 2. ✓
+- `spend_karma` (guarded, FOR UPDATE) + `refund_karma` + grants → Task 3. ✓
+- Debt model / negatives allowed on earn-side, purchase blocked → Task 3 Step 4 verifies. ✓
+- `bounces` folds only credits → Task 4. ✓
+- `v_wallet_summary` → Task 4. ✓
+- Types (`KarmaEvent`, `KarmaReason`, `WalletSnapshot`) → Task 5. ✓
+- Provider `getWallet`/`getWalletHistory`/`spendKarma` → Task 6. ✓
+- `useWallet` → Task 7. ✓ (history-on-demand divergence documented above.)
+- Wallet page: balance, earned/spent, debt hint, paginated EN/FR history, nav link → Tasks 8-9. ✓
+- Arkaik + Lab Note → Task 10 + wrap-up. ✓
+- Idempotency is C's responsibility (A stays generic) → noted in spec; no A task needed. ✓
+
+**Placeholder scan:** none — every code/SQL step is concrete. The only `<placeholders>` are migration timestamps (generated by `db:migration:new`) and `<test-user-uuid>` (a real value the engineer supplies at verification time), both unavoidable and explained.
+
+**Type consistency:** `WalletSnapshot` {balance,totalEarned,totalSpent}, `KarmaEvent` {id,type,delta,reason,ref_id?,created_at}, and `WalletHistoryPage` {events,nextCursor} are used identically across Tasks 5-9. RPC param names (`p_amount`,`p_reason`,`p_ref_id`) match between Task 3 SQL and Task 6 `.rpc()` call. `spendKarma(amount, reason, refId?)` signature matches interface and impl.

--- a/docs/superpowers/plans/2026-06-29-issue-494-karma-wallet.md
+++ b/docs/superpowers/plans/2026-06-29-issue-494-karma-wallet.md
@@ -24,7 +24,7 @@
 ## File structure
 
 **Create:**
-- `packages/supabase/supabase/migrations/<ts>_karma_events_type_axis.sql` — type column, delta→integer, reason check, indexes.
+- `packages/supabase/supabase/migrations/<ts>_karma_events_type_axis.sql` — type column, reason check, indexes (delta stays smallint — widening would force live-DB view surgery).
 - `packages/supabase/supabase/migrations/<ts>_wallet_balances.sql` — snapshot table, trigger, backfill.
 - `packages/supabase/supabase/migrations/<ts>_wallet_rpcs.sql` — `spend_karma`, `refund_karma`.
 - `packages/supabase/supabase/migrations/<ts>_wallet_summary_and_bounce_credit_only.sql` — `v_wallet_summary` view + `bounces` trigger folds credits only.
@@ -68,10 +68,10 @@ alter table public.karma_events
   add column type text not null default 'credit'
     check (type in ('credit','withdraw'));
 
--- Widen delta: smallint (max 32767) is fine per-event today, but lifetime sums
--- and future goods (themes/skins) make integer the safe choice.
-alter table public.karma_events
-  alter column delta type integer;
+-- delta stays smallint: per-event values are small (earn ≤ 10) and balance/total
+-- sums promote to integer/bigint anyway. Widening would force dropping & recreating
+-- the views that depend on this column (v_karma_summary,
+-- v_analytics_bounce_distribution_today) on the live DB — not worth it.
 
 -- Constrain reason now that it spans both sides. Existing rows are all earn-side
 -- and already use the first three reasons, so the default 'credit' covers them.
@@ -103,15 +103,13 @@ select count(*)                         as total_rows,
        count(*) filter (where type='credit')   as credit_rows,
        count(*) filter (where type='withdraw') as withdraw_rows
 from public.karma_events;
-select data_type from information_schema.columns
-where table_name='karma_events' and column_name='delta';   -- expect 'integer'
 ```
-Expected: `withdraw_rows = 0`, `credit_rows = total_rows`, `delta` is `integer`.
+Expected: `withdraw_rows = 0`, `credit_rows = total_rows` (every historical row is typed `credit`).
 
 - [ ] **Step 4: Regenerate types**
 
 Run: `npm run db:types:remote --workspace=packages/supabase`
-Expected: `packages/supabase/types/database.ts` updates (`karma_events.Row` gains `type`, `delta` becomes `number`).
+Expected: `packages/supabase/types/database.ts` updates (`karma_events.Row` gains `type`; `delta` stays `number`).
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-06-29-issue-494-karma-wallet.md
+++ b/docs/superpowers/plans/2026-06-29-issue-494-karma-wallet.md
@@ -269,10 +269,15 @@ begin
 end;
 $$;
 
-revoke all on function public.spend_karma(integer,text,uuid)  from public, anon;
-revoke all on function public.refund_karma(integer,uuid)      from public, anon;
-grant execute on function public.spend_karma(integer,text,uuid)  to authenticated;
-grant execute on function public.refund_karma(integer,uuid)      to authenticated;
+-- spend_karma is user-callable (guarded; users spend their own karma).
+revoke all on function public.spend_karma(integer,text,uuid) from public, anon;
+grant execute on function public.spend_karma(integer,text,uuid) to authenticated;
+-- refund_karma is NOT user-callable: it has no validation against an original
+-- purchase, so exposing it to `authenticated` would be a karma-minting hole.
+-- Refunds are issued by trusted server/admin logic only (service_role). The buy
+-- flow (C) needs no client refund — a failed grant rolls back the spend in-txn.
+revoke all on function public.refund_karma(integer,uuid) from public, anon, authenticated;
+grant execute on function public.refund_karma(integer,uuid) to service_role;
 ```
 
 - [ ] **Step 2: Apply**
@@ -413,7 +418,10 @@ from public.v_wallet_summary;   -- expect balance = derived_balance
 select score from public.bounces where user_id='<test-user-uuid>';   -- note value
 select public.spend_karma(1,'purchase',null);
 select score from public.bounces where user_id='<test-user-uuid>';   -- UNCHANGED
-select public.refund_karma(1, null);  -- cleanup
+-- cleanup: restore the spent karma. refund_karma is service_role-only, so as a
+-- service-role/SQL-editor session insert a compensating credit directly:
+insert into public.karma_events (user_id, type, delta, reason, ref_id)
+values ('<test-user-uuid>', 'credit', 1, 'grant', null);
 ```
 Expected: `balance = derived_balance`; the bounce `score` is identical before and after the spend.
 

--- a/docs/superpowers/specs/2026-06-29-issue-494-karma-wallet-design.md
+++ b/docs/superpowers/specs/2026-06-29-issue-494-karma-wallet-design.md
@@ -172,8 +172,15 @@ begin
 end;
 $$;
 
-grant execute on function public.spend_karma(integer,text,uuid)  to authenticated;
-grant execute on function public.refund_karma(integer,uuid)      to authenticated;
+-- spend_karma is user-callable (guarded; users spend their own karma).
+grant execute on function public.spend_karma(integer,text,uuid) to authenticated;
+-- refund_karma is NOT user-callable: as written it has no validation against an
+-- original purchase, so granting it to `authenticated` would be a karma-minting
+-- hole (any user could refund_karma(1_000_000, …)). Refunds are issued by trusted
+-- server/admin logic only. The buy flow (C) needs no client refund — a failed
+-- grant rolls back the spend in the same transaction.
+revoke execute on function public.refund_karma(integer,uuid) from public, anon, authenticated;
+grant  execute on function public.refund_karma(integer,uuid) to service_role;
 ```
 
 **Idempotency / double-charge protection.** A single purchase must not be charged twice on a network retry, and a user must not buy what they already own. The clean place for this is the *caller's* domain (C owns "what is a glyph purchase"), enforced by a unique constraint on C's ownership/grant table (e.g. `unique(user_id, glyph_id)`), with the grant + `spend_karma` happening in **one** RPC transaction in C so a failed grant rolls back the debit. A's contract: **`spend_karma` is atomic and self-contained; idempotency of a *purchase* is the caller's responsibility, and A makes that possible by being callable inside the caller's transaction.** This keeps A generic across future goods.
@@ -217,7 +224,7 @@ Once withdraw events exist, the `bounces` snapshot (Σ all delta) would silently
 | Two devices buy at once | Row lock on `wallet_balances` serializes them; the second sees the updated balance and is accepted/rejected correctly. |
 | Delete a pebble after spending | Clawback (`pebble_deleted`, credit) is **always** recorded; balance may go **negative** (debt). Deletion never blocked. |
 | Try to buy while in debt | `balance < 0 < price` → rejected until re-earned. |
-| Refund a purchase | `refund_karma` adds a positive withdraw-side event; balance recovers; `total_spent` nets down. |
+| Refund a purchase (server/admin only) | `refund_karma` (service_role) adds a positive withdraw-side event; balance recovers; `total_spent` nets down. Not user-callable. |
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-06-29-issue-494-karma-wallet-design.md
+++ b/docs/superpowers/specs/2026-06-29-issue-494-karma-wallet-design.md
@@ -1,0 +1,244 @@
+# Karma Wallet — Spendable Currency Rails
+
+> Sub-project **A** of 4 in **M36 · Pebblestore & Karma Economy**. Issue [#494](https://github.com/alexisbohns/pbbls/issues/494).
+> Blocks B (in-app activity), C (glyph marketplace), D (admin moderation).
+
+## Goal
+
+Turn **karma** from an earn-only score into a **spendable currency** with one auditable, append-only ledger: a single balance that can be debited safely, an atomic spend operation that can never let a *purchase* overdraw, and a wallet page where the user reads their full credit/withdraw history. These rails are the foundation the rest of the Pebblestore (glyphs now; themes and pebbleskins later) spends against — so nothing here hard-codes "glyph" as the thing being bought.
+
+## Non-goals
+
+- The "+karma credited" in-app activity → sub-project **B** (#495). This spec builds the credit events; B reacts to them.
+- Anything that actually *spends* karma (the glyph buy flow) → sub-project **C** (#496). This spec builds `spend_karma` + the `DataProvider` method; C is the first caller. **No spend UI ships in A.**
+- Themes / pebbleskins as goods → future, but the ledger stays generic.
+- Touching the **bounce level** (`v_bounce`, 0–7). It is computed purely from pebble active-days over a 28-day window and is **blind to karma**. It is not affected by this work and is not referenced again below.
+
+## Background: what exists today
+
+- **`public.karma_events`** — append-only earn log: `(id, user_id, delta smallint, reason text, ref_id uuid, created_at)`. `reason` ∈ `pebble_created | pebble_enriched | pebble_deleted`. Deltas can already be **negative** (enrich-down corrections; the `delete_pebble` clawback below).
+- **Write-path is already locked down.** The early permissive INSERT policy was dropped in `20260411000005_security_hardening`. `karma_events` now has only a **SELECT** policy (`user_id = auth.uid()`); every write goes through `security definer` RPCs. **There is no client path to mint karma**, and a spend RPC drops into this exact pattern.
+- **`delete_pebble` claws back karma**: on delete it inserts `(-sum_of_what_the_pebble_earned, reason='pebble_deleted', ref_id=pebble)`. This is why a balance can legitimately go negative once spending exists (see Integrity model).
+- **`public.bounces`** — a snapshot table (`user_id, score, updated_at`) maintained by an `after insert` trigger on `karma_events` that sums `delta`. Despite the name it is **not** the bounce level; its only consumer is the admin "bounce karma distribution" histogram (`get_bounce_distribution_today`). Relevant because adding withdraw events changes what it sums (see § Admin analytics).
+- **`v_karma_summary`** — view exposing `total_karma` (Σ delta) + `pebbles_count`. The web `SupabaseProvider` reads it into `store.karma`. `store.karma_log` exists but is never populated.
+- **UI**: karma shown as a `Sparkle` count in `PathBottomBar` + `GamificationBlocks`. No wallet page, no spend, no history display.
+
+## Core design decisions (settled)
+
+1. **One ledger, one balance.** `karma_events` becomes the full wallet ledger. Balance = Σ delta. "Total earned" / "total spent" are indexed sum queries, not stored numbers.
+2. **A `type` axis** (`credit` | `withdraw`) is added, keyed off the *category of movement*, **not** the raw sign:
+   - `credit` = earn-side: `pebble_created`, `pebble_enriched`, `pebble_deleted` (clawback), `grant` (admin). May be negative.
+   - `withdraw` = spend-side: `purchase` (negative), `refund` (positive reversal).
+   - This keeps each aggregate meaningful even though both sides can carry either sign:
+     - `balance` = Σ delta (all rows)
+     - `total_earned` = Σ delta WHERE `type='credit'` (net of corrections/clawbacks)
+     - `total_spent` = −Σ delta WHERE `type='withdraw'` (net of refunds)
+3. **The non-negative rule belongs to the spend path, not the balance column.** Earn-side events are *always* recorded, even when they drive the balance negative (deleting pebbles must never be blocked by wallet state). Purchases are *always* guarded (`balance ≥ amount`). A negative balance is a **debt** the user clears by re-earning before they can buy again — which needs zero special-casing, because the purchase guard already refuses any purchase while `balance < price`.
+4. **No `CHECK(balance >= 0)`.** Such a constraint would roll back a legitimate pebble deletion. The guard lives in `spend_karma`, made race-safe by a row lock (below).
+
+## Data model
+
+### Migration 1 — extend the ledger
+
+```sql
+-- karma_events gains a movement category. Sign stays in `delta`.
+alter table public.karma_events
+  add column type text not null default 'credit'
+    check (type in ('credit','withdraw'));
+
+-- Widen delta: a smallint (max 32767) is fine per-event today, but future
+-- goods (themes/skins) and lifetime sums make integer the safe choice.
+alter table public.karma_events
+  alter column delta type integer;
+
+-- Backfill is trivial: every existing row is earn-side.
+-- (default 'credit' already covers historical rows; pebble_deleted included —
+--  a downward correction is still an earn-side movement.)
+
+-- Constrain reason to the known set now that it spans both sides.
+alter table public.karma_events
+  add constraint karma_events_reason_check check (reason in (
+    'pebble_created','pebble_enriched','pebble_deleted','grant',  -- credit
+    'purchase','refund'                                           -- withdraw
+  ));
+
+-- Index for the type-filtered sum queries (earned/spent) and history reads.
+create index karma_events_user_type_idx on public.karma_events (user_id, type);
+create index karma_events_user_created_idx on public.karma_events (user_id, created_at desc);
+```
+
+`ref_id` semantics by reason: `pebble_*` → pebble id; `purchase`/`refund` → the store item (glyph id in C, generic later); `grant` → nullable. A nullable `ref_id` stays acceptable.
+
+### Migration 2 — balance snapshot
+
+```sql
+-- O(1) balance reads + a single row to lock for serializing concurrent spends.
+-- NO non-negative CHECK: clawbacks may legally drive this below zero.
+create table public.wallet_balances (
+  user_id    uuid primary key references auth.users(id) on delete cascade,
+  balance    integer not null default 0,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.wallet_balances enable row level security;
+create policy "wallet_balances_select_self" on public.wallet_balances
+  for select using (user_id = auth.uid());
+-- No INSERT/UPDATE/DELETE policies: maintained only by the trigger below.
+
+-- Maintain it from EVERY karma_events insert (credits and withdraws).
+create or replace function public.apply_karma_event_to_wallet()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  insert into public.wallet_balances (user_id, balance, updated_at)
+  values (new.user_id, new.delta, now())
+  on conflict (user_id) do update
+    set balance = public.wallet_balances.balance + excluded.balance,
+        updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger karma_events_apply_to_wallet
+  after insert on public.karma_events
+  for each row execute function public.apply_karma_event_to_wallet();
+
+-- One-shot backfill from existing ledger.
+insert into public.wallet_balances (user_id, balance, updated_at)
+select user_id, sum(delta)::int, now()
+from public.karma_events group by user_id
+on conflict (user_id) do update
+  set balance = excluded.balance, updated_at = excluded.updated_at;
+```
+
+> **Decision — why a snapshot table over a pure derived `SUM`:** it gives O(1) balance reads, a natural single row to lock for concurrency, and it mirrors the existing `bounces` pattern the codebase already trusts. The trade-off (a snapshot to keep in sync) is contained: one trigger, one backfill, and the ledger remains the source of truth (the snapshot is always reconstructible via the backfill query).
+
+### Migration 3 — RPCs
+
+```sql
+-- Spend. Guarded + race-safe. Used by C (glyph buy) and any future good.
+-- amount is POSITIVE karma to debit; recorded as a negative withdraw delta.
+create or replace function public.spend_karma(
+  p_amount integer,
+  p_reason text,                 -- 'purchase'
+  p_ref_id uuid default null
+) returns uuid                    -- the ledger event id
+language plpgsql security definer set search_path = public as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_balance integer;
+  v_event_id uuid;
+begin
+  if v_user_id is null then raise exception 'not_authenticated' using errcode='42501'; end if;
+  if p_amount is null or p_amount <= 0 then raise exception 'invalid_amount'; end if;
+  if p_reason not in ('purchase') then raise exception 'invalid_reason'; end if;
+
+  -- Serialize concurrent spends for this user; create the row if first-ever.
+  insert into public.wallet_balances (user_id, balance)
+    values (v_user_id, 0) on conflict (user_id) do nothing;
+  select balance into v_balance
+    from public.wallet_balances where user_id = v_user_id for update;
+
+  if v_balance < p_amount then
+    raise exception 'insufficient_karma' using errcode='P0001',
+      detail = format('balance=%s amount=%s', v_balance, p_amount);
+  end if;
+
+  insert into public.karma_events (user_id, type, delta, reason, ref_id)
+  values (v_user_id, 'withdraw', -p_amount, p_reason, p_ref_id)
+  returning id into v_event_id;   -- trigger updates wallet_balances
+
+  return v_event_id;
+end;
+$$;
+
+-- Refund. Symmetric reversal (positive withdraw-side delta). Idempotent per ref.
+create or replace function public.refund_karma(
+  p_amount integer,
+  p_ref_id uuid
+) returns uuid
+language plpgsql security definer set search_path = public as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_event_id uuid;
+begin
+  if v_user_id is null then raise exception 'not_authenticated' using errcode='42501'; end if;
+  if p_amount is null or p_amount <= 0 then raise exception 'invalid_amount'; end if;
+
+  insert into public.karma_events (user_id, type, delta, reason, ref_id)
+  values (v_user_id, 'withdraw', p_amount, 'refund', p_ref_id)
+  returning id into v_event_id;
+  return v_event_id;
+end;
+$$;
+
+grant execute on function public.spend_karma(integer,text,uuid)  to authenticated;
+grant execute on function public.refund_karma(integer,uuid)      to authenticated;
+```
+
+**Idempotency / double-charge protection.** A single purchase must not be charged twice on a network retry, and a user must not buy what they already own. The clean place for this is the *caller's* domain (C owns "what is a glyph purchase"), enforced by a unique constraint on C's ownership/grant table (e.g. `unique(user_id, glyph_id)`), with the grant + `spend_karma` happening in **one** RPC transaction in C so a failed grant rolls back the debit. A's contract: **`spend_karma` is atomic and self-contained; idempotency of a *purchase* is the caller's responsibility, and A makes that possible by being callable inside the caller's transaction.** This keeps A generic across future goods.
+
+### Migration 4 — keep `update_pebble` / clawback labelled correctly
+
+The existing earn-side inserts (`create_pebble`, `update_pebble`, `delete_pebble`) write `reason` but not `type`. With `type` defaulting to `'credit'`, they remain correct without change. **No edit required** — but the spec notes it explicitly so the implementer verifies the default covers all three and doesn't add `type` asymmetrically. (Per AGENTS.md "keep sibling RPCs symmetric".)
+
+### Admin analytics (`bounces`) — scope boundary
+
+Once withdraw events exist, the `bounces` snapshot (Σ all delta) would silently shift from "earned" to "spendable balance", changing what the admin histogram means. **In-scope for A:** make the `apply_karma_event_to_bounce` trigger fold **only `type='credit'`** events, so "bounce karma distribution" keeps meaning *earned*. This is a one-line `WHERE`/guard in the trigger + a note in the admin migration. (The new `wallet_balances` is the thing that tracks spendable.) No admin UI change.
+
+## Data layer (apps/web)
+
+- **Types** (`lib/types.ts`): extend `KarmaEvent` with `type: 'credit' | 'withdraw'` and the widened reason union; add a `WalletSnapshot` type (`balance`, `totalEarned`, `totalSpent`).
+- **`DataProvider` interface** + `SupabaseProvider`:
+  - `getWallet(): Promise<WalletSnapshot>` — reads `wallet_balances` + two type-filtered sums (or a small `v_wallet_summary` view for one round-trip).
+  - `getWalletHistory(cursor?, limit): Promise<{ events: KarmaEvent[]; nextCursor }>` — paginated read of `karma_events` for the user, newest first (keyset pagination on `(created_at, id)`).
+  - `spendKarma(amount, reason, refId?): Promise<string>` — calls the `spend_karma` RPC. **Built in A, no UI caller in A**; C uses it.
+  - Populate `store.karma_log` from the first history page on load so existing `useKarma` consumers keep working.
+- **Optional view** `v_wallet_summary` (`user_id, balance, total_earned, total_spent`) to collapse the summary into one select; recommended.
+- **Hook** `lib/data/useWallet.ts`: `{ balance, totalEarned, totalSpent, history, loadMore, loading, error }`. UI reads only through this hook (never the provider directly), per the data-layer convention.
+
+## Wallet page (apps/web)
+
+- **Route**: `/wallet`. Linked from the karma display in `PathBottomBar`/`GamificationBlocks` and from profile. (The existing karma stat keeps showing the live `balance`.)
+- **Contents** (read-only):
+  1. **Balance header** — current `balance` (the `Sparkle` count), with `total_earned` / `total_spent` as secondary stats.
+  2. **Debt state** — if `balance < 0`, show it honestly with a gentle hint: *"Earn karma to clear your balance before you can shop again."* Never hidden, never alarming.
+  3. **History list** — chronological credit/withdraw entries: direction icon (＋/−), human reason label, amount, date, and a link to what it referenced (pebble / store item) when resolvable. Paginated via `loadMore`.
+- **i18n**: all copy bilingual EN/FR (`next-intl`, new message keys under a `wallet` namespace).
+- **a11y/theming**: follows shadcn-first + color-world theming; amounts have non-colour-only direction cues (the ＋/− glyph, not just red/green).
+- **Build it shadcn-first**: Card for the header, a simple list/table for history, existing Badge for direction. No bespoke styling beyond tokens.
+
+## Integrity model (summary)
+
+| Scenario | Result |
+|---|---|
+| Buy when `balance ≥ price` | `spend_karma` inserts a `withdraw`; balance drops. |
+| Buy when `balance < price` | `spend_karma` raises `insufficient_karma`; nothing written. |
+| Two devices buy at once | Row lock on `wallet_balances` serializes them; the second sees the updated balance and is accepted/rejected correctly. |
+| Delete a pebble after spending | Clawback (`pebble_deleted`, credit) is **always** recorded; balance may go **negative** (debt). Deletion never blocked. |
+| Try to buy while in debt | `balance < 0 < price` → rejected until re-earned. |
+| Refund a purchase | `refund_karma` adds a positive withdraw-side event; balance recovers; `total_spent` nets down. |
+
+## Testing
+
+The repo has no test harness yet (V1), so "test-ready" + manual verification:
+
+- **SQL-level** (verify via `db:reset` + scripted RPC calls): spend success, `insufficient_karma` rejection, concurrent-spend serialization (two transactions racing one balance), clawback-into-negative, buy-while-in-debt rejection, refund recovery, backfill correctness (snapshot == Σ ledger), and that `bounces` ignores withdraws.
+- **App-level**: wallet page renders balance + paginated history in EN/FR; negative-balance hint appears; `useWallet` updates after a (C-driven) spend.
+- Pure helpers (reason→label, amount formatting, ±direction) are pure functions, unit-test-ready.
+
+## Migration checklist (per AGENTS.md)
+
+1. Add migrations 1–4 under `packages/supabase/supabase/migrations/`.
+2. `npm run db:reset` then `npm run db:types --workspace=packages/supabase`.
+3. `git add packages/supabase/types/database.ts`.
+4. Keep sibling earn-side RPCs symmetric re: `type` (verify the default covers all three; don't add `type` to one without the others).
+
+## Arkaik
+
+Adds a screen (`/wallet`) and data concepts (wallet ledger, balance, `spend_karma`/`refund_karma`). Update `docs/arkaik/bundle.json` as part of implementation (new view node + data-model/endpoint nodes), per the `arkaik` skill — this clears the user-facing-view bar, so the PR also carries a bilingual **Lab Note**.
+
+## Open questions deferred to C/D (not blocking A)
+
+- Who sets a glyph's price and where it's stored (C).
+- Whether buying is ownership vs licence-to-use (C) — drives the unique constraint shape.
+- Pricing of future goods (themes/skins) — rails are already generic.

--- a/docs/superpowers/specs/2026-06-29-issue-494-karma-wallet-design.md
+++ b/docs/superpowers/specs/2026-06-29-issue-494-karma-wallet-design.md
@@ -46,10 +46,11 @@ alter table public.karma_events
   add column type text not null default 'credit'
     check (type in ('credit','withdraw'));
 
--- Widen delta: a smallint (max 32767) is fine per-event today, but future
--- goods (themes/skins) and lifetime sums make integer the safe choice.
-alter table public.karma_events
-  alter column delta type integer;
+-- delta stays smallint. Per-event values are small (earn ≤ 10) and balance/total
+-- sums promote to integer/bigint anyway (wallet_balances.balance is integer).
+-- Widening to integer would force dropping & recreating the views that depend on
+-- this column (v_karma_summary, v_analytics_bounce_distribution_today) on the live
+-- DB — not worth it. Revisit only if one good ever needs a price > 32767 karma.
 
 -- Backfill is trivial: every existing row is earn-side.
 -- (default 'credit' already covers historical rows; pebble_deleted included —

--- a/packages/supabase/supabase/migrations/20260629192621_karma_events_type_axis.sql
+++ b/packages/supabase/supabase/migrations/20260629192621_karma_events_type_axis.sql
@@ -1,0 +1,31 @@
+-- Karma becomes a spendable currency: add a movement category to the ledger.
+-- `type` keys off the CATEGORY of movement, not the sign of `delta`:
+--   credit   = earn-side  (pebble_created, pebble_enriched, pebble_deleted, grant) — may be negative
+--   withdraw = spend-side (purchase negative, refund positive)
+-- Sign stays in `delta`. balance = Σ delta; earned = Σ delta where credit;
+-- spent = -Σ delta where withdraw.
+--
+-- delta stays smallint on purpose: per-event values are small (earn ≤ 10), and
+-- balance/total sums promote to integer/bigint anyway (wallet_balances.balance is
+-- integer). Widening the column would force dropping & recreating the views that
+-- depend on it (v_karma_summary, v_analytics_bounce_distribution_today) on the
+-- live DB — not worth it. Revisit only if a single good ever needs a price > 32767.
+
+alter table public.karma_events
+  add column type text not null default 'credit'
+    check (type in ('credit','withdraw'));
+
+-- Constrain reason now that it spans both sides. Existing rows are all earn-side
+-- and already use the first three reasons, so the default 'credit' covers them.
+alter table public.karma_events
+  add constraint karma_events_reason_check check (reason in (
+    'pebble_created','pebble_enriched','pebble_deleted','grant',  -- credit
+    'purchase','refund'                                           -- withdraw
+  ));
+
+-- Indexes: (user_id, type) powers earned/spent sums; (user_id, created_at desc)
+-- powers the wallet history read.
+create index if not exists karma_events_user_type_idx
+  on public.karma_events (user_id, type);
+create index if not exists karma_events_user_created_idx
+  on public.karma_events (user_id, created_at desc);

--- a/packages/supabase/supabase/migrations/20260629193636_wallet_balances.sql
+++ b/packages/supabase/supabase/migrations/20260629193636_wallet_balances.sql
@@ -1,0 +1,40 @@
+-- O(1) balance reads + a single row to lock for serializing concurrent spends.
+-- NO non-negative CHECK: earn-side clawbacks (pebble deletion) may legally
+-- drive this below zero. The overdraw guard lives in spend_karma, not here.
+create table if not exists public.wallet_balances (
+  user_id    uuid primary key references auth.users(id) on delete cascade,
+  balance    integer not null default 0,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.wallet_balances enable row level security;
+
+drop policy if exists "wallet_balances_select_self" on public.wallet_balances;
+create policy "wallet_balances_select_self" on public.wallet_balances
+  for select using (user_id = auth.uid());
+-- No INSERT/UPDATE/DELETE policies: maintained exclusively by the trigger below.
+
+-- Keep the snapshot in sync with EVERY karma_events insert (credit and withdraw).
+create or replace function public.apply_karma_event_to_wallet()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  insert into public.wallet_balances (user_id, balance, updated_at)
+  values (new.user_id, new.delta, now())
+  on conflict (user_id) do update
+    set balance    = public.wallet_balances.balance + excluded.balance,
+        updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists karma_events_apply_to_wallet on public.karma_events;
+create trigger karma_events_apply_to_wallet
+  after insert on public.karma_events
+  for each row execute function public.apply_karma_event_to_wallet();
+
+-- One-shot backfill from the existing ledger. Idempotent.
+insert into public.wallet_balances (user_id, balance, updated_at)
+select user_id, sum(delta)::int, now()
+from public.karma_events group by user_id
+on conflict (user_id) do update
+  set balance = excluded.balance, updated_at = excluded.updated_at;

--- a/packages/supabase/supabase/migrations/20260629193838_wallet_rpcs.sql
+++ b/packages/supabase/supabase/migrations/20260629193838_wallet_rpcs.sql
@@ -1,0 +1,60 @@
+-- Spend karma. Guarded + race-safe. Called by C (glyph buy) and future goods.
+-- p_amount is POSITIVE karma to debit; recorded as a negative withdraw delta.
+create or replace function public.spend_karma(
+  p_amount integer,
+  p_reason text,                 -- 'purchase'
+  p_ref_id uuid default null
+) returns uuid
+language plpgsql security definer set search_path = public as $$
+declare
+  v_user_id  uuid := auth.uid();
+  v_balance  integer;
+  v_event_id uuid;
+begin
+  if v_user_id is null then raise exception 'not_authenticated' using errcode='42501'; end if;
+  if p_amount is null or p_amount <= 0 then raise exception 'invalid_amount'; end if;
+  if p_reason not in ('purchase') then raise exception 'invalid_reason'; end if;
+
+  -- Serialize concurrent spends for this user; create the row if first-ever.
+  insert into public.wallet_balances (user_id, balance)
+    values (v_user_id, 0) on conflict (user_id) do nothing;
+  select balance into v_balance
+    from public.wallet_balances where user_id = v_user_id for update;
+
+  if v_balance < p_amount then
+    raise exception 'insufficient_karma' using errcode='P0001',
+      detail = format('balance=%s amount=%s', v_balance, p_amount);
+  end if;
+
+  insert into public.karma_events (user_id, type, delta, reason, ref_id)
+  values (v_user_id, 'withdraw', -p_amount, p_reason, p_ref_id)
+  returning id into v_event_id;   -- trigger updates wallet_balances in this txn
+
+  return v_event_id;
+end;
+$$;
+
+-- Refund. Symmetric reversal (positive withdraw-side delta).
+create or replace function public.refund_karma(
+  p_amount integer,
+  p_ref_id uuid
+) returns uuid
+language plpgsql security definer set search_path = public as $$
+declare
+  v_user_id  uuid := auth.uid();
+  v_event_id uuid;
+begin
+  if v_user_id is null then raise exception 'not_authenticated' using errcode='42501'; end if;
+  if p_amount is null or p_amount <= 0 then raise exception 'invalid_amount'; end if;
+
+  insert into public.karma_events (user_id, type, delta, reason, ref_id)
+  values (v_user_id, 'withdraw', p_amount, 'refund', p_ref_id)
+  returning id into v_event_id;
+  return v_event_id;
+end;
+$$;
+
+revoke all on function public.spend_karma(integer,text,uuid)  from public, anon;
+revoke all on function public.refund_karma(integer,uuid)      from public, anon;
+grant execute on function public.spend_karma(integer,text,uuid)  to authenticated;
+grant execute on function public.refund_karma(integer,uuid)      to authenticated;

--- a/packages/supabase/supabase/migrations/20260629194418_restrict_refund_karma_to_service_role.sql
+++ b/packages/supabase/supabase/migrations/20260629194418_restrict_refund_karma_to_service_role.sql
@@ -1,0 +1,8 @@
+-- Security fix: refund_karma must not be a client-callable karma mint.
+-- As written it has no validation against an original purchase, so granting it
+-- to `authenticated` lets any user mint karma via refund_karma(1_000_000, …).
+-- Refunds are issued by trusted server/admin logic only. The buy flow
+-- (sub-project C) needs no client refund: a failed grant rolls back the spend
+-- in the same transaction. Restrict execution to service_role.
+revoke execute on function public.refund_karma(integer,uuid) from public, anon, authenticated;
+grant  execute on function public.refund_karma(integer,uuid) to service_role;

--- a/packages/supabase/supabase/migrations/20260629194621_wallet_summary_and_bounce_credit_only.sql
+++ b/packages/supabase/supabase/migrations/20260629194621_wallet_summary_and_bounce_credit_only.sql
@@ -1,0 +1,44 @@
+-- 1. One-round-trip wallet summary. Filtered to the caller (mirrors how
+--    v_karma_summary was hardened with an auth.uid() filter).
+drop view if exists public.v_wallet_summary;
+create view public.v_wallet_summary as
+select
+  wb.user_id,
+  wb.balance,
+  coalesce((select sum(ke.delta) from public.karma_events ke
+            where ke.user_id = wb.user_id and ke.type='credit'), 0)::int   as total_earned,
+  coalesce(-(select sum(ke.delta) from public.karma_events ke
+            where ke.user_id = wb.user_id and ke.type='withdraw'), 0)::int as total_spent
+from public.wallet_balances wb
+where wb.user_id = auth.uid();
+
+revoke all on public.v_wallet_summary from public, anon;
+grant select on public.v_wallet_summary to authenticated;
+
+-- 2. Keep the admin "bounce karma distribution" meaning EARNED, not spendable.
+--    Now that withdraw events exist, the bounces snapshot must ignore them or
+--    it silently becomes the spendable balance. Fold only credit-type events.
+create or replace function public.apply_karma_event_to_bounce()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  -- Only earn-side movements contribute to the bounce (earned-karma) snapshot.
+  if new.type <> 'credit' then
+    return new;
+  end if;
+  insert into public.bounces (user_id, score, updated_at)
+  values (new.user_id, new.delta, now())
+  on conflict (user_id) do update
+    set score      = public.bounces.score + excluded.score,
+        updated_at = now();
+  return new;
+end;
+$$;
+-- Trigger definition is unchanged; CREATE OR REPLACE on the function is enough.
+
+-- 3. Realign existing bounces snapshots to credit-only (no-op for current data,
+--    since no withdraw events predate this, but makes the invariant explicit).
+insert into public.bounces (user_id, score, updated_at)
+select user_id, coalesce(sum(delta) filter (where type='credit'), 0)::int, now()
+from public.karma_events group by user_id
+on conflict (user_id) do update
+  set score = excluded.score, updated_at = excluded.updated_at;

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -966,6 +966,46 @@ export type Database = {
           },
         ]
       }
+      wallet_balances: {
+        Row: {
+          balance: number
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          balance?: number
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          balance?: number
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "wallet_balances_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "v_bounce"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "wallet_balances_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "v_karma_summary"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "wallet_balances_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "v_ripple"
+            referencedColumns: ["user_id"]
+          },
+        ]
+      }
     }
     Views: {
       v_analytics_active_users_daily: {

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -1274,6 +1274,49 @@ export type Database = {
         }
         Relationships: []
       }
+      v_wallet_summary: {
+        Row: {
+          balance: number | null
+          total_earned: number | null
+          total_spent: number | null
+          user_id: string | null
+        }
+        Insert: {
+          balance?: number | null
+          total_earned?: never
+          total_spent?: never
+          user_id?: string | null
+        }
+        Update: {
+          balance?: number | null
+          total_earned?: never
+          total_spent?: never
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "wallet_balances_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "v_bounce"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "wallet_balances_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "v_karma_summary"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "wallet_balances_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "v_ripple"
+            referencedColumns: ["user_id"]
+          },
+        ]
+      }
     }
     Functions: {
       compute_karma_delta: {

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -1476,6 +1476,14 @@ export type Database = {
           render_svg: string
         }[]
       }
+      refund_karma: {
+        Args: { p_amount: number; p_ref_id: string }
+        Returns: string
+      }
+      spend_karma: {
+        Args: { p_amount: number; p_reason: string; p_ref_id?: string }
+        Returns: string
+      }
       sweep_orphan_snap_files: {
         Args: never
         Returns: {

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -362,6 +362,7 @@ export type Database = {
           id: string
           reason: string
           ref_id: string | null
+          type: string
           user_id: string
         }
         Insert: {
@@ -370,6 +371,7 @@ export type Database = {
           id?: string
           reason: string
           ref_id?: string | null
+          type?: string
           user_id: string
         }
         Update: {
@@ -378,6 +380,7 @@ export type Database = {
           id?: string
           reason?: string
           ref_id?: string | null
+          type?: string
           user_id?: string
         }
         Relationships: [


### PR DESCRIPTION
Resolves #494

**Sub-project A of 4** in **M36 · Pebblestore & Karma Economy** — the foundation the rest of the store (glyph marketplace, themes, pebbleskins) spends against. Turns **karma** from an earn-only score into a **spendable currency** with one auditable ledger, an atomic spend path that can never let a *purchase* overdraw, and a read-only wallet page.

## What this does

- **One ledger, one balance.** `karma_events` gains a `type` (credit/withdraw) axis keyed off movement *category*, not sign. Balance = Σ delta; earned/spent are indexed type-filtered sums.
- **Spendable balance with a debt model.** A `wallet_balances` snapshot (O(1) reads, lock target) is maintained by a trigger. There is **deliberately no `CHECK(balance >= 0)`** — earn-side clawbacks (deleting a pebble reverses the karma it earned) must always apply, even into the negative. A negative balance is a **debt** the user clears by re-earning before they can buy again.
- **The overdraw guard lives only in `spend_karma`** — it locks the user's balance row `FOR UPDATE` (race-safe across devices) and rejects when `balance < amount`. No spend UI ships here; sub-project C is the first caller.
- **`refund_karma` is `service_role`-only** (not user-callable) — an unguarded refund granted to `authenticated` would be a karma-minting hole.
- **Bounce isolation:** the existing admin `bounces` snapshot trigger now folds **credits only**, so "bounce karma distribution" keeps meaning *earned*, not spendable. The user-facing bounce **level** (`v_bounce`) was always blind to karma and is untouched.
- **Wallet page** at `/wallet`: balance, total earned/spent, an honest debt hint when negative, and a paginated EN/FR credit/withdraw history. The bottom-bar karma stat now links here.

## Key files

- **Migrations** (`packages/supabase/supabase/migrations/`): `…_karma_events_type_axis`, `…_wallet_balances`, `…_wallet_rpcs`, `…_restrict_refund_karma_to_service_role`, `…_wallet_summary_and_bounce_credit_only`.
- **Web data layer**: `lib/types.ts` (`KarmaEvent`/`KarmaReason`/`WalletSnapshot`), `lib/data/data-provider.ts` + `supabase-provider.ts` (`getWallet`/`getWalletHistory`/`spendKarma`), `lib/data/useWallet.ts`.
- **UI**: `app/wallet/page.tsx`, `components/wallet/WalletView.tsx` + `WalletHistoryItem.tsx`, `lib/utils/wallet-format.ts`, `components/path/PathBottomBar.tsx`, i18n `en.json`/`fr.json`.
- **Docs/map**: spec + plan under `docs/superpowers/`, `docs/arkaik/bundle.json`, `docs/decisions/log.md`.

## Decision log

Added an entry — *Karma wallet: one ledger, debt allowed, refunds server-only*. Most important downstream constraint: **do not add `CHECK(balance >= 0)` to `wallet_balances`** — it would roll back legitimate pebble deletions.

## Verification

- Lint (`apps/web`) and web `next build` green; `/wallet` builds as a route.
- All 5 migrations applied to the linked remote Supabase.
- Financial-integrity invariants (overdraw guard + race-safety, no-mint posture, `service_role`-only refunds, bounce isolation, `balance = earned − spent`) were **adversarially reviewed by tracing the SQL**.
- ⚠️ **Pending:** the runtime SQL behavior checks (calling `spend_karma` to observe an `insufficient_karma` rejection and the clawback-into-debt path) need an authenticated session and have **not been executed yet** — recommend a quick manual pass as a test user before release.

## Out of scope (sibling sub-projects)

In-app "+karma" activity → #495 (B) · glyph marketplace / the buy flow → #496 (C) · admin moderation + SVG upload → #497 (D). `spend_karma` is built here; C is its first caller (idempotency is C's responsibility, enabled by `spend_karma` being callable inside C's transaction).

## Lab Note (EN/FR)

<!-- DRAFT ONLY — a human curates and publishes via the Lab admin (`logs` table, `released_at`) at release time. -->

**EN — "Your karma, now in a Wallet"**
Track your karma balance and see the full history of how you've earned it, all in one place. It's the first step toward spending karma in the Pebblestore.

**FR — "Votre karma, maintenant dans un Porte-karma"**
Suivez votre solde de karma et consultez l'historique complet de vos gains, le tout au même endroit. C'est la première étape avant de pouvoir dépenser votre karma dans la Pebblestore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
