### PR TITLE
fix(ui): make large pebble name/time readable in light mode

### DIFF
--- a/apps/ios/Pebbles/Features/Path/Components/PathPebbleRow.swift
+++ b/apps/ios/Pebbles/Features/Path/Components/PathPebbleRow.swift
@@ -7,8 +7,11 @@ import SwiftUI
 ///     `palette.secondary` glyph stroke; name color follows the scheme
 ///     (light=primary, dark=light).
 ///   - intensity 3 (large): 96pt thumbnail with `palette.primary` fill and
-///     `palette.light` glyph stroke; name color is `palette.light` in both
-///     schemes (the primary fill carries scheme contrast).
+///     `palette.light` glyph stroke.
+///
+/// Only the glyph render differs by size — the name/time color follows the
+/// scheme at every size (light=primary, dark=light), because the text sits on
+/// the row background rather than the pebble fill (#510).
 ///
 /// Colors are sourced from `palette.pebbleFrameColors(forIntensity:)`.
 ///
@@ -119,8 +122,7 @@ struct PathPebbleRow: View {
 
     private var nameColor: Color {
         guard let palette else { return Color.system.foreground }
-        if isLarge { return palette.light }
-        return colorScheme == .dark ? palette.light : palette.primary
+        return PathPebbleRow.nameColor(palette: palette, isLarge: isLarge, colorScheme: colorScheme)
     }
 
     /// Weekday + time only — the focused week is already known from
@@ -160,6 +162,15 @@ struct PathPebbleRow: View {
 }
 
 extension PathPebbleRow {
+
+    /// Name + time text color. The text sits on the row background — not on
+    /// the pebble's `primary` fill, which only backs the glyph thumbnail — so
+    /// it must contrast the scheme background at *every* size. `isLarge` is
+    /// accepted only to prove size doesn't change the answer (#510): light
+    /// scheme → `primary` (dark ink), dark scheme → `light` (pale ink).
+    static func nameColor(palette: EmotionPalette, isLarge: Bool, colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? palette.light : palette.primary
+    }
 
     /// Photo rotation by row position. Even indices (0, 2, 4...) lean
     /// counter-clockwise (-7°); odd lean clockwise (+4°).

--- a/apps/ios/PebblesTests/PathPebbleRowNameColorTests.swift
+++ b/apps/ios/PebblesTests/PathPebbleRowNameColorTests.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import Testing
+@testable import Pebbles
+
+@Suite("PathPebbleRow name color")
+struct PathPebbleRowNameColorTests {
+
+    private let palette = EmotionPalette(
+        primaryHex:   "#C07A7AFF",
+        secondaryHex: "#9B5C5CFF",
+        lightHex:     "#E8B8B8FF",
+        surfaceHex:   "#C07A7A1A"
+    )!
+
+    // Regression (#510): large pebble name/time were unreadable in light
+    // mode because they rendered in `palette.light` (a pale tint) on the
+    // white row background. The text sits on the row background, not the
+    // pebble fill, so it must contrast the scheme background at every size.
+
+    @Test("light scheme uses primary (dark ink) at every size")
+    func lightScheme() {
+        #expect(PathPebbleRow.nameColor(palette: palette, isLarge: false, colorScheme: .light) == palette.primary)
+        #expect(PathPebbleRow.nameColor(palette: palette, isLarge: true, colorScheme: .light) == palette.primary)
+    }
+
+    @Test("dark scheme uses light (pale ink) at every size")
+    func darkScheme() {
+        #expect(PathPebbleRow.nameColor(palette: palette, isLarge: false, colorScheme: .dark) == palette.light)
+        #expect(PathPebbleRow.nameColor(palette: palette, isLarge: true, colorScheme: .dark) == palette.light)
+    }
+
+    @Test("large and small resolve to the same color in a given scheme")
+    func sizeDoesNotAffectColor() {
+        for scheme in [ColorScheme.light, .dark] {
+            #expect(
+                PathPebbleRow.nameColor(palette: palette, isLarge: true, colorScheme: scheme)
+                    == PathPebbleRow.nameColor(palette: palette, isLarge: false, colorScheme: scheme),
+                "scheme \(scheme)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Resolves #510

## Problem

In light mode on the Path, a **large** pebble's name and time were invisible. Small/medium pebbles read fine, and dark mode was unaffected.

## Root cause

`PathPebbleRow.nameColor` special-cased large pebbles (`intensity ≥ 3`) to always use `palette.light`, regardless of color scheme. `palette.light` is the palette's pale accent-*foreground*, designed to sit on top of the opaque `primary` fill. But the name/time text does **not** sit on that fill — the fill only backs the glyph thumbnail on the left. The text sits on the plain list-row background:

- **Dark mode:** dark background + pale text → readable (bug masked).
- **Light mode:** white background + pale `light` text → invisible.

The struct's own doc comment justified this with "the primary fill carries scheme contrast" — a faulty rationale, since nothing carries contrast behind the text.

## Fix

Name/time now follow the same scheme-dependent rule as small/medium rows at **every** size — `light` scheme → `primary` (dark ink), `dark` scheme → `light` (pale ink). Only the petroglyph render still differs by size, exactly as the issue's *Expected* section describes.

## Key files

- `Pebbles/Features/Path/Components/PathPebbleRow.swift` — drop the `isLarge` branch in `nameColor`; extract a testable static `nameColor(palette:isLarge:colorScheme:)` helper (matching the file's existing static-helper convention) and correct the stale doc comment.
- `PebblesTests/PathPebbleRowNameColorTests.swift` — regression tests: light→primary and dark→light at every size, plus size-independence.

## Verification

`xcodebuild test -only-testing:PebblesTests/PathPebbleRowNameColorTests` — 3/3 pass; app target compiles clean as part of the test build.

## Lab Note (EN/FR)

**EN — Readable pebble names in Light mode**
Large pebble names and times on your Path are now clearly readable in Light mode, matching every other pebble size.

**FR — Noms de galets lisibles en mode clair**
Les noms et horaires des grands galets de votre Chemin sont désormais bien lisibles en mode clair, comme pour toutes les autres tailles de galet.
