### PR TITLE
feat(ui): render pebble page emotion/domain/collection as tiles

### DIFF
--- a/apps/ios/Pebbles/Features/Path/Read/PebbleReadView.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/PebbleReadView.swift
@@ -9,8 +9,6 @@ import SwiftUI
 struct PebbleReadView: View {
     let detail: PebbleDetail
 
-    @Environment(EmotionPaletteService.self) private var palettes
-
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
@@ -44,46 +42,38 @@ struct PebbleReadView: View {
         .background(Color.system.background)
     }
 
+    /// Emotion / domain / collection as the shared `SurfaceTile`s — the same
+    /// tiles used for the profile shortcuts and glyph swap stats (issue #513).
+    /// Page-wide emotion palette coloring is intentionally out of scope, so the
+    /// emotion tile keeps the default accent surface like its neighbours.
     @ViewBuilder
     private var metadataRow: some View {
-        PebblePillFlow {
+        HStack(spacing: Spacing.sm) {
             // Emotion — always present.
-            let palette = palettes.palette(for: detail.emotion.id)
-            PebbleMetaPill(
-                icon: .system("heart.fill"),
-                label: LocalizedStringResource(stringLiteral: detail.emotion.localizedName),
-                style: .emotion(
-                    background: palette?.accentBackground ?? Color.accent.primary,
-                    foreground: palette?.accentForeground ?? .white
-                )
-            )
+            SurfaceTile(systemImage: "heart.fill") {
+                Text(LocalizedStringResource(stringLiteral: detail.emotion.localizedName))
+            }
 
-            // Domain — always rendered. Set when non-empty, else dashed unset.
+            // Domain — always rendered. Muted placeholder when unset.
             if detail.domains.isEmpty {
-                PebbleMetaPill(
-                    icon: .system("square.grid.2x2"),
-                    label: "No domain",
-                    style: .unset
-                )
+                SurfaceTile(systemImage: "tag.fill", muted: true) {
+                    Text("No domain")
+                }
             } else {
-                PebbleMetaPill(
-                    icon: .system("square.grid.2x2"),
-                    label: LocalizedStringResource(
+                SurfaceTile(systemImage: "tag.fill") {
+                    Text(LocalizedStringResource(
                         stringLiteral: detail.domains.map(\.localizedName).joined(separator: ", ")
-                    ),
-                    style: .neutral
-                )
+                    ))
+                }
             }
 
             // Collections — only when non-empty.
             if !detail.collections.isEmpty {
-                PebbleMetaPill(
-                    icon: .system("folder.fill"),
-                    label: LocalizedStringResource(
+                SurfaceTile(systemImage: "square.stack.3d.up.fill") {
+                    Text(LocalizedStringResource(
                         stringLiteral: detail.collections.map(\.name).joined(separator: ", ")
-                    ),
-                    style: .neutral
-                )
+                    ))
+                }
             }
         }
     }

--- a/apps/ios/Pebbles/Theme/SurfaceTile.swift
+++ b/apps/ios/Pebbles/Theme/SurfaceTile.swift
@@ -16,9 +16,16 @@ struct SurfaceTile<Label: View>: View {
             Image(systemName: systemImage)
                 .pebblesIcon(.large)
                 .foregroundStyle(muted ? Color.system.muted : Color.accent.primary)
+                // Fixed icon slot so tiles stay equal height regardless of which
+                // SF Symbol they carry (heart/tag/stack render at different
+                // intrinsic heights). Matches the Figma tile spec (30×30).
+                .frame(width: 30, height: 30)
             label()
                 .pebblesFont(.callout)
                 .foregroundStyle(muted ? Color.system.muted : Color.system.secondary)
+                // Clamp to one line so tiles stay equal height even when a label
+                // (e.g. multiple joined domains/collections) would otherwise wrap.
+                .lineLimit(1)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, Spacing.md)

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -8,7 +8,7 @@
       "view_card_variant": "large"
     },
     "created_at": "2026-04-01T00:00:00.000Z",
-    "updated_at": "2026-07-02T00:00:00.000Z"
+    "updated_at": "2026-07-02T22:00:00.000Z"
   },
   "nodes": [
     {
@@ -206,7 +206,7 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Pebble Detail",
-      "description": "Read-only display of a recorded pebble: rendered shape, title, picture, emotion/domain/collections/souls metadata, and description. Edit button stacks the editor.",
+      "description": "Read-only display of a recorded pebble: rendered shape, title, picture, emotion/domain/collections/souls metadata shown as shared tiles, and description. Edit button stacks the editor.",
       "status": "live",
       "platforms": [
         "web",


### PR DESCRIPTION
Resolves #513

Renders emotion, domain and collection on the iOS pebble detail page using the shared `SurfaceTile` — the same tile factorized for the profile shortcuts row and the glyph-swap stats — so the three surfaces stay harmonized.

## Changes
- **`apps/ios/Pebbles/Features/Path/Read/PebbleReadView.swift`** — replaced the `PebblePillFlow` / `PebbleMetaPill` metadata row with an `HStack` of `SurfaceTile`s:
  - Emotion (`heart.fill`) — always shown; kept on the default accent surface (page-wide emotion-palette coloring is out of scope per the issue).
  - Domain (`tag.fill`) — always shown; muted "No domain" placeholder when unset.
  - Collection (`square.stack.3d.up.fill`) — only when set.
  - Dropped the now-dead `EmotionPaletteService` dependency from this view.
- **`apps/ios/Pebbles/Theme/SurfaceTile.swift`** — fixed 30×30 icon slot + `lineLimit(1)` on the label so tiles stay equal height regardless of SF Symbol or label length. Matches the Figma spec (13 padding, 3 gap, 30×30 icon). Padding/gap already matched (`Spacing.md` / `Spacing.xs`).

## Notes
- The `SurfaceTile` tweaks are in the shared component, so the profile shortcuts row and glyph-swap stat tiles pick up the same 30×30 icon slot — consistent with the harmonized intent.
- `PebblePillFlow` / `PebbleMetaPill` are now unused on this screen but left in place (`PebbleMetaPill.swift` still hosts the shared `Color(hex:)` extension used by four other files). Candidate for a follow-up cleanup.

## Verification
- `npm run build --workspace=@pbbls/ios` → **BUILD SUCCEEDED**
- `swiftlint` clean; "No domain" present in `Localizable.xcstrings` (en/fr).

## Lab Note

**EN** — *Cleaner pebble details* — A pebble's emotion, domain and collection now appear as neat, equal-sized tiles on its detail page, matching the look you already know from your profile.

**FR** — *Détails du caillou plus nets* — L'émotion, le domaine et la collection d'un caillou s'affichent désormais sous forme de tuiles nettes et de taille égale sur sa page de détail, dans le même style que votre profil.