### PR TITLE
refactor: migrate pebble editor to dedicated /record route

### DIFF
--- a/apps/web/app/record/page.tsx
+++ b/apps/web/app/record/page.tsx
@@ -1,29 +1,28 @@
 "use client"
 
-import { useState } from "react"
+import { useRouter } from "next/navigation"
+import Link from "next/link"
+import { ArrowLeft } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { QuickPebbleEditor } from "@/components/path/QuickPebbleEditor"
-import { PebblePeek } from "@/components/path/PebblePeek"
 
 export default function RecordPage() {
-  const [selectedPebbleId, setSelectedPebbleId] = useState<string | null>(null)
-  // /record is a dedicated capture route — auto-open the overlay on mount so
-  // the user lands on the editor itself, not its collapsed trigger.
-  const [editorExpanded, setEditorExpanded] = useState(true)
+  const router = useRouter()
   const t = useTranslations("record")
 
   return (
-    <section className="mx-auto max-w-lg px-4 py-8">
-      <h1 className="sr-only">{t("srTitle")}</h1>
-      <QuickPebbleEditor
-        expanded={editorExpanded}
-        onExpandedChange={setEditorExpanded}
-        onPebbleCreated={(pebble) => setSelectedPebbleId(pebble.id)}
-      />
-      <PebblePeek
-        pebbleId={selectedPebbleId}
-        onClose={() => setSelectedPebbleId(null)}
-      />
+    <section className="mx-auto w-full max-w-lg">
+      <header className="mb-4 flex items-center gap-2">
+        <Link
+          href="/path"
+          aria-label={t("back")}
+          className="-ml-2 inline-flex size-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <ArrowLeft className="size-5" aria-hidden />
+        </Link>
+        <h1 className="font-heading text-lg font-semibold">{t("srTitle")}</h1>
+      </header>
+      <QuickPebbleEditor onPebbleCreated={() => router.push("/path")} />
     </section>
   )
 }

--- a/apps/web/components/path/PathBottomDock.tsx
+++ b/apps/web/components/path/PathBottomDock.tsx
@@ -1,28 +1,21 @@
 "use client"
 
-import type { Pebble } from "@/lib/types"
-import { QuickPebbleEditor } from "@/components/path/QuickPebbleEditor"
+import Link from "next/link"
+import { useTranslations } from "next-intl"
 import { PathBottomBar } from "@/components/path/PathBottomBar"
 
-type PathBottomDockProps = {
-  editorExpanded: boolean
-  onEditorExpandedChange: (next: boolean) => void
-  onPebbleCreated: (pebble: Pebble) => void
-}
+export function PathBottomDock() {
+  const t = useTranslations("path")
 
-export function PathBottomDock({
-  editorExpanded,
-  onEditorExpandedChange,
-  onPebbleCreated,
-}: PathBottomDockProps) {
   return (
     <div className="sticky inset-x-0 bottom-0 bg-gradient-to-t from-white to-transparent dark:from-background">
       <div className="px-4">
-        <QuickPebbleEditor
-          expanded={editorExpanded}
-          onExpandedChange={onEditorExpandedChange}
-          onPebbleCreated={onPebbleCreated}
-        />
+        <Link
+          href="/record"
+          className="block w-full rounded-2xl bg-surface py-3 text-center font-heading text-[17px] font-bold text-primary transition-colors hover:bg-muted dark:bg-accent dark:text-primary"
+        >
+          {t("newPebble")}
+        </Link>
       </div>
       <PathBottomBar />
     </div>

--- a/apps/web/components/path/PathEmptyState.tsx
+++ b/apps/web/components/path/PathEmptyState.tsx
@@ -1,22 +1,19 @@
 "use client"
 
+import Link from "next/link"
 import { CirclePlus } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { Button } from "@/components/ui/button"
 import { EmptyState } from "@/components/layout/EmptyState"
 
-type PathEmptyStateProps = {
-  onCarve?: () => void
-}
-
-export function PathEmptyState({ onCarve }: PathEmptyStateProps) {
+export function PathEmptyState() {
   const t = useTranslations("path.empty.currentWeek")
   return (
     <EmptyState
       title={t("title")}
       description={t("description")}
       action={
-        <Button onClick={onCarve}>
+        <Button render={<Link href="/record" />}>
           <CirclePlus className="size-4" data-icon="inline-start" />
           {t("cta")}
         </Button>

--- a/apps/web/components/path/PathScreen.tsx
+++ b/apps/web/components/path/PathScreen.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { Loader2 } from "lucide-react"
 import { useTranslations } from "next-intl"
 import type { Pebble, Soul } from "@/lib/types"
@@ -50,8 +50,6 @@ export function PathScreen({ pebbles, souls, loading }: PathScreenProps) {
   // no setState-during-render, no useEffect setState ping-pong.
   const [focusedKey, setFocusedKey] = useState<string>(() => isoWeekKey(today))
   const [selectedPebbleId, setSelectedPebbleId] = useState<string | null>(null)
-  const [editorExpanded, setEditorExpanded] = useState(false)
-  const scrollTargetRef = useRef<string | null>(null)
 
   const focusedEntry = entries.find((e) => e.weekStartIso === focusedKey)
     ?? (entries.length > 0 ? closestEntry(entries, isoWeekStart(today)) : undefined)
@@ -82,17 +80,6 @@ export function PathScreen({ pebbles, souls, loading }: PathScreenProps) {
   const setFocusedFromDate = useCallback((date: Date) => {
     setFocusedKey(isoWeekKey(date))
   }, [])
-
-  const handlePebbleCreated = useCallback((pebble: Pebble) => {
-    // If the new pebble landed in a different week than the focused one,
-    // jump focus to that week so the user sees their just-created row.
-    const pebbleWeek = isoWeekKey(new Date(pebble.happened_at))
-    if (pebbleWeek !== focusedKey) setFocusedKey(pebbleWeek)
-    scrollTargetRef.current = pebble.id
-    setSelectedPebbleId(pebble.id)
-  }, [focusedKey])
-
-  const handleCarvePebble = useCallback(() => setEditorExpanded(true), [])
 
   const handleClosePeek = useCallback(() => setSelectedPebbleId(null), [])
 
@@ -141,15 +128,9 @@ export function PathScreen({ pebbles, souls, loading }: PathScreenProps) {
           souls={souls}
           onFocusChange={setFocusedFromDate}
           onSelectPebble={setSelectedPebbleId}
-          onCarvePebble={handleCarvePebble}
-          scrollTargetRef={scrollTargetRef}
         />
       </div>
-      <PathBottomDock
-        editorExpanded={editorExpanded}
-        onEditorExpandedChange={setEditorExpanded}
-        onPebbleCreated={handlePebbleCreated}
-      />
+      <PathBottomDock />
       <PebblePeek
         pebbleId={selectedPebbleId}
         onClose={handleClosePeek}

--- a/apps/web/components/path/QuickPebbleEditor.tsx
+++ b/apps/web/components/path/QuickPebbleEditor.tsx
@@ -8,7 +8,6 @@ import {
   Image,
   Users,
 } from "lucide-react"
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion"
 import { useTranslations } from "next-intl"
 import type { Pebble, PebbleSnap } from "@/lib/types"
 import { useFormatDate } from "@/lib/i18n"
@@ -36,8 +35,6 @@ type Intensity = 1 | 2 | 3
 type Valence = -1 | 0 | 1
 
 type QuickPebbleEditorProps = {
-  expanded?: boolean
-  onExpandedChange?: (next: boolean) => void
   onPebbleCreated?: (pebble: Pebble) => void
 }
 
@@ -47,35 +44,19 @@ function isNow(dateStr: string): boolean {
 }
 
 export function QuickPebbleEditor({
-  expanded: expandedProp,
-  onExpandedChange,
   onPebbleCreated,
 }: QuickPebbleEditorProps) {
   const { addPebble, uploadSnap } = usePebbles()
   const { souls, addSoul } = useSouls()
   const { collections } = useCollections()
   const { glyphs: marks } = useUsableGlyphs()
-  const prefersReducedMotion = useReducedMotion()
   const t = useTranslations("record")
-  const tPath = useTranslations("path")
   const tGlyph = useTranslations("record.glyph")
   const tPhoto = useTranslations("record.photo")
   const tSouls = useTranslations("record.souls")
   const tEmotion = useTranslations("record.emotion")
   const formatDate = useFormatDate()
 
-  // Collapse state — controlled-or-uncontrolled
-  const [expandedInternal, setExpandedInternal] = useState(false)
-  const isControlled = expandedProp !== undefined
-  const expanded = isControlled ? expandedProp : expandedInternal
-  const setExpanded = useCallback(
-    (next: boolean) => {
-      if (!isControlled) setExpandedInternal(next)
-      onExpandedChange?.(next)
-    },
-    [isControlled, onExpandedChange],
-  )
-  const sectionRef = useRef<HTMLElement>(null)
   const titleInputRef = useRef<HTMLTextAreaElement>(null)
 
   // Form state
@@ -164,7 +145,6 @@ export function QuickPebbleEditor({
       const pebble = await addPebble(input)
 
       resetForm()
-      setExpanded(false)
       titleInputRef.current?.blur()
       onPebbleCreated?.(pebble)
     } finally {
@@ -173,7 +153,7 @@ export function QuickPebbleEditor({
   }, [
     name, description, happenedAt, intensity, valence, visibility,
     emotionId, soulIds, domainIds, markId, collectionIds, pendingSnap,
-    saving, snapUploading, addPebble, resetForm, onPebbleCreated, setExpanded,
+    saving, snapUploading, addPebble, resetForm, onPebbleCreated,
   ])
 
   const toggleSoul = useCallback((id: string) => {
@@ -220,26 +200,6 @@ export function QuickPebbleEditor({
     setPendingSnap(undefined)
   }, [])
 
-  // Focus tracking — expand on focus, collapse on blur when empty
-  const handleFocusCapture = useCallback(() => {
-    if (!expanded) setExpanded(true)
-  }, [expanded, setExpanded])
-
-  const handleBlurCapture = useCallback(() => {
-    // rAF lets the browser settle focus after portal transitions
-    requestAnimationFrame(() => {
-      const active = document.activeElement
-      if (active && sectionRef.current?.contains(active)) return
-      if (active instanceof HTMLElement) {
-        const inPortal = active.closest(
-          '[data-slot="popover-content"], [data-slot="popover-positioner"], [data-slot="dialog-content"], [data-slot="sheet-content"], [role="dialog"]',
-        )
-        if (inPortal) return
-      }
-      if (!name.trim()) setExpanded(false)
-    })
-  }, [name, setExpanded])
-
   const dateLabel = isNow(happenedAt)
     ? t("now")
     : formatDate(happenedAt, {
@@ -251,193 +211,151 @@ export function QuickPebbleEditor({
 
   return (
     <>
-      {/* Collapsed trigger — hidden while the overlay is open.
-          Light mode: brand-light bg with brand accent label.
-          Dark mode: brand foreground (near-white) bg with brand accent label. */}
-      {!expanded && (
-        <button
-          type="button"
-          onClick={() => setExpanded(true)}
-          className="block w-full rounded-2xl bg-surface py-3 text-center font-heading text-[17px] font-bold text-primary transition-colors hover:bg-muted dark:bg-accent dark:text-primary"
-        >
-          {tPath("newPebble")}
-        </button>
-      )}
+      <section aria-label={t("editorAria")}>
+        {/* Header: date + intensity/valence grid */}
+        <div className="mb-3 flex items-center justify-between">
+          <button
+            type="button"
+            onClick={() => setDateOpen(true)}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <CalendarDays className="size-3.5" aria-hidden />
+            {dateLabel}
+          </button>
+          <ValenceIntensityGrid
+            intensity={intensity}
+            valence={valence}
+            onIntensityChange={setIntensity}
+            onValenceChange={setValence}
+          />
+        </div>
 
-      {/* Expanded overlay */}
-      <AnimatePresence>
-        {expanded && (
-          <>
-            <motion.div
-              key="backdrop"
-              className="fixed inset-0 z-30 bg-background/60 backdrop-blur-sm"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: prefersReducedMotion ? 0 : 0.15 }}
-              onClick={() => {
-                if (!name.trim()) setExpanded(false)
-              }}
-            />
-            <motion.section
-              key="overlay"
-              ref={sectionRef}
-              aria-label={t("editorAria")}
-              className="fixed inset-x-0 bottom-0 z-40 max-h-[min(72vh,640px)] overflow-y-auto rounded-t-2xl border-t bg-card p-4 pb-[calc(1rem+var(--safe-area-bottom))]"
-              initial={{ y: "100%" }}
-              animate={{ y: 0 }}
-              exit={{ y: "100%" }}
-              transition={{ duration: prefersReducedMotion ? 0 : 0.25, ease: "easeOut" }}
-              onFocusCapture={handleFocusCapture}
-              onBlurCapture={handleBlurCapture}
-            >
-              {/* Header: date + intensity/valence grid */}
-              <div className="mb-3 flex items-center justify-between">
-                <button
-                  type="button"
-                  onClick={() => setDateOpen(true)}
-                  className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                >
-                  <CalendarDays className="size-3.5" aria-hidden />
-                  {dateLabel}
-                </button>
-                <ValenceIntensityGrid
-                  intensity={intensity}
-                  valence={valence}
-                  onIntensityChange={setIntensity}
-                  onValenceChange={setValence}
-                />
-              </div>
+        {/* Title input */}
+        <textarea
+          ref={titleInputRef}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder={t("namePlaceholder")}
+          className="mb-2 w-full resize-none border-none bg-transparent font-heading text-xl font-semibold text-foreground outline-none field-sizing-content placeholder:text-muted-foreground/50"
+          rows={1}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault()
+              void handleSubmit()
+            }
+          }}
+        />
 
-              {/* Title input */}
-              <textarea
-                ref={titleInputRef}
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder={t("namePlaceholder")}
-                className="mb-2 w-full resize-none border-none bg-transparent font-heading text-xl font-semibold text-foreground outline-none field-sizing-content placeholder:text-muted-foreground/50"
-                rows={1}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && !e.shiftKey) {
-                    e.preventDefault()
-                    void handleSubmit()
-                  }
-                }}
-              />
+        {/* Qualification pills */}
+        <div className="mb-3 flex items-center gap-2">
+          <DomainSheet value={domainIds} onChange={setDomainIds} />
+          <button
+            type="button"
+            onClick={() => setEmotionPickerOpen(true)}
+            aria-label={
+              selectedEmotion
+                ? tEmotion("selectedAria", { name: selectedEmotion.name })
+                : tEmotion("pickAria")
+            }
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+              selectedEmotion
+                ? "border border-border bg-background text-foreground"
+                : "border border-dashed border-muted-foreground/30 text-muted-foreground hover:border-muted-foreground/50",
+            )}
+          >
+            {selectedEmotion ? (
+              <>
+                <span aria-hidden>{selectedEmotion.emoji}</span>
+                {selectedEmotion.name}
+              </>
+            ) : (
+              tEmotion("label")
+            )}
+          </button>
+        </div>
 
-              {/* Qualification pills */}
-              <div className="mb-3 flex items-center gap-2">
-                <DomainSheet value={domainIds} onChange={setDomainIds} />
-                <button
-                  type="button"
-                  onClick={() => setEmotionPickerOpen(true)}
-                  aria-label={
-                    selectedEmotion
-                      ? tEmotion("selectedAria", { name: selectedEmotion.name })
-                      : tEmotion("pickAria")
-                  }
-                  className={cn(
-                    "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
-                    selectedEmotion
-                      ? "border border-border bg-background text-foreground"
-                      : "border border-dashed border-muted-foreground/30 text-muted-foreground hover:border-muted-foreground/50",
-                  )}
-                >
-                  {selectedEmotion ? (
-                    <>
-                      <span aria-hidden>{selectedEmotion.emoji}</span>
-                      {selectedEmotion.name}
-                    </>
-                  ) : (
-                    tEmotion("label")
-                  )}
-                </button>
-              </div>
+        {/* Description */}
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder={t("descriptionPlaceholder")}
+          className="mb-4 w-full resize-none border-none bg-transparent text-sm text-foreground outline-none field-sizing-content placeholder:text-muted-foreground/50"
+          rows={1}
+        />
 
-              {/* Description */}
-              <textarea
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder={t("descriptionPlaceholder")}
-                className="mb-4 w-full resize-none border-none bg-transparent text-sm text-foreground outline-none field-sizing-content placeholder:text-muted-foreground/50"
-                rows={1}
-              />
+        {/* Customization tiles */}
+        <div className="mb-4 grid grid-cols-4 gap-2">
+          <CustomizationTile
+            icon={Fingerprint}
+            filled={!!selectedMark}
+            onClick={() => setGlyphOpen(true)}
+            ariaLabel={selectedMark ? tGlyph("changeAria") : tGlyph("addAria")}
+          >
+            {selectedMark && <GlyphPreview mark={selectedMark} className="size-full p-2" />}
+          </CustomizationTile>
+          <CollectionSheet
+            value={collectionIds}
+            onChange={setCollectionIds}
+            collections={collections}
+          />
+          <CustomizationTile
+            icon={Users}
+            filled={soulIds.length > 0}
+            onClick={() => setSoulsOpen(true)}
+            ariaLabel={soulIds.length > 0 ? tSouls("selectedAria", { count: soulIds.length }) : tSouls("addAria")}
+          >
+            {soulIds.length > 0 && (
+              <span className="text-xs font-medium text-muted-foreground">{soulIds.length}</span>
+            )}
+          </CustomizationTile>
+          <CustomizationTile
+            icon={Image}
+            filled={!!snapPreview}
+            onClick={() => {
+              if (snapPreview) {
+                clearSnap()
+              } else {
+                fileInputRef.current?.click()
+              }
+            }}
+            ariaLabel={snapPreview ? tPhoto("removeAria") : tPhoto("addAria")}
+          >
+            {snapPreview && (
+              /* eslint-disable-next-line @next/next/no-img-element -- object URL */
+              <img src={snapPreview} alt={tPhoto("alt")} className="size-full object-cover" />
+            )}
+          </CustomizationTile>
+        </div>
 
-              {/* Customization tiles */}
-              <div className="mb-4 grid grid-cols-4 gap-2">
-                <CustomizationTile
-                  icon={Fingerprint}
-                  filled={!!selectedMark}
-                  onClick={() => setGlyphOpen(true)}
-                  ariaLabel={selectedMark ? tGlyph("changeAria") : tGlyph("addAria")}
-                >
-                  {selectedMark && <GlyphPreview mark={selectedMark} className="size-full p-2" />}
-                </CustomizationTile>
-                <CollectionSheet
-                  value={collectionIds}
-                  onChange={setCollectionIds}
-                  collections={collections}
-                />
-                <CustomizationTile
-                  icon={Users}
-                  filled={soulIds.length > 0}
-                  onClick={() => setSoulsOpen(true)}
-                  ariaLabel={soulIds.length > 0 ? tSouls("selectedAria", { count: soulIds.length }) : tSouls("addAria")}
-                >
-                  {soulIds.length > 0 && (
-                    <span className="text-xs font-medium text-muted-foreground">{soulIds.length}</span>
-                  )}
-                </CustomizationTile>
-                <CustomizationTile
-                  icon={Image}
-                  filled={!!snapPreview}
-                  onClick={() => {
-                    if (snapPreview) {
-                      clearSnap()
-                    } else {
-                      fileInputRef.current?.click()
-                    }
-                  }}
-                  ariaLabel={snapPreview ? tPhoto("removeAria") : tPhoto("addAria")}
-                >
-                  {snapPreview && (
-                    /* eslint-disable-next-line @next/next/no-img-element -- object URL */
-                    <img src={snapPreview} alt={tPhoto("alt")} className="size-full object-cover" />
-                  )}
-                </CustomizationTile>
-              </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          aria-hidden="true"
+          tabIndex={-1}
+          onChange={(e) => {
+            void handleFileChange(e.target.files)
+            e.target.value = ""
+          }}
+        />
 
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept="image/*"
-                className="hidden"
-                aria-hidden="true"
-                tabIndex={-1}
-                onChange={(e) => {
-                  void handleFileChange(e.target.files)
-                  e.target.value = ""
-                }}
-              />
-
-              {/* Footer */}
-              <div className="flex items-center justify-between">
-                <VisibilityPicker value={visibility} onChange={setVisibility} />
-                <Button
-                  variant="default"
-                  size="icon"
-                  disabled={!name.trim() || saving || snapUploading}
-                  onClick={() => void handleSubmit()}
-                  aria-label={t("save")}
-                  className="size-9 rounded-full"
-                >
-                  <Check className="size-5" aria-hidden />
-                </Button>
-              </div>
-            </motion.section>
-          </>
-        )}
-      </AnimatePresence>
+        {/* Footer */}
+        <div className="flex items-center justify-between">
+          <VisibilityPicker value={visibility} onChange={setVisibility} />
+          <Button
+            variant="default"
+            size="icon"
+            disabled={!name.trim() || saving || snapUploading}
+            onClick={() => void handleSubmit()}
+            aria-label={t("save")}
+            className="size-9 rounded-full"
+          >
+            <Check className="size-5" aria-hidden />
+          </Button>
+        </div>
+      </section>
 
       {/* Dialogs / sheets (unchanged) */}
       <DatePickerDialog

--- a/apps/web/components/path/WeekPager.tsx
+++ b/apps/web/components/path/WeekPager.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { motion, useReducedMotion, type PanInfo } from "framer-motion"
-import { type MutableRefObject } from "react"
 import { useMediaQuery } from "@/lib/hooks/useMediaQuery"
 import type { Soul } from "@/lib/types"
 import { WeekPath } from "@/components/path/WeekPath"
@@ -16,8 +15,6 @@ type WeekPagerProps = {
   souls: Soul[]
   onFocusChange: (weekStart: Date) => void
   onSelectPebble: (id: string) => void
-  onCarvePebble: () => void
-  scrollTargetRef: MutableRefObject<string | null>
 }
 
 export function WeekPager({
@@ -26,8 +23,6 @@ export function WeekPager({
   souls,
   onFocusChange,
   onSelectPebble,
-  onCarvePebble,
-  scrollTargetRef,
 }: WeekPagerProps) {
   const focusedIndex = weekIndex(entries, focused)
   const prefersReducedMotion = useReducedMotion()
@@ -81,8 +76,6 @@ export function WeekPager({
                 souls={souls}
                 isFocused={i === focusedIndex}
                 onSelectPebble={onSelectPebble}
-                onCarvePebble={onCarvePebble}
-                scrollTargetRef={scrollTargetRef}
               />
             ) : null}
           </div>

--- a/apps/web/components/path/WeekPath.tsx
+++ b/apps/web/components/path/WeekPath.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { useEffect, type MutableRefObject } from "react"
 import { motion, useReducedMotion } from "framer-motion"
 import { useLookupMaps } from "@/lib/data/useLookupMaps"
 import { useMarks } from "@/lib/data/useMarks"
@@ -14,8 +13,6 @@ type WeekPathProps = {
   souls: Soul[]
   isFocused: boolean
   onSelectPebble: (id: string) => void
-  onCarvePebble: () => void
-  scrollTargetRef: MutableRefObject<string | null>
 }
 
 export function WeekPath({
@@ -23,8 +20,6 @@ export function WeekPath({
   souls,
   isFocused,
   onSelectPebble,
-  onCarvePebble,
-  scrollTargetRef,
 }: WeekPathProps) {
   const prefersReducedMotion = useReducedMotion()
   const { marks } = useMarks()
@@ -39,18 +34,8 @@ export function WeekPath({
     ? `${entry.weekStartIso}-focused-${entry.pebbles.length}`
     : `${entry.weekStartIso}-unfocused`
 
-  useEffect(() => {
-    const targetId = scrollTargetRef.current
-    if (!targetId) return
-    const el = document.getElementById(`pebble-${targetId}`)
-    if (el) {
-      el.scrollIntoView({ behavior: "smooth", block: "center" })
-      scrollTargetRef.current = null
-    }
-  }, [entry.pebbles, scrollTargetRef])
-
   if (entry.pebbles.length === 0) {
-    return <PathEmptyState onCarve={onCarvePebble} />
+    return <PathEmptyState />
   }
 
   return (

--- a/apps/web/components/record/DomainSheet.tsx
+++ b/apps/web/components/record/DomainSheet.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 import { Compass } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { DOMAINS, type Domain } from "@/lib/config/domains"
@@ -40,13 +40,17 @@ function DomainOption({ domain, glyph, selected, onSelect }: {
 }
 
 /**
- * Multi-select domain picker presented in the shared drawer. Toggling a row
- * keeps the sheet open; the header `X` (or a backdrop tap) dismisses it.
+ * Single-select domain picker presented in the shared drawer. Picking a row
+ * commits it and dismisses the sheet (mirrors the emotion picker); re-tapping
+ * the selected row clears it. The interface stays array-based (`value`/
+ * `onChange` over `string[]`) so the create payload's `domain_ids` is unchanged,
+ * but at most one id is ever held.
  */
 export function DomainSheet({ value, onChange }: DomainSheetProps) {
   const t = useTranslations("record.domain")
   const glyphs = useDomainGlyphs()
   const localizedNames = useLocalizedDomainMap()
+  const [open, setOpen] = useState(false)
   const selectedDomains = DOMAINS.filter((d) => value.includes(d.id))
   const selectedNames = useMemo(
     () => selectedDomains.map((d) => localizedNames.get(d.slug) ?? d.name),
@@ -54,13 +58,14 @@ export function DomainSheet({ value, onChange }: DomainSheetProps) {
   )
 
   const toggle = (id: string) => {
-    onChange(
-      value.includes(id) ? value.filter((d) => d !== id) : [...value, id],
-    )
+    onChange(value.includes(id) ? [] : [id])
+    setOpen(false)
   }
 
   return (
     <PickerSheet
+      open={open}
+      onOpenChange={setOpen}
       title={t("title")}
       closeLabel={t("close")}
       trigger={

--- a/apps/web/components/ui/sheet.tsx
+++ b/apps/web/components/ui/sheet.tsx
@@ -53,7 +53,7 @@ function SheetContent({
           // Shared
           "fixed z-[60] bg-background text-popover-foreground ring-1 ring-foreground/10 outline-none",
           // Mobile: bottom sheet
-          "inset-x-0 bottom-0 max-h-[85dvh] overflow-y-auto rounded-t-2xl p-4 pt-2",
+          "inset-x-0 bottom-0 max-h-[92dvh] overflow-y-auto rounded-t-2xl p-4 pt-2",
           "translate-y-full data-open:translate-y-0 transition-transform duration-200 ease-out",
           // Desktop: side sheet from right — full height, scrollable
           "md:top-0 md:bottom-0 md:right-0 md:left-auto md:max-h-none md:h-full md:w-[420px] md:overflow-y-auto md:rounded-t-none md:rounded-l-2xl md:p-6",

--- a/apps/web/lib/i18n/messages/en.json
+++ b/apps/web/lib/i18n/messages/en.json
@@ -540,6 +540,7 @@
   },
   "record": {
     "srTitle": "Record a pebble",
+    "back": "Back to Path",
     "editorAria": "Pebble editor",
     "triggerAria": "What happened?",
     "namePlaceholder": "What happened?",

--- a/apps/web/lib/i18n/messages/fr.json
+++ b/apps/web/lib/i18n/messages/fr.json
@@ -540,6 +540,7 @@
   },
   "record": {
     "srTitle": "Capturer l'instant",
+    "back": "Retour au chemin",
     "editorAria": "Éditeur de galet",
     "triggerAria": "Que s'est-il passé ?",
     "namePlaceholder": "Que s'est-il passé ?",


### PR DESCRIPTION
Resolves #

## Changes

**QuickPebbleEditor.tsx**
- Removed expand/collapse state management (`expanded`, `onExpandedChange` props, `expandedInternal` state)
- Removed framer-motion animations (AnimatePresence, motion divs, backdrop, overlay transitions)
- Removed focus/blur tracking logic (`handleFocusCapture`, `handleBlurCapture`, `sectionRef`)
- Removed the collapsed trigger button
- Converted to a simple, always-visible form section (no modal overlay)
- Simplified component to accept only `onPebbleCreated` callback
- Removed `setExpanded(false)` call after form submission

**record/page.tsx**
- Converted from a modal-trigger page to a dedicated capture route
- Removed `PebblePeek` component and related state
- Removed editor expand/collapse state management
- Added header with back link to `/path` and page title
- `QuickPebbleEditor` now auto-navigates to `/path` on successful pebble creation

**PathBottomDock.tsx**
- Removed `QuickPebbleEditor` component
- Replaced with a simple link button to `/record`
- Removed expand/collapse state props
- Removed `onPebbleCreated` callback

**PathScreen.tsx**
- Removed `editorExpanded` state
- Removed `scrollTargetRef` ref
- Removed `handlePebbleCreated` callback (no longer needed; navigation handled in `/record`)
- Removed `handleCarvePebble` callback
- Updated `PathBottomDock` call to remove state/callback props

**WeekPath.tsx**
- Removed `onCarvePebble` and `scrollTargetRef` props
- Removed `useEffect` that scrolled to newly created pebbles
- Updated `PathEmptyState` call to remove `onCarve` prop

**WeekPager.tsx**
- Removed `onCarvePebble` and `scrollTargetRef` props from type and component signature
- Removed prop forwarding to `WeekPath`

**PathEmptyState.tsx**
- Removed `onCarve` prop
- Replaced button `onClick` handler with `render={<Link href="/record" />}` pattern

**DomainSheet.tsx**
- Changed from multi-select to single-select behavior
- Added `open` state to control sheet visibility
- Updated `toggle` to clear selection on re-tap and auto-close sheet after selection
- Updated JSDoc to reflect single-select semantics

**i18n messages (en.json, fr.json)**
- Added `"back": "Back to Path"` / `"back": "Retour au chemin"` translation key

## Notes

This refactor decouples the pebble editor from the path view by moving it to a dedicated `/record` route. The editor is now a simple, always-visible form rather than a modal overlay with expand/collapse animations. Navigation is handled via Next.js routing:

- **Path view** → click "New Pebble" button → navigate to `/record`
- **Record view** → submit form → auto-navigate back to `/path`
- **Record view** → click back link → navigate to `/path`

Key trade-offs:
- Removed smooth animations on editor expand/collapse (simpler UX, faster load)
- Removed auto-scroll-to-new-pebble behavior (user can manually navigate or refresh)
- Domain picker changed to single-select to match emotion picker UX (simpler, more consistent)
- Editor state no longer persists across navigation (form resets on route change)

The change simplifies state management across the path view and reduces animation complexity while maintaining the core capture workflow.

## Checklist
- [x] Branch name follows `type/issueNumber-description`
- [x] PR title uses conventional commits: `type(scope): description`
- [x] Labels applied (species + scope)
- [x] Milestone assigned
- [x] `npm run build` passes
- [x] `npm run lint` passes

https://claude.ai/code/session_01AMeKMWdkPfZcG3wHfZN6tD