### PR TITLE
feat(ui): show souls drawer as a glyph grid with fade-on-select

### DIFF
--- a/apps/web/components/glyphs/GlyphPreview.tsx
+++ b/apps/web/components/glyphs/GlyphPreview.tsx
@@ -4,6 +4,7 @@ import { StrokeRenderer } from "@/components/carve/StrokeRenderer"
 type GlyphPreviewProps = {
   mark: Mark
   className?: string
+  strokeClassName?: string
 }
 
 /**
@@ -12,10 +13,10 @@ type GlyphPreviewProps = {
  * GlyphThumbnail: glyphs are shapeless squares scaled into whatever slot the
  * caller provides via `className`.
  */
-export function GlyphPreview({ mark, className }: GlyphPreviewProps) {
+export function GlyphPreview({ mark, className, strokeClassName }: GlyphPreviewProps) {
   return (
     <svg viewBox={mark.viewBox} className={className} aria-hidden="true">
-      <StrokeRenderer strokes={mark.strokes} />
+      <StrokeRenderer strokes={mark.strokes} className={strokeClassName} />
     </svg>
   )
 }

--- a/apps/web/components/path/QuickPebbleEditor.tsx
+++ b/apps/web/components/path/QuickPebbleEditor.tsx
@@ -377,6 +377,7 @@ export function QuickPebbleEditor({
         selectedIds={soulIds}
         onToggle={toggleSoul}
         souls={souls}
+        marks={marks}
         onAddSoul={handleAddSoul}
       />
       <EmotionPickerSheet

--- a/apps/web/components/pebble/PebbleDetail.tsx
+++ b/apps/web/components/pebble/PebbleDetail.tsx
@@ -285,6 +285,7 @@ export function PebbleDetail({
         selectedIds={pebble.soul_ids}
         onToggle={handleSoulToggle}
         souls={souls}
+        marks={marks}
         onAddSoul={onAddSoul}
       />
     </article>

--- a/apps/web/components/pebble/PebbleEdit.tsx
+++ b/apps/web/components/pebble/PebbleEdit.tsx
@@ -300,6 +300,7 @@ export function PebbleEdit({
         selectedIds={draft.soul_ids}
         onToggle={handleSoulToggle}
         souls={souls}
+        marks={marks}
         onAddSoul={async (name) => {
           await handleAddSoul(name)
         }}

--- a/apps/web/components/record/DatePickerDialog.tsx
+++ b/apps/web/components/record/DatePickerDialog.tsx
@@ -45,6 +45,19 @@ export function DatePickerDialog({ open, onOpenChange, initialDate, onSave }: Da
       onOpenChange={handleOpenChange}
       title={t("title")}
       closeLabel={t("close")}
+      footer={
+        <div className="flex justify-end gap-2">
+          <SheetClose>{t("cancel")}</SheetClose>
+          <Button
+            onClick={() => {
+              onSave(tempDate)
+              onOpenChange(false)
+            }}
+          >
+            {t("done")}
+          </Button>
+        </div>
+      }
     >
       <div className="space-y-4">
         <InlineDatePicker value={tempDate} onChange={handleDateChange} />
@@ -57,17 +70,6 @@ export function DatePickerDialog({ open, onOpenChange, initialDate, onSave }: Da
             {t("now")}
           </Button>
         </div>
-      </div>
-      <div className="mt-4 flex justify-end gap-2">
-        <SheetClose>{t("cancel")}</SheetClose>
-        <Button
-          onClick={() => {
-            onSave(tempDate)
-            onOpenChange(false)
-          }}
-        >
-          {t("done")}
-        </Button>
       </div>
     </PickerSheet>
   )

--- a/apps/web/components/record/DatePickerDialog.tsx
+++ b/apps/web/components/record/DatePickerDialog.tsx
@@ -3,14 +3,8 @@
 import { useState, useCallback } from "react"
 import { useTranslations } from "next-intl"
 import { Button } from "@/components/ui/button"
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-  DialogClose,
-} from "@/components/ui/dialog"
+import { PickerSheet } from "@/components/ui/PickerSheet"
+import { SheetClose } from "@/components/ui/sheet"
 import { InlineDatePicker } from "@/components/record/InlineDatePicker"
 import { TimeStepPicker } from "@/components/record/TimeStepPicker"
 
@@ -46,35 +40,35 @@ export function DatePickerDialog({ open, onOpenChange, initialDate, onSave }: Da
   }, [])
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{t("title")}</DialogTitle>
-        </DialogHeader>
-        <div className="space-y-4">
-          <InlineDatePicker value={tempDate} onChange={handleDateChange} />
-          <div className="flex items-center justify-center gap-3">
-            <TimeStepPicker value={tempDate} onChange={handleTimeChange} />
-            <Button
-              variant="outline"
-              onClick={() => setTempDate(new Date())}
-            >
-              {t("now")}
-            </Button>
-          </div>
-        </div>
-        <DialogFooter>
-          <DialogClose>{t("cancel")}</DialogClose>
+    <PickerSheet
+      open={open}
+      onOpenChange={handleOpenChange}
+      title={t("title")}
+      closeLabel={t("close")}
+    >
+      <div className="space-y-4">
+        <InlineDatePicker value={tempDate} onChange={handleDateChange} />
+        <div className="flex items-center justify-center gap-3">
+          <TimeStepPicker value={tempDate} onChange={handleTimeChange} />
           <Button
-            onClick={() => {
-              onSave(tempDate)
-              onOpenChange(false)
-            }}
+            variant="outline"
+            onClick={() => setTempDate(new Date())}
           >
-            {t("done")}
+            {t("now")}
           </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </div>
+      </div>
+      <div className="mt-4 flex justify-end gap-2">
+        <SheetClose>{t("cancel")}</SheetClose>
+        <Button
+          onClick={() => {
+            onSave(tempDate)
+            onOpenChange(false)
+          }}
+        >
+          {t("done")}
+        </Button>
+      </div>
+    </PickerSheet>
   )
 }

--- a/apps/web/components/record/GlyphPickerDialog.tsx
+++ b/apps/web/components/record/GlyphPickerDialog.tsx
@@ -1,17 +1,8 @@
 "use client"
 
-import { useState, useCallback } from "react"
 import { useTranslations } from "next-intl"
 import type { Mark } from "@/lib/types"
-import { Button } from "@/components/ui/button"
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-  DialogClose,
-} from "@/components/ui/dialog"
+import { PickerSheet } from "@/components/ui/PickerSheet"
 import { GlyphPickerGrid } from "@/components/glyphs/GlyphPickerGrid"
 
 type GlyphPickerDialogProps = {
@@ -29,43 +20,25 @@ export function GlyphPickerDialog({
   selectedMarkId,
   onSave,
 }: GlyphPickerDialogProps) {
-  const [localMarkId, setLocalMarkId] = useState<string | undefined>(selectedMarkId)
   const t = useTranslations("record.glyph")
-  const tCommon = useTranslations("common")
 
-  const handleOpenChange = useCallback(
-    (nextOpen: boolean) => {
-      onOpenChange(nextOpen)
-      if (nextOpen) setLocalMarkId(selectedMarkId)
-    },
-    [selectedMarkId, onOpenChange],
-  )
+  const handleSelect = (id: string | undefined) => {
+    onSave(id)
+    onOpenChange(false)
+  }
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{t("title")}</DialogTitle>
-        </DialogHeader>
-
-        <GlyphPickerGrid
-          marks={marks}
-          selectedMarkId={localMarkId}
-          onSelect={setLocalMarkId}
-        />
-
-        <DialogFooter>
-          <DialogClose>{tCommon("cancel")}</DialogClose>
-          <Button
-            onClick={() => {
-              onSave(localMarkId)
-              onOpenChange(false)
-            }}
-          >
-            {tCommon("save")}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <PickerSheet
+      open={open}
+      onOpenChange={onOpenChange}
+      title={t("title")}
+      closeLabel={t("close")}
+    >
+      <GlyphPickerGrid
+        marks={marks}
+        selectedMarkId={selectedMarkId}
+        onSelect={handleSelect}
+      />
+    </PickerSheet>
   )
 }

--- a/apps/web/components/record/SoulsSheet.tsx
+++ b/apps/web/components/record/SoulsSheet.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useMemo, useState } from "react"
-import { Plus, X } from "lucide-react"
+import { Check, Plus, X } from "lucide-react"
 import { useTranslations } from "next-intl"
 import type { Mark, Soul } from "@/lib/types"
 import { SearchableList } from "@/components/ui/SearchableList"
@@ -98,10 +98,17 @@ export function SoulsSheet({
       onOpenChange={handleOpenChange}
       title={t("title")}
       closeLabel={t("close")}
-      footer={
-        <div className="flex justify-end">
-          <SheetClose aria-label={t("done")}>{t("done")}</SheetClose>
-        </div>
+      overlay={
+        selectedIds.length > 0 && (
+          <SheetClose
+            aria-label={t("done")}
+            variant="default"
+            size="icon-lg"
+            className="rounded-full shadow-lg"
+          >
+            <Check className="size-5" aria-hidden />
+          </SheetClose>
+        )
       }
     >
       <SearchableList

--- a/apps/web/components/record/SoulsSheet.tsx
+++ b/apps/web/components/record/SoulsSheet.tsx
@@ -3,11 +3,12 @@
 import { useMemo, useState } from "react"
 import { Plus, X } from "lucide-react"
 import { useTranslations } from "next-intl"
-import type { Soul } from "@/lib/types"
-import { SelectableItem } from "@/components/ui/SelectableItem"
+import type { Mark, Soul } from "@/lib/types"
 import { SearchableList } from "@/components/ui/SearchableList"
 import { PickerSheet } from "@/components/ui/PickerSheet"
 import { SheetClose } from "@/components/ui/sheet"
+import { SoulGlyphThumbnail } from "@/components/souls/SoulGlyphThumbnail"
+import { cn } from "@/lib/utils"
 
 type SoulsSheetProps = {
   open: boolean
@@ -15,7 +16,45 @@ type SoulsSheetProps = {
   selectedIds: string[]
   onToggle: (id: string) => void
   souls: Soul[]
+  marks: Mark[]
   onAddSoul: (name: string) => Promise<void>
+}
+
+function SoulOption({ soul, mark, selected, muted, onSelect }: {
+  soul: Soul
+  mark: Mark | undefined
+  selected: boolean
+  muted: boolean
+  onSelect: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      aria-label={soul.name}
+      className={cn(
+        "flex w-full flex-col items-center gap-1.5 rounded-xl p-2 text-center outline-none transition-colors transition-opacity hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring",
+        muted && "opacity-50 hover:opacity-100",
+      )}
+    >
+      <span className="grid aspect-square w-full place-items-center rounded-lg bg-muted/60 p-2.5">
+        <SoulGlyphThumbnail
+          mark={mark}
+          className="size-full"
+          strokeClassName={selected ? "text-primary" : "text-foreground"}
+        />
+      </span>
+      <span
+        className={cn(
+          "line-clamp-1 w-full text-xs text-foreground",
+          selected && "font-medium text-primary",
+        )}
+      >
+        {soul.name}
+      </span>
+    </button>
+  )
 }
 
 export function SoulsSheet({
@@ -24,6 +63,7 @@ export function SoulsSheet({
   selectedIds,
   onToggle,
   souls,
+  marks,
   onAddSoul,
 }: SoulsSheetProps) {
   const [query, setQuery] = useState("")
@@ -95,17 +135,19 @@ export function SoulsSheet({
           </ul>
         )}
 
-        {filtered.map((soul) => (
-          <SelectableItem
-            key={soul.id}
-            selected={selectedIds.includes(soul.id)}
-            muted={selectedIds.length > 0 && !selectedIds.includes(soul.id)}
-            onSelect={() => onToggle(soul.id)}
-            className="py-2"
-          >
-            {soul.name}
-          </SelectableItem>
-        ))}
+        <ul role="list" className="grid grid-cols-3 gap-3">
+          {filtered.map((soul) => (
+            <li key={soul.id}>
+              <SoulOption
+                soul={soul}
+                mark={marks.find((m) => m.id === soul.glyph_id)}
+                selected={selectedIds.includes(soul.id)}
+                muted={selectedIds.length > 0 && !selectedIds.includes(soul.id)}
+                onSelect={() => onToggle(soul.id)}
+              />
+            </li>
+          ))}
+        </ul>
 
         {canAddNew && (
           <button

--- a/apps/web/components/record/SoulsSheet.tsx
+++ b/apps/web/components/record/SoulsSheet.tsx
@@ -98,6 +98,11 @@ export function SoulsSheet({
       onOpenChange={handleOpenChange}
       title={t("title")}
       closeLabel={t("close")}
+      footer={
+        <div className="flex justify-end">
+          <SheetClose aria-label={t("done")}>{t("done")}</SheetClose>
+        </div>
+      }
     >
       <SearchableList
         query={query}
@@ -160,12 +165,6 @@ export function SoulsSheet({
           </button>
         )}
       </SearchableList>
-
-      <div className="mt-4 flex justify-end">
-        <SheetClose aria-label={t("done")}>
-          {t("done")}
-        </SheetClose>
-      </div>
     </PickerSheet>
   )
 }

--- a/apps/web/components/souls/SoulGlyphThumbnail.tsx
+++ b/apps/web/components/souls/SoulGlyphThumbnail.tsx
@@ -5,13 +5,14 @@ import { GlyphPreview } from "@/components/glyphs/GlyphPreview"
 type SoulGlyphThumbnailProps = {
   mark: Mark | undefined
   className?: string
+  strokeClassName?: string
 }
 
 // Renders a soul's glyph thumbnail. When the soul still points at the system
 // default glyph (or its row is not yet hydrated in `marks`), falls back to a
 // dashed placeholder — same affordance iOS uses in `CreateSoulSheet.GlyphRow`.
-export function SoulGlyphThumbnail({ mark, className }: SoulGlyphThumbnailProps) {
-  if (mark) return <GlyphPreview mark={mark} className={className} />
+export function SoulGlyphThumbnail({ mark, className, strokeClassName }: SoulGlyphThumbnailProps) {
+  if (mark) return <GlyphPreview mark={mark} className={className} strokeClassName={strokeClassName} />
   return (
     <span
       aria-hidden="true"

--- a/apps/web/components/ui/PickerSheet.tsx
+++ b/apps/web/components/ui/PickerSheet.tsx
@@ -9,6 +9,7 @@ import {
   SheetTitle,
   SheetClose,
 } from "@/components/ui/sheet"
+import { cn } from "@/lib/utils"
 
 type PickerSheetProps = {
   title: string
@@ -24,13 +25,19 @@ type PickerSheetProps = {
   open?: boolean
   onOpenChange?: (open: boolean) => void
   contentClassName?: string
+  /** Optional footer (e.g. a "Done" button), pinned below the scrollable body. */
+  footer?: ReactNode
 }
 
 /**
  * Shared drawer shell for all pickers. Captures the identical Sheet chrome —
  * responsive panel, header with title + `X` close — so every picker (domain,
- * collection, valence, emotion, souls) opens the same drawer; only the body
- * differs. When `open`/`onOpenChange` are omitted the Sheet runs uncontrolled.
+ * collection, valence, emotion, souls) opens the same drawer at the same
+ * size; only the body differs. The body sits in a flex-1 scroll region so
+ * short content (e.g. a handful of souls) fills the available height instead
+ * of leaving blank space below it, and `footer` — when provided — stays
+ * pinned below that region instead of scrolling away with the content. When
+ * `open`/`onOpenChange` are omitted the Sheet runs uncontrolled.
  */
 export function PickerSheet({
   title,
@@ -40,12 +47,13 @@ export function PickerSheet({
   open,
   onOpenChange,
   contentClassName,
+  footer,
 }: PickerSheetProps) {
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       {trigger}
-      <SheetContent className={contentClassName}>
-        <SheetHeader className="relative">
+      <SheetContent className={cn("flex h-[92dvh] flex-col md:h-full", contentClassName)}>
+        <SheetHeader className="relative shrink-0">
           <SheetTitle>{title}</SheetTitle>
           <SheetClose
             aria-label={closeLabel}
@@ -56,7 +64,8 @@ export function PickerSheet({
             <X aria-hidden />
           </SheetClose>
         </SheetHeader>
-        {children}
+        <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
+        {footer && <div className="mt-4 shrink-0">{footer}</div>}
       </SheetContent>
     </Sheet>
   )

--- a/apps/web/components/ui/PickerSheet.tsx
+++ b/apps/web/components/ui/PickerSheet.tsx
@@ -27,6 +27,11 @@ type PickerSheetProps = {
   contentClassName?: string
   /** Optional footer (e.g. a "Done" button), pinned below the scrollable body. */
   footer?: ReactNode
+  /**
+   * Optional floating element (e.g. a FAB) absolutely positioned over the
+   * bottom-right of the scrollable body, instead of occupying its own row.
+   */
+  overlay?: ReactNode
 }
 
 /**
@@ -48,6 +53,7 @@ export function PickerSheet({
   onOpenChange,
   contentClassName,
   footer,
+  overlay,
 }: PickerSheetProps) {
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -66,6 +72,11 @@ export function PickerSheet({
         </SheetHeader>
         <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
         {footer && <div className="mt-4 shrink-0">{footer}</div>}
+        {overlay && (
+          <div className="absolute right-4 bottom-4 z-10 md:right-6 md:bottom-6">
+            {overlay}
+          </div>
+        )}
       </SheetContent>
     </Sheet>
   )

--- a/apps/web/components/ui/SearchableList.tsx
+++ b/apps/web/components/ui/SearchableList.tsx
@@ -33,7 +33,7 @@ export function SearchableList({
           onKeyDown={onKeyDown}
         />
       </div>
-      <div className="max-h-[200px] overflow-y-auto">
+      <div className="max-h-[320px] overflow-y-auto">
         {children}
         {isEmpty && (
           <p className="px-2 py-4 text-center text-sm text-muted-foreground">

--- a/apps/web/components/ui/SearchableList.tsx
+++ b/apps/web/components/ui/SearchableList.tsx
@@ -29,7 +29,7 @@ export function SearchableList({
           value={query}
           onChange={(e) => onQueryChange(e.target.value)}
           placeholder={placeholder}
-          className="h-7 w-full min-w-0 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          className="h-7 w-full min-w-0 bg-transparent text-base outline-none placeholder:text-muted-foreground md:text-sm"
           onKeyDown={onKeyDown}
         />
       </div>

--- a/apps/web/components/ui/SearchableList.tsx
+++ b/apps/web/components/ui/SearchableList.tsx
@@ -21,8 +21,8 @@ export function SearchableList({
   onKeyDown,
 }: SearchableListProps) {
   return (
-    <>
-      <div className="flex items-center gap-2 border-b border-border pb-2 mb-1">
+    <div className="flex h-full flex-col">
+      <div className="mb-1 flex shrink-0 items-center gap-2 border-b border-border pb-2">
         <Search className="size-4 shrink-0 text-muted-foreground" aria-hidden />
         <input
           type="text"
@@ -33,7 +33,7 @@ export function SearchableList({
           onKeyDown={onKeyDown}
         />
       </div>
-      <div className="max-h-[320px] overflow-y-auto">
+      <div className="min-h-0 flex-1 overflow-y-auto">
         {children}
         {isEmpty && (
           <p className="px-2 py-4 text-center text-sm text-muted-foreground">
@@ -41,6 +41,6 @@ export function SearchableList({
           </p>
         )}
       </div>
-    </>
+    </div>
   )
 }

--- a/apps/web/components/ui/sheet.tsx
+++ b/apps/web/components/ui/sheet.tsx
@@ -53,7 +53,7 @@ function SheetContent({
           // Shared
           "fixed z-[60] bg-background text-popover-foreground ring-1 ring-foreground/10 outline-none",
           // Mobile: bottom sheet
-          "inset-x-0 bottom-0 max-h-[92dvh] overflow-y-auto rounded-t-2xl p-4 pt-2",
+          "inset-x-0 bottom-0 h-[92dvh] overflow-y-auto rounded-t-2xl p-4 pt-2",
           "duration-200 ease-out data-open:animate-in data-open:slide-in-from-bottom-full data-closed:animate-out data-closed:slide-out-to-bottom-full",
           // Desktop: side sheet from right — full height, scrollable
           "md:top-0 md:bottom-0 md:right-0 md:left-auto md:max-h-none md:h-full md:w-[420px] md:overflow-y-auto md:rounded-t-none md:rounded-l-2xl md:p-6",

--- a/apps/web/components/ui/sheet.tsx
+++ b/apps/web/components/ui/sheet.tsx
@@ -53,7 +53,7 @@ function SheetContent({
           // Shared
           "fixed z-[60] bg-background text-popover-foreground ring-1 ring-foreground/10 outline-none",
           // Mobile: bottom sheet
-          "inset-x-0 bottom-0 h-[92dvh] overflow-y-auto rounded-t-2xl p-4 pt-2",
+          "inset-x-0 bottom-0 max-h-[92dvh] overflow-y-auto rounded-t-2xl p-4 pt-2",
           "duration-200 ease-out data-open:animate-in data-open:slide-in-from-bottom-full data-closed:animate-out data-closed:slide-out-to-bottom-full",
           // Desktop: side sheet from right — full height, scrollable
           "md:top-0 md:bottom-0 md:right-0 md:left-auto md:max-h-none md:h-full md:w-[420px] md:overflow-y-auto md:rounded-t-none md:rounded-l-2xl md:p-6",

--- a/apps/web/lib/i18n/messages/en.json
+++ b/apps/web/lib/i18n/messages/en.json
@@ -598,6 +598,7 @@
     },
     "glyph": {
       "title": "Glyph",
+      "close": "Close",
       "addAria": "Add glyph",
       "changeAria": "Change glyph"
     },
@@ -649,6 +650,7 @@
     },
     "date": {
       "title": "When",
+      "close": "Close",
       "now": "Now",
       "cancel": "Cancel",
       "done": "Done",

--- a/apps/web/lib/i18n/messages/fr.json
+++ b/apps/web/lib/i18n/messages/fr.json
@@ -598,6 +598,7 @@
     },
     "glyph": {
       "title": "Glyphe",
+      "close": "Fermer",
       "addAria": "Ajouter un glyphe",
       "changeAria": "Changer de glyphe"
     },
@@ -649,6 +650,7 @@
     },
     "date": {
       "title": "Quand",
+      "close": "Fermer",
       "now": "Maintenant",
       "cancel": "Annuler",
       "done": "Terminé",


### PR DESCRIPTION
Bring the pebble creation/edit/detail souls picker to grid parity with
iOS: souls now render as glyph+name tiles instead of a plain text
list, and selecting one fades every other tile (opacity-50, same
mechanism DomainSheet already uses) instead of iOS's color-only swap.
Search field, selected chips, and inline "add new soul" are unchanged.