### PR TITLE
feat: glyph marketplace — submit, buy, favourite community glyphs

### DIFF
--- a/apps/web/app/glyphs/[id]/page.tsx
+++ b/apps/web/app/glyphs/[id]/page.tsx
@@ -6,8 +6,10 @@ import Link from "next/link"
 import { useTranslations } from "next-intl"
 import { useMark } from "@/lib/data/useMark"
 import { useMarks } from "@/lib/data/useMarks"
+import { useGlyphSubmissions } from "@/lib/data/useGlyphSubmissions"
 import { GlyphDetail } from "@/components/glyphs/GlyphDetail"
 import { GlyphNotFound } from "@/components/glyphs/GlyphNotFound"
+import { SubmitToCommunity } from "@/components/glyphs/SubmitToCommunity"
 import { PageLayout } from "@/components/layout/PageLayout"
 
 export default function GlyphDetailPage({
@@ -20,7 +22,12 @@ export default function GlyphDetailPage({
   const tDetail = useTranslations("glyphs.detail")
   const { mark, loading } = useMark(id)
   const { removeMark, updateMark } = useMarks()
+  const { submissions, submit } = useGlyphSubmissions()
   const router = useRouter()
+
+  const submission = submissions.find((s) => s.glyph_id === id)
+  const locked =
+    submission?.status === "pending" || submission?.status === "approved"
 
   const handleDelete = async () => {
     await removeMark(id)
@@ -50,6 +57,13 @@ export default function GlyphDetailPage({
           mark={mark}
           onDelete={handleDelete}
           onUpdateName={handleUpdateName}
+          locked={locked}
+          submitSlot={
+            <SubmitToCommunity
+              status={submission?.status}
+              onSubmit={() => submit(id).then(() => {})}
+            />
+          }
         />
       ) : (
         <GlyphNotFound />

--- a/apps/web/app/glyphs/page.tsx
+++ b/apps/web/app/glyphs/page.tsx
@@ -1,42 +1,60 @@
 "use client"
 
+import { Suspense } from "react"
 import Link from "next/link"
+import { useSearchParams } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useMarks } from "@/lib/data/useMarks"
 import { GlyphList } from "@/components/glyphs/GlyphList"
 import { GlyphsEmptyState } from "@/components/glyphs/GlyphsEmptyState"
+import { GlyphTabs, type GlyphTab } from "@/components/glyphs/GlyphTabs"
+import { MarketGlyphs } from "@/components/glyphs/MarketGlyphs"
+import { FavouriteGlyphs } from "@/components/glyphs/FavouriteGlyphs"
 import { PageLayout } from "@/components/layout/PageLayout"
 import { PageHeader } from "@/components/layout/PageHeader"
 
-export default function GlyphsPage() {
-  const { marks, loading } = useMarks()
+function GlyphsView() {
+  const params = useSearchParams()
+  const tab = (params.get("tab") as GlyphTab) ?? "mine"
   const t = useTranslations("glyphs")
+  const { marks, loading } = useMarks()
 
   return (
-    <PageLayout>
-      <section>
-        <PageHeader
-          title={t("title")}
-          rightSlot={
-            marks.length > 0 ? (
-              <Link
-                href="/carve"
-                className="text-sm font-medium text-primary underline underline-offset-4 hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-              >
-                {t("carveNew")}
-              </Link>
-            ) : undefined
-          }
-        />
+    <section>
+      <PageHeader
+        title={t("title")}
+        rightSlot={
+          <Link
+            href="/carve"
+            className="text-sm font-medium text-primary underline underline-offset-4 hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            {t("carveNew")}
+          </Link>
+        }
+      />
+      <GlyphTabs active={tab} />
 
-        {loading ? (
-          <p className="text-sm text-muted-foreground">{t("loading")}</p>
-        ) : marks.length === 0 ? (
-          <GlyphsEmptyState />
-        ) : (
-          <GlyphList marks={marks} />
-        )}
-      </section>
+      {tab === "market" ? (
+        <MarketGlyphs />
+      ) : tab === "favourites" ? (
+        <FavouriteGlyphs />
+      ) : loading ? (
+        <p className="text-sm text-muted-foreground">{t("loading")}</p>
+      ) : marks.length === 0 ? (
+        <GlyphsEmptyState />
+      ) : (
+        <GlyphList marks={marks} />
+      )}
+    </section>
+  )
+}
+
+export default function GlyphsPage() {
+  return (
+    <PageLayout>
+      <Suspense>
+        <GlyphsView />
+      </Suspense>
     </PageLayout>
   )
 }

--- a/apps/web/app/pebble/[id]/edit/page.tsx
+++ b/apps/web/app/pebble/[id]/edit/page.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl"
 import { usePebble } from "@/lib/data/usePebble"
 import { useSouls } from "@/lib/data/useSouls"
 import { useCollections } from "@/lib/data/useCollections"
-import { useMarks } from "@/lib/data/useMarks"
+import { useUsableGlyphs } from "@/lib/data/useUsableGlyphs"
 import { PebbleEdit } from "@/components/pebble/PebbleEdit"
 import { PebbleNotFound } from "@/components/pebble/PebbleNotFound"
 import { PageLayout } from "@/components/layout/PageLayout"
@@ -26,7 +26,7 @@ export default function PebbleEditPage({
   } = usePebble(id)
   const { souls, loading: soulsLoading, addSoul } = useSouls()
   const { collections, loading: collectionsLoading } = useCollections()
-  const { marks, loading: marksLoading } = useMarks()
+  const { glyphs: marks, loading: marksLoading } = useUsableGlyphs()
 
   const loading = pebbleLoading || soulsLoading || collectionsLoading || marksLoading
   const mark = pebble ? marks.find((m) => m.id === pebble.mark_id) : undefined

--- a/apps/web/app/pebble/[id]/page.tsx
+++ b/apps/web/app/pebble/[id]/page.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from "next-intl"
 import { usePebble } from "@/lib/data/usePebble"
 import { useSouls } from "@/lib/data/useSouls"
 import { useCollections } from "@/lib/data/useCollections"
-import { useMarks } from "@/lib/data/useMarks"
+import { useUsableGlyphs } from "@/lib/data/useUsableGlyphs"
 import { PebbleDetail } from "@/components/pebble/PebbleDetail"
 import { PebbleNotFound } from "@/components/pebble/PebbleNotFound"
 import { PageLayout } from "@/components/layout/PageLayout"
@@ -22,7 +22,7 @@ export default function PebbleDetailPage({
   const { pebble, loading: pebbleLoading, updatePebble, uploadSnap } = usePebble(id)
   const { souls, loading: soulsLoading, addSoul } = useSouls()
   const { collections, loading: collectionsLoading } = useCollections()
-  const { marks, loading: marksLoading } = useMarks()
+  const { glyphs: marks, loading: marksLoading } = useUsableGlyphs()
 
   const loading = pebbleLoading || soulsLoading || collectionsLoading || marksLoading
 

--- a/apps/web/app/souls/[id]/page.tsx
+++ b/apps/web/app/souls/[id]/page.tsx
@@ -8,7 +8,7 @@ import { useTranslations } from "next-intl"
 import { useSoul } from "@/lib/data/useSoul"
 import { usePebbles } from "@/lib/data/usePebbles"
 import { useSouls } from "@/lib/data/useSouls"
-import { useMarks } from "@/lib/data/useMarks"
+import { useUsableGlyphs } from "@/lib/data/useUsableGlyphs"
 import { SoulDetailHeader } from "@/components/souls/SoulDetailHeader"
 import { SoulPebbleList } from "@/components/souls/SoulPebbleList"
 import { SoulNotFound } from "@/components/souls/SoulNotFound"
@@ -28,7 +28,7 @@ export default function SoulDetailPage({
   const { soul, loading: soulLoading, updateSoul } = useSoul(id)
   const { pebbles, loading: pebblesLoading } = usePebbles()
   const { souls, loading: soulsLoading, removeSoul } = useSouls()
-  const { marks } = useMarks()
+  const { glyphs: marks } = useUsableGlyphs()
 
   const loading = soulLoading || pebblesLoading || soulsLoading
 

--- a/apps/web/app/souls/page.tsx
+++ b/apps/web/app/souls/page.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react"
 import { useTranslations } from "next-intl"
 import { useSouls } from "@/lib/data/useSouls"
 import { usePebbles } from "@/lib/data/usePebbles"
-import { useMarks } from "@/lib/data/useMarks"
+import { useUsableGlyphs } from "@/lib/data/useUsableGlyphs"
 import { AddSoulForm } from "@/components/souls/AddSoulForm"
 import { SoulList } from "@/components/souls/SoulList"
 import { SoulsEmptyState } from "@/components/souls/SoulsEmptyState"
@@ -14,7 +14,7 @@ import { PageHeader } from "@/components/layout/PageHeader"
 export default function SoulsPage() {
   const { souls, loading: soulsLoading, addSoul } = useSouls()
   const { pebbles, loading: pebblesLoading } = usePebbles()
-  const { marks } = useMarks()
+  const { glyphs: marks } = useUsableGlyphs()
   const t = useTranslations("souls")
 
   const loading = soulsLoading || pebblesLoading

--- a/apps/web/components/activity/GlyphPurchasePill.tsx
+++ b/apps/web/components/activity/GlyphPurchasePill.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useTranslations } from "next-intl"
+import { Sparkle } from "lucide-react"
+import { toast } from "sonner"
+
+type GlyphPurchasePillProps = {
+  toastId: string | number
+  glyphId: string
+  name: string
+  amount: number
+}
+
+export function GlyphPurchasePill({ toastId, glyphId, name, amount }: GlyphPurchasePillProps) {
+  const router = useRouter()
+  const t = useTranslations("activity")
+
+  const handleTap = () => {
+    toast.dismiss(toastId)
+    router.push(`/glyphs/${glyphId}`)
+  }
+
+  // "Unlocked Star — 25 karma spent. View glyph."
+  const label = `${t("srUnlocked", { name, amount })} ${t("viewGlyph")}.`
+
+  return (
+    <button
+      type="button"
+      onClick={handleTap}
+      aria-label={label}
+      className="flex items-center gap-2 rounded-full bg-neutral-900 px-4 py-2 text-sm font-semibold text-white shadow-lg ring-1 ring-white/10 transition active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 dark:bg-neutral-800 motion-reduce:transition-none motion-reduce:active:scale-100"
+    >
+      <Sparkle aria-hidden className="size-4 text-amber-300" />
+      <span aria-hidden>{t("glyphUnlocked")}</span>
+      <span aria-hidden className="text-amber-300">{t("spent", { amount })}</span>
+    </button>
+  )
+}

--- a/apps/web/components/glyphs/BuyGlyphDialog.tsx
+++ b/apps/web/components/glyphs/BuyGlyphDialog.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { useState, type ReactElement } from "react"
+import { useTranslations } from "next-intl"
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+
+type ErrorKey =
+  | "insufficient"
+  | "notInMarket"
+  | "cannotBuyOwn"
+  | "alreadyOwned"
+  | "generic"
+
+function messageKey(error: unknown): ErrorKey {
+  const msg = error instanceof Error ? error.message : ""
+  if (msg.includes("insufficient_karma")) return "insufficient"
+  if (msg.includes("not_in_market")) return "notInMarket"
+  if (msg.includes("cannot_buy_own")) return "cannotBuyOwn"
+  if (msg.includes("already_owned")) return "alreadyOwned"
+  return "generic"
+}
+
+type BuyGlyphDialogProps = {
+  trigger: ReactElement
+  amount: number
+  onBuy: () => Promise<void>
+}
+
+export function BuyGlyphDialog({ trigger, amount, onBuy }: BuyGlyphDialogProps) {
+  const t = useTranslations("market")
+  const [open, setOpen] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [errorKey, setErrorKey] = useState<ErrorKey | null>(null)
+
+  const handleConfirm = async () => {
+    setBusy(true)
+    setErrorKey(null)
+    try {
+      await onBuy()
+      setOpen(false)
+    } catch (e) {
+      setErrorKey(messageKey(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger render={trigger} />
+      <AlertDialogContent size="sm">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("buyTitle")}</AlertDialogTitle>
+          <AlertDialogDescription>{t("buyDescription", { amount })}</AlertDialogDescription>
+        </AlertDialogHeader>
+        {errorKey && (
+          <p role="alert" className="text-sm text-destructive">
+            {t(`errors.${errorKey}`)}
+          </p>
+        )}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy}>{t("cancel")}</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault() // keep the dialog open to show errors / busy state
+              void handleConfirm()
+            }}
+            disabled={busy}
+          >
+            {t("buyConfirm", { amount })}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/web/components/glyphs/FavouriteGlyphs.tsx
+++ b/apps/web/components/glyphs/FavouriteGlyphs.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import { useGlyphFavourites } from "@/lib/data/useGlyphFavourites"
+import { MarketGlyphCard } from "@/components/glyphs/MarketGlyphCard"
+import { EmptyState } from "@/components/layout/EmptyState"
+
+export function FavouriteGlyphs() {
+  const t = useTranslations("glyphs")
+  const tEmpty = useTranslations("glyphs.empty")
+  const { glyphs, loading, favourite } = useGlyphFavourites()
+
+  if (loading) return <p className="text-sm text-muted-foreground">{t("loading")}</p>
+  if (glyphs.length === 0)
+    return (
+      <EmptyState title={tEmpty("favouritesTitle")} description={tEmpty("favouritesDescription")} />
+    )
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {glyphs.map((glyph) => (
+        <li key={glyph.id}>
+          {/* Favourites are already owned/favourited; Buy still guarded by `owned`. */}
+          <MarketGlyphCard glyph={glyph} onBuy={async () => {}} onFavourite={favourite} />
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/apps/web/components/glyphs/FavouriteGlyphs.tsx
+++ b/apps/web/components/glyphs/FavouriteGlyphs.tsx
@@ -8,7 +8,7 @@ import { EmptyState } from "@/components/layout/EmptyState"
 export function FavouriteGlyphs() {
   const t = useTranslations("glyphs")
   const tEmpty = useTranslations("glyphs.empty")
-  const { glyphs, loading, favourite } = useGlyphFavourites()
+  const { glyphs, loading, favourite, buy } = useGlyphFavourites()
 
   if (loading) return <p className="text-sm text-muted-foreground">{t("loading")}</p>
   if (glyphs.length === 0)
@@ -20,8 +20,9 @@ export function FavouriteGlyphs() {
     <ul className="flex flex-col gap-2">
       {glyphs.map((glyph) => (
         <li key={glyph.id}>
-          {/* Favourites are already owned/favourited; Buy still guarded by `owned`. */}
-          <MarketGlyphCard glyph={glyph} onBuy={async () => {}} onFavourite={favourite} />
+          {/* Owned glyphs show an "Owned" badge; favourited-not-owned ones stay
+              buyable, so wire the real buy path (MarketGlyphCard gates on `owned`). */}
+          <MarketGlyphCard glyph={glyph} onBuy={buy} onFavourite={favourite} />
         </li>
       ))}
     </ul>

--- a/apps/web/components/glyphs/GlyphDetail.tsx
+++ b/apps/web/components/glyphs/GlyphDetail.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { useState, type FormEvent, type KeyboardEvent } from "react"
+import {
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react"
 import { Pencil, Trash2 } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { PEBBLE_SHAPES } from "@/lib/config"
@@ -9,17 +14,27 @@ import { useFormatDate, useShapeName } from "@/lib/i18n"
 import { GlyphPreview } from "@/components/glyphs/GlyphPreview"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
 
 type GlyphDetailProps = {
   mark: Mark
   onDelete: () => void
   onUpdateName: (name: string | null) => Promise<void>
+  locked?: boolean // listed/bought → no edit/delete
+  submitSlot?: ReactNode // SubmitToCommunity rendered by the page
 }
 
-export function GlyphDetail({ mark, onDelete, onUpdateName }: GlyphDetailProps) {
+export function GlyphDetail({
+  mark,
+  onDelete,
+  onUpdateName,
+  locked,
+  submitSlot,
+}: GlyphDetailProps) {
   const t = useTranslations("glyphs")
   const tDetail = useTranslations("glyphs.detail")
+  const tSubmit = useTranslations("glyphs.submit")
   const tCard = useTranslations("glyphs.card")
   const formatDate = useFormatDate()
   const shape = PEBBLE_SHAPES.find((s) => s.id === mark.shape_id)
@@ -82,17 +97,20 @@ export function GlyphDetail({ mark, onDelete, onUpdateName }: GlyphDetailProps) 
             <h1 className="text-2xl font-semibold">
               {mark.name || t("untitled")}
             </h1>
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              onClick={() => {
-                setEditValue(mark.name ?? "")
-                setIsEditing(true)
-              }}
-              aria-label={tDetail("editAria")}
-            >
-              <Pencil className="size-3.5" />
-            </Button>
+            {!locked && (
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => {
+                  setEditValue(mark.name ?? "")
+                  setIsEditing(true)
+                }}
+                aria-label={tDetail("editAria")}
+              >
+                <Pencil className="size-3.5" />
+              </Button>
+            )}
+            {submitSlot}
           </div>
         )}
 
@@ -111,18 +129,22 @@ export function GlyphDetail({ mark, onDelete, onUpdateName }: GlyphDetailProps) 
       </div>
 
       <div className="mt-8 flex justify-center">
-        <ConfirmDialog
-          trigger={
-            <Button variant="outline" size="sm">
-              <Trash2 className="size-4" aria-hidden="true" />
-              {tDetail("deleteCta")}
-            </Button>
-          }
-          title={tDetail("deleteTitle")}
-          description={tDetail("deleteDescription")}
-          confirmLabel={tDetail("deleteConfirm")}
-          onConfirm={onDelete}
-        />
+        {locked ? (
+          <Badge variant="secondary">{tSubmit("locked")}</Badge>
+        ) : (
+          <ConfirmDialog
+            trigger={
+              <Button variant="outline" size="sm">
+                <Trash2 className="size-4" aria-hidden="true" />
+                {tDetail("deleteCta")}
+              </Button>
+            }
+            title={tDetail("deleteTitle")}
+            description={tDetail("deleteDescription")}
+            confirmLabel={tDetail("deleteConfirm")}
+            onConfirm={onDelete}
+          />
+        )}
       </div>
     </article>
   )

--- a/apps/web/components/glyphs/GlyphTabs.tsx
+++ b/apps/web/components/glyphs/GlyphTabs.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { useRouter, useSearchParams } from "next/navigation"
+import { useTranslations } from "next-intl"
+
+export type GlyphTab = "mine" | "favourites" | "market"
+const TABS: GlyphTab[] = ["mine", "favourites", "market"]
+
+export function GlyphTabs({ active }: { active: GlyphTab }) {
+  const router = useRouter()
+  const params = useSearchParams()
+  const t = useTranslations("glyphs.tabs")
+
+  const select = (tab: GlyphTab) => {
+    const next = new URLSearchParams(params)
+    next.set("tab", tab)
+    router.replace(`/glyphs?${next.toString()}`)
+  }
+
+  return (
+    <nav className="mb-6 flex gap-1 rounded-lg bg-muted p-1" role="tablist">
+      {TABS.map((tab) => (
+        <button
+          key={tab}
+          role="tab"
+          aria-selected={active === tab}
+          onClick={() => select(tab)}
+          className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+            active === tab
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          {t(tab)}
+        </button>
+      ))}
+    </nav>
+  )
+}

--- a/apps/web/components/glyphs/MarketGlyphCard.tsx
+++ b/apps/web/components/glyphs/MarketGlyphCard.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import { Heart } from "lucide-react"
+import type { MarketGlyph } from "@/lib/types"
+import { GlyphPreview } from "@/components/glyphs/GlyphPreview"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { BuyGlyphDialog } from "@/components/glyphs/BuyGlyphDialog"
+
+type MarketGlyphCardProps = {
+  glyph: MarketGlyph
+  onBuy: (glyph: MarketGlyph) => Promise<void>
+  onFavourite: (glyphId: string, value: boolean) => void
+}
+
+export function MarketGlyphCard({ glyph, onBuy, onFavourite }: MarketGlyphCardProps) {
+  const t = useTranslations("glyphs")
+  const tMarket = useTranslations("market")
+
+  return (
+    <article className="flex items-center gap-4 rounded-lg border border-border px-4 py-3">
+      <GlyphPreview mark={glyph} className="w-14 shrink-0 aspect-square" />
+      <div className="min-w-0 flex-1">
+        <h3 className="truncate text-sm font-medium">{glyph.name || t("untitled")}</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {tMarket("price", { amount: glyph.price })}
+        </p>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onFavourite(glyph.id, !glyph.favourited)}
+        aria-label={glyph.favourited ? tMarket("unfavourite") : tMarket("favourite")}
+        aria-pressed={glyph.favourited}
+        className="rounded-full p-2 text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <Heart className={`size-4 ${glyph.favourited ? "fill-current text-rose-500" : ""}`} />
+      </button>
+
+      {glyph.owned ? (
+        <Badge variant="secondary">{tMarket("owned")}</Badge>
+      ) : (
+        <BuyGlyphDialog
+          amount={glyph.price}
+          onBuy={() => onBuy(glyph)}
+          trigger={<Button size="sm">{tMarket("buy")}</Button>}
+        />
+      )}
+    </article>
+  )
+}

--- a/apps/web/components/glyphs/MarketGlyphs.tsx
+++ b/apps/web/components/glyphs/MarketGlyphs.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import { useGlyphMarket } from "@/lib/data/useGlyphMarket"
+import { MarketGlyphCard } from "@/components/glyphs/MarketGlyphCard"
+import { EmptyState } from "@/components/layout/EmptyState"
+
+export function MarketGlyphs() {
+  const t = useTranslations("glyphs")
+  const tEmpty = useTranslations("glyphs.empty")
+  const { glyphs, loading, buy, favourite } = useGlyphMarket()
+
+  if (loading) return <p className="text-sm text-muted-foreground">{t("loading")}</p>
+  if (glyphs.length === 0)
+    return <EmptyState title={tEmpty("marketTitle")} description={tEmpty("marketDescription")} />
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {glyphs.map((glyph) => (
+        <li key={glyph.id}>
+          <MarketGlyphCard glyph={glyph} onBuy={buy} onFavourite={favourite} />
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/apps/web/components/glyphs/SubmitToCommunity.tsx
+++ b/apps/web/components/glyphs/SubmitToCommunity.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import { useState, type ReactElement } from "react"
+import { useTranslations } from "next-intl"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import type { GlyphSubmissionStatus } from "@/lib/types"
+
+type SubmitToCommunityProps = {
+  status?: GlyphSubmissionStatus // undefined = not submitted
+  onSubmit: () => Promise<void>
+}
+
+export function SubmitToCommunity({ status, onSubmit }: SubmitToCommunityProps) {
+  const t = useTranslations("glyphs.submit")
+  const [open, setOpen] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  if (status) {
+    const variant =
+      status === "approved"
+        ? "default"
+        : status === "rejected"
+          ? "destructive"
+          : "secondary"
+    return <Badge variant={variant}>{t(status)}</Badge>
+  }
+
+  const confirm = async () => {
+    setBusy(true)
+    try {
+      await onSubmit()
+      setOpen(false)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const trigger: ReactElement = (
+    <Button variant="outline" size="sm">
+      {t("cta")}
+    </Button>
+  )
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger render={trigger} />
+      <AlertDialogContent size="sm">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("confirmTitle")}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("confirmDescription")}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy}>{t("cancel")}</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault()
+              void confirm()
+            }}
+            disabled={busy}
+          >
+            {t("confirm")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/web/components/path/PebblePeek.tsx
+++ b/apps/web/components/path/PebblePeek.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils"
 import { usePebble } from "@/lib/data/usePebble"
 import { useSouls } from "@/lib/data/useSouls"
 import { useCollections } from "@/lib/data/useCollections"
-import { useMarks } from "@/lib/data/useMarks"
+import { useUsableGlyphs } from "@/lib/data/useUsableGlyphs"
 import { PebbleDetail } from "@/components/pebble/PebbleDetail"
 
 type PebblePeekProps = {
@@ -30,7 +30,7 @@ export function PebblePeek({ pebbleId, onClose }: PebblePeekProps) {
   const { pebble, loading: pebbleLoading, updatePebble, uploadSnap } = usePebble(id)
   const { souls, loading: soulsLoading, addSoul } = useSouls()
   const { collections, loading: collectionsLoading } = useCollections()
-  const { marks, loading: marksLoading } = useMarks()
+  const { glyphs: marks, loading: marksLoading } = useUsableGlyphs()
 
   const loading = pebbleLoading || soulsLoading || collectionsLoading || marksLoading
 

--- a/apps/web/lib/activity/glyph-activity.tsx
+++ b/apps/web/lib/activity/glyph-activity.tsx
@@ -1,0 +1,18 @@
+import { toast } from "sonner"
+import { GlyphPurchasePill } from "@/components/activity/GlyphPurchasePill"
+
+// Stable id → a new purchase replaces the current pill rather than stacking.
+const GLYPH_ACTIVITY_ID = "glyph-activity"
+
+/** Fire a glanceable "Glyph unlocked · −N karma" pill after a purchase. */
+export function notifyGlyphPurchased(glyphId: string, name: string, amount: number): void {
+  if (amount <= 0) return
+  toast.custom(
+    (id) => (
+      <div className="flex w-full justify-center">
+        <GlyphPurchasePill toastId={id} glyphId={glyphId} name={name} amount={amount} />
+      </div>
+    ),
+    { id: GLYPH_ACTIVITY_ID, duration: 3000 },
+  )
+}

--- a/apps/web/lib/config/glyphs.ts
+++ b/apps/web/lib/config/glyphs.ts
@@ -6,3 +6,10 @@
 // in `public.glyphs` with `user_id = null` and empty strokes, so it renders
 // as a blank pebble outline. Mirrors `SystemGlyph.default` on iOS.
 export const DEFAULT_GLYPH_ID = "4759c37c-68a6-46a6-b4fc-046bd0316752"
+
+/**
+ * Flat community-glyph price in karma. Mirrors the `price` DEFAULT in
+ * `<timestamp>_glyph_marketplace.sql`. Server (`buy_glyph`) is authoritative;
+ * this is for display only. Keep both in sync.
+ */
+export const GLYPH_PRICE_DEFAULT = 25

--- a/apps/web/lib/data/data-provider.ts
+++ b/apps/web/lib/data/data-provider.ts
@@ -5,6 +5,8 @@ import type {
   Collection,
   KarmaEvent,
   Mark,
+  MarketGlyph,
+  GlyphSubmission,
   WalletSnapshot,
 } from "@/lib/types"
 
@@ -18,6 +20,7 @@ export type Store = {
   souls: Soul[]
   collections: Collection[]
   marks: Mark[]
+  entitledMarks: Mark[]
   pebbles_count: number
   karma: number
   karma_log: KarmaEvent[]
@@ -30,6 +33,7 @@ export const EMPTY_STORE: Store = {
   souls: [],
   collections: [],
   marks: [],
+  entitledMarks: [],
   pebbles_count: 0,
   karma: 0,
   karma_log: [],
@@ -125,4 +129,11 @@ export interface DataProvider {
   createMark(input: CreateMarkInput): Promise<Mark>
   updateMark(id: string, input: UpdateMarkInput): Promise<Mark>
   deleteMark(id: string): Promise<void>
+
+  listMarketGlyphs(): Promise<MarketGlyph[]>     // approved, others' glyphs, + caller flags
+  listFavouriteGlyphs(): Promise<MarketGlyph[]>  // entitled ∪ favourited
+  getMySubmissions(): Promise<GlyphSubmission[]> // caller's submissions (status badges)
+  submitGlyph(glyphId: string): Promise<GlyphSubmission>
+  buyGlyph(glyphId: string): Promise<{ entitlementId: string; karma: number }>
+  setFavourite(glyphId: string, favourite: boolean): Promise<void>
 }

--- a/apps/web/lib/data/supabase-provider.ts
+++ b/apps/web/lib/data/supabase-provider.ts
@@ -708,6 +708,7 @@ export class SupabaseProvider implements DataProvider {
       .from("glyph_submissions")
       .select("id, glyph_id, status, price, created_at")
       .eq("submitter_id", this.userId)
+      .order("created_at", { ascending: false }) // newest first → page's .find picks the active row
     if (error) throw new Error(`Failed to load submissions: ${error.message}`)
     return (data ?? []).map((row) => {
       const r = row as Record<string, unknown>

--- a/apps/web/lib/data/supabase-provider.ts
+++ b/apps/web/lib/data/supabase-provider.ts
@@ -19,6 +19,8 @@ import type {
   Soul,
   Collection,
   Mark,
+  MarketGlyph,
+  GlyphSubmission,
   KarmaEvent,
   WalletSnapshot,
 } from "@/lib/types"
@@ -72,6 +74,7 @@ export class SupabaseProvider implements DataProvider {
       collectionsRes,
       collectionPebblesRes,
       glyphsRes,
+      entitledRes,
       karmaRes,
       bounceRes,
     ] = await Promise.all([
@@ -84,6 +87,7 @@ export class SupabaseProvider implements DataProvider {
       this.supabase.from("collections").select("*").eq("user_id", this.userId),
       this.supabase.from("collection_pebbles").select("*, collections!inner(user_id)").eq("collections.user_id", this.userId),
       this.supabase.from("glyphs").select("*").eq("user_id", this.userId),
+      this.supabase.from("v_glyph_market").select("*").eq("owned", true),
       this.supabase.from("v_karma_summary").select("*").eq("user_id", this.userId).maybeSingle(),
       this.supabase.from("v_bounce").select("*").eq("user_id", this.userId).maybeSingle(),
     ])
@@ -93,6 +97,7 @@ export class SupabaseProvider implements DataProvider {
     if (soulsRes.error) throw new Error(`Failed to load souls: ${soulsRes.error.message}`)
     if (collectionsRes.error) throw new Error(`Failed to load collections: ${collectionsRes.error.message}`)
     if (glyphsRes.error) throw new Error(`Failed to load glyphs: ${glyphsRes.error.message}`)
+    if (entitledRes.error) throw new Error(`Failed to load entitled glyphs: ${entitledRes.error.message}`)
 
     const renderById = new Map<
       string,
@@ -214,6 +219,10 @@ export class SupabaseProvider implements DataProvider {
       updated_at: row.updated_at as string,
     }))
 
+    const entitledMarks: Mark[] = (entitledRes.data ?? []).map((row) =>
+      this.rowToMark(row as Record<string, unknown>),
+    )
+
     const karma = (karmaRes.data as Record<string, unknown>)?.total_karma as number ?? 0
     const pebblesCount = (karmaRes.data as Record<string, unknown>)?.pebbles_count as number ?? 0
     const bounce = (bounceRes.data as Record<string, unknown>)?.bounce_level as number ?? 0
@@ -223,6 +232,7 @@ export class SupabaseProvider implements DataProvider {
       souls,
       collections,
       marks,
+      entitledMarks,
       pebbles_count: pebblesCount,
       karma,
       karma_log: [],
@@ -594,6 +604,18 @@ export class SupabaseProvider implements DataProvider {
   // Mark mutations (DB table: glyphs)
   // ---------------------------------------------------------------------------
 
+  private rowToMark(row: Record<string, unknown>): Mark {
+    return {
+      id: row.id as string,
+      name: (row.name as string) ?? undefined,
+      shape_id: row.shape_id as string,
+      strokes: row.strokes as Mark["strokes"],
+      viewBox: row.view_box as string,
+      created_at: row.created_at as string,
+      updated_at: row.updated_at as string,
+    }
+  }
+
   async createMark(input: CreateMarkInput): Promise<Mark> {
     const result = await this.supabase
       .from("glyphs")
@@ -646,5 +668,95 @@ export class SupabaseProvider implements DataProvider {
     this.unwrap(await this.supabase.from("glyphs").delete().eq("id", id))
     const marks = this.store.marks.filter((m) => m.id !== id)
     this.mutate({ ...this.store, marks })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Glyph marketplace (#496)
+  // ---------------------------------------------------------------------------
+
+  private rowToMarketGlyph(row: Record<string, unknown>): MarketGlyph {
+    return {
+      ...this.rowToMark(row),
+      price: row.price as number,
+      owned: Boolean(row.owned),
+      favourited: Boolean(row.favourited),
+    }
+  }
+
+  async listMarketGlyphs(): Promise<MarketGlyph[]> {
+    const { data, error } = await this.supabase.from("v_glyph_market").select("*")
+    if (error) throw new Error(`Failed to load market glyphs: ${error.message}`)
+    // Hide the caller's own creations — they live under Mine, not the Market.
+    return (data ?? [])
+      .filter((row) => (row as Record<string, unknown>).user_id !== this.userId)
+      .map((row) => this.rowToMarketGlyph(row as Record<string, unknown>))
+  }
+
+  async listFavouriteGlyphs(): Promise<MarketGlyph[]> {
+    // Bought (owned) ∪ favourited, both drawn from approved listings. (A glyph
+    // delisted after purchase would drop out — acceptable for V1; D doesn't exist yet.)
+    const { data, error } = await this.supabase
+      .from("v_glyph_market")
+      .select("*")
+      .or("owned.eq.true,favourited.eq.true")
+    if (error) throw new Error(`Failed to load favourites: ${error.message}`)
+    return (data ?? []).map((row) => this.rowToMarketGlyph(row as Record<string, unknown>))
+  }
+
+  async getMySubmissions(): Promise<GlyphSubmission[]> {
+    const { data, error } = await this.supabase
+      .from("glyph_submissions")
+      .select("id, glyph_id, status, price, created_at")
+      .eq("submitter_id", this.userId)
+    if (error) throw new Error(`Failed to load submissions: ${error.message}`)
+    return (data ?? []).map((row) => {
+      const r = row as Record<string, unknown>
+      return {
+        id: r.id as string,
+        glyph_id: r.glyph_id as string,
+        status: r.status as GlyphSubmission["status"],
+        price: r.price as number,
+        created_at: r.created_at as string,
+      }
+    })
+  }
+
+  async submitGlyph(glyphId: string): Promise<GlyphSubmission> {
+    const { data, error } = await this.supabase.rpc("submit_glyph", { p_glyph_id: glyphId })
+    if (error) throw new Error(error.message)
+    const r = data as Record<string, unknown>
+    return {
+      id: r.id as string,
+      glyph_id: r.glyph_id as string,
+      status: r.status as GlyphSubmission["status"],
+      price: r.price as number,
+      created_at: r.created_at as string,
+    }
+  }
+
+  async buyGlyph(glyphId: string): Promise<{ entitlementId: string; karma: number }> {
+    const { data, error } = await this.supabase.rpc("buy_glyph", { p_glyph_id: glyphId })
+    if (error) throw new Error(error.message)
+    const r = data as { entitlement_id: string; balance: number }
+    // Reload so karma and entitledMarks refresh together (the bought glyph
+    // becomes usable in the picker).
+    await this.loadFromSupabase()
+    return { entitlementId: r.entitlement_id, karma: this.store.karma }
+  }
+
+  async setFavourite(glyphId: string, favourite: boolean): Promise<void> {
+    if (favourite) {
+      const { error } = await this.supabase
+        .from("glyph_favourites")
+        .upsert({ user_id: this.userId, glyph_id: glyphId }, { onConflict: "user_id,glyph_id" })
+      if (error) throw new Error(error.message)
+    } else {
+      const { error } = await this.supabase
+        .from("glyph_favourites")
+        .delete()
+        .eq("user_id", this.userId)
+        .eq("glyph_id", glyphId)
+      if (error) throw new Error(error.message)
+    }
   }
 }

--- a/apps/web/lib/data/useGlyphFavourites.ts
+++ b/apps/web/lib/data/useGlyphFavourites.ts
@@ -1,0 +1,37 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { useDataProvider } from "@/lib/data/provider-context"
+import type { MarketGlyph } from "@/lib/types"
+
+export function useGlyphFavourites() {
+  const { provider } = useDataProvider()
+  const [glyphs, setGlyphs] = useState<MarketGlyph[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    if (!provider) return
+    setGlyphs(await provider.listFavouriteGlyphs())
+    setLoading(false)
+  }, [provider])
+
+  useEffect(() => {
+    // Defer the setState past the synchronous render boundary (mirrors
+    // useWallet.ts) to satisfy react-hooks/set-state-in-effect.
+    void (async () => {
+      await Promise.resolve()
+      await refresh()
+    })()
+  }, [refresh])
+
+  const favourite = useCallback(
+    async (glyphId: string, value: boolean) => {
+      if (!provider) return
+      await provider.setFavourite(glyphId, value)
+      await refresh()
+    },
+    [provider, refresh],
+  )
+
+  return { glyphs, loading, favourite, refresh }
+}

--- a/apps/web/lib/data/useGlyphFavourites.ts
+++ b/apps/web/lib/data/useGlyphFavourites.ts
@@ -1,11 +1,14 @@
 "use client"
 
 import { useCallback, useEffect, useState } from "react"
+import { useTranslations } from "next-intl"
 import { useDataProvider } from "@/lib/data/provider-context"
+import { notifyGlyphPurchased } from "@/lib/activity/glyph-activity"
 import type { MarketGlyph } from "@/lib/types"
 
 export function useGlyphFavourites() {
-  const { provider } = useDataProvider()
+  const { provider, setStore } = useDataProvider()
+  const tGlyphs = useTranslations("glyphs")
   const [glyphs, setGlyphs] = useState<MarketGlyph[]>([])
   const [loading, setLoading] = useState(true)
 
@@ -33,5 +36,18 @@ export function useGlyphFavourites() {
     [provider, refresh],
   )
 
-  return { glyphs, loading, favourite, refresh }
+  // A favourited-but-not-owned glyph is still buyable from the Favourites tab,
+  // so it needs a real purchase path — not a no-op. Mirrors useGlyphMarket.buy.
+  const buy = useCallback(
+    async (glyph: MarketGlyph) => {
+      if (!provider) throw new Error("Not authenticated")
+      await provider.buyGlyph(glyph.id)
+      setStore(provider.getStore())
+      notifyGlyphPurchased(glyph.id, glyph.name || tGlyphs("untitled"), glyph.price)
+      await refresh()
+    },
+    [provider, setStore, refresh, tGlyphs],
+  )
+
+  return { glyphs, loading, favourite, buy, refresh }
 }

--- a/apps/web/lib/data/useGlyphMarket.ts
+++ b/apps/web/lib/data/useGlyphMarket.ts
@@ -1,0 +1,52 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { useTranslations } from "next-intl"
+import { useDataProvider } from "@/lib/data/provider-context"
+import { notifyGlyphPurchased } from "@/lib/activity/glyph-activity"
+import type { MarketGlyph } from "@/lib/types"
+
+export function useGlyphMarket() {
+  const { provider, setStore } = useDataProvider()
+  const tGlyphs = useTranslations("glyphs")
+  const [glyphs, setGlyphs] = useState<MarketGlyph[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    if (!provider) return
+    setGlyphs(await provider.listMarketGlyphs())
+    setLoading(false)
+  }, [provider])
+
+  useEffect(() => {
+    // Defer the setState past the synchronous render boundary (mirrors
+    // useWallet.ts) to satisfy react-hooks/set-state-in-effect.
+    void (async () => {
+      await Promise.resolve()
+      await refresh()
+    })()
+  }, [refresh])
+
+  // Throws on failure (e.g. "insufficient_karma") — caller maps to a message.
+  const buy = useCallback(
+    async (glyph: MarketGlyph) => {
+      if (!provider) throw new Error("Not authenticated")
+      await provider.buyGlyph(glyph.id)
+      setStore(provider.getStore()) // karma + entitledMarks refreshed by reload-on-buy
+      notifyGlyphPurchased(glyph.id, glyph.name || tGlyphs("untitled"), glyph.price)
+      await refresh()
+    },
+    [provider, setStore, refresh, tGlyphs],
+  )
+
+  const favourite = useCallback(
+    async (glyphId: string, value: boolean) => {
+      if (!provider) return
+      await provider.setFavourite(glyphId, value)
+      await refresh()
+    },
+    [provider, refresh],
+  )
+
+  return { glyphs, loading, buy, favourite, refresh }
+}

--- a/apps/web/lib/data/useGlyphSubmissions.ts
+++ b/apps/web/lib/data/useGlyphSubmissions.ts
@@ -1,0 +1,38 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { useDataProvider } from "@/lib/data/provider-context"
+import type { GlyphSubmission } from "@/lib/types"
+
+export function useGlyphSubmissions() {
+  const { provider } = useDataProvider()
+  const [submissions, setSubmissions] = useState<GlyphSubmission[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    if (!provider) return
+    setSubmissions(await provider.getMySubmissions())
+    setLoading(false)
+  }, [provider])
+
+  useEffect(() => {
+    // Defer the setState past the synchronous render boundary (mirrors
+    // useWallet.ts) to satisfy react-hooks/set-state-in-effect.
+    void (async () => {
+      await Promise.resolve()
+      await refresh()
+    })()
+  }, [refresh])
+
+  const submit = useCallback(
+    async (glyphId: string) => {
+      if (!provider) throw new Error("Not authenticated")
+      const created = await provider.submitGlyph(glyphId)
+      await refresh()
+      return created
+    },
+    [provider, refresh],
+  )
+
+  return { submissions, loading, submit, refresh }
+}

--- a/apps/web/lib/data/useLookupMaps.ts
+++ b/apps/web/lib/data/useLookupMaps.ts
@@ -1,8 +1,11 @@
 import { useMemo } from "react"
 import type { Soul, Emotion, Mark } from "@/lib/types"
 import { EMOTIONS } from "@/lib/config"
+import { useDataProvider } from "@/lib/data/provider-context"
 
 export function useLookupMaps(souls: Soul[], marks: Mark[] = []) {
+  const { store } = useDataProvider()
+
   const emotionMap = useMemo(
     () => new Map<string, Emotion>(EMOTIONS.map((e) => [e.id, e])),
     [],
@@ -13,9 +16,14 @@ export function useLookupMaps(souls: Soul[], marks: Mark[] = []) {
     [souls],
   )
 
+  // Include entitled (bought) glyphs so a bought glyph attached to a
+  // pebble/soul renders. Keyed by id, so own ∪ entitled dedupes naturally.
   const markMap = useMemo(
-    () => new Map<string, Mark>(marks.map((m) => [m.id, m])),
-    [marks],
+    () =>
+      new Map<string, Mark>(
+        [...marks, ...store.entitledMarks].map((m) => [m.id, m]),
+      ),
+    [marks, store.entitledMarks],
   )
 
   return { emotionMap, soulMap, markMap }

--- a/apps/web/lib/data/useUsableGlyphs.ts
+++ b/apps/web/lib/data/useUsableGlyphs.ts
@@ -1,0 +1,12 @@
+"use client"
+
+import { useDataProvider } from "@/lib/data/provider-context"
+import type { Mark } from "@/lib/types"
+
+/** Glyphs the user may attach to pebbles/souls: own ∪ entitled (bought). */
+export function useUsableGlyphs(): { glyphs: Mark[]; loading: boolean } {
+  const { store, loading } = useDataProvider()
+  const seen = new Set(store.marks.map((m) => m.id))
+  const glyphs = [...store.marks, ...store.entitledMarks.filter((m) => !seen.has(m.id))]
+  return { glyphs, loading }
+}

--- a/apps/web/lib/i18n/messages/en.json
+++ b/apps/web/lib/i18n/messages/en.json
@@ -140,7 +140,11 @@
     "empty": {
       "title": "No glyphs yet",
       "description": "Glyphs are symbols you carve on pebble surfaces. Create your first one.",
-      "cta": "Carve a glyph"
+      "cta": "Carve a glyph",
+      "marketTitle": "No glyphs for sale yet",
+      "marketDescription": "Community glyphs will appear here once they're approved.",
+      "favouritesTitle": "No favourites yet",
+      "favouritesDescription": "Glyphs you buy or favourite from the Market show up here."
     },
     "detail": {
       "back": "← Back to Glyphs",
@@ -161,6 +165,36 @@
       "label": "Glyphs",
       "empty": "No glyphs yet. Carve one from the Glyphs page.",
       "fallbackName": "Glyph {short}"
+    },
+    "tabs": { "mine": "Mine", "favourites": "Favourites", "market": "Market" },
+    "submit": {
+      "cta": "Submit to community",
+      "pending": "Pending review",
+      "approved": "Listed",
+      "rejected": "Not accepted",
+      "locked": "Listed — locked",
+      "confirmTitle": "Submit this glyph to the community?",
+      "confirmDescription": "It will be reviewed before appearing in the Market. Once submitted, you can no longer edit or delete it.",
+      "confirm": "Submit",
+      "cancel": "Cancel"
+    }
+  },
+  "market": {
+    "price": "{amount} karma",
+    "buy": "Buy",
+    "owned": "Owned",
+    "buyTitle": "Buy this glyph?",
+    "buyDescription": "This spends {amount} karma. You'll be able to use it on your pebbles and souls.",
+    "buyConfirm": "Buy for {amount} karma",
+    "cancel": "Cancel",
+    "favourite": "Add to favourites",
+    "unfavourite": "Remove from favourites",
+    "errors": {
+      "insufficient": "You don't have enough karma for this glyph.",
+      "notInMarket": "This glyph is no longer available.",
+      "cannotBuyOwn": "You can't buy your own glyph.",
+      "alreadyOwned": "You already own this glyph.",
+      "generic": "Something went wrong. Please try again."
     }
   },
   "carve": {

--- a/apps/web/lib/i18n/messages/en.json
+++ b/apps/web/lib/i18n/messages/en.json
@@ -105,7 +105,11 @@
   "activity": {
     "amount": "+{amount} karma",
     "srEarned": "Earned {amount} karma — {reason}.",
-    "viewWallet": "View wallet"
+    "viewWallet": "View wallet",
+    "glyphUnlocked": "Glyph unlocked",
+    "spent": "−{amount} karma",
+    "srUnlocked": "Unlocked {name} — {amount} karma spent.",
+    "viewGlyph": "View glyph"
   },
   "wallet": {
     "title": "Wallet",

--- a/apps/web/lib/i18n/messages/fr.json
+++ b/apps/web/lib/i18n/messages/fr.json
@@ -105,7 +105,11 @@
   "activity": {
     "amount": "+{amount} karma",
     "srEarned": "Vous avez gagné {amount} karma — {reason}.",
-    "viewWallet": "Voir le porte-karma"
+    "viewWallet": "Voir le porte-karma",
+    "glyphUnlocked": "Glyphe débloqué",
+    "spent": "−{amount} karma",
+    "srUnlocked": "{name} débloqué — {amount} karma dépensés.",
+    "viewGlyph": "Voir le glyphe"
   },
   "wallet": {
     "title": "Porte-karma",

--- a/apps/web/lib/i18n/messages/fr.json
+++ b/apps/web/lib/i18n/messages/fr.json
@@ -140,7 +140,11 @@
     "empty": {
       "title": "Aucun glyphe pour l'instant",
       "description": "Les glyphes sont des symboles que vous gravez à la surface des galets. Créez le premier.",
-      "cta": "Graver un glyphe"
+      "cta": "Graver un glyphe",
+      "marketTitle": "Aucun glyphe en vente",
+      "marketDescription": "Les glyphes de la communauté apparaîtront ici après validation.",
+      "favouritesTitle": "Aucun favori",
+      "favouritesDescription": "Les glyphes achetés ou mis en favori depuis le Marché apparaissent ici."
     },
     "detail": {
       "back": "← Retour aux glyphes",
@@ -161,6 +165,36 @@
       "label": "Glyphes",
       "empty": "Aucun glyphe pour l'instant. Gravez-en un depuis la page Glyphes.",
       "fallbackName": "Glyphe {short}"
+    },
+    "tabs": { "mine": "Mes glyphes", "favourites": "Favoris", "market": "Marché" },
+    "submit": {
+      "cta": "Proposer à la communauté",
+      "pending": "En attente de validation",
+      "approved": "Publié",
+      "rejected": "Refusé",
+      "locked": "Publié — verrouillé",
+      "confirmTitle": "Proposer ce glyphe à la communauté ?",
+      "confirmDescription": "Il sera examiné avant d'apparaître dans le Marché. Une fois proposé, vous ne pourrez plus le modifier ni le supprimer.",
+      "confirm": "Proposer",
+      "cancel": "Annuler"
+    }
+  },
+  "market": {
+    "price": "{amount} karma",
+    "buy": "Acheter",
+    "owned": "Acquis",
+    "buyTitle": "Acheter ce glyphe ?",
+    "buyDescription": "Cela dépense {amount} karma. Vous pourrez l'utiliser sur vos cailloux et vos âmes.",
+    "buyConfirm": "Acheter pour {amount} karma",
+    "cancel": "Annuler",
+    "favourite": "Ajouter aux favoris",
+    "unfavourite": "Retirer des favoris",
+    "errors": {
+      "insufficient": "Vous n'avez pas assez de karma pour ce glyphe.",
+      "notInMarket": "Ce glyphe n'est plus disponible.",
+      "cannotBuyOwn": "Vous ne pouvez pas acheter votre propre glyphe.",
+      "alreadyOwned": "Vous possédez déjà ce glyphe.",
+      "generic": "Une erreur est survenue. Veuillez réessayer."
     }
   },
   "carve": {

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -103,6 +103,24 @@ export type Mark = {
   updated_at: string
 }
 
+export type GlyphSubmissionStatus = "pending" | "approved" | "rejected"
+
+// A community-market glyph: the glyph plus its listing price and the caller's
+// relationship to it. Extends Mark (becomes Glyph when #488 lands).
+export type MarketGlyph = Mark & {
+  price: number
+  owned: boolean // caller is entitled (bought)
+  favourited: boolean // caller has favourited
+}
+
+export type GlyphSubmission = {
+  id: string
+  glyph_id: string
+  status: GlyphSubmissionStatus
+  price: number
+  created_at: string
+}
+
 // ---------------------------------------------------------------------------
 // Lab — product-transparency feed (announcements, changelog, backlog)
 // ---------------------------------------------------------------------------

--- a/docs/decisions/log.md
+++ b/docs/decisions/log.md
@@ -103,3 +103,25 @@ Append-only ledger of **significant** product/engineering decisions. One terse e
 - **Consequences:** New credit sources surface a pill by adding one `notifyKarma(...)` call at their action site — and must wire it on the hook the live surface actually uses (enrichment goes through the singular `usePebble(id)`, not `usePebbles()`). Credit-only by design: clawbacks (delta ≤ 0) stay silent. The pill uses a stable toast id so a new credit replaces the prior one. Reused by C (e.g. "glyph purchased") via the same primitive.
 - **Supersedes / Superseded-by:** —
 - **Refs:** #495, `docs/superpowers/specs/2026-06-29-issue-495-in-app-activity-design.md`, `apps/web/lib/activity/karma-activity.tsx`, `apps/web/components/activity/KarmaActivityPill.tsx`.
+
+## 2026-06-30 — Glyph marketplace: use-rights entitlements, per-listing price, atomic buy
+
+- **Status:** taken
+- **Scope:** db, webapp
+- **Context:** M36 sub-project C (#496) makes community glyphs the first thing the Pebblestore sells — buyable with karma over A's spend rails. We had to decide what a purchase grants, where price lives, and how to keep the spend+grant consistent.
+- **Decision:** Buying grants a **use-rights entitlement** (`glyph_entitlements` row), **not a copy** — the original glyph stays single-source and the creator keeps authorship. **Price lives on the listing row** (`glyph_submissions.price`, flat-defaulted to 25 via a constant mirrored in `apps/web/lib/config/glyphs.ts`), read server-side by `buy_glyph` so the client can't set it. Each purchase snapshots **`price_paid`** on the entitlement. The **`buy_glyph` RPC** does spend (`spend_karma`) + entitlement insert in **one transaction**, idempotent via `unique(user_id, glyph_id)`.
+- **Why:** Entitlements avoid stroke duplication and keep authorship/attribution clean, and make a glyph usable everywhere own glyphs are (picker + lookup map). Per-listing price (vs a single global constant) lets D re-price one glyph later with no schema change while staying flat now. `price_paid` preserves a per-glyph purchase ledger (buyers-per-month, revenue) that survives future price changes — so "glyph value" can be a derived aggregate, never a stored column (YAGNI: capture data, defer analytics). Single-transaction buy + the unique constraint make a concurrent double-buy roll back the loser's spend too, so a buyer is charged at most once.
+- **Consequences:** New store goods (themes, pebbleskins) reuse the `buy_glyph` shape: validate listing → `spend_karma(price,'purchase',ref)` → grant, in one txn. Entitlement rows are insertable **only** via the `security definer` RPC (no INSERT policy). The purchase fires a dedicated **spend** pill (`notifyGlyphPurchased`), not credit-only `notifyKarma`. Market stays empty until a submission is `approved` (no moderation UI in C — that's D).
+- **Supersedes / Superseded-by:** —
+- **Refs:** #496, `docs/superpowers/specs/2026-06-30-issue-496-glyph-marketplace-design.md`, `packages/supabase/supabase/migrations/20260630003348_glyph_marketplace.sql`.
+
+## 2026-06-30 — Glyphs become readable when listed/entitled; listed glyphs are creator-immutable (D8)
+
+- **Status:** taken
+- **Scope:** db
+- **Context:** A community market means other users must read a creator's glyph rows (strokes/viewBox) to render and buy them — but glyphs were own-only readable. And once a glyph is listed/bought, letting the creator edit its strokes would be bait-and-switch on what buyers paid for.
+- **Decision:** The `glyphs` SELECT policy widens to **own ∪ system-seeds (`user_id is null`) ∪ approved-listed ∪ own-entitled** — the single place community glyph rows become readable. The `glyphs` UPDATE/DELETE policies are rewritten to **lock** a glyph once it has an active submission (`pending`|`approved`) **or** any entitlement: only `is_admin(auth.uid())` may then modify it; the creator cannot. The market view `v_glyph_market` is `security_invoker` so the caller's RLS applies.
+- **Why:** The widened SELECT exposes *only* glyphs that are genuinely listed or that the caller already bought — no broad leak. The lock is backend-enforced (RLS), not UI-only, because a frontend-only guard is bypassable via the raw update path; `on delete cascade` would otherwise let a creator wipe buyers' entitlements. Admins are exempt because curating/adjusting listed glyphs is D's domain.
+- **Consequences:** **Do not narrow `glyphs_select` back to own-only** — the market and picker depend on the widened policy. Future market goods must keep their listed rows readable the same way. The web UI reflects the lock (`GlyphDetail` hides edit/delete, shows a "Listed — locked" badge) but RLS is the real enforcement. Admin moderation that re-prices or edits listed glyphs (D) relies on the `is_admin` exemption.
+- **Supersedes / Superseded-by:** —
+- **Refs:** #496, `packages/supabase/supabase/migrations/20260630003348_glyph_marketplace.sql` (glyphs policy rewrite, `v_glyph_market`).

--- a/docs/superpowers/plans/2026-06-30-issue-496-glyph-marketplace.md
+++ b/docs/superpowers/plans/2026-06-30-issue-496-glyph-marketplace.md
@@ -1,0 +1,1389 @@
+# Glyph Marketplace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users submit glyphs to a community market, buy them with karma over Sub-project A's atomic spend rails (granting use-rights, not a copy), favourite them, and surface each purchase via Sub-project B's activity pill — organised into Mine / Favourites / Market tabs.
+
+**Architecture:** Three new tables (`glyph_submissions` = submission *and* listing; `glyph_entitlements` = use-rights grant + purchase ledger; `glyph_favourites`) + two security-definer RPCs (`submit_glyph`, `buy_glyph`) + a `security_invoker` market view. The `glyphs` SELECT policy widens to expose listed/entitled rows; UPDATE/DELETE lock listed/bought glyphs against their creator (admin-exempt). Web reads through new `DataProvider` methods + hooks; the buy flow updates the karma store and fires a sibling activity pill.
+
+**Tech Stack:** Supabase/Postgres (RLS, plpgsql RPCs, security_invoker view), Next.js 16 App Router (client components), next-intl (EN/FR), Sonner (reused activity), shadcn `alert-dialog`/`badge`/`button`, Lucide icons.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-30-issue-496-glyph-marketplace-design.md`
+
+**Verification model:** No web test runner (V1). Each task verifies with `npm run lint --workspace=apps/web` (and `next build` / `db:types` where types change), plus the manual checklist in the spec §9. DB migrations deploy to **remote** Supabase (no local Docker — see decision log).
+
+**Naming note:** Per the #488 sequencing decision, all *new* code here is `Glyph`-named; pre-existing `Mark`/`useMarks`/`listMarks` stay as-is until #488. New types that extend the glyph domain reference the existing `Mark` type (it becomes `Glyph` automatically when #488 lands).
+
+---
+
+## Task 1: Database — tables, RLS, policy rewrite, RPCs, market view
+
+**Files:**
+- Create: `packages/supabase/supabase/migrations/<timestamp>_glyph_marketplace.sql` (generate the timestamp with `supabase migration new glyph_marketplace`)
+- Modify (regenerate): `packages/supabase/types/database.ts`
+
+- [ ] **Step 1: Create the migration file**
+
+Run: `supabase migration new glyph_marketplace` (creates the timestamped empty file under `packages/supabase/supabase/migrations/`). Paste the full SQL below into it.
+
+```sql
+-- =============================================================================
+-- Glyph marketplace (#496) — submissions/listings, entitlements, favourites,
+-- submit_glyph + buy_glyph RPCs, market view, and glyphs policy rewrite (D8).
+-- Price is per-listing, flat-defaulted; GLYPH_PRICE_DEFAULT mirror in
+-- apps/web/lib/config/glyphs.ts must stay in sync with the default literal below.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Tables
+-- ---------------------------------------------------------------------------
+create table public.glyph_submissions (
+  id            uuid primary key default gen_random_uuid(),
+  glyph_id      uuid not null references public.glyphs(id) on delete cascade,
+  submitter_id  uuid not null references auth.users(id),
+  status        text not null default 'pending'
+                  check (status in ('pending','approved','rejected')),
+  price         integer not null default 25 check (price > 0),  -- GLYPH_PRICE_DEFAULT
+  created_at    timestamptz not null default now(),
+  reviewed_at   timestamptz,
+  reviewed_by   uuid references auth.users(id)
+);
+
+-- At most one active (pending|approved) submission per glyph.
+create unique index glyph_submissions_one_active
+  on public.glyph_submissions (glyph_id)
+  where status in ('pending','approved');
+
+create index glyph_submissions_status_idx on public.glyph_submissions (status);
+
+create table public.glyph_entitlements (
+  id              uuid primary key default gen_random_uuid(),
+  user_id         uuid not null references auth.users(id),
+  glyph_id        uuid not null references public.glyphs(id) on delete cascade,
+  karma_event_id  uuid not null references public.karma_events(id),
+  price_paid      integer not null check (price_paid > 0),
+  created_at      timestamptz not null default now(),
+  unique (user_id, glyph_id)
+);
+
+create index glyph_entitlements_glyph_idx on public.glyph_entitlements (glyph_id);
+
+create table public.glyph_favourites (
+  user_id     uuid not null references auth.users(id),
+  glyph_id    uuid not null references public.glyphs(id) on delete cascade,
+  created_at  timestamptz not null default now(),
+  primary key (user_id, glyph_id)
+);
+
+-- ---------------------------------------------------------------------------
+-- 2. RLS
+-- ---------------------------------------------------------------------------
+alter table public.glyph_submissions enable row level security;
+alter table public.glyph_entitlements enable row level security;
+alter table public.glyph_favourites   enable row level security;
+
+create policy glyph_submissions_select on public.glyph_submissions for select
+  to authenticated
+  using (submitter_id = auth.uid() or status = 'approved');
+
+create policy glyph_entitlements_select on public.glyph_entitlements for select
+  to authenticated using (user_id = auth.uid());
+
+create policy glyph_favourites_all on public.glyph_favourites for all
+  to authenticated using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+-- ---------------------------------------------------------------------------
+-- 3. glyphs policy rewrite — widen SELECT, lock UPDATE/DELETE (D8)
+--    Current (snapshot): glyphs_select = own ∪ null; update/delete = own.
+-- ---------------------------------------------------------------------------
+drop policy if exists "glyphs_select" on public.glyphs;
+create policy "glyphs_select" on public.glyphs for select to authenticated
+  using (
+    user_id = auth.uid()
+    or user_id is null
+    or exists (select 1 from public.glyph_submissions s
+               where s.glyph_id = glyphs.id and s.status = 'approved')
+    or exists (select 1 from public.glyph_entitlements e
+               where e.glyph_id = glyphs.id and e.user_id = auth.uid())
+  );
+
+drop policy if exists "glyphs_update" on public.glyphs;
+create policy "glyphs_update" on public.glyphs for update to authenticated
+  using (
+    public.is_admin(auth.uid())
+    or (
+      user_id = auth.uid()
+      and not exists (select 1 from public.glyph_submissions s
+                      where s.glyph_id = glyphs.id and s.status in ('pending','approved'))
+      and not exists (select 1 from public.glyph_entitlements e
+                      where e.glyph_id = glyphs.id)
+    )
+  );
+
+drop policy if exists "glyphs_delete" on public.glyphs;
+create policy "glyphs_delete" on public.glyphs for delete to authenticated
+  using (
+    public.is_admin(auth.uid())
+    or (
+      user_id = auth.uid()
+      and not exists (select 1 from public.glyph_submissions s
+                      where s.glyph_id = glyphs.id and s.status in ('pending','approved'))
+      and not exists (select 1 from public.glyph_entitlements e
+                      where e.glyph_id = glyphs.id)
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 4. RPCs
+-- ---------------------------------------------------------------------------
+-- Submit one of your own custom glyphs to the community (lands pending for D).
+create or replace function public.submit_glyph(p_glyph_id uuid)
+returns jsonb
+language plpgsql security definer set search_path = public as $$
+declare
+  v_user  uuid := auth.uid();
+  v_owner uuid;
+  v_row   public.glyph_submissions;
+begin
+  if v_user is null then raise exception 'not_authenticated' using errcode='42501'; end if;
+
+  select user_id into v_owner from public.glyphs where id = p_glyph_id;
+  if v_owner is distinct from v_user then
+    raise exception 'not_owner' using errcode='42501';  -- covers system glyphs (null owner)
+  end if;
+
+  if exists (select 1 from public.glyph_submissions s
+             where s.glyph_id = p_glyph_id and s.status in ('pending','approved')) then
+    raise exception 'already_submitted';
+  end if;
+
+  insert into public.glyph_submissions (glyph_id, submitter_id)
+  values (p_glyph_id, v_user)
+  returning * into v_row;
+
+  return to_jsonb(v_row);
+end;
+$$;
+
+-- Buy a community glyph: spend karma + grant use-rights, atomically.
+create or replace function public.buy_glyph(p_glyph_id uuid)
+returns jsonb
+language plpgsql security definer set search_path = public as $$
+declare
+  v_user    uuid := auth.uid();
+  v_price   integer;
+  v_owner   uuid;
+  v_event   uuid;
+  v_ent     uuid;
+  v_balance integer;
+begin
+  if v_user is null then raise exception 'not_authenticated' using errcode='42501'; end if;
+
+  -- Must be an approved (in-market) listing.
+  select s.price, g.user_id into v_price, v_owner
+  from public.glyph_submissions s
+  join public.glyphs g on g.id = s.glyph_id
+  where s.glyph_id = p_glyph_id and s.status = 'approved'
+  limit 1;
+  if v_price is null then raise exception 'not_in_market'; end if;
+
+  if v_owner = v_user then raise exception 'cannot_buy_own'; end if;
+
+  if exists (select 1 from public.glyph_entitlements e
+             where e.user_id = v_user and e.glyph_id = p_glyph_id) then
+    raise exception 'already_owned';
+  end if;
+
+  -- Spend (row-locked, raises insufficient_karma); records a withdraw event.
+  v_event := public.spend_karma(v_price, 'purchase', p_glyph_id);
+
+  -- Grant. unique(user_id, glyph_id) is the race backstop — a concurrent
+  -- double-buy rolls back the loser's spend too (same txn).
+  insert into public.glyph_entitlements (user_id, glyph_id, karma_event_id, price_paid)
+  values (v_user, p_glyph_id, v_event, v_price)
+  returning id into v_ent;
+
+  select balance into v_balance from public.wallet_balances where user_id = v_user;
+
+  return jsonb_build_object('entitlement_id', v_ent, 'balance', v_balance);
+end;
+$$;
+
+revoke all on function public.submit_glyph(uuid) from public, anon;
+revoke all on function public.buy_glyph(uuid)    from public, anon;
+grant execute on function public.submit_glyph(uuid) to authenticated;
+grant execute on function public.buy_glyph(uuid)    to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 5. Market view — approved listings + per-caller owned/favourited flags.
+--    security_invoker so the caller's RLS (widened glyphs SELECT, own
+--    entitlements/favourites) applies.
+-- ---------------------------------------------------------------------------
+create view public.v_glyph_market with (security_invoker = true) as
+select
+  g.id, g.user_id, g.name, g.shape_id, g.strokes, g.view_box,
+  g.created_at, g.updated_at,
+  s.price,
+  exists (select 1 from public.glyph_entitlements e
+          where e.glyph_id = g.id and e.user_id = auth.uid()) as owned,
+  exists (select 1 from public.glyph_favourites f
+          where f.glyph_id = g.id and f.user_id = auth.uid()) as favourited
+from public.glyph_submissions s
+join public.glyphs g on g.id = s.glyph_id
+where s.status = 'approved';
+
+revoke all on public.v_glyph_market from public, anon;
+grant select on public.v_glyph_market to authenticated;
+```
+
+- [ ] **Step 2: Deploy to remote Supabase**
+
+Run: `supabase db push` (remote-first per the decision log). Expected: migration applies cleanly, no errors.
+
+- [ ] **Step 3: Regenerate TypeScript types**
+
+Run: `npm run db:types --workspace=packages/supabase`
+Then: `git add packages/supabase/types/database.ts`
+Expected: `database.ts` now contains `glyph_submissions`, `glyph_entitlements`, `glyph_favourites`, `v_glyph_market`, and the `submit_glyph` / `buy_glyph` function signatures.
+
+- [ ] **Step 4: Sanity-check the RPCs against remote (manual)**
+
+In the Supabase SQL editor (as an authenticated test user, or via `set local role`): create a custom glyph, `select submit_glyph('<id>')` → pending row; `update glyph_submissions set status='approved' where glyph_id='<id>'`; as a *second* user `select buy_glyph('<id>')` → returns `{entitlement_id, balance}` and debits karma; calling `buy_glyph` again → `already_owned`; the seller calling it → `cannot_buy_own`. Confirm a listed glyph can no longer be updated/deleted by its creator (RLS denies).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/supabase/supabase/migrations/ packages/supabase/types/database.ts
+git commit -m "feat(db): glyph marketplace tables, rpcs, market view and glyph lock"
+```
+
+---
+
+## Task 2: Data layer — types, price constant, provider interface
+
+**Files:**
+- Modify: `apps/web/lib/config/glyphs.ts`
+- Modify: `apps/web/lib/types.ts`
+- Modify: `apps/web/lib/data/data-provider.ts`
+
+- [ ] **Step 1: Add the price constant**
+
+In `apps/web/lib/config/glyphs.ts`, add (mirror of the SQL default — keep in sync):
+
+```ts
+/**
+ * Flat community-glyph price in karma. Mirrors the `price` DEFAULT in
+ * `<timestamp>_glyph_marketplace.sql`. Server (`buy_glyph`) is authoritative;
+ * this is for display only. Keep both in sync.
+ */
+export const GLYPH_PRICE_DEFAULT = 25
+```
+
+- [ ] **Step 2: Add domain types**
+
+In `apps/web/lib/types.ts`, after the `Mark` type, add:
+
+```ts
+export type GlyphSubmissionStatus = "pending" | "approved" | "rejected"
+
+// A community-market glyph: the glyph plus its listing price and the caller's
+// relationship to it. Extends Mark (becomes Glyph when #488 lands).
+export type MarketGlyph = Mark & {
+  price: number
+  owned: boolean // caller is entitled (bought)
+  favourited: boolean // caller has favourited
+}
+
+export type GlyphSubmission = {
+  id: string
+  glyph_id: string
+  status: GlyphSubmissionStatus
+  price: number
+  created_at: string
+}
+```
+
+- [ ] **Step 3: Extend the Store with entitled glyphs (for D7 rendering/picker)**
+
+In `apps/web/lib/data/data-provider.ts`, add `entitledMarks: Mark[]` to the `Store` type and `entitledMarks: []` to `EMPTY_STORE` (place both next to `marks`).
+
+- [ ] **Step 4: Extend the DataProvider interface**
+
+In the same file, import `MarketGlyph` and `GlyphSubmission` from `@/lib/types`, then add these methods to the `DataProvider` interface (near the existing Mark methods):
+
+```ts
+listMarketGlyphs(): Promise<MarketGlyph[]>     // approved, others' glyphs, + caller flags
+listFavouriteGlyphs(): Promise<MarketGlyph[]>  // entitled ∪ favourited
+getMySubmissions(): Promise<GlyphSubmission[]> // caller's submissions (status badges)
+submitGlyph(glyphId: string): Promise<GlyphSubmission>
+buyGlyph(glyphId: string): Promise<{ entitlementId: string; karma: number }>
+setFavourite(glyphId: string, favourite: boolean): Promise<void>
+```
+
+- [ ] **Step 5: Verify + commit**
+
+Run: `npm run lint --workspace=apps/web` (expect: passes; SupabaseProvider will error on missing methods only after it's the next task — if lint fails on the interface, that's expected until Task 3. Run `tsc` only after Task 3.)
+
+```bash
+git add apps/web/lib/config/glyphs.ts apps/web/lib/types.ts apps/web/lib/data/data-provider.ts
+git commit -m "feat(core): glyph market types, price constant and provider interface"
+```
+
+---
+
+## Task 3: SupabaseProvider — implement the market methods + load entitled glyphs
+
+**Files:**
+- Modify: `apps/web/lib/data/supabase-provider.ts`
+
+- [ ] **Step 1: Import the new types**
+
+Add `MarketGlyph`, `GlyphSubmission` to the `@/lib/types` import block.
+
+- [ ] **Step 2: Add a row→Mark mapper helper (DRY)**
+
+The provider repeats the `glyphs` row→`Mark` shape three times. Add a private helper and reuse it in the new methods (do not refactor existing call sites unless trivial):
+
+```ts
+private rowToMark(row: Record<string, unknown>): Mark {
+  return {
+    id: row.id as string,
+    name: (row.name as string) ?? undefined,
+    shape_id: row.shape_id as string,
+    strokes: row.strokes as Mark["strokes"],
+    viewBox: row.view_box as string,
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string,
+  }
+}
+```
+
+- [ ] **Step 3: Load entitled glyphs in `loadFromSupabase`**
+
+Add a parallel query to the `Promise.all` (alongside `glyphsRes`):
+
+```ts
+this.supabase.from("v_glyph_market").select("*").eq("owned", true),
+```
+
+Name the result `entitledRes`, add an error guard mirroring the others, and after the `marks` mapping add:
+
+```ts
+const entitledMarks: Mark[] = (entitledRes.data ?? []).map((row) =>
+  this.rowToMark(row as Record<string, unknown>),
+)
+```
+
+Include `entitledMarks` in the returned/mutated store object next to `marks`.
+
+- [ ] **Step 4: Implement the market methods**
+
+Add near the Mark mutations section:
+
+```ts
+// ---------------------------------------------------------------------------
+// Glyph marketplace (#496)
+// ---------------------------------------------------------------------------
+private rowToMarketGlyph(row: Record<string, unknown>): MarketGlyph {
+  return {
+    ...this.rowToMark(row),
+    price: row.price as number,
+    owned: Boolean(row.owned),
+    favourited: Boolean(row.favourited),
+  }
+}
+
+async listMarketGlyphs(): Promise<MarketGlyph[]> {
+  const { data, error } = await this.supabase.from("v_glyph_market").select("*")
+  if (error) throw new Error(`Failed to load market glyphs: ${error.message}`)
+  // Hide the caller's own creations — they live under Mine, not the Market.
+  return (data ?? [])
+    .filter((row) => (row as Record<string, unknown>).user_id !== this.userId)
+    .map((row) => this.rowToMarketGlyph(row as Record<string, unknown>))
+}
+
+async listFavouriteGlyphs(): Promise<MarketGlyph[]> {
+  // Bought (owned) ∪ favourited, both drawn from approved listings. (A glyph
+  // delisted after purchase would drop out — acceptable for V1; D doesn't exist yet.)
+  const { data, error } = await this.supabase
+    .from("v_glyph_market")
+    .select("*")
+    .or("owned.eq.true,favourited.eq.true")
+  if (error) throw new Error(`Failed to load favourites: ${error.message}`)
+  return (data ?? []).map((row) => this.rowToMarketGlyph(row as Record<string, unknown>))
+}
+
+async getMySubmissions(): Promise<GlyphSubmission[]> {
+  const { data, error } = await this.supabase
+    .from("glyph_submissions")
+    .select("id, glyph_id, status, price, created_at")
+    .eq("submitter_id", this.userId)
+  if (error) throw new Error(`Failed to load submissions: ${error.message}`)
+  return (data ?? []).map((row) => {
+    const r = row as Record<string, unknown>
+    return {
+      id: r.id as string,
+      glyph_id: r.glyph_id as string,
+      status: r.status as GlyphSubmission["status"],
+      price: r.price as number,
+      created_at: r.created_at as string,
+    }
+  })
+}
+
+async submitGlyph(glyphId: string): Promise<GlyphSubmission> {
+  const { data, error } = await this.supabase.rpc("submit_glyph", { p_glyph_id: glyphId })
+  if (error) throw new Error(error.message)
+  const r = data as Record<string, unknown>
+  return {
+    id: r.id as string,
+    glyph_id: r.glyph_id as string,
+    status: r.status as GlyphSubmission["status"],
+    price: r.price as number,
+    created_at: r.created_at as string,
+  }
+}
+
+async buyGlyph(glyphId: string): Promise<{ entitlementId: string; karma: number }> {
+  const { data, error } = await this.supabase.rpc("buy_glyph", { p_glyph_id: glyphId })
+  if (error) throw new Error(error.message)
+  const r = data as { entitlement_id: string; balance: number }
+  this.mutate({ ...this.store, karma: r.balance })
+  return { entitlementId: r.entitlement_id, karma: r.balance }
+}
+
+async setFavourite(glyphId: string, favourite: boolean): Promise<void> {
+  if (favourite) {
+    const { error } = await this.supabase
+      .from("glyph_favourites")
+      .upsert({ user_id: this.userId, glyph_id: glyphId }, { onConflict: "user_id,glyph_id" })
+    if (error) throw new Error(error.message)
+  } else {
+    const { error } = await this.supabase
+      .from("glyph_favourites")
+      .delete()
+      .eq("user_id", this.userId)
+      .eq("glyph_id", glyphId)
+    if (error) throw new Error(error.message)
+  }
+}
+```
+
+- [ ] **Step 5: Verify + commit**
+
+Run: `npm run lint --workspace=apps/web` then `npm run build --workspace=apps/web` (types changed). Expect both green.
+
+```bash
+git add apps/web/lib/data/supabase-provider.ts
+git commit -m "feat(core): implement glyph market provider methods"
+```
+
+---
+
+## Task 4: Hooks — market, favourites, submissions, usable glyphs
+
+**Files:**
+- Create: `apps/web/lib/data/useGlyphMarket.ts`
+- Create: `apps/web/lib/data/useGlyphFavourites.ts`
+- Create: `apps/web/lib/data/useGlyphSubmissions.ts`
+- Create: `apps/web/lib/data/useUsableGlyphs.ts`
+
+- [ ] **Step 1: `useUsableGlyphs` (own ∪ entitled, for the picker)**
+
+```ts
+"use client"
+
+import { useDataProvider } from "@/lib/data/provider-context"
+import type { Mark } from "@/lib/types"
+
+/** Glyphs the user may attach to pebbles/souls: own ∪ entitled (bought). */
+export function useUsableGlyphs(): { glyphs: Mark[]; loading: boolean } {
+  const { store, loading } = useDataProvider()
+  const seen = new Set(store.marks.map((m) => m.id))
+  const glyphs = [...store.marks, ...store.entitledMarks.filter((m) => !seen.has(m.id))]
+  return { glyphs, loading }
+}
+```
+
+- [ ] **Step 2: `useGlyphSubmissions` (Mine-tab badges + submit)**
+
+```ts
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { useDataProvider } from "@/lib/data/provider-context"
+import type { GlyphSubmission } from "@/lib/types"
+
+export function useGlyphSubmissions() {
+  const { provider } = useDataProvider()
+  const [submissions, setSubmissions] = useState<GlyphSubmission[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    if (!provider) return
+    setSubmissions(await provider.getMySubmissions())
+    setLoading(false)
+  }, [provider])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const submit = useCallback(
+    async (glyphId: string) => {
+      if (!provider) throw new Error("Not authenticated")
+      const created = await provider.submitGlyph(glyphId)
+      await refresh()
+      return created
+    },
+    [provider, refresh],
+  )
+
+  return { submissions, loading, submit, refresh }
+}
+```
+
+- [ ] **Step 3: `useGlyphMarket` (list + buy + favourite)**
+
+```ts
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { useTranslations } from "next-intl"
+import { useDataProvider } from "@/lib/data/provider-context"
+import { notifyGlyphPurchased } from "@/lib/activity/glyph-activity"
+import type { MarketGlyph } from "@/lib/types"
+
+export function useGlyphMarket() {
+  const { provider, setStore } = useDataProvider()
+  const tGlyphs = useTranslations("glyphs")
+  const [glyphs, setGlyphs] = useState<MarketGlyph[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    if (!provider) return
+    setGlyphs(await provider.listMarketGlyphs())
+    setLoading(false)
+  }, [provider])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  // Throws on failure (e.g. "insufficient_karma") — caller maps to a message.
+  const buy = useCallback(
+    async (glyph: MarketGlyph) => {
+      if (!provider) throw new Error("Not authenticated")
+      await provider.buyGlyph(glyph.id)
+      setStore(provider.getStore()) // karma + entitledMarks refreshed by reload-on-buy
+      notifyGlyphPurchased(glyph.id, glyph.name || tGlyphs("untitled"), glyph.price)
+      await refresh()
+    },
+    [provider, setStore, refresh, tGlyphs],
+  )
+
+  const favourite = useCallback(
+    async (glyphId: string, value: boolean) => {
+      if (!provider) return
+      await provider.setFavourite(glyphId, value)
+      await refresh()
+    },
+    [provider, refresh],
+  )
+
+  return { glyphs, loading, buy, favourite, refresh }
+}
+```
+
+> Note: `buyGlyph` updates only `karma` in the provider store. To also refresh
+> `entitledMarks` (so the bought glyph becomes usable immediately) the buy hook
+> can call `await provider.loadFromSupabase()` then `setStore(provider.getStore())`.
+> Use whichever the implementer confirms reloads the store; the existing pebble
+> hooks call `loadFromSupabase` internally — check `buyGlyph` vs that pattern and
+> prefer a full reload after buy for correctness.
+
+- [ ] **Step 4: `useGlyphFavourites` (list + favourite toggle)**
+
+```ts
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { useDataProvider } from "@/lib/data/provider-context"
+import type { MarketGlyph } from "@/lib/types"
+
+export function useGlyphFavourites() {
+  const { provider } = useDataProvider()
+  const [glyphs, setGlyphs] = useState<MarketGlyph[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    if (!provider) return
+    setGlyphs(await provider.listFavouriteGlyphs())
+    setLoading(false)
+  }, [provider])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const favourite = useCallback(
+    async (glyphId: string, value: boolean) => {
+      if (!provider) return
+      await provider.setFavourite(glyphId, value)
+      await refresh()
+    },
+    [provider, refresh],
+  )
+
+  return { glyphs, loading, favourite, refresh }
+}
+```
+
+- [ ] **Step 5: Reconcile buy → store reload**
+
+In `supabase-provider.ts` `buyGlyph`, after the RPC succeeds, replace the `this.mutate({ ...this.store, karma })` line with a full reload so `entitledMarks` (and karma) refresh together:
+
+```ts
+await this.loadFromSupabase()  // refreshes karma + entitledMarks
+return { entitlementId: r.entitlement_id, karma: this.store.karma }
+```
+
+(Then the hook's `setStore(provider.getStore())` reflects both.)
+
+- [ ] **Step 6: Verify + commit**
+
+Run: `npm run lint --workspace=apps/web` (build deferred until activity exists in Task 5). Expect lint green except the not-yet-created `@/lib/activity/glyph-activity` import — that's resolved in Task 5; if lint blocks on it, do Task 5 before re-running build.
+
+```bash
+git add apps/web/lib/data/useGlyphMarket.ts apps/web/lib/data/useGlyphFavourites.ts apps/web/lib/data/useGlyphSubmissions.ts apps/web/lib/data/useUsableGlyphs.ts apps/web/lib/data/supabase-provider.ts
+git commit -m "feat(core): glyph market hooks (market, favourites, submissions, usable)"
+```
+
+---
+
+## Task 5: Activity — glyph purchase pill (reuses Sonner)
+
+**Files:**
+- Create: `apps/web/components/activity/GlyphPurchasePill.tsx`
+- Create: `apps/web/lib/activity/glyph-activity.tsx`
+- Modify: `apps/web/lib/i18n/messages/en.json`, `apps/web/lib/i18n/messages/fr.json`
+
+- [ ] **Step 1: Add `activity` i18n keys (EN then FR)**
+
+EN — extend the existing `activity` object:
+```json
+"glyphUnlocked": "Glyph unlocked",
+"spent": "−{amount} karma",
+"srUnlocked": "Unlocked {name} — {amount} karma spent.",
+"viewGlyph": "View glyph"
+```
+FR:
+```json
+"glyphUnlocked": "Glyphe débloqué",
+"spent": "−{amount} karma",
+"srUnlocked": "{name} débloqué — {amount} karma dépensés.",
+"viewGlyph": "Voir le glyphe"
+```
+
+- [ ] **Step 2: Create `GlyphPurchasePill` (mirror `KarmaActivityPill`)**
+
+```tsx
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useTranslations } from "next-intl"
+import { Sparkle } from "lucide-react"
+import { toast } from "sonner"
+
+type GlyphPurchasePillProps = {
+  toastId: string | number
+  glyphId: string
+  name: string
+  amount: number
+}
+
+export function GlyphPurchasePill({ toastId, glyphId, name, amount }: GlyphPurchasePillProps) {
+  const router = useRouter()
+  const t = useTranslations("activity")
+
+  const handleTap = () => {
+    toast.dismiss(toastId)
+    router.push(`/glyphs/${glyphId}`)
+  }
+
+  // "Unlocked Star — 25 karma spent. View glyph."
+  const label = `${t("srUnlocked", { name, amount })} ${t("viewGlyph")}.`
+
+  return (
+    <button
+      type="button"
+      onClick={handleTap}
+      aria-label={label}
+      className="flex items-center gap-2 rounded-full bg-neutral-900 px-4 py-2 text-sm font-semibold text-white shadow-lg ring-1 ring-white/10 transition active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 dark:bg-neutral-800 motion-reduce:transition-none motion-reduce:active:scale-100"
+    >
+      <Sparkle aria-hidden className="size-4 text-amber-300" />
+      <span aria-hidden>{t("glyphUnlocked")}</span>
+      <span aria-hidden className="text-amber-300">{t("spent", { amount })}</span>
+    </button>
+  )
+}
+```
+
+- [ ] **Step 3: Create `glyph-activity.tsx` (mirror `karma-activity.tsx`)**
+
+```tsx
+import { toast } from "sonner"
+import { GlyphPurchasePill } from "@/components/activity/GlyphPurchasePill"
+
+// Stable id → a new purchase replaces the current pill rather than stacking.
+const GLYPH_ACTIVITY_ID = "glyph-activity"
+
+/** Fire a glanceable "Glyph unlocked · −N karma" pill after a purchase. */
+export function notifyGlyphPurchased(glyphId: string, name: string, amount: number): void {
+  if (amount <= 0) return
+  toast.custom(
+    (id) => (
+      <div className="flex w-full justify-center">
+        <GlyphPurchasePill toastId={id} glyphId={glyphId} name={name} amount={amount} />
+      </div>
+    ),
+    { id: GLYPH_ACTIVITY_ID, duration: 3000 },
+  )
+}
+```
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `npm run lint --workspace=apps/web` then `npm run build --workspace=apps/web`. Expect green (Task 4's import now resolves).
+
+```bash
+git add apps/web/components/activity/GlyphPurchasePill.tsx apps/web/lib/activity/glyph-activity.tsx apps/web/lib/i18n/messages/en.json apps/web/lib/i18n/messages/fr.json
+git commit -m "feat(ui): glyph purchase activity pill"
+```
+
+---
+
+## Task 6: i18n — glyph tabs, empty states, submit, market namespace
+
+**Files:**
+- Modify: `apps/web/lib/i18n/messages/en.json`, `apps/web/lib/i18n/messages/fr.json`
+
+- [ ] **Step 1: Extend the `glyphs` namespace (EN)**
+
+Add to the existing `glyphs` object:
+```json
+"tabs": { "mine": "Mine", "favourites": "Favourites", "market": "Market" },
+"submit": {
+  "cta": "Submit to community",
+  "pending": "Pending review",
+  "approved": "Listed",
+  "rejected": "Not accepted",
+  "locked": "Listed — locked",
+  "confirmTitle": "Submit this glyph to the community?",
+  "confirmDescription": "It will be reviewed before appearing in the Market. Once submitted, you can no longer edit or delete it.",
+  "confirm": "Submit",
+  "cancel": "Cancel"
+}
+```
+Extend `glyphs.empty` with per-tab entries (keep the existing `title`/`description`/`cta` for Mine):
+```json
+"marketTitle": "No glyphs for sale yet",
+"marketDescription": "Community glyphs will appear here once they're approved.",
+"favouritesTitle": "No favourites yet",
+"favouritesDescription": "Glyphs you buy or favourite from the Market show up here."
+```
+
+- [ ] **Step 2: Add the `market` namespace (EN, top-level)**
+
+```json
+"market": {
+  "price": "{amount} karma",
+  "buy": "Buy",
+  "owned": "Owned",
+  "buyTitle": "Buy this glyph?",
+  "buyDescription": "This spends {amount} karma. You'll be able to use it on your pebbles and souls.",
+  "buyConfirm": "Buy for {amount} karma",
+  "cancel": "Cancel",
+  "favourite": "Add to favourites",
+  "unfavourite": "Remove from favourites",
+  "errors": {
+    "insufficient": "You don't have enough karma for this glyph.",
+    "notInMarket": "This glyph is no longer available.",
+    "cannotBuyOwn": "You can't buy your own glyph.",
+    "alreadyOwned": "You already own this glyph.",
+    "generic": "Something went wrong. Please try again."
+  }
+}
+```
+
+- [ ] **Step 3: Mirror everything in FR**
+
+```json
+"tabs": { "mine": "Mes glyphes", "favourites": "Favoris", "market": "Marché" },
+"submit": {
+  "cta": "Proposer à la communauté",
+  "pending": "En attente de validation",
+  "approved": "Publié",
+  "rejected": "Refusé",
+  "locked": "Publié — verrouillé",
+  "confirmTitle": "Proposer ce glyphe à la communauté ?",
+  "confirmDescription": "Il sera examiné avant d'apparaître dans le Marché. Une fois proposé, vous ne pourrez plus le modifier ni le supprimer.",
+  "confirm": "Proposer",
+  "cancel": "Annuler"
+}
+```
+`glyphs.empty` FR additions:
+```json
+"marketTitle": "Aucun glyphe en vente",
+"marketDescription": "Les glyphes de la communauté apparaîtront ici après validation.",
+"favouritesTitle": "Aucun favori",
+"favouritesDescription": "Les glyphes achetés ou mis en favori depuis le Marché apparaissent ici."
+```
+`market` FR namespace:
+```json
+"market": {
+  "price": "{amount} karma",
+  "buy": "Acheter",
+  "owned": "Acquis",
+  "buyTitle": "Acheter ce glyphe ?",
+  "buyDescription": "Cela dépense {amount} karma. Vous pourrez l'utiliser sur vos cailloux et vos âmes.",
+  "buyConfirm": "Acheter pour {amount} karma",
+  "cancel": "Annuler",
+  "favourite": "Ajouter aux favoris",
+  "unfavourite": "Retirer des favoris",
+  "errors": {
+    "insufficient": "Vous n'avez pas assez de karma pour ce glyphe.",
+    "notInMarket": "Ce glyphe n'est plus disponible.",
+    "cannotBuyOwn": "Vous ne pouvez pas acheter votre propre glyphe.",
+    "alreadyOwned": "Vous possédez déjà ce glyphe.",
+    "generic": "Une erreur est survenue. Veuillez réessayer."
+  }
+}
+```
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `npm run lint --workspace=apps/web` (and confirm both JSON files parse — `node -e "require('./apps/web/lib/i18n/messages/en.json'); require('./apps/web/lib/i18n/messages/fr.json')"`).
+
+```bash
+git add apps/web/lib/i18n/messages/en.json apps/web/lib/i18n/messages/fr.json
+git commit -m "feat(ui): en/fr copy for glyph tabs, submit and market"
+```
+
+---
+
+## Task 7: Tabs scaffold — `/glyphs` page + `GlyphTabs`
+
+**Files:**
+- Create: `apps/web/components/glyphs/GlyphTabs.tsx`
+- Modify: `apps/web/app/glyphs/page.tsx`
+
+- [ ] **Step 1: Create `GlyphTabs` (URL-synced segmented nav)**
+
+```tsx
+"use client"
+
+import { useRouter, useSearchParams } from "next/navigation"
+import { useTranslations } from "next-intl"
+
+export type GlyphTab = "mine" | "favourites" | "market"
+const TABS: GlyphTab[] = ["mine", "favourites", "market"]
+
+export function GlyphTabs({ active }: { active: GlyphTab }) {
+  const router = useRouter()
+  const params = useSearchParams()
+  const t = useTranslations("glyphs.tabs")
+
+  const select = (tab: GlyphTab) => {
+    const next = new URLSearchParams(params)
+    next.set("tab", tab)
+    router.replace(`/glyphs?${next.toString()}`)
+  }
+
+  return (
+    <nav className="mb-6 flex gap-1 rounded-lg bg-muted p-1" role="tablist">
+      {TABS.map((tab) => (
+        <button
+          key={tab}
+          role="tab"
+          aria-selected={active === tab}
+          onClick={() => select(tab)}
+          className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+            active === tab
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          {t(tab)}
+        </button>
+      ))}
+    </nav>
+  )
+}
+```
+
+- [ ] **Step 2: Rebuild `/glyphs/page.tsx` with tabs (Suspense-wrapped for `useSearchParams`)**
+
+```tsx
+"use client"
+
+import { Suspense } from "react"
+import Link from "next/link"
+import { useSearchParams } from "next/navigation"
+import { useTranslations } from "next-intl"
+import { useMarks } from "@/lib/data/useMarks"
+import { GlyphList } from "@/components/glyphs/GlyphList"
+import { GlyphsEmptyState } from "@/components/glyphs/GlyphsEmptyState"
+import { GlyphTabs, type GlyphTab } from "@/components/glyphs/GlyphTabs"
+import { MarketGlyphs } from "@/components/glyphs/MarketGlyphs"
+import { FavouriteGlyphs } from "@/components/glyphs/FavouriteGlyphs"
+import { PageLayout } from "@/components/layout/PageLayout"
+import { PageHeader } from "@/components/layout/PageHeader"
+
+function GlyphsView() {
+  const params = useSearchParams()
+  const tab = (params.get("tab") as GlyphTab) ?? "mine"
+  const t = useTranslations("glyphs")
+  const { marks, loading } = useMarks()
+
+  return (
+    <section>
+      <PageHeader
+        title={t("title")}
+        rightSlot={
+          <Link
+            href="/carve"
+            className="text-sm font-medium text-primary underline underline-offset-4 hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            {t("carveNew")}
+          </Link>
+        }
+      />
+      <GlyphTabs active={tab} />
+
+      {tab === "market" ? (
+        <MarketGlyphs />
+      ) : tab === "favourites" ? (
+        <FavouriteGlyphs />
+      ) : loading ? (
+        <p className="text-sm text-muted-foreground">{t("loading")}</p>
+      ) : marks.length === 0 ? (
+        <GlyphsEmptyState />
+      ) : (
+        <GlyphList marks={marks} />
+      )}
+    </section>
+  )
+}
+
+export default function GlyphsPage() {
+  return (
+    <PageLayout>
+      <Suspense>
+        <GlyphsView />
+      </Suspense>
+    </PageLayout>
+  )
+}
+```
+
+- [ ] **Step 3: Verify + commit**
+
+`MarketGlyphs`/`FavouriteGlyphs` don't exist yet — lint/build will fail until Task 8/9. Commit the tab scaffold together with Task 8 if execution order matters; otherwise stub the two imports temporarily. Preferred: implement Task 8 and 9 before building, then verify all three together.
+
+```bash
+git add apps/web/components/glyphs/GlyphTabs.tsx apps/web/app/glyphs/page.tsx
+git commit -m "feat(ui): glyph space tabs (mine/favourites/market)"
+```
+
+---
+
+## Task 8: Market tab — card, list, buy dialog, wiring
+
+**Files:**
+- Create: `apps/web/components/glyphs/MarketGlyphCard.tsx`
+- Create: `apps/web/components/glyphs/BuyGlyphDialog.tsx`
+- Create: `apps/web/components/glyphs/MarketGlyphs.tsx`
+
+- [ ] **Step 1: `BuyGlyphDialog` (async buy + inline error mapping)**
+
+Uses `alert-dialog` primitives directly (ConfirmDialog's `onConfirm` is sync and can't show errors/loading).
+
+```tsx
+"use client"
+
+import { useState, type ReactElement } from "react"
+import { useTranslations } from "next-intl"
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+
+const ERROR_KEYS = ["insufficient", "notInMarket", "cannotBuyOwn", "alreadyOwned"] as const
+
+function messageKey(error: unknown): string {
+  const msg = error instanceof Error ? error.message : ""
+  if (msg.includes("insufficient_karma")) return "insufficient"
+  if (msg.includes("not_in_market")) return "notInMarket"
+  if (msg.includes("cannot_buy_own")) return "cannotBuyOwn"
+  if (msg.includes("already_owned")) return "alreadyOwned"
+  return "generic"
+}
+
+type BuyGlyphDialogProps = {
+  trigger: ReactElement
+  amount: number
+  onBuy: () => Promise<void>
+}
+
+export function BuyGlyphDialog({ trigger, amount, onBuy }: BuyGlyphDialogProps) {
+  const t = useTranslations("market")
+  const [open, setOpen] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [errorKey, setErrorKey] = useState<string | null>(null)
+
+  const handleConfirm = async () => {
+    setBusy(true)
+    setErrorKey(null)
+    try {
+      await onBuy()
+      setOpen(false)
+    } catch (e) {
+      setErrorKey(messageKey(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger render={trigger} />
+      <AlertDialogContent size="sm">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("buyTitle")}</AlertDialogTitle>
+          <AlertDialogDescription>{t("buyDescription", { amount })}</AlertDialogDescription>
+        </AlertDialogHeader>
+        {errorKey && (
+          <p role="alert" className="text-sm text-destructive">
+            {t(`errors.${errorKey}` as `errors.${(typeof ERROR_KEYS)[number]}` | "errors.generic")}
+          </p>
+        )}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy}>{t("cancel")}</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault() // keep the dialog open to show errors / busy state
+              void handleConfirm()
+            }}
+            disabled={busy}
+          >
+            {t("buyConfirm", { amount })}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+```
+
+- [ ] **Step 2: `MarketGlyphCard` (preview, price, buy/owned, favourite heart)**
+
+```tsx
+"use client"
+
+import { useTranslations } from "next-intl"
+import { Heart } from "lucide-react"
+import type { MarketGlyph } from "@/lib/types"
+import { GlyphPreview } from "@/components/glyphs/GlyphPreview"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { BuyGlyphDialog } from "@/components/glyphs/BuyGlyphDialog"
+
+type MarketGlyphCardProps = {
+  glyph: MarketGlyph
+  onBuy: (glyph: MarketGlyph) => Promise<void>
+  onFavourite: (glyphId: string, value: boolean) => void
+}
+
+export function MarketGlyphCard({ glyph, onBuy, onFavourite }: MarketGlyphCardProps) {
+  const t = useTranslations("glyphs")
+  const tMarket = useTranslations("market")
+
+  return (
+    <article className="flex items-center gap-4 rounded-lg border border-border px-4 py-3">
+      <GlyphPreview mark={glyph} className="w-14 shrink-0 aspect-square" />
+      <div className="min-w-0 flex-1">
+        <h3 className="truncate text-sm font-medium">{glyph.name || t("untitled")}</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {tMarket("price", { amount: glyph.price })}
+        </p>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onFavourite(glyph.id, !glyph.favourited)}
+        aria-label={glyph.favourited ? tMarket("unfavourite") : tMarket("favourite")}
+        aria-pressed={glyph.favourited}
+        className="rounded-full p-2 text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <Heart className={`size-4 ${glyph.favourited ? "fill-current text-rose-500" : ""}`} />
+      </button>
+
+      {glyph.owned ? (
+        <Badge variant="secondary">{tMarket("owned")}</Badge>
+      ) : (
+        <BuyGlyphDialog
+          amount={glyph.price}
+          onBuy={() => onBuy(glyph)}
+          trigger={<Button size="sm">{tMarket("buy")}</Button>}
+        />
+      )}
+    </article>
+  )
+}
+```
+
+- [ ] **Step 3: `MarketGlyphs` (tab content)**
+
+```tsx
+"use client"
+
+import { useTranslations } from "next-intl"
+import { useGlyphMarket } from "@/lib/data/useGlyphMarket"
+import { MarketGlyphCard } from "@/components/glyphs/MarketGlyphCard"
+import { EmptyState } from "@/components/layout/EmptyState"
+
+export function MarketGlyphs() {
+  const t = useTranslations("glyphs")
+  const tEmpty = useTranslations("glyphs.empty")
+  const { glyphs, loading, buy, favourite } = useGlyphMarket()
+
+  if (loading) return <p className="text-sm text-muted-foreground">{t("loading")}</p>
+  if (glyphs.length === 0)
+    return <EmptyState title={tEmpty("marketTitle")} description={tEmpty("marketDescription")} />
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {glyphs.map((glyph) => (
+        <li key={glyph.id}>
+          <MarketGlyphCard glyph={glyph} onBuy={buy} onFavourite={favourite} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+```
+
+- [ ] **Step 4: Verify (deferred to Task 9 — `FavouriteGlyphs` still missing). Commit**
+
+```bash
+git add apps/web/components/glyphs/MarketGlyphCard.tsx apps/web/components/glyphs/BuyGlyphDialog.tsx apps/web/components/glyphs/MarketGlyphs.tsx
+git commit -m "feat(ui): glyph market tab with buy flow"
+```
+
+---
+
+## Task 9: Favourites tab
+
+**Files:**
+- Create: `apps/web/components/glyphs/FavouriteGlyphs.tsx`
+
+- [ ] **Step 1: `FavouriteGlyphs` (reuses `MarketGlyphCard`)**
+
+```tsx
+"use client"
+
+import { useTranslations } from "next-intl"
+import { useGlyphFavourites } from "@/lib/data/useGlyphFavourites"
+import { MarketGlyphCard } from "@/components/glyphs/MarketGlyphCard"
+import { EmptyState } from "@/components/layout/EmptyState"
+
+export function FavouriteGlyphs() {
+  const t = useTranslations("glyphs")
+  const tEmpty = useTranslations("glyphs.empty")
+  const { glyphs, loading, favourite } = useGlyphFavourites()
+
+  if (loading) return <p className="text-sm text-muted-foreground">{t("loading")}</p>
+  if (glyphs.length === 0)
+    return (
+      <EmptyState title={tEmpty("favouritesTitle")} description={tEmpty("favouritesDescription")} />
+    )
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {glyphs.map((glyph) => (
+        <li key={glyph.id}>
+          {/* Favourites are already owned/favourited; Buy still guarded by `owned`. */}
+          <MarketGlyphCard glyph={glyph} onBuy={async () => {}} onFavourite={favourite} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+```
+
+- [ ] **Step 2: Verify the whole tab surface + commit**
+
+Run: `npm run lint --workspace=apps/web` then `npm run build --workspace=apps/web`. Expect green (Tasks 7–9 now resolve each other). Manually: `/glyphs?tab=market` and `?tab=favourites` render (empty states until a row is approved).
+
+```bash
+git add apps/web/components/glyphs/FavouriteGlyphs.tsx
+git commit -m "feat(ui): glyph favourites tab"
+```
+
+---
+
+## Task 10: Mine — submit to community + D8 lock reflection
+
+**Files:**
+- Create: `apps/web/components/glyphs/SubmitToCommunity.tsx`
+- Modify: `apps/web/components/glyphs/GlyphDetail.tsx`
+- Modify: `apps/web/app/glyphs/[id]/page.tsx`
+
+- [ ] **Step 1: `SubmitToCommunity` (status-aware action/badge)**
+
+```tsx
+"use client"
+
+import { useState, type ReactElement } from "react"
+import { useTranslations } from "next-intl"
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import type { GlyphSubmissionStatus } from "@/lib/types"
+
+type SubmitToCommunityProps = {
+  status?: GlyphSubmissionStatus // undefined = not submitted
+  onSubmit: () => Promise<void>
+}
+
+export function SubmitToCommunity({ status, onSubmit }: SubmitToCommunityProps) {
+  const t = useTranslations("glyphs.submit")
+  const [open, setOpen] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  if (status) {
+    const variant = status === "approved" ? "default" : status === "rejected" ? "destructive" : "secondary"
+    return <Badge variant={variant}>{t(status)}</Badge>
+  }
+
+  const confirm = async () => {
+    setBusy(true)
+    try {
+      await onSubmit()
+      setOpen(false)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const trigger: ReactElement = <Button variant="outline" size="sm">{t("cta")}</Button>
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger render={trigger} />
+      <AlertDialogContent size="sm">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("confirmTitle")}</AlertDialogTitle>
+          <AlertDialogDescription>{t("confirmDescription")}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy}>{t("cancel")}</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => { e.preventDefault(); void confirm() }}
+            disabled={busy}
+          >
+            {t("confirm")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+```
+
+- [ ] **Step 2: Add `locked` + `submitSlot` to `GlyphDetail`**
+
+Extend `GlyphDetailProps`:
+```ts
+type GlyphDetailProps = {
+  mark: Mark
+  onDelete: () => void
+  onUpdateName: (name: string | null) => Promise<void>
+  locked?: boolean              // listed/bought → no edit/delete
+  submitSlot?: React.ReactNode  // SubmitToCommunity rendered by the page
+}
+```
+Then in the component:
+- When `locked`, **hide** the edit pencil button and the delete `ConfirmDialog`, and show `glyphs.submit.locked` as a `Badge` where the delete button was.
+- Render `submitSlot` in the header area (next to the title) when provided.
+Apply minimally — wrap the pencil `<Button>` in `{!locked && (…)}`, and replace the bottom delete block with `locked ? <Badge variant="secondary">{tDetail wiring}</Badge> : <ConfirmDialog …/>`. Use `useTranslations("glyphs.submit")` for the `locked` label (add `const tSubmit = useTranslations("glyphs.submit")`).
+
+- [ ] **Step 3: Wire the page**
+
+In `apps/web/app/glyphs/[id]/page.tsx`:
+- `const { submissions, submit } = useGlyphSubmissions()`
+- `const submission = submissions.find((s) => s.glyph_id === id)`
+- `const locked = submission?.status === "pending" || submission?.status === "approved"`
+- Pass to `GlyphDetail`: `locked={locked}` and
+  `submitSlot={<SubmitToCommunity status={submission?.status} onSubmit={() => submit(id).then(() => {})} />}`
+- The system-seed case (a glyph with no `user_id`) can't be submitted; since the Mine list only shows the user's own glyphs this is moot, but guard `submitSlot` behind "is a real owned glyph" if the page can render seeds (it can't today — own-only load).
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `npm run lint --workspace=apps/web` then `npm run build --workspace=apps/web`. Manually: open an owned glyph → "Submit to community" → confirm → badge flips to "Pending review"; the edit/delete controls disappear and a "Listed — locked" badge shows.
+
+```bash
+git add apps/web/components/glyphs/SubmitToCommunity.tsx apps/web/components/glyphs/GlyphDetail.tsx apps/web/app/glyphs/[id]/page.tsx
+git commit -m "feat(ui): submit glyph to community and lock listed glyphs"
+```
+
+---
+
+## Task 11: Picker — make bought glyphs usable (D7)
+
+**Files:**
+- Modify: `apps/web/lib/data/useLookupMaps.ts` (glyph rendering map)
+- Modify: `apps/web/app/pebble/[id]/page.tsx`, `apps/web/app/pebble/[id]/edit/page.tsx`, `apps/web/app/souls/page.tsx`, `apps/web/app/souls/[id]/page.tsx`, `apps/web/components/path/PebblePeek.tsx` (picker feeders)
+
+- [ ] **Step 1: Include entitled glyphs in the lookup map**
+
+In `useLookupMaps.ts`, the `glyphMap` is built from `store.marks`. Change its source to `[...store.marks, ...store.entitledMarks]` (dedupe by id) so a bought glyph attached to a pebble/soul renders. Read the file first to match its exact construction; apply the smallest change that merges `entitledMarks`.
+
+- [ ] **Step 2: Feed the picker from usable glyphs**
+
+At each of the five call sites currently doing `const { marks } = useMarks()` and passing `marks` into `GlyphPickerDialog`, switch the picker's source to `useUsableGlyphs()`:
+```ts
+import { useUsableGlyphs } from "@/lib/data/useUsableGlyphs"
+const { glyphs: usableGlyphs } = useUsableGlyphs()
+```
+Pass `usableGlyphs` (own ∪ entitled) to the `GlyphPickerDialog` `marks` prop. Keep any *other* uses of `marks` on those pages unchanged unless they also drive glyph display (in which case prefer `usableGlyphs` so bought glyphs resolve). Read each file before editing; this is a prop-source swap, not a refactor.
+
+- [ ] **Step 3: Verify + commit**
+
+Run: `npm run lint --workspace=apps/web` then `npm run build --workspace=apps/web`. Manually (after buying a glyph): open the glyph picker on a pebble → the bought glyph appears and can be attached and renders.
+
+```bash
+git add apps/web/lib/data/useLookupMaps.ts apps/web/app/pebble apps/web/app/souls apps/web/components/path/PebblePeek.tsx
+git commit -m "feat(ui): make bought glyphs usable in the glyph picker"
+```
+
+---
+
+## Final review
+
+After all tasks: dispatch the whole-branch code review (subagent-driven-development's final step), then `superpowers:finishing-a-development-branch`. Before opening the PR, complete the spec §9 manual checklist against a hand-approved listing, append the three decision-log entries (spec §10), and add the gated bilingual Lab Note (this PR has `feat` + touches user-visible glyph surfaces).
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** tabs (T7), submit→pending (T10), atomic buy/no-double/no-overdraw (T1 RPC + T8), favourites incl. bought (T1 view + T9), EN/FR (T6), activity pill (T5), D7 usable (T11), D8 lock (T1 RLS + T10 reflection), price-on-row + price_paid ledger (T1), market empty until approved (T1, no approve UI). All covered.
+- **Type consistency:** `MarketGlyph`/`GlyphSubmission`/`GlyphSubmissionStatus` defined in T2, used unchanged in T3–T10. Provider method names match interface (T2) and impl (T3) and hooks (T4). `notifyGlyphPurchased(glyphId, name, amount)` consistent across T4/T5.
+- **Known sequencing coupling:** T7 imports components from T8/T9; build green only after all three land. Flagged in T7 Step 3. Execute T7→T8→T9 before the first full build.
+- **Risk to watch:** the `buyGlyph` reload-on-buy (T4 Step 5) — confirm `loadFromSupabase` is the right refresh and doesn't double-count; the existing pebble mutation hooks are the reference pattern.

--- a/docs/superpowers/specs/2026-06-30-issue-496-glyph-marketplace-design.md
+++ b/docs/superpowers/specs/2026-06-30-issue-496-glyph-marketplace-design.md
@@ -275,7 +275,8 @@ export type GlyphSubmission = {
 ```ts
 listMarketGlyphs(): Promise<MarketGlyph[]>          // approved ∪ flags for caller
 listFavouriteGlyphs(): Promise<MarketGlyph[]>       // entitled ∪ favourited
-listUsableMarks(): Promise<Mark[]>                  // own ∪ entitled (for the picker, D7)
+listUsableGlyphs(): Promise<Mark[]>                 // own ∪ entitled (for the picker, D7)
+                                                   // returns Mark[] until #488 renames the type
 getMySubmissions(): Promise<GlyphSubmission[]>      // for Mine-tab status badges
 submitGlyph(glyphId: string): Promise<GlyphSubmission>
 buyGlyph(glyphId: string): Promise<{ entitlementId: string; karma: number }>
@@ -337,7 +338,7 @@ default `mine`) so the purchase pill and favourites are deep-linkable. New
 
 ### 7.2 Picker (D7)
 
-`GlyphPickerDialog`/`GlyphPickerGrid` source from `listUsableMarks()` (own ∪ entitled) so a
+`GlyphPickerDialog`/`GlyphPickerGrid` source from `listUsableGlyphs()` (own ∪ entitled) so a
 bought glyph is attachable to pebbles/souls. (Confirm exact current data source during
 implementation.)
 

--- a/docs/superpowers/specs/2026-06-30-issue-496-glyph-marketplace-design.md
+++ b/docs/superpowers/specs/2026-06-30-issue-496-glyph-marketplace-design.md
@@ -1,0 +1,342 @@
+# Glyph marketplace — share, submit, favourite & buy glyphs (#496)
+
+**Sub-project C of 4** in **M36 · Pebblestore & Karma Economy**. The first thing the
+Pebblestore actually sells: **community glyphs**, bought with karma over Sub-project
+A's spend rails, surfaced via Sub-project B's in-app activity.
+
+- **Depends on:** A (`spend_karma` RPC, wallet store) and B (`notifyKarma` activity primitive).
+- **Feeds:** D (admin moderation + raw-SVG upload moderates the submissions this creates).
+
+---
+
+## 1. Context & current state
+
+Glyphs are typed **`Mark`** in code (DB table `glyphs`; UI says "glyph"). Hooks `useMarks`/
+`useMark`; provider methods `listMarks`/`getMark`/`createMark`/`updateMark`/`deleteMark`.
+The `Mark` domain type is `{ id, name?, shape_id, strokes, viewBox, created_at, updated_at }`
+(no `user_id`/`is_custom` surfaced client-side). `glyphs.user_id` is nullable — `NULL` rows
+are per-domain system seeds; `is_custom` is a generated column (`user_id IS NOT NULL`).
+
+Today glyphs are **single-owner** (`glyphs.user_id`), loaded own-only
+(`.eq("user_id", userId)`). There is **no sharing, no favourites, no ownership beyond the
+creator, no market.** Surfaces: `/glyphs` gallery (`GlyphList`/`GlyphCard`/`GlyphDetail`),
+`/carve` editor, `GlyphPickerDialog` for attaching a glyph to pebbles/souls.
+
+Sub-project A already exposes `spendKarma(amount, "purchase", refId?)` on `DataProvider`
+and the `spend_karma(p_amount, p_reason, p_ref_id)` RPC (race-safe, row-locked, raises
+`insufficient_karma`). Sub-project B exposes `notifyKarma(amount, reason)` (credit-only;
+no-ops on non-positive delta) plus the Sonner `Toaster` mounted in `app/layout.tsx`.
+
+---
+
+## 2. Decisions (locked)
+
+- **D1 — Buying grants use-rights, not a copy.** A purchase inserts an *entitlement* row
+  granting the buyer the right to **use** the original glyph (attach to pebbles/souls). One
+  source of truth; the creator keeps authorship; no stroke duplication.
+- **D2 — Price lives on the listing row, flat-defaulted.** `glyph_submissions.price` is a
+  per-listing column defaulting to a single constant (`GLYPH_PRICE_DEFAULT`). Flat today
+  (every row gets the default), but per-glyph already, so D can re-price one glyph later
+  without a schema change. The buy RPC reads the price **from the approved row** — the
+  client never supplies it.
+- **D3 — The submission row *is* the market listing.** `glyph_submissions.status` drives it:
+  `pending` (awaiting D) → `approved` (live in Market) → `rejected`. No separate listing table.
+- **D4 — Purchase history is captured now, analytics deferred (YAGNI).** `glyph_entitlements`
+  records `(glyph_id, user_id, karma_event_id, price_paid, created_at)` per purchase — enough
+  to derive buyers-per-glyph, buyers-per-month, and per-glyph revenue *whenever* those views
+  are built. `price_paid` is a **snapshot** so history survives any future price change.
+  "Glyph value" stays a derived aggregate (`SUM(price_paid)`, `COUNT(buyers)`, …), never a
+  stored column.
+- **D5 — Market stays empty until D approves.** Submissions land `pending`; Market shows only
+  `status='approved'`. Until D ships, approve a row by hand (`UPDATE … SET status='approved'`)
+  to test the buy flow. C ships **no** approve/reject UI.
+- **D6 — Purchase fires a *spend* activity, reusing B's Sonner infra.** A purchase is a debit,
+  so B's credit-only `notifyKarma` deliberately won't fire. C adds a sibling
+  `notifyGlyphPurchased(glyphId, name, amount)` rendering a **"✨ Glyph unlocked · −N karma"**
+  pill (tappable → the glyph's detail).
+- **D7 — Entitlement = usable everywhere own glyphs are.** For the grant to mean anything,
+  entitled glyphs appear in the glyph picker alongside owned glyphs (own ∪ entitled).
+
+---
+
+## 3. Data model
+
+Three new tables, all under RLS. Migrations in `packages/supabase/supabase/migrations/`.
+Regenerate `packages/supabase/types/database.ts` after (`npm run db:types --workspace=packages/supabase`).
+
+### 3.1 `glyph_submissions` — submission *and* market listing
+
+```sql
+create table public.glyph_submissions (
+  id            uuid primary key default gen_random_uuid(),
+  glyph_id      uuid not null references public.glyphs(id) on delete cascade,
+  submitter_id  uuid not null references auth.users(id),
+  status        text not null default 'pending'
+                  check (status in ('pending','approved','rejected')),
+  price         integer not null default 25 check (price > 0),  -- GLYPH_PRICE_DEFAULT
+  created_at    timestamptz not null default now(),
+  reviewed_at   timestamptz,
+  reviewed_by   uuid references auth.users(id)
+);
+
+-- At most one *active* (pending or approved) submission per glyph.
+create unique index glyph_submissions_one_active
+  on public.glyph_submissions (glyph_id)
+  where status in ('pending','approved');
+```
+
+`reviewed_at`/`reviewed_by` are written by D (left null by C). The `price` default literal
+must match `GLYPH_PRICE_DEFAULT` in TS (§5.1) — documented in a migration comment.
+
+### 3.2 `glyph_entitlements` — the use-rights grant + purchase ledger
+
+```sql
+create table public.glyph_entitlements (
+  id              uuid primary key default gen_random_uuid(),
+  user_id         uuid not null references auth.users(id),       -- buyer
+  glyph_id        uuid not null references public.glyphs(id) on delete cascade,
+  karma_event_id  uuid not null references public.karma_events(id),
+  price_paid      integer not null check (price_paid > 0),       -- snapshot at purchase
+  created_at      timestamptz not null default now(),
+  unique (user_id, glyph_id)   -- idempotency: no double-buy
+);
+```
+
+### 3.3 `glyph_favourites`
+
+```sql
+create table public.glyph_favourites (
+  user_id     uuid not null references auth.users(id),
+  glyph_id    uuid not null references public.glyphs(id) on delete cascade,
+  created_at  timestamptz not null default now(),
+  primary key (user_id, glyph_id)
+);
+```
+
+### 3.4 RLS
+
+```sql
+alter table public.glyph_submissions enable row level security;
+alter table public.glyph_entitlements enable row level security;
+alter table public.glyph_favourites   enable row level security;
+
+-- Submissions: read your own + any approved (the Market). Writes go through RPCs / D.
+create policy glyph_submissions_select on public.glyph_submissions for select
+  to authenticated
+  using (submitter_id = auth.uid() or status = 'approved');
+
+-- Entitlements: read your own. Inserts only via buy_glyph (security definer bypasses RLS).
+create policy glyph_entitlements_select on public.glyph_entitlements for select
+  to authenticated using (user_id = auth.uid());
+
+-- Favourites: full self-management.
+create policy glyph_favourites_all on public.glyph_favourites for all
+  to authenticated using (user_id = auth.uid()) with check (user_id = auth.uid());
+```
+
+**Critical knock-on — widen `glyphs` SELECT.** The Market and the picker must read *other
+people's* glyph rows (strokes/viewBox/name), which today's own-only policy forbids. Add a
+SELECT policy exposing exactly: own ∪ approved-in-market ∪ entitled.
+
+```sql
+create policy glyphs_select_market on public.glyphs for select
+  to authenticated
+  using (
+    user_id = auth.uid()
+    or exists (select 1 from public.glyph_submissions s
+               where s.glyph_id = glyphs.id and s.status = 'approved')
+    or exists (select 1 from public.glyph_entitlements e
+               where e.glyph_id = glyphs.id and e.user_id = auth.uid())
+  );
+```
+
+(If a single permissive `glyphs` SELECT policy already exists, replace it; verify the exact
+existing policy name during implementation before dropping.)
+
+---
+
+## 4. RPCs
+
+Both `security definer set search_path = public`, granted to `authenticated`, revoked from
+`public`/`anon`. New migration alongside the tables.
+
+### 4.1 `submit_glyph(p_glyph_id uuid) returns uuid`
+
+Multi-table (reads `glyphs`, writes `glyph_submissions`) → RPC per AGENTS.md.
+
+Logic / guards (each raises a distinct error):
+1. `not_authenticated` if `auth.uid()` is null.
+2. `not_owner` if the glyph's `user_id <> auth.uid()`.
+3. `not_custom` if the glyph is a system seed (`user_id is null` / `is_custom = false`).
+4. `already_submitted` if an active (pending|approved) submission exists for it
+   (the partial-unique index is the backstop; pre-check gives the clean error).
+5. Insert `(glyph_id, submitter_id, status='pending', price=default)`; return the new id.
+
+### 4.2 `buy_glyph(p_glyph_id uuid) returns table(entitlement_id uuid, balance integer)`
+
+Atomic spend + grant in **one transaction**.
+
+Logic / guards:
+1. `not_authenticated` if `auth.uid()` is null.
+2. Read the **approved** submission for `p_glyph_id` (`for share`); raise `not_in_market`
+   if none. Capture its `price`.
+3. `cannot_buy_own` if the glyph's `user_id = auth.uid()` (creators already hold use-rights).
+4. `already_owned` if an entitlement already exists for `(auth.uid(), p_glyph_id)`.
+5. `v_event_id := spend_karma(price, 'purchase', p_glyph_id)` — reuses A's row-locked guard;
+   propagates `insufficient_karma` on overdraw.
+6. Insert `glyph_entitlements (user_id, glyph_id, karma_event_id=v_event_id, price_paid=price)`.
+   The `unique(user_id, glyph_id)` is the race backstop — a concurrent double-buy rolls back
+   the loser's spend too (same txn), so the buyer is charged at most once.
+7. Return `(entitlement_id, new wallet balance)` so the client updates the karma store
+   without a full reload.
+
+**Error contract** (surfaced to UI, mapped EN/FR): `not_authenticated`, `not_in_market`,
+`cannot_buy_own`, `already_owned`, `insufficient_karma`.
+
+---
+
+## 5. Data layer (apps/web)
+
+### 5.1 Types & price constant
+
+`lib/config/glyphs.ts` (already holds `DEFAULT_GLYPH_ID`): add
+`export const GLYPH_PRICE_DEFAULT = 25` — display + sanity mirror of the SQL default
+(documented to stay in sync; server is authoritative).
+
+`lib/types.ts`:
+```ts
+export type GlyphSubmissionStatus = "pending" | "approved" | "rejected"
+
+export type MarketGlyph = Mark & {
+  price: number
+  owned: boolean        // caller is entitled (bought)
+  favourited: boolean   // caller has favourited
+}
+
+export type GlyphSubmission = {
+  id: string
+  glyph_id: string
+  status: GlyphSubmissionStatus
+  price: number
+  created_at: string
+}
+```
+
+### 5.2 `DataProvider` additions
+
+```ts
+listMarketGlyphs(): Promise<MarketGlyph[]>          // approved ∪ flags for caller
+listFavouriteGlyphs(): Promise<MarketGlyph[]>       // entitled ∪ favourited
+listUsableMarks(): Promise<Mark[]>                  // own ∪ entitled (for the picker, D7)
+getMySubmissions(): Promise<GlyphSubmission[]>      // for Mine-tab status badges
+submitGlyph(glyphId: string): Promise<GlyphSubmission>
+buyGlyph(glyphId: string): Promise<{ entitlementId: string; karma: number }>
+setFavourite(glyphId: string, favourite: boolean): Promise<void>
+```
+
+- **SupabaseProvider:** `submitGlyph`/`buyGlyph` call the RPCs; `buyGlyph` returns the
+  RPC's `balance` so the karma store updates in place. `setFavourite` is a single-table
+  insert/delete (RLS-guarded) — direct client call, no RPC. List methods join
+  `glyph_submissions`/`glyph_entitlements`/`glyph_favourites` to `glyphs` and map to
+  `MarketGlyph` (reuse the existing row→`Mark` mapper).
+- **LocalProvider:** mirror with local arrays. The local market is inherently self-only, so
+  `listMarketGlyphs` returns approved local submissions (empty by default). `buyGlyph`
+  debits local karma via the existing local spend path. Keeps the interface honest for
+  local-mode dev.
+
+### 5.3 Hooks
+
+- `useGlyphMarket()` → `{ glyphs, loading, buy, favourite, error }` (Market tab).
+- `useGlyphFavourites()` → `{ glyphs, loading, favourite }` (Favourites tab).
+- `useGlyphSubmissions()` → `{ submissions, loading, submit }` (Mine-tab badges + submit action).
+- `buy` updates the karma store from the RPC's returned balance, then fires
+  `notifyGlyphPurchased` (§6). It does **not** go through `notifyKarma`.
+
+---
+
+## 6. Activity — reuse B's primitive (D6)
+
+- `components/activity/GlyphPurchasePill.tsx` — sibling of `KarmaActivityPill`, same
+  always-dark capsule, `Sparkle` icon, text **"Glyph unlocked"** + **"−{amount} karma"**.
+  Tappable → the glyph's detail (`/glyphs/<id>`). Same a11y treatment: full sentence via
+  `aria-label`, visible content `aria-hidden`, `focus-visible` ring, `motion-reduce`.
+- `lib/activity/glyph-activity.tsx` — `notifyGlyphPurchased(glyphId, name, amount)` via
+  `toast.custom` with stable id `"glyph-activity"` (replace-on-new), `duration: 3000`,
+  wrapped in `flex w-full justify-center` (the centering fix B already learned).
+
+---
+
+## 7. UI
+
+### 7.1 `/glyphs` — three tabs
+
+shadcn `Tabs`: **Mine** · **Favourites** · **Market**. Tab state in the URL (`?tab=`,
+default `mine`) so the purchase pill and favourites are deep-linkable. New
+`components/glyphs/GlyphTabs.tsx` (client) owns tab state from `useSearchParams`.
+
+- **Mine** — existing `GlyphList`; each owned **custom** glyph gains a status-aware
+  "Submit to community" affordance (in `GlyphDetail` and/or card): not-submitted → CTA;
+  `pending`/`approved`/`rejected` → a badge. System seeds show no submit CTA.
+- **Market** — `MarketGlyphList` + `MarketGlyphCard` (glyph preview, karma price, Buy /
+  "Owned" state, favourite heart). Buy opens a shadcn confirm dialog → `buyGlyph`; on
+  success the glyph moves into Favourites and the pill fires; `insufficient_karma` and other
+  errors render inline (mapped EN/FR). Empty state when no approved listings.
+- **Favourites** — entitled ∪ favourited, rendered with the market card; heart toggles
+  favourite. Bought glyphs always appear here even if not explicitly favourited. Empty state.
+
+### 7.2 Picker (D7)
+
+`GlyphPickerDialog`/`GlyphPickerGrid` source from `listUsableMarks()` (own ∪ entitled) so a
+bought glyph is attachable to pebbles/souls. (Confirm exact current data source during
+implementation.)
+
+### 7.3 i18n (EN + FR, both files)
+
+- `glyphs.tabs.{mine,favourites,market}`
+- `glyphs.empty.{market,favourites}.{title,description}` (Mine keeps the existing empty state)
+- `glyphs.submit.{cta,pending,approved,rejected,confirmTitle,confirmDescription,confirm,cancel}`
+- `market.{price,buy,owned,buyTitle,buyDescription,buyConfirm,cancel,favourite,unfavourite}`
+  (`favourite`/`unfavourite` are aria-labels; `price` = `"{amount} karma"`)
+- `market.errors.{insufficient,notInMarket,cannotBuyOwn,alreadyOwned,generic}`
+- `activity.{glyphUnlocked,spent,srUnlocked,viewGlyph}` (`spent` = `"−{amount} karma"`;
+  `srUnlocked` = the full screen-reader sentence). FR mirrors using existing tone
+  (e.g. wallet is "Porte-karma").
+
+---
+
+## 8. Out of scope (→ Sub-project D)
+
+Admin moderation UI (approve/reject), raw-SVG upload/adjust, per-glyph price *editing* UI,
+themes/pebbleskins, creator payouts / revenue-share / resale. No Arkaik view-node change
+beyond the glyph tabs (revisit during the plan: tabs may warrant a bundle note).
+
+---
+
+## 9. Verification
+
+No web test runner (V1) — verification is lint + build + manual, per the prior sub-projects.
+
+- `npm run lint --workspace=apps/web` and `next build` green; `npm run db:types` regenerated
+  and committed.
+- **Manual (needs an authenticated dev session + a hand-approved listing):**
+  1. Submit an owned custom glyph → lands `pending`, badge shows; system seeds show no CTA.
+  2. `UPDATE glyph_submissions SET status='approved' WHERE …` → glyph appears in Market with price.
+  3. Buy with sufficient karma → karma debits by `price`, "✨ Glyph unlocked · −N karma" pill
+     fires, glyph appears under Favourites, Buy becomes "Owned".
+  4. Re-buy the same glyph → blocked (`already_owned`), not charged again.
+  5. Buy with insufficient karma → inline error, no debit.
+  6. Buy your own approved glyph → blocked (`cannot_buy_own`).
+  7. Favourite/unfavourite a market glyph → moves in/out of Favourites.
+  8. Attach a bought glyph to a pebble via the picker (D7).
+  9. EN + FR across all new surfaces; pill respects reduced-motion + dark/color-world.
+
+---
+
+## 10. Decision-log entries to append at PR time
+
+- Glyph buy = use-rights entitlement (not a copy); price on the listing row, flat-defaulted;
+  `price_paid` snapshot captures the purchase ledger for deferred per-glyph analytics.
+- `buy_glyph` RPC wraps `spend_karma` + entitlement insert atomically; idempotent via
+  `unique(user_id, glyph_id)`. New goods reuse this shape.
+- `glyphs` SELECT widened to own ∪ approved-listed ∪ entitled — the one place community
+  glyph rows become readable; future market goods must keep this policy in mind.

--- a/docs/superpowers/specs/2026-06-30-issue-496-glyph-marketplace-design.md
+++ b/docs/superpowers/specs/2026-06-30-issue-496-glyph-marketplace-design.md
@@ -56,6 +56,12 @@ no-ops on non-positive delta) plus the Sonner `Toaster` mounted in `app/layout.t
   pill (tappable → the glyph's detail).
 - **D7 — Entitlement = usable everywhere own glyphs are.** For the grant to mean anything,
   entitled glyphs appear in the glyph picker alongside owned glyphs (own ∪ entitled).
+- **D8 — A listed/bought glyph is immutable to its creator (backend-enforced).** Once a glyph
+  is actively listed (`pending`|`approved`) or has any entitlement, the creator can no longer
+  edit or delete it — **only an admin can** (D's curation domain). Enforced in RLS (§3.4), not
+  just the UI; a frontend-only lock would be bypassable via the raw update path. Rationale:
+  the strokes are what buyers paid for (no bait-and-switch), and `on delete cascade` would
+  otherwise let a creator erase buyers' entitlements.
 
 ---
 
@@ -134,15 +140,27 @@ create policy glyph_favourites_all on public.glyph_favourites for all
   to authenticated using (user_id = auth.uid()) with check (user_id = auth.uid());
 ```
 
-**Critical knock-on — widen `glyphs` SELECT.** The Market and the picker must read *other
-people's* glyph rows (strokes/viewBox/name), which today's own-only policy forbids. Add a
-SELECT policy exposing exactly: own ∪ approved-in-market ∪ entitled.
+**Critical knock-on — rewrite `glyphs` SELECT/UPDATE/DELETE.** Today (from
+`20260415000001_remote_pebble_engine.sql` + `20260411000001_core_tables.sql`):
 
 ```sql
-create policy glyphs_select_market on public.glyphs for select
-  to authenticated
+glyphs_select : using (user_id = auth.uid() or user_id is null)   -- own ∪ system seeds
+glyphs_update : using (user_id = auth.uid())
+glyphs_delete : using (user_id = auth.uid())
+```
+
+Two changes, both drop-and-recreate the named policies (preserving the `user_id is null`
+system-seed clause):
+
+**(a) Widen SELECT** so the Market and picker can read *other people's* listed/bought glyph
+rows (strokes/viewBox/name) — own ∪ system seeds ∪ approved-in-market ∪ entitled:
+
+```sql
+drop policy if exists "glyphs_select" on public.glyphs;
+create policy "glyphs_select" on public.glyphs for select to authenticated
   using (
     user_id = auth.uid()
+    or user_id is null                                          -- system seeds
     or exists (select 1 from public.glyph_submissions s
                where s.glyph_id = glyphs.id and s.status = 'approved')
     or exists (select 1 from public.glyph_entitlements e
@@ -150,8 +168,38 @@ create policy glyphs_select_market on public.glyphs for select
   );
 ```
 
-(If a single permissive `glyphs` SELECT policy already exists, replace it; verify the exact
-existing policy name during implementation before dropping.)
+**(b) Lock listed/bought glyphs (D8).** A creator may no longer UPDATE or DELETE a glyph once
+it is actively listed (`pending`|`approved`) **or** has been bought by anyone — admins are
+exempt (D curates listed glyphs). This is the integrity rule behind the user's "once locked,
+not editable except by admin": the strokes are what buyers paid for, and `on delete cascade`
+would otherwise let a creator wipe buyers' entitlements.
+
+```sql
+-- shared lock predicate, inlined into both policies:
+--   not actively listed AND not bought
+--   not exists (… glyph_submissions s where s.glyph_id = id and s.status in ('pending','approved'))
+--   not exists (… glyph_entitlements e where e.glyph_id = id)
+
+drop policy if exists "glyphs_update" on public.glyphs;
+create policy "glyphs_update" on public.glyphs for update to authenticated
+  using (
+    public.is_admin(auth.uid())
+    or (
+      user_id = auth.uid()
+      and not exists (select 1 from public.glyph_submissions s
+                      where s.glyph_id = glyphs.id and s.status in ('pending','approved'))
+      and not exists (select 1 from public.glyph_entitlements e
+                      where e.glyph_id = glyphs.id)
+    )
+  );
+
+drop policy if exists "glyphs_delete" on public.glyphs;
+create policy "glyphs_delete" on public.glyphs for delete to authenticated
+  using ( /* identical predicate to glyphs_update */ );
+```
+
+Verify the exact live policy names/bodies before dropping (they match the snapshot above as of
+this spec).
 
 ---
 
@@ -276,7 +324,10 @@ default `mine`) so the purchase pill and favourites are deep-linkable. New
 
 - **Mine** — existing `GlyphList`; each owned **custom** glyph gains a status-aware
   "Submit to community" affordance (in `GlyphDetail` and/or card): not-submitted → CTA;
-  `pending`/`approved`/`rejected` → a badge. System seeds show no submit CTA.
+  `pending`/`approved`/`rejected` → a badge. System seeds show no submit CTA. **Reflect the
+  D8 lock:** when a glyph is actively listed or bought, `GlyphDetail` hides the
+  edit-name/delete controls and shows a "Listed — locked" indicator (the RLS policy is the
+  real enforcement; this is just honest UX so the user isn't offered an action that will fail).
 - **Market** — `MarketGlyphList` + `MarketGlyphCard` (glyph preview, karma price, Buy /
   "Owned" state, favourite heart). Buy opens a shadcn confirm dialog → `buyGlyph`; on
   success the glyph moves into Favourites and the pill fires; `insufficient_karma` and other
@@ -328,7 +379,10 @@ No web test runner (V1) — verification is lint + build + manual, per the prior
   6. Buy your own approved glyph → blocked (`cannot_buy_own`).
   7. Favourite/unfavourite a market glyph → moves in/out of Favourites.
   8. Attach a bought glyph to a pebble via the picker (D7).
-  9. EN + FR across all new surfaces; pill respects reduced-motion + dark/color-world.
+  9. **D8 lock:** with a glyph listed (pending or approved) or bought, `updateMark`/`deleteMark`
+     are rejected by RLS for the creator (and the UI hides the controls); an admin can still
+     edit. Confirm a non-listed glyph remains editable as before.
+  10. EN + FR across all new surfaces; pill respects reduced-motion + dark/color-world.
 
 ---
 
@@ -338,5 +392,7 @@ No web test runner (V1) — verification is lint + build + manual, per the prior
   `price_paid` snapshot captures the purchase ledger for deferred per-glyph analytics.
 - `buy_glyph` RPC wraps `spend_karma` + entitlement insert atomically; idempotent via
   `unique(user_id, glyph_id)`. New goods reuse this shape.
-- `glyphs` SELECT widened to own ∪ approved-listed ∪ entitled — the one place community
-  glyph rows become readable; future market goods must keep this policy in mind.
+- `glyphs` SELECT widened to own ∪ system seeds ∪ approved-listed ∪ entitled — the one place
+  community glyph rows become readable; future market goods must keep this policy in mind.
+- Listed/bought glyphs are immutable to their creator (RLS UPDATE/DELETE lock, admin-exempt) —
+  protects what buyers paid for; only an admin (D) may edit a listed glyph.

--- a/packages/supabase/supabase/migrations/20260630003348_glyph_marketplace.sql
+++ b/packages/supabase/supabase/migrations/20260630003348_glyph_marketplace.sql
@@ -1,0 +1,207 @@
+-- =============================================================================
+-- Glyph marketplace (#496) — submissions/listings, entitlements, favourites,
+-- submit_glyph + buy_glyph RPCs, market view, and glyphs policy rewrite (D8).
+-- Price is per-listing, flat-defaulted; GLYPH_PRICE_DEFAULT mirror in
+-- apps/web/lib/config/glyphs.ts must stay in sync with the default literal below.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Tables
+-- ---------------------------------------------------------------------------
+create table public.glyph_submissions (
+  id            uuid primary key default gen_random_uuid(),
+  glyph_id      uuid not null references public.glyphs(id) on delete cascade,
+  submitter_id  uuid not null references auth.users(id),
+  status        text not null default 'pending'
+                  check (status in ('pending','approved','rejected')),
+  price         integer not null default 25 check (price > 0),  -- GLYPH_PRICE_DEFAULT
+  created_at    timestamptz not null default now(),
+  reviewed_at   timestamptz,
+  reviewed_by   uuid references auth.users(id)
+);
+
+-- At most one active (pending|approved) submission per glyph.
+create unique index glyph_submissions_one_active
+  on public.glyph_submissions (glyph_id)
+  where status in ('pending','approved');
+
+create index glyph_submissions_status_idx on public.glyph_submissions (status);
+
+create table public.glyph_entitlements (
+  id              uuid primary key default gen_random_uuid(),
+  user_id         uuid not null references auth.users(id),
+  glyph_id        uuid not null references public.glyphs(id) on delete cascade,
+  karma_event_id  uuid not null references public.karma_events(id),
+  price_paid      integer not null check (price_paid > 0),
+  created_at      timestamptz not null default now(),
+  unique (user_id, glyph_id)
+);
+
+create index glyph_entitlements_glyph_idx on public.glyph_entitlements (glyph_id);
+
+create table public.glyph_favourites (
+  user_id     uuid not null references auth.users(id),
+  glyph_id    uuid not null references public.glyphs(id) on delete cascade,
+  created_at  timestamptz not null default now(),
+  primary key (user_id, glyph_id)
+);
+
+-- ---------------------------------------------------------------------------
+-- 2. RLS
+-- ---------------------------------------------------------------------------
+alter table public.glyph_submissions enable row level security;
+alter table public.glyph_entitlements enable row level security;
+alter table public.glyph_favourites   enable row level security;
+
+create policy glyph_submissions_select on public.glyph_submissions for select
+  to authenticated
+  using (submitter_id = auth.uid() or status = 'approved');
+
+create policy glyph_entitlements_select on public.glyph_entitlements for select
+  to authenticated using (user_id = auth.uid());
+
+create policy glyph_favourites_all on public.glyph_favourites for all
+  to authenticated using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+-- ---------------------------------------------------------------------------
+-- 3. glyphs policy rewrite — widen SELECT, lock UPDATE/DELETE (D8)
+--    Current (snapshot): glyphs_select = own ∪ null; update/delete = own.
+-- ---------------------------------------------------------------------------
+drop policy if exists "glyphs_select" on public.glyphs;
+create policy "glyphs_select" on public.glyphs for select to authenticated
+  using (
+    user_id = auth.uid()
+    or user_id is null
+    or exists (select 1 from public.glyph_submissions s
+               where s.glyph_id = glyphs.id and s.status = 'approved')
+    or exists (select 1 from public.glyph_entitlements e
+               where e.glyph_id = glyphs.id and e.user_id = auth.uid())
+  );
+
+drop policy if exists "glyphs_update" on public.glyphs;
+create policy "glyphs_update" on public.glyphs for update to authenticated
+  using (
+    public.is_admin(auth.uid())
+    or (
+      user_id = auth.uid()
+      and not exists (select 1 from public.glyph_submissions s
+                      where s.glyph_id = glyphs.id and s.status in ('pending','approved'))
+      and not exists (select 1 from public.glyph_entitlements e
+                      where e.glyph_id = glyphs.id)
+    )
+  );
+
+drop policy if exists "glyphs_delete" on public.glyphs;
+create policy "glyphs_delete" on public.glyphs for delete to authenticated
+  using (
+    public.is_admin(auth.uid())
+    or (
+      user_id = auth.uid()
+      and not exists (select 1 from public.glyph_submissions s
+                      where s.glyph_id = glyphs.id and s.status in ('pending','approved'))
+      and not exists (select 1 from public.glyph_entitlements e
+                      where e.glyph_id = glyphs.id)
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 4. RPCs
+-- ---------------------------------------------------------------------------
+-- Submit one of your own custom glyphs to the community (lands pending for D).
+create or replace function public.submit_glyph(p_glyph_id uuid)
+returns jsonb
+language plpgsql security definer set search_path = public as $$
+declare
+  v_user  uuid := auth.uid();
+  v_owner uuid;
+  v_row   public.glyph_submissions;
+begin
+  if v_user is null then raise exception 'not_authenticated' using errcode='42501'; end if;
+
+  select user_id into v_owner from public.glyphs where id = p_glyph_id;
+  if v_owner is distinct from v_user then
+    raise exception 'not_owner' using errcode='42501';  -- covers system glyphs (null owner)
+  end if;
+
+  if exists (select 1 from public.glyph_submissions s
+             where s.glyph_id = p_glyph_id and s.status in ('pending','approved')) then
+    raise exception 'already_submitted';
+  end if;
+
+  insert into public.glyph_submissions (glyph_id, submitter_id)
+  values (p_glyph_id, v_user)
+  returning * into v_row;
+
+  return to_jsonb(v_row);
+end;
+$$;
+
+-- Buy a community glyph: spend karma + grant use-rights, atomically.
+create or replace function public.buy_glyph(p_glyph_id uuid)
+returns jsonb
+language plpgsql security definer set search_path = public as $$
+declare
+  v_user    uuid := auth.uid();
+  v_price   integer;
+  v_owner   uuid;
+  v_event   uuid;
+  v_ent     uuid;
+  v_balance integer;
+begin
+  if v_user is null then raise exception 'not_authenticated' using errcode='42501'; end if;
+
+  -- Must be an approved (in-market) listing.
+  select s.price, g.user_id into v_price, v_owner
+  from public.glyph_submissions s
+  join public.glyphs g on g.id = s.glyph_id
+  where s.glyph_id = p_glyph_id and s.status = 'approved'
+  limit 1;
+  if v_price is null then raise exception 'not_in_market'; end if;
+
+  if v_owner = v_user then raise exception 'cannot_buy_own'; end if;
+
+  if exists (select 1 from public.glyph_entitlements e
+             where e.user_id = v_user and e.glyph_id = p_glyph_id) then
+    raise exception 'already_owned';
+  end if;
+
+  -- Spend (row-locked, raises insufficient_karma); records a withdraw event.
+  v_event := public.spend_karma(v_price, 'purchase', p_glyph_id);
+
+  -- Grant. unique(user_id, glyph_id) is the race backstop — a concurrent
+  -- double-buy rolls back the loser's spend too (same txn).
+  insert into public.glyph_entitlements (user_id, glyph_id, karma_event_id, price_paid)
+  values (v_user, p_glyph_id, v_event, v_price)
+  returning id into v_ent;
+
+  select balance into v_balance from public.wallet_balances where user_id = v_user;
+
+  return jsonb_build_object('entitlement_id', v_ent, 'balance', v_balance);
+end;
+$$;
+
+revoke all on function public.submit_glyph(uuid) from public, anon;
+revoke all on function public.buy_glyph(uuid)    from public, anon;
+grant execute on function public.submit_glyph(uuid) to authenticated;
+grant execute on function public.buy_glyph(uuid)    to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 5. Market view — approved listings + per-caller owned/favourited flags.
+--    security_invoker so the caller's RLS (widened glyphs SELECT, own
+--    entitlements/favourites) applies.
+-- ---------------------------------------------------------------------------
+create view public.v_glyph_market with (security_invoker = true) as
+select
+  g.id, g.user_id, g.name, g.shape_id, g.strokes, g.view_box,
+  g.created_at, g.updated_at,
+  s.price,
+  exists (select 1 from public.glyph_entitlements e
+          where e.glyph_id = g.id and e.user_id = auth.uid()) as owned,
+  exists (select 1 from public.glyph_favourites f
+          where f.glyph_id = g.id and f.user_id = auth.uid()) as favourited
+from public.glyph_submissions s
+join public.glyphs g on g.id = s.glyph_id
+where s.status = 'approved';
+
+revoke all on public.v_glyph_market from public, anon;
+grant select on public.v_glyph_market to authenticated;

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -216,6 +216,13 @@ export type Database = {
             referencedRelation: "glyphs"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "domains_default_glyph_id_fkey"
+            columns: ["default_glyph_id"]
+            isOneToOne: false
+            referencedRelation: "v_glyph_market"
+            referencedColumns: ["id"]
+          },
         ]
       }
       emotion_categories: {
@@ -287,6 +294,220 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "v_emotions_with_palette"
             referencedColumns: ["category_id"]
+          },
+        ]
+      }
+      glyph_entitlements: {
+        Row: {
+          created_at: string
+          glyph_id: string
+          id: string
+          karma_event_id: string
+          price_paid: number
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          glyph_id: string
+          id?: string
+          karma_event_id: string
+          price_paid: number
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          glyph_id?: string
+          id?: string
+          karma_event_id?: string
+          price_paid?: number
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "glyph_entitlements_glyph_id_fkey"
+            columns: ["glyph_id"]
+            isOneToOne: false
+            referencedRelation: "glyphs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "glyph_entitlements_glyph_id_fkey"
+            columns: ["glyph_id"]
+            isOneToOne: false
+            referencedRelation: "v_glyph_market"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "glyph_entitlements_karma_event_id_fkey"
+            columns: ["karma_event_id"]
+            isOneToOne: false
+            referencedRelation: "karma_events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "glyph_entitlements_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "v_bounce"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "glyph_entitlements_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "v_karma_summary"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "glyph_entitlements_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "v_ripple"
+            referencedColumns: ["user_id"]
+          },
+        ]
+      }
+      glyph_favourites: {
+        Row: {
+          created_at: string
+          glyph_id: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          glyph_id: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          glyph_id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "glyph_favourites_glyph_id_fkey"
+            columns: ["glyph_id"]
+            isOneToOne: false
+            referencedRelation: "glyphs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "glyph_favourites_glyph_id_fkey"
+            columns: ["glyph_id"]
+            isOneToOne: false
+            referencedRelation: "v_glyph_market"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "glyph_favourites_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "v_bounce"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "glyph_favourites_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "v_karma_summary"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "glyph_favourites_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "v_ripple"
+            referencedColumns: ["user_id"]
+          },
+        ]
+      }
+      glyph_submissions: {
+        Row: {
+          created_at: string
+          glyph_id: string
+          id: string
+          price: number
+          reviewed_at: string | null
+          reviewed_by: string | null
+          status: string
+          submitter_id: string
+        }
+        Insert: {
+          created_at?: string
+          glyph_id: string
+          id?: string
+          price?: number
+          reviewed_at?: string | null
+          reviewed_by?: string | null
+          status?: string
+          submitter_id: string
+        }
+        Update: {
+          created_at?: string
+          glyph_id?: string
+          id?: string
+          price?: number
+          reviewed_at?: string | null
+          reviewed_by?: string | null
+          status?: string
+          submitter_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "glyph_submissions_glyph_id_fkey"
+            columns: ["glyph_id"]
+            isOneToOne: false
+            referencedRelation: "glyphs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "glyph_submissions_glyph_id_fkey"
+            columns: ["glyph_id"]
+            isOneToOne: false
+            referencedRelation: "v_glyph_market"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "glyph_submissions_reviewed_by_fkey"
+            columns: ["reviewed_by"]
+            isOneToOne: false
+            referencedRelation: "v_bounce"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "glyph_submissions_reviewed_by_fkey"
+            columns: ["reviewed_by"]
+            isOneToOne: false
+            referencedRelation: "v_karma_summary"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "glyph_submissions_reviewed_by_fkey"
+            columns: ["reviewed_by"]
+            isOneToOne: false
+            referencedRelation: "v_ripple"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "glyph_submissions_submitter_id_fkey"
+            columns: ["submitter_id"]
+            isOneToOne: false
+            referencedRelation: "v_bounce"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "glyph_submissions_submitter_id_fkey"
+            columns: ["submitter_id"]
+            isOneToOne: false
+            referencedRelation: "v_karma_summary"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "glyph_submissions_submitter_id_fkey"
+            columns: ["submitter_id"]
+            isOneToOne: false
+            referencedRelation: "v_ripple"
+            referencedColumns: ["user_id"]
           },
         ]
       }
@@ -751,6 +972,13 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "pebbles_glyph_id_fkey"
+            columns: ["glyph_id"]
+            isOneToOne: false
+            referencedRelation: "v_glyph_market"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "pebbles_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
@@ -822,6 +1050,13 @@ export type Database = {
             columns: ["glyph_id"]
             isOneToOne: false
             referencedRelation: "glyphs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "profiles_glyph_id_fkey"
+            columns: ["glyph_id"]
+            isOneToOne: false
+            referencedRelation: "v_glyph_market"
             referencedColumns: ["id"]
           },
           {
@@ -941,6 +1176,13 @@ export type Database = {
             columns: ["glyph_id"]
             isOneToOne: false
             referencedRelation: "glyphs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "souls_glyph_id_fkey"
+            columns: ["glyph_id"]
+            isOneToOne: false
+            referencedRelation: "v_glyph_market"
             referencedColumns: ["id"]
           },
           {
@@ -1150,6 +1392,51 @@ export type Database = {
         }
         Relationships: []
       }
+      v_glyph_market: {
+        Row: {
+          created_at: string | null
+          favourited: boolean | null
+          id: string | null
+          name: string | null
+          owned: boolean | null
+          price: number | null
+          shape_id: string | null
+          strokes: Json | null
+          updated_at: string | null
+          user_id: string | null
+          view_box: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "glyphs_shape_id_fkey"
+            columns: ["shape_id"]
+            isOneToOne: false
+            referencedRelation: "pebble_shapes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "glyphs_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "v_bounce"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "glyphs_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "v_karma_summary"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "glyphs_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "v_ripple"
+            referencedColumns: ["user_id"]
+          },
+        ]
+      }
       v_karma_summary: {
         Row: {
           pebbles_count: number | null
@@ -1243,6 +1530,13 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "pebbles_glyph_id_fkey"
+            columns: ["glyph_id"]
+            isOneToOne: false
+            referencedRelation: "v_glyph_market"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "pebbles_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
@@ -1319,6 +1613,7 @@ export type Database = {
       }
     }
     Functions: {
+      buy_glyph: { Args: { p_glyph_id: string }; Returns: Json }
       compute_karma_delta: {
         Args: {
           p_cards_count: number
@@ -1527,6 +1822,7 @@ export type Database = {
         Args: { p_amount: number; p_reason: string; p_ref_id?: string }
         Returns: string
       }
+      submit_glyph: { Args: { p_glyph_id: string }; Returns: Json }
       sweep_orphan_snap_files: {
         Args: never
         Returns: {


### PR DESCRIPTION
Resolves #496

**Sub-project C of 4** in **M36 · Pebblestore & Karma Economy**. The first thing the Pebblestore actually sells: **community glyphs**, bought with karma over Sub-project A's spend rails and surfaced via Sub-project B's activity pill.

## What this does

- **Three tabs on `/glyphs`** — **Mine** · **Favourites** · **Market** (URL-synced via `?tab=`, Suspense-wrapped).
- **Submit to community.** An owned *custom* glyph can be submitted (`submit_glyph`) → lands **pending** for admin review (moderation UI is Sub-project D). Mine shows a status badge.
- **Buy with karma.** `buy_glyph` spends karma and grants a **use-rights entitlement** (not a copy) in **one transaction** — race-safe (wallet row-lock + `unique(user_id, glyph_id)`), idempotent, and guarded (`not_in_market` / `cannot_buy_own` / `already_owned` / `insufficient_karma`, mapped to inline EN/FR errors). A successful buy fires a **"✨ Glyph unlocked · −N karma"** pill (a dedicated *spend* activity, reusing B's Sonner primitive — not credit-only `notifyKarma`).
- **Favourites.** Heart-toggle on market cards; the Favourites tab is **bought ∪ favourited** (favourited-but-not-owned glyphs stay buyable from there).
- **Use-rights are real (D7).** Entitled glyphs render when attached to pebbles/souls (merged into `useLookupMaps`) and are selectable in the glyph picker (`own ∪ entitled`).
- **Listed glyphs are creator-immutable (D8).** Once a glyph is listed (pending/approved) or bought, its creator can no longer edit or delete it — **only an admin** can. Enforced in **RLS** (not just UI); the UI reflects it ("Listed — locked"). Protects what buyers paid for and prevents a cascade-delete from wiping entitlements.

## Pricing & ledger

Price is **per-listing** (`glyph_submissions.price`, flat-defaulted to 25, server-authoritative), so D can re-price one glyph later with no schema change. Each purchase snapshots **`price_paid`** on the entitlement — a per-glyph purchase ledger (buyers/month, revenue) that survives future price changes. "Glyph value" stays a derived aggregate, not a stored column.

## Key files

- **DB:** `packages/supabase/supabase/migrations/20260630003348_glyph_marketplace.sql` (3 tables, RLS, `glyphs` policy rewrite for D8, `submit_glyph`/`buy_glyph`, `v_glyph_market` `security_invoker` view) + regenerated `types/database.ts`.
- **Data layer:** `lib/types.ts`, `lib/config/glyphs.ts`, `lib/data/data-provider.ts`, `lib/data/supabase-provider.ts`, hooks `useGlyphMarket`/`useGlyphFavourites`/`useGlyphSubmissions`/`useUsableGlyphs`, `useLookupMaps.ts`.
- **UI:** `components/glyphs/` (`GlyphTabs`, `MarketGlyphCard`, `BuyGlyphDialog`, `MarketGlyphs`, `FavouriteGlyphs`, `SubmitToCommunity`, `GlyphDetail`), `app/glyphs/page.tsx`, `app/glyphs/[id]/page.tsx`, picker call-sites; `components/activity/GlyphPurchasePill.tsx`, `lib/activity/glyph-activity.tsx`; EN/FR i18n.
- **Docs:** spec + plan under `docs/superpowers/`, two `docs/decisions/log.md` entries.

## RLS / security summary

Entitlements are insertable **only** via the `security definer` `buy_glyph` (no INSERT policy); entitlements/favourites are self-read-only; submissions are own + approved. The widened `glyphs` SELECT exposes **only** own ∪ system-seeds ∪ approved-listed ∪ own-entitled. Reviewed end-to-end (whole-branch adversarial pass on the DB/atomicity/RLS layer) — no blockers.

## Verification

- `tsc --noEmit`, `eslint`, and `next build` green; migration applied to remote, `db:types:remote` regenerated.
- ⚠️ **Pending (pre-release human step):** the interactive manual pass — submit → **hand-approve a listing** (`update glyph_submissions set status='approved'`) → buy as a **second** account → pill → favourites → attach via picker; plus the D8 lock (creator update/delete denied while listed, admin allowed) and EN/FR + reduced-motion/dark. Needs two authenticated accounts, so it wasn't automated.

## Decision log

Two entries added (2026-06-30): *use-rights entitlements + per-listing price + atomic buy*, and *widened glyph SELECT + creator-immutability lock (D8)*.

## Out of scope (→ Sub-project D)

Admin moderation UI (approve/reject), raw-SVG upload/adjust, per-glyph price *editing* UI. Themes/pebbleskins and creator payouts/resale are future. Market stays empty until a submission is approved.

## Lab Note (EN/FR)

<!-- DRAFT ONLY — a human curates and publishes via the Lab admin (`logs` table, `released_at`) at release time. -->

**EN — "A glyph market, powered by your karma"**
Share your glyphs with the community, discover others', and unlock the ones you love with the karma you've earned — they're yours to use on your pebbles. A quick spark celebrates each unlock.

**FR — "Un marché de glyphes, animé par votre karma"**
Partagez vos glyphes avec la communauté, découvrez ceux des autres et débloquez vos préférés avec le karma gagné — ils sont à vous, à poser sur vos cailloux. Une petite étincelle célèbre chaque déblocage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
