### PR TITLE
feat(ui): in-app karma activity primitive

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,6 +7,7 @@ import { DataProvider } from "@/components/layout/DataProvider";
 import { AuthProvider } from "@/components/layout/AuthProvider";
 import { SerwistRegistration } from "@/components/layout/SerwistRegistration";
 import { MainContent } from "@/components/layout/MainContent";
+import { Toaster } from "@/components/ui/sonner";
 import { LocaleProvider } from "@/lib/i18n/LocaleProvider";
 import "./globals.css";
 
@@ -89,6 +90,7 @@ export default function RootLayout({
                 <ColorWorldProvider>
                   <ThemeProvider>
                     <ThemeColorSync />
+                    <Toaster />
                     <div className="flex h-full pl-[var(--safe-area-left)] pr-[var(--safe-area-right)]">
                       <MainContent>{children}</MainContent>
                     </div>

--- a/apps/web/components/activity/KarmaActivityPill.tsx
+++ b/apps/web/components/activity/KarmaActivityPill.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useTranslations } from "next-intl"
+import { Sparkle } from "lucide-react"
+import { toast } from "sonner"
+import type { KarmaReason } from "@/lib/types"
+
+type KarmaActivityPillProps = {
+  toastId: string | number
+  amount: number
+  reason: KarmaReason
+}
+
+export function KarmaActivityPill({ toastId, amount, reason }: KarmaActivityPillProps) {
+  const router = useRouter()
+  const t = useTranslations("activity")
+  const tReason = useTranslations("wallet.reason")
+
+  const handleTap = () => {
+    toast.dismiss(toastId)
+    router.push("/wallet")
+  }
+
+  // Full spoken sentence: "Earned 5 karma — Pebble created. View wallet."
+  const label = `${t("srEarned", { amount, reason: tReason(reason) })} ${t("viewWallet")}.`
+
+  return (
+    <button
+      type="button"
+      onClick={handleTap}
+      aria-label={label}
+      className="flex items-center gap-2 rounded-full bg-neutral-900 px-4 py-2 text-sm font-semibold text-white shadow-lg ring-1 ring-white/10 transition active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 dark:bg-neutral-800 motion-reduce:transition-none motion-reduce:active:scale-100"
+    >
+      <Sparkle aria-hidden className="size-4 text-amber-300" />
+      <span aria-hidden>{t("amount", { amount })}</span>
+    </button>
+  )
+}

--- a/apps/web/components/ui/sonner.tsx
+++ b/apps/web/components/ui/sonner.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      position="bottom-center"
+      // Lift toasts above the mobile BottomNav (fixed bottom-0, ~64px + safe area).
+      // On desktop there is no bottom nav, so the default desktop offset is fine.
+      mobileOffset={{ bottom: "calc(80px + env(safe-area-inset-bottom))" }}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/apps/web/lib/activity/karma-activity.tsx
+++ b/apps/web/lib/activity/karma-activity.tsx
@@ -1,0 +1,19 @@
+import { toast } from "sonner"
+import { KarmaActivityPill } from "@/components/activity/KarmaActivityPill"
+import type { KarmaReason } from "@/lib/types"
+
+// Stable id → a new credit replaces the current pill rather than stacking.
+const KARMA_ACTIVITY_ID = "karma-activity"
+
+/**
+ * Fire a glanceable "+N karma" activity pill. No-op for non-positive amounts
+ * (deletions/clawbacks must stay silent). Feature-agnostic: any credit source
+ * calls this with the amount and the reason.
+ */
+export function notifyKarma(amount: number, reason: KarmaReason): void {
+  if (amount <= 0) return
+  toast.custom(
+    (id) => <KarmaActivityPill toastId={id} amount={amount} reason={reason} />,
+    { id: KARMA_ACTIVITY_ID, duration: 3000 },
+  )
+}

--- a/apps/web/lib/activity/karma-activity.tsx
+++ b/apps/web/lib/activity/karma-activity.tsx
@@ -13,7 +13,13 @@ const KARMA_ACTIVITY_ID = "karma-activity"
 export function notifyKarma(amount: number, reason: KarmaReason): void {
   if (amount <= 0) return
   toast.custom(
-    (id) => <KarmaActivityPill toastId={id} amount={amount} reason={reason} />,
+    // Sonner's toast row is full-width on mobile, so center the content-width
+    // pill within it — `position="bottom-center"` only centers the container.
+    (id) => (
+      <div className="flex w-full justify-center">
+        <KarmaActivityPill toastId={id} amount={amount} reason={reason} />
+      </div>
+    ),
     { id: KARMA_ACTIVITY_ID, duration: 3000 },
   )
 }

--- a/apps/web/lib/data/usePebble.ts
+++ b/apps/web/lib/data/usePebble.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useDataProvider } from "@/lib/data/provider-context"
+import { notifyKarma } from "@/lib/activity/karma-activity"
 import type { UpdatePebbleInput } from "@/lib/data/data-provider"
 import type { Pebble, PebbleSnap } from "@/lib/types"
 
@@ -15,8 +16,12 @@ export function usePebble(id: string) {
     input: UpdatePebbleInput,
   ): Promise<Pebble> => {
     if (!provider) throw new Error("Not authenticated")
+    const before = provider.getStore().karma
     const updated = await provider.updatePebble(id, input)
-    setStore(provider.getStore())
+    const after = provider.getStore()
+    setStore(after)
+    const delta = after.karma - before
+    if (delta > 0) notifyKarma(delta, "pebble_enriched")
     return updated
   }
 

--- a/apps/web/lib/data/usePebbles.ts
+++ b/apps/web/lib/data/usePebbles.ts
@@ -10,20 +10,22 @@ export function usePebbles() {
 
   const addPebble = async (input: CreatePebbleInput): Promise<Pebble> => {
     if (!provider) throw new Error("Not authenticated")
-    const before = store.karma
+    const before = provider.getStore().karma
     const pebble = await provider.createPebble(input)
-    setStore(provider.getStore())
-    const delta = provider.getStore().karma - before
+    const after = provider.getStore()
+    setStore(after)
+    const delta = after.karma - before
     if (delta > 0) notifyKarma(delta, "pebble_created")
     return pebble
   }
 
   const updatePebble = async (id: string, input: UpdatePebbleInput): Promise<Pebble> => {
     if (!provider) throw new Error("Not authenticated")
-    const before = store.karma
+    const before = provider.getStore().karma
     const pebble = await provider.updatePebble(id, input)
-    setStore(provider.getStore())
-    const delta = provider.getStore().karma - before
+    const after = provider.getStore()
+    setStore(after)
+    const delta = after.karma - before
     if (delta > 0) notifyKarma(delta, "pebble_enriched")
     return pebble
   }

--- a/apps/web/lib/data/usePebbles.ts
+++ b/apps/web/lib/data/usePebbles.ts
@@ -1,5 +1,6 @@
 "use client"
 
+import { notifyKarma } from "@/lib/activity/karma-activity"
 import { useDataProvider } from "@/lib/data/provider-context"
 import type { CreatePebbleInput, UpdatePebbleInput } from "@/lib/data/data-provider"
 import type { Pebble, PebbleSnap } from "@/lib/types"
@@ -9,15 +10,21 @@ export function usePebbles() {
 
   const addPebble = async (input: CreatePebbleInput): Promise<Pebble> => {
     if (!provider) throw new Error("Not authenticated")
+    const before = store.karma
     const pebble = await provider.createPebble(input)
     setStore(provider.getStore())
+    const delta = provider.getStore().karma - before
+    if (delta > 0) notifyKarma(delta, "pebble_created")
     return pebble
   }
 
   const updatePebble = async (id: string, input: UpdatePebbleInput): Promise<Pebble> => {
     if (!provider) throw new Error("Not authenticated")
+    const before = store.karma
     const pebble = await provider.updatePebble(id, input)
     setStore(provider.getStore())
+    const delta = provider.getStore().karma - before
+    if (delta > 0) notifyKarma(delta, "pebble_enriched")
     return pebble
   }
 

--- a/apps/web/lib/data/usePebbles.ts
+++ b/apps/web/lib/data/usePebbles.ts
@@ -19,6 +19,9 @@ export function usePebbles() {
     return pebble
   }
 
+  // Karma fire kept symmetric with usePebble(id).updatePebble — the singular
+  // hook is what the live enrichment surfaces use; this path is for parity if a
+  // future caller updates through the plural hook.
   const updatePebble = async (id: string, input: UpdatePebbleInput): Promise<Pebble> => {
     if (!provider) throw new Error("Not authenticated")
     const before = provider.getStore().karma

--- a/apps/web/lib/i18n/messages/en.json
+++ b/apps/web/lib/i18n/messages/en.json
@@ -102,6 +102,11 @@
       "removeUpvoteAria": "Remove upvote"
     }
   },
+  "activity": {
+    "amount": "+{amount} karma",
+    "srEarned": "Earned {amount} karma — {reason}.",
+    "viewWallet": "View wallet"
+  },
   "wallet": {
     "title": "Wallet",
     "balance": "Balance",

--- a/apps/web/lib/i18n/messages/fr.json
+++ b/apps/web/lib/i18n/messages/fr.json
@@ -102,6 +102,11 @@
       "removeUpvoteAria": "Ôter mon vote"
     }
   },
+  "activity": {
+    "amount": "+{amount} karma",
+    "srEarned": "Vous avez gagné {amount} karma — {reason}.",
+    "viewWallet": "Voir le porte-karma"
+  },
   "wallet": {
     "title": "Porte-karma",
     "balance": "Solde",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,7 @@
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
     "serwist": "^9.5.7",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "unified": "^11.0.5"

--- a/docs/decisions/log.md
+++ b/docs/decisions/log.md
@@ -92,3 +92,14 @@ Append-only ledger of **significant** product/engineering decisions. One terse e
 - **Consequences:** **Do not add `CHECK(balance >= 0)` to `wallet_balances`** — it would break pebble deletion. New spend-side reasons go through `spend_karma`; new earn-side reasons just insert credit events. The `bounces` admin snapshot trigger now folds **credits only** so "bounce karma distribution" keeps meaning *earned*. `delta` stays `smallint` (widening would force dropping/recreating dependent views on the live DB). Idempotency of a *purchase* is the caller's (sub-project C's) responsibility, enabled by `spend_karma` being callable inside the caller's transaction.
 - **Supersedes / Superseded-by:** —
 - **Refs:** #494, `docs/superpowers/specs/2026-06-29-issue-494-karma-wallet-design.md`, `packages/supabase/supabase/migrations/20260629192621_karma_events_type_axis.sql` … `20260629194621_wallet_summary_and_bounce_credit_only.sql`.
+
+## 2026-06-29 — Web in-app notifications: Sonner + explicit-fire, no realtime
+
+- **Status:** taken
+- **Scope:** webapp
+- **Context:** M36 sub-project B (#495) needed a non-invasive in-app activity primitive, first used for a "+N karma" pill on wallet credit. A web PWA cannot render into the iOS Dynamic Island, so the admired Opal effect had to be approximated within web limits, and we needed a way to know when a credit happened.
+- **Decision:** We will build in-app activity on **Sonner** (ported from `apps/admin`), rendering a compact custom pill via `toast.custom()` bottom-center. The trigger is **explicit fire at the action site** via store-diff: the pebble mutation hooks read karma from provider truth before/after the action and call `notifyKarma(delta, reason)` on a positive delta. No Supabase realtime, no central balance-watcher.
+- **Why:** Sonner gives queueing, timeout, swipe-dismiss, `aria-live`, and reduced-motion handling for free. Explicit fire is the cleanest feature-agnostic primitive (carries a reason label, no false-fire surface), needs no backend change, and suits a personal PWA where credits come from the user's own on-device actions. Realtime would be heavier and double-fire against the optimistic store reload.
+- **Consequences:** New credit sources surface a pill by adding one `notifyKarma(...)` call at their action site — and must wire it on the hook the live surface actually uses (enrichment goes through the singular `usePebble(id)`, not `usePebbles()`). Credit-only by design: clawbacks (delta ≤ 0) stay silent. The pill uses a stable toast id so a new credit replaces the prior one. Reused by C (e.g. "glyph purchased") via the same primitive.
+- **Supersedes / Superseded-by:** —
+- **Refs:** #495, `docs/superpowers/specs/2026-06-29-issue-495-in-app-activity-design.md`, `apps/web/lib/activity/karma-activity.tsx`, `apps/web/components/activity/KarmaActivityPill.tsx`.

--- a/docs/superpowers/plans/2026-06-29-issue-495-in-app-activity.md
+++ b/docs/superpowers/plans/2026-06-29-issue-495-in-app-activity.md
@@ -1,0 +1,401 @@
+# In-App Activity Primitive (Opal-style karma credit) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a non-invasive in-app activity primitive to `apps/web` (Sonner-based) and wire its first consumer: a glanceable "+N karma" pill that fires when a pebble action credits karma.
+
+**Architecture:** Copy admin's themed Sonner `Toaster` into `apps/web`, mount it bottom-center above the nav bar. A small `KarmaActivityPill` renders inside `toast.custom()`; a plain module function `notifyKarma(amount, reason)` is the feature-agnostic API. The trigger is explicit: the pebble mutation hooks diff `store.karma` before/after the store reload that already happens, and fire on a positive delta. No backend change, no realtime.
+
+**Tech Stack:** Next.js 16 (App Router), React 19, TypeScript strict, Tailwind 4, Sonner 2, next-intl, next-themes, Lucide.
+
+> **Testing note:** `apps/web` has no test runner in V1 (consistent with sub-project A). Verification per task is **workspace lint** + (final) **`next build`** + a **manual pass**. The primitive's only logic — the `amount <= 0` guard and the reason→label mapping — is trivial and verified by the manual pass. Steps below use implement → lint → commit, with a dedicated final verification task.
+
+> **Spec:** `docs/superpowers/specs/2026-06-29-issue-495-in-app-activity-design.md`. Read it if a decision here is unclear.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `apps/web/components/ui/sonner.tsx` (create) | Themed `Toaster` wrapper, bottom-center, offset to clear the nav bar. Drop-in copy of admin's, retuned for web. |
+| `apps/web/app/layout.tsx` (modify) | Mount `<Toaster />` once inside `ThemeProvider`. |
+| `apps/web/lib/i18n/messages/en.json` + `fr.json` (modify) | `activity` namespace: visible amount, screen-reader sentence, tap label. Reuses existing `wallet.reason.*`. |
+| `apps/web/components/activity/KarmaActivityPill.tsx` (create) | The compact dark capsule rendered inside the custom toast; tappable → `/wallet`; a11y + reduced-motion. |
+| `apps/web/lib/activity/karma-activity.tsx` (create) | `notifyKarma(amount, reason)` — the imperative primitive over `toast.custom()`. |
+| `apps/web/lib/data/usePebbles.ts` (modify) | Store-diff trigger in `addPebble` / `updatePebble`; fire `notifyKarma` on positive delta. |
+
+---
+
+## Task 1: Add Sonner + themed Toaster wrapper, mounted bottom-center
+
+**Files:**
+- Modify: `apps/web/package.json` (add `sonner` dep)
+- Create: `apps/web/components/ui/sonner.tsx`
+- Modify: `apps/web/app/layout.tsx`
+- Reference: `apps/admin/components/ui/sonner.tsx` (the wrapper being adapted)
+
+- [ ] **Step 1: Add the Sonner dependency**
+
+Run (from repo root):
+```bash
+npm install sonner@^2.0.7 --workspace=apps/web
+```
+Expected: `apps/web/package.json` gains `"sonner": "^2.0.7"` under `dependencies`, lockfile updated.
+
+- [ ] **Step 2: Create the themed Toaster wrapper**
+
+Create `apps/web/components/ui/sonner.tsx`. This is admin's wrapper with three web-specific changes: `position="bottom-center"`, a `mobileOffset` that clears the mobile `BottomNav` (which is `fixed bottom-0`, ~64px tall plus `--safe-area-bottom`), and the same CSS-variable theming.
+
+```tsx
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      position="bottom-center"
+      // Lift toasts above the mobile BottomNav (fixed bottom-0, ~64px + safe area).
+      // On desktop there is no bottom nav, so the default desktop offset is fine.
+      mobileOffset={{ bottom: "calc(80px + env(safe-area-inset-bottom))" }}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }
+```
+
+Note: `mobileOffset`/`offset` are Sonner v2 props. If ESLint or the type checker rejects the `calc(...)` string value for `mobileOffset`, consult the installed Sonner types (`node_modules/sonner/dist/index.d.ts`) and fall back to a numeric `{ bottom: 80 }` plus the safe-area handled by the toast's own padding. Per AGENTS.md, prefer reading the installed package over assuming an API.
+
+- [ ] **Step 3: Mount the Toaster in the root layout**
+
+In `apps/web/app/layout.tsx`, add the import near the other layout imports:
+```tsx
+import { Toaster } from "@/components/ui/sonner";
+```
+
+Then render it inside `ThemeProvider`, immediately after `<ThemeColorSync />`:
+```tsx
+                  <ThemeProvider>
+                    <ThemeColorSync />
+                    <Toaster />
+                    <div className="flex h-full pl-[var(--safe-area-left)] pr-[var(--safe-area-right)]">
+                      <MainContent>{children}</MainContent>
+                    </div>
+                  </ThemeProvider>
+```
+
+- [ ] **Step 4: Lint the workspace**
+
+Run:
+```bash
+npm run lint --workspace=apps/web
+```
+Expected: PASS (no new errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/package.json package-lock.json apps/web/components/ui/sonner.tsx apps/web/app/layout.tsx
+git commit -m "feat(ui): add sonner toaster to web app"
+```
+
+---
+
+## Task 2: Add the `activity` i18n namespace (EN + FR)
+
+**Files:**
+- Modify: `apps/web/lib/i18n/messages/en.json`
+- Modify: `apps/web/lib/i18n/messages/fr.json`
+- Reference: existing `wallet.reason.*` keys (reused for the reason label)
+
+- [ ] **Step 1: Add the `activity` namespace to `en.json`**
+
+Insert a new `"activity"` object (place it alphabetically/near `wallet`, valid JSON — mind the trailing comma):
+```json
+  "activity": {
+    "amount": "+{amount} karma",
+    "srEarned": "Earned {amount} karma — {reason}.",
+    "viewWallet": "View wallet"
+  },
+```
+
+- [ ] **Step 2: Add the matching `activity` namespace to `fr.json`**
+
+```json
+  "activity": {
+    "amount": "+{amount} karma",
+    "srEarned": "Vous avez gagné {amount} karma — {reason}.",
+    "viewWallet": "Voir le porte-karma"
+  },
+```
+
+Note: confirm the FR wording for "wallet" matches the existing `wallet.title` in `fr.json` (sub-project A). If A used a different term than "porte-karma", match it here for consistency.
+
+- [ ] **Step 3: Verify `wallet.reason.*` exists in BOTH locale files**
+
+Run:
+```bash
+grep -A8 '"reason"' apps/web/lib/i18n/messages/en.json apps/web/lib/i18n/messages/fr.json
+```
+Expected: both files show `pebble_created` and `pebble_enriched` under `wallet.reason`. The pill reuses these; if FR is missing any, add it mirroring EN before proceeding.
+
+- [ ] **Step 4: Validate JSON**
+
+Run:
+```bash
+node -e "JSON.parse(require('fs').readFileSync('apps/web/lib/i18n/messages/en.json','utf8'));JSON.parse(require('fs').readFileSync('apps/web/lib/i18n/messages/fr.json','utf8'));console.log('valid')"
+```
+Expected: prints `valid`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/lib/i18n/messages/en.json apps/web/lib/i18n/messages/fr.json
+git commit -m "feat(ui): add activity i18n namespace (en/fr)"
+```
+
+---
+
+## Task 3: Build the `KarmaActivityPill` component
+
+**Files:**
+- Create: `apps/web/components/activity/KarmaActivityPill.tsx`
+- Reference: `apps/web/lib/types.ts` (`KarmaReason`)
+
+The pill matches the approved mockup C: a compact **always-dark** capsule (the "island" signature — intentionally theme-independent, with a subtle lift in dark mode for separation), `✨` + amber **+N karma**, tappable, accessible, reduced-motion aware. The reason is not shown visually (mockup C had no subtitle) but is spoken to screen readers for context.
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useTranslations } from "next-intl"
+import { Sparkle } from "lucide-react"
+import { toast } from "sonner"
+import type { KarmaReason } from "@/lib/types"
+
+type KarmaActivityPillProps = {
+  toastId: string | number
+  amount: number
+  reason: KarmaReason
+}
+
+export function KarmaActivityPill({ toastId, amount, reason }: KarmaActivityPillProps) {
+  const router = useRouter()
+  const t = useTranslations("activity")
+  const tReason = useTranslations("wallet.reason")
+
+  const handleTap = () => {
+    toast.dismiss(toastId)
+    router.push("/wallet")
+  }
+
+  // Full spoken sentence: "Earned 5 karma — Pebble created. View wallet."
+  const label = `${t("srEarned", { amount, reason: tReason(reason) })} ${t("viewWallet")}.`
+
+  return (
+    <button
+      type="button"
+      onClick={handleTap}
+      aria-label={label}
+      className="flex items-center gap-2 rounded-full bg-neutral-900 px-4 py-2 text-sm font-semibold text-white shadow-lg ring-1 ring-white/10 transition active:scale-95 dark:bg-neutral-800 motion-reduce:transition-none motion-reduce:active:scale-100"
+    >
+      <Sparkle aria-hidden className="size-4 text-amber-300" />
+      <span aria-hidden>{t("amount", { amount })}</span>
+    </button>
+  )
+}
+```
+
+Why `aria-label` on the button with `aria-hidden` inner content: the visible "+5 karma" is decorative; the button's accessible name is the full sentence, so when Sonner announces the toast (it renders into an `aria-live` region) a screen reader hears the complete context plus the tap affordance.
+
+- [ ] **Step 2: Lint the workspace**
+
+Run:
+```bash
+npm run lint --workspace=apps/web
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/components/activity/KarmaActivityPill.tsx
+git commit -m "feat(ui): add karma activity pill component"
+```
+
+---
+
+## Task 4: Build the `notifyKarma` primitive
+
+**Files:**
+- Create: `apps/web/lib/activity/karma-activity.tsx`
+- Reference: `apps/web/components/activity/KarmaActivityPill.tsx` (Task 3), `apps/web/lib/types.ts` (`KarmaReason`)
+
+`.tsx` because it returns JSX from `toast.custom`. Stable `id` makes a new credit replace the current pill (one at a time, newest wins).
+
+- [ ] **Step 1: Create the primitive**
+
+```tsx
+import { toast } from "sonner"
+import { KarmaActivityPill } from "@/components/activity/KarmaActivityPill"
+import type { KarmaReason } from "@/lib/types"
+
+// Stable id → a new credit replaces the current pill rather than stacking.
+const KARMA_ACTIVITY_ID = "karma-activity"
+
+/**
+ * Fire a glanceable "+N karma" activity pill. No-op for non-positive amounts
+ * (deletions/clawbacks must stay silent). Feature-agnostic: any credit source
+ * calls this with the amount and the reason.
+ */
+export function notifyKarma(amount: number, reason: KarmaReason): void {
+  if (amount <= 0) return
+  toast.custom(
+    (id) => <KarmaActivityPill toastId={id} amount={amount} reason={reason} />,
+    { id: KARMA_ACTIVITY_ID, duration: 3000 },
+  )
+}
+```
+
+- [ ] **Step 2: Lint the workspace**
+
+Run:
+```bash
+npm run lint --workspace=apps/web
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/lib/activity/karma-activity.tsx
+git commit -m "feat(core): add notifyKarma activity primitive"
+```
+
+---
+
+## Task 5: Wire the explicit-fire trigger into the pebble hooks
+
+**Files:**
+- Modify: `apps/web/lib/data/usePebbles.ts`
+- Reference: `apps/web/lib/activity/karma-activity.tsx` (Task 4)
+
+The store is reloaded inside `createPebble`/`updatePebble`, so `provider.getStore().karma` is correct right after the await. Diff against the value captured before the action; fire only on a positive delta.
+
+- [ ] **Step 1: Import the primitive**
+
+At the top of `apps/web/lib/data/usePebbles.ts`, add:
+```ts
+import { notifyKarma } from "@/lib/activity/karma-activity"
+```
+
+- [ ] **Step 2: Diff-and-fire in `addPebble`**
+
+Replace the existing `addPebble` body:
+```ts
+  const addPebble = async (input: CreatePebbleInput): Promise<Pebble> => {
+    if (!provider) throw new Error("Not authenticated")
+    const before = store.karma
+    const pebble = await provider.createPebble(input)
+    setStore(provider.getStore())
+    const delta = provider.getStore().karma - before
+    if (delta > 0) notifyKarma(delta, "pebble_created")
+    return pebble
+  }
+```
+
+- [ ] **Step 3: Diff-and-fire in `updatePebble`**
+
+Replace the existing `updatePebble` body:
+```ts
+  const updatePebble = async (id: string, input: UpdatePebbleInput): Promise<Pebble> => {
+    if (!provider) throw new Error("Not authenticated")
+    const before = store.karma
+    const pebble = await provider.updatePebble(id, input)
+    setStore(provider.getStore())
+    const delta = provider.getStore().karma - before
+    if (delta > 0) notifyKarma(delta, "pebble_enriched")
+    return pebble
+  }
+```
+
+Leave `removePebble` untouched — deletions claw back karma (delta < 0) and must stay silent (D4).
+
+- [ ] **Step 4: Lint the workspace**
+
+Run:
+```bash
+npm run lint --workspace=apps/web
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/lib/data/usePebbles.ts
+git commit -m "feat(core): fire karma activity pill on pebble credit"
+```
+
+---
+
+## Task 6: Final verification (build + manual pass)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Production build of the web workspace**
+
+Run:
+```bash
+npm run build --workspace=apps/web
+```
+Expected: build succeeds; no type errors.
+
+- [ ] **Step 2: Manual pass (dev server)**
+
+Run `npm run dev --workspace=apps/web`, sign in, then verify:
+- Create a pebble that earns karma → a compact "+N karma" pill rises bottom-center, above the nav bar, then auto-dismisses (~3s).
+- Create two pebbles quickly → only one pill shows at a time (replace, not stack).
+- Tap the pill → navigates to `/wallet` and the pill dismisses.
+- Delete a pebble → **no** pill.
+- Toggle the OS "reduce motion" setting → the pill fades without the scale/rise.
+- Switch to dark mode and a non-default color-world → the pill remains legible (dark capsule, amber amount, visible ring).
+- With a screen reader (VoiceOver), creating a pebble announces "Earned N karma — Pebble created. View wallet."
+
+- [ ] **Step 3: Confirm no commit needed**
+
+This task changes no files. If the manual pass surfaces a defect, fix it in the relevant task's file, re-lint, and commit with a `fix(...)` message describing the correction.
+
+---
+
+## Housekeeping (at PR time, not per-task)
+
+- **Arkaik:** no new route/data model/endpoint → no-op.
+- **Decision log:** append one entry — *web in-app notifications = Sonner + explicit-fire + no realtime* (foundation future features build on).
+- **Lab Note:** user-facing (`feat`) → bilingual EN/FR blurb in the PR body (proposal only).
+- **PR:** branch `feat/495-in-app-activity-primitive`; title `feat(ui): in-app karma activity primitive`; body opens `Resolves #495`; inherit #495 labels (`feat`, `ui`, `core`, `web`) + milestone `M36 · Pebblestore & Karma Economy` (confirm with user).

--- a/docs/superpowers/specs/2026-06-29-issue-495-in-app-activity-design.md
+++ b/docs/superpowers/specs/2026-06-29-issue-495-in-app-activity-design.md
@@ -1,0 +1,102 @@
+# In-App Activity Primitive (Opal-style karma credit) — Design Spec
+
+> **Sub-project B of 4** in **M36 · Pebblestore & Karma Economy**. Issue #495.
+> Pairs with Sub-project A (#494, merged) which produces the credit events this primitive reacts to.
+
+**Goal:** Introduce a non-invasive, glanceable in-app activity primitive for `apps/web`, whose first consumer animates a "+N karma" pill when the karma wallet is credited.
+
+**Status:** Approved design. Next step: implementation plan (writing-plans).
+
+---
+
+## 1. Intent & constraints
+
+Surface moments worth noticing — starting with **"karma pouch credited"** — as a small, transient, delightful activity that never blocks the user. Inspired by Opal's Dynamic-Island streak increment, **not** an invasive full sheet.
+
+**Web reality check:** a PWA cannot render into the iOS Dynamic Island hardware region, and a top-anchored pill fights the status-bar safe area in standalone mode. So the foundation is **Sonner** (already proven in `apps/admin`), styled and placed to chase the Opal *feeling* within web limits — a compact pill, bottom-center, in the thumb zone next to the karma counter it relates to.
+
+Non-negotiables from the issue:
+- Any feature can fire a transient, non-blocking activity via **one call**.
+- A wallet credit surfaces a glanceable **"+N karma"** pill, never a full-screen interruption.
+- Theming-aware (light/dark + color-world), accessible (respects reduced-motion, screen-reader friendly), bilingual (EN/FR).
+
+## 2. Decisions (the forks, settled)
+
+| # | Decision | Why |
+|---|----------|-----|
+| D1 | **Foundation = Sonner**, copied from admin into `apps/web`. | Proven wrapper; gives queueing, timeout, swipe-dismiss, `aria-live`, reduced-motion handling for free. A web PWA can't use a real Dynamic Island. |
+| D2 | **Compact pill, bottom-center** via `toast.custom()`. | Keeps the Opal compact-glance feeling; sits in the thumb zone above the nav bar, beside the karma stat that's incrementing; avoids the status-bar collision a top pill would cause. |
+| D3 | **Explicit fire at the action site**, amount from **store-diff**. | Cleanest *primitive* (feature-agnostic, imperative — exactly what the issue asks for); carries a *reason* label; zero backend change, no realtime, no false-fire surface. Rejected: central karma-watcher (no reason, load-time false fires) and Supabase realtime (heaviest, double-fire risk, overkill for a personal PWA). |
+| D4 | **Credit-only.** delta ≤ 0 stays silent. | Matches the "increment" spirit. Deletions/clawbacks must not nag; spends are sub-project C's concern. |
+| D5 | **Single pill, replace-on-new** (stable `id: "karma-activity"`). | At most one glanceable pill; newest credit wins. No stacking, no summing. On-brand for "one living moment." |
+| D6 | **Tappable → `/wallet`** (then dismiss). | Connects B's transient pill to A's durable wallet history; a natural "see more" gesture. |
+| D7 | **Plain module primitive**, not a hook/context. | Sonner's `toast` is a global singleton importable anywhere, so a `useActivity()` hook would be pure ceremony. |
+
+## 3. Architecture & components
+
+Data flow today (verified): `usePebbles.addPebble` → `provider.createPebble` → `compose-pebble` edge function → `provider.loadFromSupabase()` reloads the whole store (karma comes from `v_karma_summary`) → hook calls `setStore`. So `store.karma` is **fresh and correct immediately after any mutation**, but the delta is not returned and `store.karma_log` is always `[]`. The store-diff trigger (D3) exploits exactly this: read `karma` before, read it after the reload, fire on the positive difference.
+
+### Files
+
+**Create:**
+
+- `apps/web/components/ui/sonner.tsx` — themed `Toaster` wrapper, copied from `apps/admin/components/ui/sonner.tsx`. Differences:
+  - `position="bottom-center"`.
+  - Bottom offset that clears the nav bar + bottom safe area (nav is ~64px; offset accounts for `var(--safe-area-bottom)`).
+  - Keeps admin's CSS-variable theming (`--popover`, `--popover-foreground`, `--border`, `--radius`) and Lucide status icons (the icons are unused by the custom karma pill but kept so the wrapper is a drop-in for future default toasts).
+
+- `apps/web/components/activity/KarmaActivityPill.tsx` — the custom pill content rendered inside `toast.custom()`. Compact dark capsule: `✨` icon + **+N karma** (amount tinted), optional reason subtext. Themed for light/dark + color-world via existing CSS variables. The whole pill is a button that calls the dismiss + navigate-to-`/wallet` handler. Includes visually-hidden screen-reader text describing the event.
+
+- `apps/web/lib/activity/karma-activity.ts` — the primitive. Exports `notifyKarma(amount: number, reason: KarmaActivityReason)`:
+  - Guard: `if (amount <= 0) return` (defensive; callers already gate on delta > 0).
+  - Calls `toast.custom((id) => <KarmaActivityPill ... />, { id: "karma-activity", duration: 3000 })`.
+  - `KarmaActivityReason` is a small union (`"pebble_created" | "enriched"`) — extends as future credit sources appear.
+
+**Modify:**
+
+- `apps/web/app/layout.tsx` — mount `<Toaster />` once, inside `ThemeProvider`, beside `<ThemeColorSync />`.
+- `apps/web/lib/data/usePebbles.ts` — in `addPebble` and `updatePebble`, capture `const before = store.karma` before the await, then after `setStore(provider.getStore())` compute `const delta = provider.getStore().karma - before` and `if (delta > 0) notifyKarma(delta, reason)` (`"pebble_created"` for add, `"enriched"` for update). `store` is already in scope.
+- `apps/web/lib/i18n/messages/en.json` + `fr.json` — add an `activity` namespace: the unit label ("karma"), the reason labels, and the screen-reader sentence template.
+- `apps/web/package.json` — add `sonner` dependency (matching admin's version).
+
+### Why these boundaries
+
+The **primitive** (`karma-activity.ts` + `KarmaActivityPill.tsx` + the `Toaster` mount) knows nothing about pebbles — it only knows "show a +N karma pill." The **wiring** (the two edits in `usePebbles.ts`) knows nothing about Sonner — it only knows "a credit of N happened for reason R, announce it." This is the decoupling the issue asks for: the next credit source (a grant, a purchase refund in C) adds one `notifyKarma(...)` call and nothing else.
+
+## 4. Behavior
+
+- **One pill at a time.** The stable `id` means rapid successive credits replace, not stack. If three pebbles are created in a burst, the user sees the latest "+N karma," not a tower of toasts.
+- **Duration** ~3s, then auto-dismiss. Sonner's swipe-to-dismiss remains available.
+- **Tap** anywhere on the pill → dismiss it and `router.push("/wallet")`.
+- **Entrance:** a soft rise + fade (translateY + opacity). Sonner owns enter/exit; the custom content adds no competing animation beyond what reduced-motion allows.
+
+## 5. Accessibility, motion, i18n
+
+- **Screen reader:** Sonner mounts toasts in an `aria-live` region. The pill includes visually-hidden text built from the `activity` namespace, e.g. EN "Earned 5 karma for carving a pebble." / FR "Vous avez gagné 5 karma pour avoir taillé un caillou." The visible "+5 karma" is decorative-adjacent but also readable; the hidden sentence gives full context.
+- **Reduced motion:** under `prefers-reduced-motion: reduce`, drop the rise/scale and fade only. Use Tailwind's `motion-reduce:` variants on the pill; rely on Sonner honoring reduced motion for its own transitions (verify during implementation; if Sonner still animates, pass options to soften).
+- **Theming:** the pill uses the same CSS variables as the rest of the app, so light/dark and all five color-worlds are covered without per-world code.
+- **Bilingual:** all strings come from `en.json`/`fr.json`. No hardcoded copy in the component.
+
+## 6. Out of scope
+
+- Persistent notification center / inbox / history feed — the **wallet page** (Sub-project A) is the durable home for karma history.
+- Push / OS-level notifications.
+- Triggers other than karma credit — glyph purchased, submission approved, etc. land with their own features (reusing this primitive).
+- Spend/withdraw pills — sub-project C decides whether spends surface an activity.
+
+## 7. Acceptance
+
+- [ ] Any feature can fire a transient, non-blocking pill via a single `notifyKarma(amount, reason)` call.
+- [ ] Creating a pebble that earns karma surfaces a glanceable bottom-center "+N karma" pill, not a full-screen interruption.
+- [ ] The pill replaces (does not stack) on rapid successive credits.
+- [ ] Tapping the pill opens `/wallet` and dismisses.
+- [ ] delta ≤ 0 (deletions/clawbacks) fires nothing.
+- [ ] Respects `prefers-reduced-motion`; screen-reader announces the credit; EN + FR.
+- [ ] Light/dark + color-world themed.
+
+## 8. Housekeeping (at PR time)
+
+- **Arkaik:** no new route, data model, or endpoint → **no-op**.
+- **Decision log:** one entry — *web in-app notifications = Sonner + explicit-fire + no realtime* (a foundation future features build on).
+- **Lab Note:** user-facing (`feat`) → bilingual EN/FR blurb in the PR body (proposal only).
+- **Testing:** no web test runner in V1; the `delta > 0` guard and reason→label map are pure and trivially checkable. Verification = workspace lint + `next build` + manual pass (create a pebble, observe the pill, tap to wallet, toggle reduced-motion and dark/color-world).

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "serwist": "^9.5.7",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
         "unified": "^11.0.5"


### PR DESCRIPTION
Resolves #495

**Sub-project B of 4** in **M36 · Pebblestore & Karma Economy**. A cross-cutting **in-app activity primitive** for `apps/web`, whose first consumer is a glanceable **"+N karma"** pill when the wallet (Sub-project A) is credited. Non-invasive, in the Opal spirit — never a full sheet.

## What this does

- **Sonner in `apps/web`.** Ported admin's themed `Toaster` (`components/ui/sonner.tsx`), mounted bottom-center with a mobile offset that clears the nav bar. A web PWA can't use the real Dynamic Island, so we approximate the Opal feeling within web limits.
- **The pill.** `KarmaActivityPill` renders via `toast.custom()` — a compact always-dark capsule (✨ + amber **+N karma**), tappable → `/wallet`, with a stable id so a new credit **replaces** the prior pill (one glanceable thing, never a stack).
- **The primitive.** `notifyKarma(amount, reason)` — a feature-agnostic module function (Sonner's `toast` is a singleton, so no context needed). No-ops on non-positive amounts. Any future credit source fires a pill with one call.
- **Explicit-fire trigger.** The pebble mutation hooks read karma from provider truth before/after the action (the provider already reloads the store) and fire only on a **positive delta** — `pebble_created` from `usePebbles.addPebble`, `pebble_enriched` from `usePebble.updatePebble` (the hook the live enrichment surfaces actually use). Clawbacks (delta ≤ 0) stay silent.
- **a11y / motion / i18n.** Screen readers hear the full sentence via `aria-label` (visible content `aria-hidden`); `focus-visible` ring for keyboard; reduced-motion handled (pill tap + Sonner's own `prefers-reduced-motion` rule); EN/FR `activity` namespace reusing the existing `wallet.reason.*` labels.

## Key files

- **UI:** `components/ui/sonner.tsx`, `components/activity/KarmaActivityPill.tsx`, `app/layout.tsx` (mount), i18n `en.json`/`fr.json`.
- **Primitive:** `lib/activity/karma-activity.tsx`.
- **Trigger:** `lib/data/usePebbles.ts`, `lib/data/usePebble.ts`.
- **Docs:** spec + plan under `docs/superpowers/`, `docs/decisions/log.md`.

## Decision log

Added an entry — *Web in-app notifications: Sonner + explicit-fire, no realtime*. Most important downstream constraint: **new credit sources must wire `notifyKarma` on the hook the live surface actually uses** (enrichment goes through the singular `usePebble(id)`, not `usePebbles()`).

## Verification

- Workspace lint (`apps/web`) and `next build` green; `/wallet` and all routes compile.
- The primitive → component → trigger chain was reviewed end-to-end (spec + code quality per task, plus a whole-branch final review). The review caught a real plan gap — the plan wired only `usePebbles().updatePebble`, but every enrichment surface uses `usePebble(id)` — now corrected so enrichment credits actually surface a pill.
- ⚠️ **Pending:** the interactive manual pass (create a pebble → observe the pill; rapid creates → replace-not-stack; tap → `/wallet`; delete → no pill; VoiceOver announcement; reduced-motion + dark/color-world) needs an authenticated dev session and has **not** been run yet — recommend a quick pass before release.

## Out of scope (sibling sub-projects)

No notification center/inbox (that's the wallet page in A) · no push/OS notifications · no non-karma triggers yet (glyph purchased / submission approved land with C, reusing this primitive) · spend/withdraw pills are C's call. No Arkaik change (no route/data model/endpoint).

## Lab Note (EN/FR)

<!-- DRAFT ONLY — a human curates and publishes via the Lab admin (`logs` table, `released_at`) at release time. -->

**EN — "A little spark when your karma grows"**
Earn karma and a small, friendly pill now slides up to show the moment — tap it to jump straight to your Wallet. Quick, quiet, and never in your way.

**FR — "Une étincelle quand votre karma grandit"**
Gagnez du karma et une petite pastille discrète apparaît pour célébrer l'instant — touchez-la pour aller droit à votre Porte-karma. Rapide, discret, jamais encombrant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
