### PR TITLE
feat(ui): unify pickers on shared drawer shell

### DIFF
--- a/apps/web/components/path/QuickPebbleEditor.tsx
+++ b/apps/web/components/path/QuickPebbleEditor.tsx
@@ -19,12 +19,12 @@ import { useUsableGlyphs } from "@/lib/data/useUsableGlyphs"
 import { Button } from "@/components/ui/button"
 import { ValenceIntensityGrid } from "@/components/record/ValenceIntensityGrid"
 import { CustomizationTile } from "@/components/record/CustomizationTile"
-import { DomainPopover } from "@/components/record/DomainPopover"
+import { DomainSheet } from "@/components/record/DomainSheet"
 import {
   EmotionPickerSheet,
   useSelectedEmotionDisplay,
 } from "@/components/record/EmotionPicker"
-import { CollectionPopover } from "@/components/record/CollectionPopover"
+import { CollectionSheet } from "@/components/record/CollectionSheet"
 import { VisibilityPicker } from "@/components/record/VisibilityPicker"
 import { DatePickerDialog } from "@/components/record/DatePickerDialog"
 import { GlyphPickerDialog } from "@/components/record/GlyphPickerDialog"
@@ -327,7 +327,7 @@ export function QuickPebbleEditor({
 
               {/* Qualification pills */}
               <div className="mb-3 flex items-center gap-2">
-                <DomainPopover value={domainIds} onChange={setDomainIds} />
+                <DomainSheet value={domainIds} onChange={setDomainIds} />
                 <button
                   type="button"
                   onClick={() => setEmotionPickerOpen(true)}
@@ -373,7 +373,7 @@ export function QuickPebbleEditor({
                 >
                   {selectedMark && <GlyphPreview mark={selectedMark} className="size-full p-2" />}
                 </CustomizationTile>
-                <CollectionPopover
+                <CollectionSheet
                   value={collectionIds}
                   onChange={setCollectionIds}
                   collections={collections}

--- a/apps/web/components/pebble/PebbleDetail.tsx
+++ b/apps/web/components/pebble/PebbleDetail.tsx
@@ -14,8 +14,9 @@ import {
 } from "@/components/pebble/PebbleDetailTiles"
 import { PebbleDetailSoulsGrid } from "@/components/pebble/PebbleDetailSoulsGrid"
 import { PebbleDetailAddToolbar } from "@/components/pebble/PebbleDetailAddToolbar"
-import { Sheet } from "@/components/ui/sheet"
-import { ValencePickerBody } from "@/components/record/ValenceIntensityGrid"
+import { SheetTrigger } from "@/components/ui/sheet"
+import { PickerSheet } from "@/components/ui/PickerSheet"
+import { ValenceGrid } from "@/components/record/ValenceIntensityGrid"
 import { SoulsSheet } from "@/components/record/SoulsSheet"
 import { cn } from "@/lib/utils"
 
@@ -49,6 +50,7 @@ export function PebbleDetail({
   const fileInputRef = useRef<HTMLInputElement>(null)
   const t = useTranslations("pebble")
   const tVisibility = useTranslations("record.visibility")
+  const tValencePicker = useTranslations("record.valencePicker")
   const formatPeekDate = useFormatPeekDate()
   const formattedDate = formatPeekDate(pebble.happened_at)
 
@@ -159,41 +161,46 @@ export function PebbleDetail({
       </header>
 
       {/* Pebble visual (and snap if present) — opens valence/intensity sheet */}
-      <Sheet open={valenceOpen} onOpenChange={setValenceOpen}>
-        <button
-          type="button"
-          onClick={() => setValenceOpen(true)}
-          className="mx-auto mt-8 mb-4 block cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-2xl"
-          aria-label={t("editIntensityAria")}
-        >
-          {hasPicture ? (
-            <div className="relative mx-auto w-[240px]">
-              {/* eslint-disable-next-line @next/next/no-img-element -- base64 data URL, next/image optimization not applicable */}
-              <img
-                src={snap}
-                alt={t("photoAlt")}
-                className="aspect-square w-full rounded-2xl object-cover scale-90 -rotate-4"
-              />
+      <PickerSheet
+        open={valenceOpen}
+        onOpenChange={setValenceOpen}
+        title={tValencePicker("title")}
+        closeLabel={tValencePicker("close")}
+        trigger={
+          <SheetTrigger
+            className="mx-auto mt-8 mb-4 block cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-2xl"
+            aria-label={t("editIntensityAria")}
+          >
+            {hasPicture ? (
+              <div className="relative mx-auto w-[240px]">
+                {/* eslint-disable-next-line @next/next/no-img-element -- base64 data URL, next/image optimization not applicable */}
+                <img
+                  src={snap}
+                  alt={t("photoAlt")}
+                  className="aspect-square w-full rounded-2xl object-cover scale-90 -rotate-4"
+                />
+                <PebbleFramed
+                  pebble={pebble}
+                  mark={mark}
+                  tier="detail"
+                  className="absolute -right-4 -top-4 size-[100px] rotate-7"
+                  animateIn
+                />
+              </div>
+            ) : (
               <PebbleFramed
                 pebble={pebble}
                 mark={mark}
                 tier="detail"
-                className="absolute -right-4 -top-4 size-[100px] rotate-7"
+                className="mx-auto size-[100px]"
                 animateIn
               />
-            </div>
-          ) : (
-            <PebbleFramed
-              pebble={pebble}
-              mark={mark}
-              tier="detail"
-              className="mx-auto size-[100px]"
-              animateIn
-            />
-          )}
-        </button>
+            )}
+          </SheetTrigger>
+        }
+      >
         {valenceOpen && (
-          <ValencePickerBody
+          <ValenceGrid
             intensity={pebble.intensity}
             valence={pebble.positiveness}
             onSelect={(size, polarity) => {
@@ -202,7 +209,7 @@ export function PebbleDetail({
             }}
           />
         )}
-      </Sheet>
+      </PickerSheet>
 
       {/* Title */}
       <h1 className="text-center font-heading text-2xl font-semibold text-foreground">

--- a/apps/web/components/pebble/PebbleEdit.tsx
+++ b/apps/web/components/pebble/PebbleEdit.tsx
@@ -21,8 +21,9 @@ import {
   useSnapStaging,
 } from "@/components/pebble/PebbleEditPicture"
 import { PebbleEditSoulsGrid } from "@/components/pebble/PebbleEditSoulsGrid"
-import { Sheet } from "@/components/ui/sheet"
-import { ValencePickerBody } from "@/components/record/ValenceIntensityGrid"
+import { SheetTrigger } from "@/components/ui/sheet"
+import { PickerSheet } from "@/components/ui/PickerSheet"
+import { ValenceGrid } from "@/components/record/ValenceIntensityGrid"
 import { EmotionPickerSheet } from "@/components/record/EmotionPicker"
 import { SoulsSheet } from "@/components/record/SoulsSheet"
 import {
@@ -65,6 +66,7 @@ export function PebbleEdit({
 }: PebbleEditProps) {
   const t = useTranslations("pebble.edit")
   const tPebble = useTranslations("pebble")
+  const tValencePicker = useTranslations("record.valencePicker")
   const router = useRouter()
 
   const { draft, setField, setFields, isDirty, buildPayload } =
@@ -146,8 +148,6 @@ export function PebbleEdit({
   // on select, close it and open the Emotion picker prefilled with the new
   // valence/intensity; on emotion-pick, write everything into the draft in
   // one dispatch.
-  const handleGlyphTap = () => setValenceOpen(true)
-
   const handleValenceSelect = (
     intensity: Pebble["intensity"],
     positiveness: Pebble["positiveness"],
@@ -193,28 +193,33 @@ export function PebbleEdit({
           onPick={(file) => void snap.pickFile(file)}
           onRemove={() => void snap.remove()}
         />
-        <Sheet open={valenceOpen} onOpenChange={setValenceOpen}>
-          <button
-            type="button"
-            onClick={handleGlyphTap}
-            aria-label={tPebble("editIntensityAria")}
-            className="mt-4 cursor-pointer rounded-2xl outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <PebbleFramed
-              pebble={draftPebble}
-              mark={draftMark}
-              tier="detail"
-              className="size-24 rotate-[7.52deg]"
-            />
-          </button>
+        <PickerSheet
+          open={valenceOpen}
+          onOpenChange={setValenceOpen}
+          title={tValencePicker("title")}
+          closeLabel={tValencePicker("close")}
+          trigger={
+            <SheetTrigger
+              aria-label={tPebble("editIntensityAria")}
+              className="mt-4 cursor-pointer rounded-2xl outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <PebbleFramed
+                pebble={draftPebble}
+                mark={draftMark}
+                tier="detail"
+                className="size-24 rotate-[7.52deg]"
+              />
+            </SheetTrigger>
+          }
+        >
           {valenceOpen && (
-            <ValencePickerBody
+            <ValenceGrid
               intensity={draft.intensity}
               valence={draft.positiveness}
               onSelect={handleValenceSelect}
             />
           )}
-        </Sheet>
+        </PickerSheet>
       </section>
 
       <PebbleEditTitle

--- a/apps/web/components/record/CollectionSheet.tsx
+++ b/apps/web/components/record/CollectionSheet.tsx
@@ -4,21 +4,22 @@ import { Layers } from "lucide-react"
 import { useTranslations } from "next-intl"
 import type { Collection } from "@/lib/types"
 import { SelectableItem } from "@/components/ui/SelectableItem"
-import {
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-} from "@/components/ui/popover"
+import { PickerSheet } from "@/components/ui/PickerSheet"
+import { SheetTrigger } from "@/components/ui/sheet"
 import { cn } from "@/lib/utils"
 
-type CollectionPopoverProps = {
+type CollectionSheetProps = {
   value: string[]
   onChange: (ids: string[]) => void
   collections: Collection[]
   variant?: "tile" | "chip"
 }
 
-export function CollectionPopover({ value, onChange, collections, variant = "tile" }: CollectionPopoverProps) {
+/**
+ * Multi-select collection picker presented in the shared drawer. Toggling a
+ * row keeps the sheet open; the header `X` (or a backdrop tap) dismisses it.
+ */
+export function CollectionSheet({ value, onChange, collections, variant = "tile" }: CollectionSheetProps) {
   const t = useTranslations("record.collection")
   const selectedNames = collections
     .filter((c) => value.includes(c.id))
@@ -32,7 +33,7 @@ export function CollectionPopover({ value, onChange, collections, variant = "til
 
   const trigger =
     variant === "chip" ? (
-      <PopoverTrigger
+      <SheetTrigger
         className={cn(
           "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
           value.length > 0
@@ -43,9 +44,9 @@ export function CollectionPopover({ value, onChange, collections, variant = "til
       >
         <Layers className="size-3.5" aria-hidden />
         {selectedNames.length > 0 ? selectedNames.join(", ") : t("label")}
-      </PopoverTrigger>
+      </SheetTrigger>
     ) : (
-      <PopoverTrigger
+      <SheetTrigger
         className={cn(
           "relative flex aspect-square items-center justify-center rounded-xl transition-all duration-100 outline-none focus-visible:ring-2 focus-visible:ring-ring active:scale-95 overflow-hidden",
           value.length > 0
@@ -61,29 +62,29 @@ export function CollectionPopover({ value, onChange, collections, variant = "til
         ) : (
           <Layers className="size-5 text-muted-foreground/50" aria-hidden />
         )}
-      </PopoverTrigger>
+      </SheetTrigger>
     )
 
   return (
-    <Popover>
-      {trigger}
-      <PopoverContent align="start" className="min-w-[180px]">
-        {collections.length === 0 ? (
-          <p className="px-2 py-4 text-center text-sm text-muted-foreground">
-            {t("empty")}
-          </p>
-        ) : (
-          collections.map((coll) => (
+    <PickerSheet title={t("title")} closeLabel={t("close")} trigger={trigger}>
+      {collections.length === 0 ? (
+        <p className="px-2 py-4 text-center text-sm text-muted-foreground">
+          {t("empty")}
+        </p>
+      ) : (
+        <div className="flex flex-col gap-0.5">
+          {collections.map((coll) => (
             <SelectableItem
               key={coll.id}
               selected={value.includes(coll.id)}
               onSelect={() => toggle(coll.id)}
+              className="py-2"
             >
               {coll.name}
             </SelectableItem>
-          ))
-        )}
-      </PopoverContent>
-    </Popover>
+          ))}
+        </div>
+      )}
+    </PickerSheet>
   )
 }

--- a/apps/web/components/record/DomainSheet.tsx
+++ b/apps/web/components/record/DomainSheet.tsx
@@ -6,16 +6,13 @@ import { useTranslations } from "next-intl"
 import { DOMAINS, type Domain } from "@/lib/config/domains"
 import { useDomainLocalized } from "@/lib/i18n"
 import { SelectableItem } from "@/components/ui/SelectableItem"
-import {
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-} from "@/components/ui/popover"
+import { PickerSheet } from "@/components/ui/PickerSheet"
+import { SheetTrigger } from "@/components/ui/sheet"
 import { cn } from "@/lib/utils"
 import { useDomainGlyphs, type DomainGlyph as DomainGlyphData } from "@/lib/data/useDomainGlyphs"
 import { DomainGlyph } from "@/components/record/DomainGlyph"
 
-type DomainPopoverProps = {
+type DomainSheetProps = {
   value: string[]
   onChange: (ids: string[]) => void
 }
@@ -28,7 +25,7 @@ function DomainOption({ domain, glyph, selected, onSelect }: {
 }) {
   const { name, label } = useDomainLocalized(domain)
   return (
-    <SelectableItem selected={selected} onSelect={onSelect}>
+    <SelectableItem selected={selected} onSelect={onSelect} className="py-2">
       <span className="flex items-center gap-2">
         {glyph ? (
           <DomainGlyph strokes={glyph.strokes} viewBox={glyph.viewBox} className="size-6 shrink-0" />
@@ -42,7 +39,11 @@ function DomainOption({ domain, glyph, selected, onSelect }: {
   )
 }
 
-export function DomainPopover({ value, onChange }: DomainPopoverProps) {
+/**
+ * Multi-select domain picker presented in the shared drawer. Toggling a row
+ * keeps the sheet open; the header `X` (or a backdrop tap) dismisses it.
+ */
+export function DomainSheet({ value, onChange }: DomainSheetProps) {
   const t = useTranslations("record.domain")
   const glyphs = useDomainGlyphs()
   const localizedNames = useLocalizedDomainMap()
@@ -59,22 +60,25 @@ export function DomainPopover({ value, onChange }: DomainPopoverProps) {
   }
 
   return (
-    <Popover>
-      <PopoverTrigger
-        className={cn(
-          "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
-          value.length > 0
-            ? "border border-border bg-background text-foreground"
-            : "border border-dashed border-muted-foreground/30 text-muted-foreground hover:border-muted-foreground/50",
-        )}
-        aria-label={value.length > 0 ? t("selectedAria", { names: selectedNames.join(", ") }) : t("pickAria")}
-      >
-        <Compass className="size-3.5" aria-hidden />
-        {selectedDomains.length > 0
-          ? selectedNames.join(", ")
-          : t("label")}
-      </PopoverTrigger>
-      <PopoverContent align="start" className="min-w-[180px]">
+    <PickerSheet
+      title={t("title")}
+      closeLabel={t("close")}
+      trigger={
+        <SheetTrigger
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+            value.length > 0
+              ? "border border-border bg-background text-foreground"
+              : "border border-dashed border-muted-foreground/30 text-muted-foreground hover:border-muted-foreground/50",
+          )}
+          aria-label={value.length > 0 ? t("selectedAria", { names: selectedNames.join(", ") }) : t("pickAria")}
+        >
+          <Compass className="size-3.5" aria-hidden />
+          {selectedDomains.length > 0 ? selectedNames.join(", ") : t("label")}
+        </SheetTrigger>
+      }
+    >
+      <div className="flex flex-col gap-0.5">
         {DOMAINS.map((domain) => (
           <DomainOption
             key={domain.id}
@@ -84,8 +88,8 @@ export function DomainPopover({ value, onChange }: DomainPopoverProps) {
             onSelect={() => toggle(domain.id)}
           />
         ))}
-      </PopoverContent>
-    </Popover>
+      </div>
+    </PickerSheet>
   )
 }
 

--- a/apps/web/components/record/EmotionPicker/EmotionPickerSheet.tsx
+++ b/apps/web/components/record/EmotionPicker/EmotionPickerSheet.tsx
@@ -2,14 +2,7 @@
 
 import { useMemo } from "react"
 import { useLocale, useTranslations } from "next-intl"
-import { X } from "lucide-react"
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetClose,
-} from "@/components/ui/sheet"
+import { PickerSheet } from "@/components/ui/PickerSheet"
 import { useEmotionsWithPalette, type EmotionWithPalette } from "@/lib/data/useEmotionsWithPalette"
 import {
   emotionCategoryOrder,
@@ -113,38 +106,29 @@ export function EmotionPickerSheet({
   }
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent>
-        <SheetHeader className="relative">
-          <SheetTitle>{t("title")}</SheetTitle>
-          <SheetClose
-            aria-label={t("close")}
-            variant="ghost"
-            size="icon-sm"
-            className="absolute right-0 top-0"
-          >
-            <X aria-hidden />
-          </SheetClose>
-        </SheetHeader>
-
-        {loading || groups.length === 0 ? (
-          <EmotionPickerEmpty />
-        ) : (
-          <div className="flex flex-col gap-6 pb-4">
-            {groups.map((group) => (
-              <EmotionPickerSection
-                key={group.slug}
-                categorySlug={group.slug}
-                categoryName={group.name}
-                primaryColor={group.primaryColor}
-                rows={group.rows}
-                selectedId={value}
-                onSelect={handleChipSelect}
-              />
-            ))}
-          </div>
-        )}
-      </SheetContent>
-    </Sheet>
+    <PickerSheet
+      open={open}
+      onOpenChange={onOpenChange}
+      title={t("title")}
+      closeLabel={t("close")}
+    >
+      {loading || groups.length === 0 ? (
+        <EmotionPickerEmpty />
+      ) : (
+        <div className="flex flex-col gap-6 pb-4">
+          {groups.map((group) => (
+            <EmotionPickerSection
+              key={group.slug}
+              categorySlug={group.slug}
+              categoryName={group.name}
+              primaryColor={group.primaryColor}
+              rows={group.rows}
+              selectedId={value}
+              onSelect={handleChipSelect}
+            />
+          ))}
+        </div>
+      )}
+    </PickerSheet>
   )
 }

--- a/apps/web/components/record/SoulsSheet.tsx
+++ b/apps/web/components/record/SoulsSheet.tsx
@@ -6,13 +6,8 @@ import { useTranslations } from "next-intl"
 import type { Soul } from "@/lib/types"
 import { SelectableItem } from "@/components/ui/SelectableItem"
 import { SearchableList } from "@/components/ui/SearchableList"
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetClose,
-} from "@/components/ui/sheet"
+import { PickerSheet } from "@/components/ui/PickerSheet"
+import { SheetClose } from "@/components/ui/sheet"
 
 type SoulsSheetProps = {
   open: boolean
@@ -58,77 +53,76 @@ export function SoulsSheet({
   }
 
   return (
-    <Sheet open={open} onOpenChange={handleOpenChange}>
-      <SheetContent>
-        <SheetHeader>
-          <SheetTitle>{t("title")}</SheetTitle>
-        </SheetHeader>
+    <PickerSheet
+      open={open}
+      onOpenChange={handleOpenChange}
+      title={t("title")}
+      closeLabel={t("close")}
+    >
+      <SearchableList
+        query={query}
+        onQueryChange={setQuery}
+        placeholder={t("searchPlaceholder")}
+        isEmpty={filtered.length === 0 && !canAddNew}
+        emptyMessage={t("empty")}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && canAddNew) {
+            e.preventDefault()
+            void handleAdd()
+          }
+        }}
+      >
+        {/* Selected chips */}
+        {selectedIds.length > 0 && (
+          <ul className="mb-3 flex flex-wrap gap-1.5" role="list" aria-label={t("selectedListAria")}>
+            {selectedIds.map((id) => {
+              const soul = souls.find((s) => s.id === id)
+              if (!soul) return null
+              return (
+                <li key={id}>
+                  <button
+                    type="button"
+                    onClick={() => onToggle(id)}
+                    className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+                    aria-label={t("removeAria", { name: soul.name })}
+                  >
+                    {soul.name}
+                    <X className="size-3" aria-hidden />
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        )}
 
-        <SearchableList
-          query={query}
-          onQueryChange={setQuery}
-          placeholder={t("searchPlaceholder")}
-          isEmpty={filtered.length === 0 && !canAddNew}
-          emptyMessage={t("empty")}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && canAddNew) {
-              e.preventDefault()
-              void handleAdd()
-            }
-          }}
-        >
-          {/* Selected chips */}
-          {selectedIds.length > 0 && (
-            <ul className="mb-3 flex flex-wrap gap-1.5" role="list" aria-label={t("selectedListAria")}>
-              {selectedIds.map((id) => {
-                const soul = souls.find((s) => s.id === id)
-                if (!soul) return null
-                return (
-                  <li key={id}>
-                    <button
-                      type="button"
-                      onClick={() => onToggle(id)}
-                      className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
-                      aria-label={t("removeAria", { name: soul.name })}
-                    >
-                      {soul.name}
-                      <X className="size-3" aria-hidden />
-                    </button>
-                  </li>
-                )
-              })}
-            </ul>
-          )}
+        {filtered.map((soul) => (
+          <SelectableItem
+            key={soul.id}
+            selected={selectedIds.includes(soul.id)}
+            onSelect={() => onToggle(soul.id)}
+            className="py-2"
+          >
+            {soul.name}
+          </SelectableItem>
+        ))}
 
-          {filtered.map((soul) => (
-            <SelectableItem
-              key={soul.id}
-              selected={selectedIds.includes(soul.id)}
-              onSelect={() => onToggle(soul.id)}
-              className="py-2"
-            >
-              {soul.name}
-            </SelectableItem>
-          ))}
+        {canAddNew && (
+          <button
+            type="button"
+            onClick={() => void handleAdd()}
+            className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-sm text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <Plus className="size-4 shrink-0" />
+            {t("addNew", { name: query.trim() })}
+          </button>
+        )}
+      </SearchableList>
 
-          {canAddNew && (
-            <button
-              type="button"
-              onClick={() => void handleAdd()}
-              className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-sm text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground"
-            >
-              <Plus className="size-4 shrink-0" />
-              {t("addNew", { name: query.trim() })}
-            </button>
-          )}
-        </SearchableList>
-
-        <div className="mt-4 flex justify-end">
-          <SheetClose aria-label={t("done")}>
-            {t("done")}
-          </SheetClose>
-        </div>
-      </SheetContent>
-    </Sheet>
+      <div className="mt-4 flex justify-end">
+        <SheetClose aria-label={t("done")}>
+          {t("done")}
+        </SheetClose>
+      </div>
+    </PickerSheet>
   )
 }

--- a/apps/web/components/record/ValenceIntensityGrid.tsx
+++ b/apps/web/components/record/ValenceIntensityGrid.tsx
@@ -3,13 +3,8 @@
 import { useEffect, useId, useRef, useState } from "react"
 import { useTranslations } from "next-intl"
 import { cn } from "@/lib/utils"
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from "@/components/ui/sheet"
+import { PickerSheet } from "@/components/ui/PickerSheet"
+import { SheetTrigger } from "@/components/ui/sheet"
 
 type Intensity = 1 | 2 | 3
 type Valence = -1 | 0 | 1
@@ -61,6 +56,10 @@ function shapeUrl(size: Intensity, polarity: Valence): string {
   return `${SHAPE_BASE_URL}/${SHAPE_INTENSITY[size]}-${SHAPE_POLARITY[polarity]}.svg`
 }
 
+/**
+ * Self-contained valence/intensity picker: a chip trigger that opens the
+ * shared drawer hosting the 3×3 grid. Selection commits both axes and closes.
+ */
 export function ValenceIntensityGrid({
   intensity,
   valence,
@@ -76,21 +75,27 @@ export function ValenceIntensityGrid({
   const valenceLabel = tPicker(VALENCE_KEY[valence]).toLowerCase()
 
   return (
-    <Sheet open={open} onOpenChange={setOpen}>
-      <SheetTrigger
-        className="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted"
-        aria-label={tIntensity("ariaSelected", {
-          intensity: tIntensity(INTENSITY_KEY[intensity]),
-          valence: tValence(VALENCE_KEY[valence]),
-        })}
-      >
-        <span>{`${longIntensity} ${valenceLabel}`}</span>
-      </SheetTrigger>
-
-      {/* Remount the picker body each time the sheet opens so the initial
-          focus target is always derived fresh from the current selection. */}
+    <PickerSheet
+      open={open}
+      onOpenChange={setOpen}
+      title={tPicker("title")}
+      closeLabel={tPicker("close")}
+      trigger={
+        <SheetTrigger
+          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted"
+          aria-label={tIntensity("ariaSelected", {
+            intensity: tIntensity(INTENSITY_KEY[intensity]),
+            valence: tValence(VALENCE_KEY[valence]),
+          })}
+        >
+          <span>{`${longIntensity} ${valenceLabel}`}</span>
+        </SheetTrigger>
+      }
+    >
+      {/* Remount the grid each time the sheet opens so the initial focus
+          target is always derived fresh from the current selection. */}
       {open && (
-        <ValencePickerBody
+        <ValenceGrid
           intensity={intensity}
           valence={valence}
           onSelect={(size, polarity) => {
@@ -100,26 +105,29 @@ export function ValenceIntensityGrid({
           }}
         />
       )}
-    </Sheet>
+    </PickerSheet>
   )
 }
 
-type ValencePickerBodyProps = {
+type ValenceGridProps = {
   intensity: Intensity
   valence: Valence
   onSelect: (size: Intensity, polarity: Valence) => void
 }
 
-// Exported so callers can host the picker inside their own controlled Sheet
-// when they want a different trigger surface (e.g. PebbleDetail opens it from
-// the pebble visual itself instead of a separate chip button).
-export function ValencePickerBody({
+/**
+ * The 3 rows × 3 cells valence/intensity grid body. Rendered inside a
+ * `PickerSheet` — either via the self-contained `ValenceIntensityGrid` chip
+ * trigger, or hosted directly by callers with a different trigger surface
+ * (e.g. PebbleDetail opens it from the pebble visual itself).
+ */
+export function ValenceGrid({
   intensity,
   valence,
   onSelect,
-}: ValencePickerBodyProps) {
+}: ValenceGridProps) {
   const tPicker = useTranslations("record.valencePicker")
-  const titleId = useId()
+  const groupId = useId()
 
   // cellsRef[row][col] where row = polarity index, col = size index.
   const cellsRef = useRef<Array<Array<HTMLButtonElement | null>>>(
@@ -144,106 +152,100 @@ export function ValencePickerBody({
   }
 
   return (
-    <SheetContent
-      aria-labelledby={titleId}
-      className="motion-reduce:transition-none"
-    >
-      <SheetHeader>
-        <SheetTitle id={titleId}>{tPicker("title")}</SheetTitle>
-      </SheetHeader>
+    <div role="group" aria-labelledby={groupId} className="flex flex-col gap-6">
+      <span id={groupId} className="sr-only">
+        {tPicker("title")}
+      </span>
+      {SIZE_GROUPS.map((size, colIndex) => (
+        <section key={size} className="flex flex-col gap-3">
+          <header className="flex flex-col gap-1">
+            <h3 className="font-heading text-sm font-semibold text-foreground">
+              {tPicker(`${INTENSITY_KEY[size]}.name`)}
+            </h3>
+            <p className="text-xs text-muted-foreground">
+              {tPicker(`${INTENSITY_KEY[size]}.description`)}
+            </p>
+          </header>
 
-      <div role="group" aria-labelledby={titleId} className="flex flex-col gap-6">
-        {SIZE_GROUPS.map((size, colIndex) => (
-          <section key={size} className="flex flex-col gap-3">
-            <header className="flex flex-col gap-1">
-              <h3 className="font-heading text-sm font-semibold text-foreground">
-                {tPicker(`${INTENSITY_KEY[size]}.name`)}
-              </h3>
-              <p className="text-xs text-muted-foreground">
-                {tPicker(`${INTENSITY_KEY[size]}.description`)}
-              </p>
-            </header>
-
-            <div className="grid grid-cols-3 gap-2">
-              {POLARITIES.map((polarity, rowIndex) => {
-                const selected = intensity === size && valence === polarity
-                const isFocusTarget =
-                  focus.row === rowIndex && focus.col === colIndex
-                return (
-                  <button
-                    key={polarity}
-                    ref={(el) => {
-                      cellsRef.current[rowIndex]![colIndex] = el
+          <div className="grid grid-cols-3 gap-2">
+            {POLARITIES.map((polarity, rowIndex) => {
+              const selected = intensity === size && valence === polarity
+              const isFocusTarget =
+                focus.row === rowIndex && focus.col === colIndex
+              return (
+                <button
+                  key={polarity}
+                  ref={(el) => {
+                    cellsRef.current[rowIndex]![colIndex] = el
+                  }}
+                  type="button"
+                  role="radio"
+                  aria-checked={selected}
+                  tabIndex={isFocusTarget ? 0 : -1}
+                  onClick={() => onSelect(size, polarity)}
+                  onKeyDown={(e) => {
+                    switch (e.key) {
+                      case "ArrowRight":
+                        e.preventDefault()
+                        moveFocus(0, 1)
+                        break
+                      case "ArrowLeft":
+                        e.preventDefault()
+                        moveFocus(0, -1)
+                        break
+                      case "ArrowDown":
+                        e.preventDefault()
+                        moveFocus(1, 0)
+                        break
+                      case "ArrowUp":
+                        e.preventDefault()
+                        moveFocus(-1, 0)
+                        break
+                      case " ":
+                      case "Enter":
+                        e.preventDefault()
+                        onSelect(size, polarity)
+                        break
+                    }
+                  }}
+                  aria-label={tPicker("optionAria", {
+                    section: tPicker(`${INTENSITY_KEY[size]}.name`),
+                    polarity: tPicker(VALENCE_KEY[polarity]),
+                  })}
+                  className={cn(
+                    "flex flex-col items-center gap-2 rounded-xl border px-2 py-3 outline-none transition-colors",
+                    "focus-visible:ring-2 focus-visible:ring-ring",
+                    selected
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-border bg-card text-muted-foreground hover:bg-muted hover:text-foreground",
+                  )}
+                >
+                  {/* SVG rendered as a CSS mask so its color follows
+                      the button's text color (muted-foreground when
+                      idle, primary when selected). */}
+                  <span
+                    aria-hidden
+                    className="size-12 bg-current"
+                    style={{
+                      WebkitMaskImage: `url(${shapeUrl(size, polarity)})`,
+                      maskImage: `url(${shapeUrl(size, polarity)})`,
+                      WebkitMaskRepeat: "no-repeat",
+                      maskRepeat: "no-repeat",
+                      WebkitMaskPosition: "center",
+                      maskPosition: "center",
+                      WebkitMaskSize: "contain",
+                      maskSize: "contain",
                     }}
-                    type="button"
-                    role="radio"
-                    aria-checked={selected}
-                    tabIndex={isFocusTarget ? 0 : -1}
-                    onClick={() => onSelect(size, polarity)}
-                    onKeyDown={(e) => {
-                      switch (e.key) {
-                        case "ArrowRight":
-                          e.preventDefault()
-                          moveFocus(0, 1)
-                          break
-                        case "ArrowLeft":
-                          e.preventDefault()
-                          moveFocus(0, -1)
-                          break
-                        case "ArrowDown":
-                          e.preventDefault()
-                          moveFocus(1, 0)
-                          break
-                        case "ArrowUp":
-                          e.preventDefault()
-                          moveFocus(-1, 0)
-                          break
-                        case " ":
-                        case "Enter":
-                          e.preventDefault()
-                          onSelect(size, polarity)
-                          break
-                      }
-                    }}
-                    aria-label={tPicker("optionAria", {
-                      section: tPicker(`${INTENSITY_KEY[size]}.name`),
-                      polarity: tPicker(VALENCE_KEY[polarity]),
-                    })}
-                    className={cn(
-                      "flex flex-col items-center gap-2 rounded-xl border px-2 py-3 outline-none transition-colors",
-                      "focus-visible:ring-2 focus-visible:ring-ring",
-                      selected
-                        ? "border-primary bg-primary/10 text-primary"
-                        : "border-border bg-card text-muted-foreground hover:bg-muted hover:text-foreground",
-                    )}
-                  >
-                    {/* SVG rendered as a CSS mask so its color follows
-                        the button's text color (muted-foreground when
-                        idle, primary when selected). */}
-                    <span
-                      aria-hidden
-                      className="size-12 bg-current"
-                      style={{
-                        WebkitMaskImage: `url(${shapeUrl(size, polarity)})`,
-                        maskImage: `url(${shapeUrl(size, polarity)})`,
-                        WebkitMaskRepeat: "no-repeat",
-                        maskRepeat: "no-repeat",
-                        WebkitMaskPosition: "center",
-                        maskPosition: "center",
-                        WebkitMaskSize: "contain",
-                        maskSize: "contain",
-                      }}
-                    />
-                    <span className="text-xs font-medium">
-                      {tPicker(VALENCE_KEY[polarity])}
-                    </span>
-                  </button>
-                )
-              })}
-            </div>
-          </section>
-        ))}
-      </div>
-    </SheetContent>
+                  />
+                  <span className="text-xs font-medium">
+                    {tPicker(VALENCE_KEY[polarity])}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        </section>
+      ))}
+    </div>
   )
 }

--- a/apps/web/components/ui/PickerSheet.tsx
+++ b/apps/web/components/ui/PickerSheet.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { X } from "lucide-react"
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetClose,
+} from "@/components/ui/sheet"
+
+type PickerSheetProps = {
+  title: string
+  /** Accessible label for the header close (X) button. */
+  closeLabel: string
+  children: ReactNode
+  /**
+   * Optional trigger placed inside the Sheet root. Omit for controlled callers
+   * whose trigger lives elsewhere (e.g. a pill button in a parent form that
+   * drives `open`). When provided, pass a `<SheetTrigger …/>` element.
+   */
+  trigger?: ReactNode
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  contentClassName?: string
+}
+
+/**
+ * Shared drawer shell for all pickers. Captures the identical Sheet chrome —
+ * responsive panel, header with title + `X` close — so every picker (domain,
+ * collection, valence, emotion, souls) opens the same drawer; only the body
+ * differs. When `open`/`onOpenChange` are omitted the Sheet runs uncontrolled.
+ */
+export function PickerSheet({
+  title,
+  closeLabel,
+  children,
+  trigger,
+  open,
+  onOpenChange,
+  contentClassName,
+}: PickerSheetProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      {trigger}
+      <SheetContent className={contentClassName}>
+        <SheetHeader className="relative">
+          <SheetTitle>{title}</SheetTitle>
+          <SheetClose
+            aria-label={closeLabel}
+            variant="ghost"
+            size="icon-sm"
+            className="absolute right-0 top-0"
+          >
+            <X aria-hidden />
+          </SheetClose>
+        </SheetHeader>
+        {children}
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/apps/web/lib/i18n/messages/en.json
+++ b/apps/web/lib/i18n/messages/en.json
@@ -551,7 +551,9 @@
       "pickerLabel": "Domains",
       "pickerAria": "Life domains",
       "pickAria": "Pick domains",
-      "selectedAria": "Domains: {names}"
+      "selectedAria": "Domains: {names}",
+      "title": "Domains",
+      "close": "Close"
     },
     "emotion": {
       "label": "Emotion",
@@ -571,11 +573,14 @@
       "selectedAria": "Collections: {names}",
       "tilePickAria": "Add to collection",
       "tileSelectedAria": "{count, plural, one {# collection selected} other {# collections selected}}",
-      "empty": "No collections yet"
+      "empty": "No collections yet",
+      "title": "Collections",
+      "close": "Close"
     },
     "souls": {
       "label": "Souls",
       "title": "Souls",
+      "close": "Close",
       "addAria": "Add souls",
       "selectedAria": "{count, plural, one {# soul selected} other {# souls selected}}",
       "selectedListAria": "Selected souls",
@@ -623,6 +628,7 @@
     },
     "valencePicker": {
       "title": "Choose a valence",
+      "close": "Close",
       "optionAria": "{section}, {polarity}",
       "highlight": "Highlight",
       "neutral": "Neutral",

--- a/apps/web/lib/i18n/messages/fr.json
+++ b/apps/web/lib/i18n/messages/fr.json
@@ -551,7 +551,9 @@
       "pickerLabel": "Domaines",
       "pickerAria": "Domaines de vie",
       "pickAria": "Choisir des domaines",
-      "selectedAria": "Domaines : {names}"
+      "selectedAria": "Domaines : {names}",
+      "title": "Domaines",
+      "close": "Fermer"
     },
     "emotion": {
       "label": "Émotion",
@@ -571,11 +573,14 @@
       "selectedAria": "Collections : {names}",
       "tilePickAria": "Ajouter à une collection",
       "tileSelectedAria": "{count, plural, one {# collection sélectionnée} other {# collections sélectionnées}}",
-      "empty": "Aucune collection pour l'instant"
+      "empty": "Aucune collection pour l'instant",
+      "title": "Collections",
+      "close": "Fermer"
     },
     "souls": {
       "label": "Âmes",
       "title": "Âmes",
+      "close": "Fermer",
       "addAria": "Ajouter des âmes",
       "selectedAria": "{count, plural, one {# âme sélectionnée} other {# âmes sélectionnées}}",
       "selectedListAria": "Âmes sélectionnées",
@@ -623,6 +628,7 @@
     },
     "valencePicker": {
       "title": "Choisir une valence",
+      "close": "Fermer",
       "optionAria": "{section}, {polarity}",
       "highlight": "Temps fort",
       "neutral": "Neutre",


### PR DESCRIPTION
Align the domain, collection and valence pickers on the emotion drawer
experience. Introduce a shared PickerSheet shell (Sheet + header + X
close) and migrate every picker onto it:

- Convert DomainPopover/CollectionPopover dropdowns into DomainSheet/
  CollectionSheet drawers rendering a vertical list.
- Split the valence 3x3 grid into a reusable ValenceGrid body hosted by
  the shared shell (drops ValencePickerBody).
- Migrate EmotionPickerSheet, SoulsSheet, and the PebbleDetail/PebbleEdit
  valence hosts onto the same shell.
- Add drawer title/close i18n keys (EN/FR) for domain, collection,
  valence and souls.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013hqkiseH78gR9QG5YNesU5