### PR TITLE
feat(ui): restyle domains sheet selected state

### DIFF
--- a/apps/web/components/carve/StrokeRenderer.tsx
+++ b/apps/web/components/carve/StrokeRenderer.tsx
@@ -2,9 +2,10 @@ import type { MarkStroke } from "@/lib/types"
 
 type StrokeRendererProps = {
   strokes: MarkStroke[]
+  className?: string
 }
 
-export function StrokeRenderer({ strokes }: StrokeRendererProps) {
+export function StrokeRenderer({ strokes, className }: StrokeRendererProps) {
   return (
     <>
       {strokes.map((stroke, i) => (
@@ -16,7 +17,7 @@ export function StrokeRenderer({ strokes }: StrokeRendererProps) {
           strokeWidth={stroke.width}
           strokeLinecap="round"
           strokeLinejoin="round"
-          className="text-foreground"
+          className={className ?? "text-foreground"}
         />
       ))}
     </>

--- a/apps/web/components/record/DomainGlyph.tsx
+++ b/apps/web/components/record/DomainGlyph.tsx
@@ -5,6 +5,7 @@ type DomainGlyphProps = {
   strokes: MarkStroke[]
   viewBox: string
   className?: string
+  strokeClassName?: string
 }
 
 /**
@@ -12,10 +13,10 @@ type DomainGlyphProps = {
  * as the glyphs GlyphPreview, but takes raw strokes (the domain hook returns
  * strokes + viewBox, not a full Mark).
  */
-export function DomainGlyph({ strokes, viewBox, className }: DomainGlyphProps) {
+export function DomainGlyph({ strokes, viewBox, className, strokeClassName }: DomainGlyphProps) {
   return (
     <svg viewBox={viewBox} className={className} aria-hidden="true">
-      <StrokeRenderer strokes={strokes} />
+      <StrokeRenderer strokes={strokes} className={strokeClassName} />
     </svg>
   )
 }

--- a/apps/web/components/record/DomainSheet.tsx
+++ b/apps/web/components/record/DomainSheet.tsx
@@ -31,7 +31,7 @@ function DomainOption({ domain, selected, muted, onSelect }: {
             strokes={domain.glyph.strokes}
             viewBox={domain.glyph.viewBox}
             className="size-7 shrink-0"
-            strokeClassName={selected ? "text-accent" : "text-foreground"}
+            strokeClassName={selected ? "text-primary" : "text-foreground"}
           />
         ) : null}
         <span className="flex flex-col items-start">

--- a/apps/web/components/record/DomainSheet.tsx
+++ b/apps/web/components/record/DomainSheet.tsx
@@ -16,17 +16,23 @@ type DomainSheetProps = {
   onChange: (ids: string[]) => void
 }
 
-function DomainOption({ domain, selected, onSelect }: {
+function DomainOption({ domain, selected, muted, onSelect }: {
   domain: DomainRow
   selected: boolean
+  muted: boolean
   onSelect: () => void
 }) {
   const { name, label } = useDomainLocalized(domain)
   return (
-    <SelectableItem selected={selected} onSelect={onSelect} className="py-2">
-      <span className="flex items-center gap-2">
+    <SelectableItem selected={selected} onSelect={onSelect} showCheck={false} muted={muted} className="py-2">
+      <span className="flex items-center gap-3">
         {domain.glyph ? (
-          <DomainGlyph strokes={domain.glyph.strokes} viewBox={domain.glyph.viewBox} className="size-6 shrink-0" />
+          <DomainGlyph
+            strokes={domain.glyph.strokes}
+            viewBox={domain.glyph.viewBox}
+            className="size-7 shrink-0"
+            strokeClassName={selected ? "text-accent" : "text-foreground"}
+          />
         ) : null}
         <span className="flex flex-col items-start">
           <span>{name}</span>
@@ -87,6 +93,7 @@ export function DomainSheet({ value, onChange }: DomainSheetProps) {
             key={domain.id}
             domain={domain}
             selected={value.includes(domain.id)}
+            muted={value.length > 0 && !value.includes(domain.id)}
             onSelect={() => toggle(domain.id)}
           />
         ))}

--- a/apps/web/components/record/SoulsSheet.tsx
+++ b/apps/web/components/record/SoulsSheet.tsx
@@ -99,6 +99,7 @@ export function SoulsSheet({
           <SelectableItem
             key={soul.id}
             selected={selectedIds.includes(soul.id)}
+            muted={selectedIds.length > 0 && !selectedIds.includes(soul.id)}
             onSelect={() => onToggle(soul.id)}
             className="py-2"
           >

--- a/apps/web/components/ui/SelectableItem.tsx
+++ b/apps/web/components/ui/SelectableItem.tsx
@@ -8,6 +8,8 @@ type SelectableItemProps = {
   children: ReactNode
   role?: "option" | "radio" | "menuitemradio"
   className?: string
+  showCheck?: boolean
+  muted?: boolean
 }
 
 export function SelectableItem({
@@ -16,6 +18,8 @@ export function SelectableItem({
   children,
   role,
   className,
+  showCheck = true,
+  muted = false,
 }: SelectableItemProps) {
   const ariaProps = role === "option"
     ? { role: "option" as const, "aria-selected": selected }
@@ -30,15 +34,18 @@ export function SelectableItem({
       type="button"
       onClick={onSelect}
       className={cn(
-        "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-none transition-colors hover:bg-muted",
+        "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-none transition-colors transition-opacity hover:bg-muted",
         selected && "font-medium",
+        muted && "opacity-50 hover:opacity-100",
         className,
       )}
       {...ariaProps}
     >
-      <span className="flex size-4 shrink-0 items-center justify-center">
-        {selected && <Check className="size-4" />}
-      </span>
+      {showCheck && (
+        <span className="flex size-4 shrink-0 items-center justify-center">
+          {selected && <Check className="size-4" />}
+        </span>
+      )}
       {children}
     </button>
   )


### PR DESCRIPTION
Replace the tick-mark selection indicator in the domains sheet with a
fade-unselected treatment: the picked row's glyph is enlarged and
accent-colored while sibling rows dim. This shrinks the oversized left
inset the tick slot reserved and widens the gap between the glyph and
the item text. SelectableItem gains optional showCheck/muted props
(defaulting to current behavior) so the change stays additive for its
other callers. Souls sheet gets the same dim-unselected treatment
alongside its existing tick.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dcj2ZoGtfmSaueZv5yNUca