### PR TITLE
feat(android): implement entry funnel (Welcome, Auth, Onboarding)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -42,8 +42,18 @@ jobs:
           # Validate the committed wrapper JAR against known-good checksums.
           validate-wrappers: true
 
+      # Bake the Supabase config into the debug APK from repo Actions secrets so
+      # the CI artifact is installable-and-functional (the maintainer has no
+      # local Android SDK). build.gradle.kts reads these env vars when
+      # secrets.properties is absent. Both values are publishable — the anon key
+      # already ships in the web and iOS clients — so a downloadable debug
+      # artifact adds no exposure. If the secrets are unset (e.g. a fork), the
+      # values default to empty and AppEnvironment fails loud at launch (D8).
       - name: ktlint, unit tests, assemble debug APK
         working-directory: apps/android
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
         run: ./gradlew ktlintCheck testDebugUnitTest assembleDebug
 
       - name: Upload debug APK

--- a/apps/android/CLAUDE.md
+++ b/apps/android/CLAUDE.md
@@ -169,12 +169,23 @@ bundled. Android resource filenames must be lowercase
   change. To adopt visual-regression later, commit the references and switch CI to
   `validateDebugScreenshotTest`. Add a preview per screen/state as real UI lands.
 
-## What's scaffolded but not used yet (sub-project A/B)
+## What's scaffolded but not used yet (post sub-project C)
 
-- `PebblesApp` only initializes Rive — the rest of the service graph
-  (`SupabaseService` and friends) lands in C.
+- `PebblesApp` now constructs `SupabaseService` (entry funnel, sub-project C) and
+  provides it via `LocalSupabaseService`. The remaining services
+  (`EmotionPaletteService`, `PathService`, `SnapURLCache`) land with the
+  read-only Path (sub-project D).
 - No app icon slot — the launcher shows the default system icon. Expected.
-- `DebugTokenPreviewScreen` is `MainActivity`'s temporary home (design-system
-  screenshot review); the real home (auth gate / NavHost) lands in C.
-- `PebblesTextInput`/`PebblesCheckbox`/`PebblesPrimaryButton` are unconsumed
-  until the entry funnel (C) wires them into real screens.
+- `MainActivity` now hosts `RootScreen` (the auth gate / single NavHost) and
+  forwards `pebbles://auth-callback` deep links to supabase-kt's
+  `handleDeeplinks` (`onCreate` + `onNewIntent`, `launchMode="singleTask"`).
+  `DebugTokenPreviewScreen` is retained only as a screenshot-test preview.
+- `features/path/PathScreen.kt` is a placeholder (logo + a temporary sign-out so
+  the funnel is re-testable on device); the real read-only timeline
+  (`path_pebbles()` → week-grouped list) lands in D.
+- Onboarding illustrations render a placeholder surface — the iOS asset-catalog
+  artwork is not yet exported to Android drawable densities (milestone risk 6,
+  needs the maintainer's design sources).
+- Funnel screens take plain action lambdas rather than reading the service
+  directly, so they stay previewable (screenshot tests) and keep the supabase-kt
+  calls at the `RootScreen`/NavHost binding layer.

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -69,6 +69,8 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.rive.android)
     implementation(libs.androidx.startup.runtime)
+    implementation(libs.androidx.browser)
+    implementation(libs.kotlinx.coroutines.android)
 
     val composeBom = platform(libs.androidx.compose.bom)
     implementation(composeBom)
@@ -76,7 +78,17 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.navigation.compose)
     debugImplementation(libs.androidx.compose.ui.tooling)
+
+    // supabase-kt: BOM pins the module versions; OkHttp is the Ktor engine and
+    // kotlinx-serialization-json backs the consent-metadata JSON block.
+    implementation(platform(libs.supabase.bom))
+    implementation(libs.supabase.auth)
+    implementation(libs.supabase.postgrest)
+    implementation(libs.ktor.client.okhttp)
+    implementation(libs.kotlinx.serialization.json)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -8,10 +8,15 @@ plugins {
 }
 
 // Secrets chain (D8): read the git-ignored secrets.properties if present,
-// otherwise default every key to an empty string so the build NEVER fails
-// without secrets (CI has none). AppEnvironment turns an empty value into a
-// loud runtime crash with setup instructions — the iOS contract: setup bugs
-// fail at launch, never at build.
+// otherwise fall back to an environment variable of the same name, otherwise
+// default to an empty string so the build NEVER fails without secrets.
+// AppEnvironment turns an empty value into a loud runtime crash with setup
+// instructions — the iOS contract: setup bugs fail at launch, never at build.
+//
+// The env-var fallback lets CI bake real config into the debug APK from GitHub
+// Actions secrets (the maintainer has no local Android SDK and installs the CI
+// artifact directly), while local builds keep using secrets.properties. Local
+// file wins over env when both are set.
 val secretsFile = rootProject.file("secrets.properties")
 val secrets =
     Properties().apply {
@@ -20,7 +25,11 @@ val secrets =
         }
     }
 
-fun secret(key: String): String = secrets.getProperty(key, "")
+fun secret(key: String): String {
+    val fromFile = secrets.getProperty(key)
+    if (!fromFile.isNullOrBlank()) return fromFile
+    return System.getenv(key).orEmpty()
+}
 
 android {
     namespace = "app.pbbls.android"

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- supabase-kt (auth, OAuth, Postgrest) requires network access. -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".PebblesApp"
         android:allowBackup="true"
@@ -12,10 +15,26 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:theme="@style/Theme.Pebbles">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <!--
+              OAuth deep-link return (D15). The Google hosted-OAuth custom tab
+              redirects to pebbles://auth-callback; singleTask + this filter route
+              it back to the existing MainActivity, where supabase-kt's
+              handleDeeplinks(intent) parses the session. Scheme+host are shared
+              with iOS, so the Supabase dashboard allowlist needs no change
+              (verify on device — risk 1 in the milestone design).
+            -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="pebbles" android:host="auth-callback" />
             </intent-filter>
         </activity>
     </application>

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/MainActivity.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/MainActivity.kt
@@ -1,25 +1,42 @@
 package app.pbbls.android
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.CompositionLocalProvider
+import app.pbbls.android.services.LocalSupabaseService
 import app.pbbls.android.theme.PebblesTheme
+import io.github.jan.supabase.auth.handleDeeplinks
 
 /**
- * The single activity hosting the Compose tree (D5 — single activity, one host).
- * For sub-project B it renders the themed debug token-preview as a temporary
- * home; the auth gate / NavHost and the service CompositionLocals arrive with
- * the entry funnel (sub-project C).
+ * The single activity hosting the Compose tree and the auth gate (D5). Provides
+ * the [SupabaseService][app.pbbls.android.services.SupabaseService] constructed
+ * in [PebblesApp] to the tree via CompositionLocal, and forwards OAuth
+ * deep-link returns (`pebbles://auth-callback`) to supabase-kt so the session
+ * lands (D15). `launchMode="singleTask"` (manifest) means the redirect reuses
+ * this activity and arrives at [onNewIntent].
  */
 class MainActivity : ComponentActivity() {
+    private val supabase get() = (application as PebblesApp).supabase
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        supabase.client.handleDeeplinks(intent)
         setContent {
             PebblesTheme {
-                DebugTokenPreviewScreen()
+                CompositionLocalProvider(LocalSupabaseService provides supabase) {
+                    RootScreen()
+                }
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        supabase.client.handleDeeplinks(intent)
     }
 }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/PebblesApp.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/PebblesApp.kt
@@ -1,17 +1,27 @@
 package app.pbbls.android
 
 import android.app.Application
+import app.pbbls.android.services.SupabaseService
 import app.rive.runtime.kotlin.core.Rive
 
 /**
- * Application entry point — the `PebblesApp.swift` analog. The service graph
- * (`SupabaseService` and friends, wired the way `PebblesApp.swift` constructs
- * and injects them) lands with the entry funnel (sub-project C); for now this
- * only initializes Rive (D14) so `RiveLogo` can load `.riv` resources.
+ * Application entry point — the `PebblesApp.swift` analog. Initializes Rive (D14)
+ * and constructs the service graph exactly like `PebblesApp.swift`:
+ * [SupabaseService] first, dependents (added in sub-project D) taking it by
+ * constructor. `MainActivity` reads the graph off this instance and provides it
+ * to Compose via CompositionLocals (D4).
+ *
+ * [SupabaseService]'s constructor reads Supabase secrets through `AppEnvironment`,
+ * which throws with setup instructions if they are blank — a setup bug that fails
+ * loud at launch, never at build (D8).
  */
 class PebblesApp : Application() {
+    lateinit var supabase: SupabaseService
+        private set
+
     override fun onCreate() {
         super.onCreate()
         Rive.init(this)
+        supabase = SupabaseService()
     }
 }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/RootScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/RootScreen.kt
@@ -1,0 +1,142 @@
+package app.pbbls.android
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import app.pbbls.android.features.auth.AuthMode
+import app.pbbls.android.features.auth.AuthScreen
+import app.pbbls.android.features.onboarding.OnboardingGate
+import app.pbbls.android.features.onboarding.OnboardingScreen
+import app.pbbls.android.features.onboarding.OnboardingSteps
+import app.pbbls.android.features.path.PathScreen
+import app.pbbls.android.features.welcome.WelcomeScreen
+import app.pbbls.android.services.LocalSupabaseService
+import app.pbbls.android.services.OnboardingPreferences
+import app.pbbls.android.theme.PebblesTheme
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private const val MIN_SPLASH_MILLIS = 2_500L
+private const val ROUTE_WELCOME = "welcome"
+private const val ROUTE_AUTH = "auth"
+
+/**
+ * Top-level auth gate — the `RootView` analog (D5). The gate is conditional
+ * composition, not navigation:
+ *   - `canShowAuthedTabs` (session AND resolved AND splash held ~2.5s) →
+ *     [PathScreen], with [OnboardingScreen] as a full-screen overlay the first
+ *     time a user id appears while `hasSeenOnboarding` is false.
+ *   - otherwise → a NavHost (Welcome → Auth), with Welcome revealing its content
+ *     only once auth has settled to "no session" and the splash hold elapsed.
+ *
+ * The Rive logo plays for at least the splash hold either way, satisfying the
+ * "splash before Path" intent.
+ */
+@Composable
+fun RootScreen() {
+    val supabase = LocalSupabaseService.current
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    var hasSeenOnboarding by rememberSaveable { mutableStateOf(OnboardingPreferences.hasSeenOnboarding(context)) }
+    var isPresentingOnboarding by rememberSaveable { mutableStateOf(false) }
+    var minSplashDone by rememberSaveable { mutableStateOf(false) }
+
+    // supabase.start() collects the auth-status stream for the app's lifetime.
+    LaunchedEffect(Unit) { supabase.start() }
+    LaunchedEffect(Unit) {
+        delay(MIN_SPLASH_MILLIS)
+        minSplashDone = true
+    }
+
+    val session = supabase.session
+    val isInitializing = supabase.isInitializing
+    // session?.user?.id is null when this composes, so the first authenticated
+    // status delivers a real null→id transition even for already-signed-in users.
+    val userId = session?.user?.id
+
+    val canShowAuthedTabs = session != null && !isInitializing && minSplashDone
+    val welcomeContentRevealed = session == null && !isInitializing && minSplashDone
+
+    LaunchedEffect(userId) {
+        if (OnboardingGate.shouldPresent(userId, hasSeenOnboarding)) {
+            isPresentingOnboarding = true
+        }
+    }
+
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(PebblesTheme.colors.system.background),
+    ) {
+        if (canShowAuthedTabs) {
+            PathScreen(onSignOut = { scope.launch { supabase.signOut() } })
+            if (isPresentingOnboarding) {
+                OnboardingScreen(
+                    steps = OnboardingSteps.all,
+                    onFinish = {
+                        OnboardingPreferences.setHasSeenOnboarding(context, true)
+                        hasSeenOnboarding = true
+                        isPresentingOnboarding = false
+                    },
+                )
+            }
+        } else {
+            WelcomeAuthNavHost(
+                contentRevealed = welcomeContentRevealed,
+                onGoogleSignIn = { supabase.signInWithGoogle() },
+                onSubmit = { mode, email, password ->
+                    when (mode) {
+                        AuthMode.LOGIN -> supabase.signIn(email, password)
+                        AuthMode.SIGNUP -> supabase.signUp(email, password)
+                    }
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun WelcomeAuthNavHost(
+    contentRevealed: Boolean,
+    onGoogleSignIn: suspend () -> Unit,
+    onSubmit: suspend (AuthMode, String, String) -> Unit,
+) {
+    val navController = rememberNavController()
+    NavHost(navController = navController, startDestination = ROUTE_WELCOME) {
+        composable(ROUTE_WELCOME) {
+            WelcomeScreen(
+                contentRevealed = contentRevealed,
+                onCreateAccount = { navController.navigate("$ROUTE_AUTH/${AuthMode.SIGNUP.route}") },
+                onLogin = { navController.navigate("$ROUTE_AUTH/${AuthMode.LOGIN.route}") },
+                onGoogleSignIn = onGoogleSignIn,
+            )
+        }
+        composable(
+            route = "$ROUTE_AUTH/{mode}",
+            arguments = listOf(navArgument("mode") { type = NavType.StringType }),
+        ) { backStackEntry ->
+            val mode = AuthMode.fromRoute(backStackEntry.arguments?.getString("mode"))
+            AuthScreen(
+                initialMode = mode,
+                onSubmit = onSubmit,
+                onGoogleSignIn = onGoogleSignIn,
+            )
+        }
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/components/GoogleSignInButton.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/components/GoogleSignInButton.kt
@@ -1,0 +1,67 @@
+package app.pbbls.android.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import app.pbbls.android.R
+import app.pbbls.android.theme.PebblesTheme
+import app.pbbls.android.theme.PebblesTypography
+
+/**
+ * White capsule button with the multi-color Google G mark and "Continue with
+ * Google" label; 1dp `system.muted` border so it reads against the page. Ports
+ * `GoogleSignInButton.swift`. (No Apple sign-in on Android — settled non-goal.)
+ */
+@Composable
+fun GoogleSignInButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    val system = PebblesTheme.colors.system
+    val shape = RoundedCornerShape(50)
+
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .heightIn(min = 52.dp)
+                .clip(shape)
+                .background(Color.White)
+                .border(1.dp, system.muted, shape)
+                .clickable(enabled = enabled, role = Role.Button) { onClick() },
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Image(
+            painter = painterResource(R.drawable.ic_google_g),
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = stringResource(R.string.welcome_continue_google),
+            style = PebblesTypography.calloutEmphasized,
+            color = system.foreground,
+        )
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/components/LegalDisclaimer.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/components/LegalDisclaimer.kt
@@ -1,0 +1,101 @@
+package app.pbbls.android.components
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.unit.sp
+import app.pbbls.android.R
+import app.pbbls.android.theme.PebblesTheme
+import app.pbbls.android.theme.PebblesTypography
+
+/**
+ * "Read our [Terms] and [Privacy] before creating an account…" disclaimer with
+ * two inline tappable links. Ports `LegalDisclaimerText.swift`. The iOS version
+ * embeds `pebbles://legal/...` markdown links intercepted by an `OpenURLAction`;
+ * here the links are [LinkAnnotation.Clickable]s whose listener calls the tap
+ * handler directly — the custom scheme never reaches the OS, same net behavior.
+ *
+ * The sentence is a single localized template ([R.string.welcome_legal_disclaimer])
+ * with `{terms}`/`{privacy}` tokens, so translations control word order and the
+ * links stay inline in both en and fr.
+ */
+@Composable
+fun LegalDisclaimer(
+    onTermsTap: () -> Unit,
+    onPrivacyTap: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val system = PebblesTheme.colors.system
+    val accent = PebblesTheme.colors.accent
+    val template = stringResource(R.string.welcome_legal_disclaimer)
+    val termsLabel = stringResource(R.string.legal_link_terms)
+    val privacyLabel = stringResource(R.string.legal_link_privacy)
+    val linkStyles = TextLinkStyles(SpanStyle(color = accent.primary, textDecoration = TextDecoration.Underline))
+
+    val text =
+        buildLegalDisclaimer(
+            template = template,
+            tokens =
+                listOf(
+                    LegalToken("{terms}", termsLabel, onTermsTap),
+                    LegalToken("{privacy}", privacyLabel, onPrivacyTap),
+                ),
+            linkStyles = linkStyles,
+        )
+
+    Text(
+        text = text,
+        style = PebblesTypography.subhead.copy(fontSize = 12.sp),
+        color = system.secondary,
+        textAlign = TextAlign.Center,
+        modifier = modifier,
+    )
+}
+
+private data class LegalToken(
+    val token: String,
+    val label: String,
+    val onTap: () -> Unit,
+)
+
+/**
+ * Assembles the disclaimer by scanning [template] for each token in order of
+ * appearance, appending literal text between tokens and a styled link for each.
+ * Deterministic — link placement follows the localized template, so word order
+ * is respected per locale.
+ */
+private fun buildLegalDisclaimer(
+    template: String,
+    tokens: List<LegalToken>,
+    linkStyles: TextLinkStyles,
+): AnnotatedString =
+    buildAnnotatedString {
+        var cursor = 0
+        while (cursor < template.length) {
+            val next =
+                tokens
+                    .mapNotNull { t ->
+                        val idx = template.indexOf(t.token, cursor)
+                        if (idx >= 0) idx to t else null
+                    }.minByOrNull { it.first }
+            if (next == null) {
+                append(template.substring(cursor))
+                break
+            }
+            val (idx, matched) = next
+            if (idx > cursor) append(template.substring(cursor, idx))
+            withLink(LinkAnnotation.Clickable(tag = matched.token, styles = linkStyles) { _ -> matched.onTap() }) {
+                append(matched.label)
+            }
+            cursor = idx + matched.token.length
+        }
+    }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/components/LegalDocs.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/components/LegalDocs.kt
@@ -1,0 +1,29 @@
+package app.pbbls.android.components
+
+import android.content.Context
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
+
+/**
+ * The two legal documents linked from the funnel. URLs match iOS
+ * (`LegalDocumentSheet.swift`).
+ */
+enum class LegalDoc(
+    val url: String,
+) {
+    TERMS("https://www.pbbls.app/docs/terms"),
+    PRIVACY("https://www.pbbls.app/docs/privacy"),
+}
+
+/**
+ * Opens a legal document in a Custom Tab — the in-app-browser analog of iOS's
+ * `SFSafariViewController` sheet (D15). The `pebbles://legal/...` scheme never
+ * reaches the OS: links are intercepted in-Compose (see [LegalDisclaimer]) and
+ * routed here.
+ */
+fun openLegalDoc(
+    context: Context,
+    doc: LegalDoc,
+) {
+    CustomTabsIntent.Builder().build().launchUrl(context, Uri.parse(doc.url))
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/components/PebblesAuthSwitcher.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/components/PebblesAuthSwitcher.kt
@@ -1,0 +1,66 @@
+package app.pbbls.android.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import app.pbbls.android.features.auth.AuthMode
+import app.pbbls.android.theme.PebblesTheme
+import app.pbbls.android.theme.PebblesTypography
+
+/**
+ * Login/Sign-up segmented switcher — the `PebblesAuthSwitcher` analog. A pill
+ * track in `system.muted` with the selected segment filled `system.secondary`
+ * and a white label; unselected labels are `system.secondary`. Colors mirror the
+ * globally-restyled iOS `UISegmentedControl` (`PebblesApp.init`).
+ */
+@Composable
+fun PebblesAuthSwitcher(
+    mode: AuthMode,
+    onModeChange: (AuthMode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val system = PebblesTheme.colors.system
+    val trackShape = RoundedCornerShape(50)
+
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(trackShape)
+                .background(system.muted)
+                .padding(4.dp),
+    ) {
+        AuthMode.entries.forEach { entry ->
+            val selected = entry == mode
+            Box(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .clip(trackShape)
+                        .background(if (selected) system.secondary else Color.Transparent)
+                        .clickable(role = Role.Tab) { onModeChange(entry) }
+                        .padding(vertical = 10.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(entry.labelRes),
+                    style = PebblesTypography.callout,
+                    color = if (selected) Color.White else system.secondary,
+                )
+            }
+        }
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/auth/AuthLogic.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/auth/AuthLogic.kt
@@ -1,0 +1,38 @@
+package app.pbbls.android.features.auth
+
+/**
+ * Pure auth-form logic, extracted so it is unit-tested to iOS parity without a
+ * live client — the `AuthView.canSubmit` / `AuthView.normalizeEmailInput`
+ * analogs (`apps/ios/Pebbles/Features/Auth/AuthView.swift`).
+ */
+object AuthLogic {
+    /**
+     * Whether the submit button is enabled. Email must be non-blank, contain
+     * `@` and `.`, and contain no `+`; password ≥ 6; sign-up additionally
+     * requires both consent checkboxes. Always false while a request is in flight.
+     */
+    fun canSubmit(
+        mode: AuthMode,
+        email: String,
+        password: String,
+        termsAccepted: Boolean,
+        privacyAccepted: Boolean,
+        isSubmitting: Boolean,
+    ): Boolean {
+        val trimmed = email.trim()
+        if (isSubmitting) return false
+        if (trimmed.isEmpty()) return false
+        if (!trimmed.contains("@")) return false
+        if (!trimmed.contains(".")) return false
+        if (trimmed.contains("+")) return false
+        if (password.length < 6) return false
+        return if (mode == AuthMode.SIGNUP) termsAccepted && privacyAccepted else true
+    }
+
+    /**
+     * Lowercases and strips disallowed characters (`+`) from raw email input.
+     * Real-time scrubbing keeps the visible field, the submitted value, and the
+     * server's view of the address in sync.
+     */
+    fun normalizeEmailInput(raw: String): String = raw.lowercase().filter { it != '+' }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/auth/AuthMode.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/auth/AuthMode.kt
@@ -1,0 +1,22 @@
+package app.pbbls.android.features.auth
+
+import androidx.annotation.StringRes
+import app.pbbls.android.R
+
+/**
+ * Login vs Sign-up mode for [AuthScreen] — the `AuthView.Mode` analog. [route] is
+ * the NavHost path argument; [labelRes] the switcher label.
+ */
+enum class AuthMode(
+    val route: String,
+    @StringRes val labelRes: Int,
+) {
+    LOGIN("login", R.string.auth_mode_login),
+    SIGNUP("signup", R.string.auth_mode_signup),
+    ;
+
+    companion object {
+        /** Maps a NavHost `{mode}` argument back to a mode, defaulting to [LOGIN]. */
+        fun fromRoute(route: String?): AuthMode = entries.firstOrNull { it.route == route } ?: LOGIN
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/auth/AuthScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/auth/AuthScreen.kt
@@ -1,0 +1,239 @@
+package app.pbbls.android.features.auth
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.ContentType
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.pbbls.android.R
+import app.pbbls.android.components.GoogleSignInButton
+import app.pbbls.android.components.LegalDisclaimer
+import app.pbbls.android.components.LegalDoc
+import app.pbbls.android.components.PebblesAuthSwitcher
+import app.pbbls.android.components.PebblesCheckbox
+import app.pbbls.android.components.PebblesPrimaryButton
+import app.pbbls.android.components.PebblesTextInput
+import app.pbbls.android.components.openLegalDoc
+import app.pbbls.android.theme.PebblesTheme
+import app.pbbls.android.theme.PebblesTypography
+import kotlinx.coroutines.launch
+
+private val ErrorRed = Color(0xFFDC2626)
+
+/**
+ * Email + password auth screen — the `AuthView` analog. The switcher toggles
+ * Login/Sign-up; sign-up adds two consent checkboxes. Email is live-normalized
+ * (lowercase, strip `+`), and typing a `+` surfaces an inline explanation. All
+ * state is view-local; the actual auth calls are supplied as suspend lambdas
+ * ([onSubmit]/[onGoogleSignIn]) so the screen stays previewable and business
+ * logic lives at the NavHost binding layer.
+ */
+@Composable
+fun AuthScreen(
+    initialMode: AuthMode,
+    onSubmit: suspend (AuthMode, String, String) -> Unit,
+    onGoogleSignIn: suspend () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val system = PebblesTheme.colors.system
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    var mode by rememberSaveable { mutableStateOf(initialMode) }
+    var email by rememberSaveable { mutableStateOf("") }
+    var password by rememberSaveable { mutableStateOf("") }
+    var termsAccepted by rememberSaveable { mutableStateOf(false) }
+    var privacyAccepted by rememberSaveable { mutableStateOf(false) }
+    var isSubmitting by remember { mutableStateOf(false) }
+    var authError by remember { mutableStateOf<String?>(null) }
+    // True while the raw input contained a '+' that was just stripped — drives the
+    // inline explanation. Lowercasing is silent on purpose (no error shown).
+    var showPlusError by remember { mutableStateOf(false) }
+
+    val canSubmit =
+        AuthLogic.canSubmit(
+            mode = mode,
+            email = email,
+            password = password,
+            termsAccepted = termsAccepted,
+            privacyAccepted = privacyAccepted,
+            isSubmitting = isSubmitting,
+        )
+
+    fun onEmailChange(raw: String) {
+        if (authError != null) authError = null
+        showPlusError = raw.contains("+")
+        email = AuthLogic.normalizeEmailInput(raw)
+    }
+
+    fun onModeChange(newMode: AuthMode) {
+        mode = newMode
+        authError = null
+        if (newMode == AuthMode.LOGIN) {
+            termsAccepted = false
+            privacyAccepted = false
+        }
+    }
+
+    fun submit() {
+        scope.launch {
+            isSubmitting = true
+            authError = null
+            try {
+                onSubmit(mode, email.trim(), password)
+            } catch (e: Exception) {
+                authError = e.message
+            }
+            isSubmitting = false
+        }
+    }
+
+    fun runGoogle() {
+        if (isSubmitting) return
+        scope.launch {
+            isSubmitting = true
+            authError = null
+            try {
+                onGoogleSignIn()
+            } catch (e: Exception) {
+                authError = e.message
+            }
+            isSubmitting = false
+        }
+    }
+
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(system.background)
+                .systemBarsPadding()
+                .imePadding()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        Spacer(modifier = Modifier.padding(top = 8.dp))
+
+        PebblesAuthSwitcher(mode = mode, onModeChange = ::onModeChange)
+
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                PebblesTextInput(
+                    placeholder = stringResource(R.string.auth_email_placeholder),
+                    value = email,
+                    onValueChange = ::onEmailChange,
+                    contentType = ContentType.EmailAddress,
+                    keyboardOptions =
+                        KeyboardOptions(
+                            keyboardType = KeyboardType.Email,
+                            capitalization = KeyboardCapitalization.None,
+                            autoCorrectEnabled = false,
+                        ),
+                )
+                if (showPlusError) {
+                    Text(
+                        text = stringResource(R.string.auth_email_plus_error),
+                        style = PebblesTypography.subhead.copy(fontSize = 12.sp),
+                        color = ErrorRed,
+                    )
+                }
+            }
+
+            PebblesTextInput(
+                placeholder = stringResource(R.string.auth_password_placeholder),
+                value = password,
+                onValueChange = {
+                    if (authError != null) authError = null
+                    password = it
+                },
+                isSecure = true,
+                contentType = if (mode == AuthMode.LOGIN) ContentType.Password else ContentType.NewPassword,
+                keyboardOptions =
+                    KeyboardOptions(
+                        keyboardType = KeyboardType.Password,
+                        capitalization = KeyboardCapitalization.None,
+                        autoCorrectEnabled = false,
+                    ),
+            )
+        }
+
+        if (mode == AuthMode.SIGNUP) {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                PebblesCheckbox(
+                    isChecked = termsAccepted,
+                    onCheckedChange = { termsAccepted = it },
+                    prefix = stringResource(R.string.auth_consent_prefix),
+                    linkText = stringResource(R.string.auth_consent_terms_link),
+                    onLinkTap = { openLegalDoc(context, LegalDoc.TERMS) },
+                )
+                PebblesCheckbox(
+                    isChecked = privacyAccepted,
+                    onCheckedChange = { privacyAccepted = it },
+                    prefix = stringResource(R.string.auth_consent_prefix),
+                    linkText = stringResource(R.string.auth_consent_privacy_link),
+                    onLinkTap = { openLegalDoc(context, LegalDoc.PRIVACY) },
+                )
+            }
+        }
+
+        if (authError != null) {
+            Text(
+                text = authError.orEmpty(),
+                style = PebblesTypography.subhead.copy(fontSize = 12.sp),
+                color = ErrorRed,
+                textAlign = TextAlign.Start,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+
+        PebblesPrimaryButton(
+            text =
+                stringResource(
+                    if (mode == AuthMode.LOGIN) R.string.auth_submit_login else R.string.auth_submit_signup,
+                ),
+            onClick = ::submit,
+            enabled = canSubmit,
+            isLoading = isSubmitting,
+        )
+
+        // The screen scrolls (keyboard-safe), so OAuth follows the primary action
+        // rather than being pinned to the bottom as on iOS — same content, order
+        // preserved.
+        GoogleSignInButton(onClick = ::runGoogle, enabled = !isSubmitting)
+
+        LegalDisclaimer(
+            onTermsTap = { openLegalDoc(context, LegalDoc.TERMS) },
+            onPrivacyTap = { openLegalDoc(context, LegalDoc.PRIVACY) },
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp, bottom = 32.dp),
+        )
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/onboarding/OnboardingGate.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/onboarding/OnboardingGate.kt
@@ -1,0 +1,14 @@
+package app.pbbls.android.features.onboarding
+
+/**
+ * Pure gating logic for the onboarding overlay, extracted from `RootScreen` so
+ * it can be unit-tested (the `RootView.onChange(of: session?.user.id)` analog).
+ * Onboarding presents the first time a user id appears while the
+ * `hasSeenOnboarding` flag (SharedPreferences, D5) is still false.
+ */
+object OnboardingGate {
+    fun shouldPresent(
+        userId: String?,
+        hasSeenOnboarding: Boolean,
+    ): Boolean = userId != null && !hasSeenOnboarding
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/onboarding/OnboardingPageView.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/onboarding/OnboardingPageView.kt
@@ -1,0 +1,87 @@
+package app.pbbls.android.features.onboarding
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.pbbls.android.theme.PebblesTheme
+import app.pbbls.android.theme.PebblesTypography
+
+/**
+ * Renders a single [OnboardingStep] — the `OnboardingPageView` analog: a large
+ * illustration card, title, and body. The illustration switches on the image
+ * type; [OnboardingImage.Placeholder] shows the accent surface until real
+ * artwork is exported (risk 6).
+ */
+@Composable
+fun OnboardingPageView(
+    step: OnboardingStep,
+    modifier: Modifier = Modifier,
+) {
+    val system = PebblesTheme.colors.system
+    val accent = PebblesTheme.colors.accent
+
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp)
+                .padding(top = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(32.dp),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(360.dp)
+                    .clip(RoundedCornerShape(24.dp))
+                    .background(accent.surface),
+        ) {
+            when (val image = step.image) {
+                is OnboardingImage.Asset -> {
+                    Image(
+                        painter = painterResource(image.resId),
+                        contentDescription = null,
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+
+                OnboardingImage.Placeholder -> {
+                    Unit
+                }
+            }
+        }
+
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(step.titleRes),
+                style = PebblesTypography.title.copy(fontSize = 24.sp),
+                color = system.foreground,
+            )
+            Text(
+                text = stringResource(step.descriptionRes),
+                style = PebblesTypography.body,
+                color = system.secondary,
+            )
+        }
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/onboarding/OnboardingScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/onboarding/OnboardingScreen.kt
@@ -1,0 +1,142 @@
+package app.pbbls.android.features.onboarding
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.unit.dp
+import app.pbbls.android.R
+import app.pbbls.android.components.PebblesPrimaryButton
+import app.pbbls.android.theme.PebblesTheme
+import app.pbbls.android.theme.PebblesTypography
+
+/**
+ * Paged onboarding flow — the `OnboardingView` analog. One [OnboardingPageView]
+ * per step inside a [HorizontalPager] with page dots; a top bar with close (✕)
+ * and Skip (both finish), and a "Start your path" button on the last page.
+ *
+ * Rendered by `RootScreen` as a full-screen overlay (the `fullScreenCover`
+ * analog); [onFinish] persists the `hasSeenOnboarding` flag at the call site so
+ * this view stays previewable and serves both the initial gate and any replay.
+ * System back is blocked while shown — the flow is dismissible only via skip or
+ * close (D5).
+ */
+@Composable
+fun OnboardingScreen(
+    steps: List<OnboardingStep>,
+    onFinish: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val system = PebblesTheme.colors.system
+    val accent = PebblesTheme.colors.accent
+    val pagerState = rememberPagerState(pageCount = { steps.size })
+
+    // Block system back so the flow is dismissible only via skip/close. Skipped
+    // under @Preview/screenshot rendering, where no back dispatcher is provided.
+    if (!LocalInspectionMode.current) {
+        BackHandler(enabled = true) { /* consume — no-op */ }
+    }
+
+    Box(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(system.background),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .safeDrawingPadding(),
+        ) {
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp, vertical = 4.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                val closeLabel = stringResource(R.string.onboarding_close)
+                TextButton(
+                    onClick = onFinish,
+                    modifier = Modifier.clearAndSetSemantics { contentDescription = closeLabel },
+                ) {
+                    Text(text = "✕", style = PebblesTypography.headline, color = system.secondary)
+                }
+                TextButton(onClick = onFinish) {
+                    Text(
+                        text = stringResource(R.string.onboarding_skip),
+                        style = PebblesTypography.callout,
+                        color = system.secondary,
+                    )
+                }
+            }
+
+            HorizontalPager(
+                state = pagerState,
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+            ) { page ->
+                OnboardingPageView(step = steps[page])
+            }
+
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                steps.indices.forEach { index ->
+                    Box(
+                        modifier =
+                            Modifier
+                                .padding(horizontal = 4.dp)
+                                .size(if (index == pagerState.currentPage) 8.dp else 6.dp)
+                                .clip(CircleShape)
+                                .background(if (index == pagerState.currentPage) accent.primary else system.muted),
+                    )
+                }
+            }
+
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp)
+                        .padding(bottom = 24.dp),
+            ) {
+                AnimatedVisibility(visible = pagerState.currentPage == steps.size - 1) {
+                    PebblesPrimaryButton(
+                        text = stringResource(R.string.onboarding_start),
+                        onClick = onFinish,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/onboarding/OnboardingScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/onboarding/OnboardingScreen.kt
@@ -123,19 +123,20 @@ fun OnboardingScreen(
                 }
             }
 
-            Box(
+            // Direct child of the Column (not wrapped in a Box) so this resolves
+            // to ColumnScope.AnimatedVisibility with the innermost receiver.
+            AnimatedVisibility(
+                visible = pagerState.currentPage == steps.size - 1,
                 modifier =
                     Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 24.dp)
                         .padding(bottom = 24.dp),
             ) {
-                AnimatedVisibility(visible = pagerState.currentPage == steps.size - 1) {
-                    PebblesPrimaryButton(
-                        text = stringResource(R.string.onboarding_start),
-                        onClick = onFinish,
-                    )
-                }
+                PebblesPrimaryButton(
+                    text = stringResource(R.string.onboarding_start),
+                    onClick = onFinish,
+                )
             }
         }
     }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/onboarding/OnboardingSteps.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/onboarding/OnboardingSteps.kt
@@ -1,0 +1,65 @@
+package app.pbbls.android.features.onboarding
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import app.pbbls.android.R
+
+/**
+ * Source of an onboarding illustration — the `OnboardingImage` analog. The iOS
+ * asset-catalog illustrations are not yet exported to Android drawable densities
+ * (milestone risk 6 — needs the maintainer's design sources), so every step ships
+ * [Placeholder] for now; swapping to [Asset] later is a data-only change.
+ */
+sealed interface OnboardingImage {
+    data class Asset(
+        @DrawableRes val resId: Int,
+    ) : OnboardingImage
+
+    data object Placeholder : OnboardingImage
+}
+
+/**
+ * Single onboarding screen's content — the `OnboardingStep` analog. The view
+ * never branches on [id]; copy lives in `strings.xml`.
+ */
+data class OnboardingStep(
+    val id: String,
+    val image: OnboardingImage,
+    @StringRes val titleRes: Int,
+    @StringRes val descriptionRes: Int,
+)
+
+/**
+ * The four onboarding steps shown to new users on sign-up. Editing copy or
+ * reordering is a single-file change — `OnboardingScreen` reads `.all` opaquely
+ * and `OnboardingStepsTest` enforces count, unique ids, and id order.
+ */
+object OnboardingSteps {
+    val all: List<OnboardingStep> =
+        listOf(
+            OnboardingStep(
+                id = "intro",
+                image = OnboardingImage.Placeholder,
+                titleRes = R.string.onboarding_intro_title,
+                descriptionRes = R.string.onboarding_intro_description,
+            ),
+            OnboardingStep(
+                id = "concept",
+                image = OnboardingImage.Placeholder,
+                titleRes = R.string.onboarding_concept_title,
+                descriptionRes = R.string.onboarding_concept_description,
+            ),
+            OnboardingStep(
+                id = "qualify",
+                image = OnboardingImage.Placeholder,
+                titleRes = R.string.onboarding_qualify_title,
+                descriptionRes = R.string.onboarding_qualify_description,
+            ),
+            OnboardingStep(
+                id = "carving",
+                image = OnboardingImage.Placeholder,
+                titleRes = R.string.onboarding_carving_title,
+                descriptionRes = R.string.onboarding_carving_description,
+            ),
+        )
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/PathScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/PathScreen.kt
@@ -1,0 +1,69 @@
+package app.pbbls.android.features.path
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import app.pbbls.android.R
+import app.pbbls.android.rive.RiveLogo
+import app.pbbls.android.theme.PebblesTheme
+import app.pbbls.android.theme.PebblesTypography
+
+/**
+ * Authenticated landing surface — a placeholder for sub-project C. The real
+ * read-only Path timeline (`path_pebbles()` → week-grouped list) lands in
+ * sub-project D; this proves the session gate and provides a temporary sign-out
+ * so the funnel can be re-tested on device until Profile exists.
+ */
+@Composable
+fun PathScreen(
+    onSignOut: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val system = PebblesTheme.colors.system
+    val accent = PebblesTheme.colors.accent
+
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(system.background)
+                .safeDrawingPadding()
+                .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        RiveLogo(modifier = Modifier.size(120.dp))
+        Text(
+            text = stringResource(R.string.path_placeholder_title),
+            style = PebblesTypography.title,
+            color = system.foreground,
+            modifier = Modifier.padding(top = 24.dp),
+        )
+        Text(
+            text = stringResource(R.string.path_placeholder_subtitle),
+            style = PebblesTypography.body,
+            color = system.secondary,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 8.dp),
+        )
+        TextButton(onClick = onSignOut, modifier = Modifier.padding(top = 24.dp)) {
+            Text(
+                text = stringResource(R.string.path_sign_out),
+                style = PebblesTypography.buttonLabel,
+                color = accent.primary,
+            )
+        }
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/welcome/WelcomeCarousel.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/welcome/WelcomeCarousel.kt
@@ -1,0 +1,77 @@
+package app.pbbls.android.features.welcome
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import app.pbbls.android.theme.PebblesTheme
+import kotlinx.coroutines.delay
+
+private const val AUTO_ADVANCE_MILLIS = 4_000L
+
+/**
+ * Three-slide welcome carousel — the `WelcomeCarousel` analog. A [HorizontalPager]
+ * (swipeable) with custom pagination dots beneath, auto-advancing every 4s. The
+ * auto-advance honors reduced motion ([reduceMotion]) by not running, mirroring
+ * the iOS `!reduceMotion` guard.
+ */
+@Composable
+fun WelcomeCarousel(
+    reduceMotion: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val steps = WelcomeSteps.all
+    val accent = PebblesTheme.colors.accent
+    val system = PebblesTheme.colors.system
+    val pagerState = rememberPagerState(pageCount = { steps.size })
+
+    LaunchedEffect(pagerState, reduceMotion) {
+        if (reduceMotion) return@LaunchedEffect
+        while (true) {
+            delay(AUTO_ADVANCE_MILLIS)
+            val next = (pagerState.currentPage + 1) % steps.size
+            pagerState.animateScrollToPage(next)
+        }
+    }
+
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+        HorizontalPager(
+            state = pagerState,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(110.dp),
+        ) { page ->
+            WelcomeSlideView(step = steps[page])
+        }
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            steps.indices.forEach { index ->
+                Box(
+                    modifier =
+                        Modifier
+                            .size(6.dp)
+                            .clip(CircleShape)
+                            .background(if (index == pagerState.currentPage) accent.primary else system.muted),
+                )
+            }
+        }
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/welcome/WelcomeScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/welcome/WelcomeScreen.kt
@@ -1,0 +1,293 @@
+package app.pbbls.android.features.welcome
+
+import android.provider.Settings
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.pbbls.android.R
+import app.pbbls.android.components.GoogleSignInButton
+import app.pbbls.android.components.LegalDisclaimer
+import app.pbbls.android.components.LegalDoc
+import app.pbbls.android.components.PebblesPrimaryButton
+import app.pbbls.android.components.openLegalDoc
+import app.pbbls.android.rive.RiveLogo
+import app.pbbls.android.theme.PebblesTheme
+import app.pbbls.android.theme.PebblesTypography
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+// One entry per revealed element, in fade-in order. iOS's 7th step (Continue
+// with Apple) is dropped — no Apple sign-in on Android (settled non-goal).
+private const val REVEAL_STEPS = 6
+private val REVEAL_SCHEDULE_MILLIS = longArrayOf(0, 200, 450, 600, 750, 1100)
+
+private val ErrorRed = Color(0xFFDC2626)
+
+/**
+ * Pre-login landing AND splash — the `WelcomeView` analog. `RootScreen` keeps
+ * this mounted for the whole splash hold so the Rive logo plays through without a
+ * view-swap. While [contentRevealed] is false only the logo shows, centered; when
+ * the parent flips it true, the carousel + buttons + disclaimer fade in one-by-one
+ * on a timed schedule (all at once under reduced motion).
+ *
+ * Email buttons navigate to Auth via the parent NavHost; [onGoogleSignIn] is a
+ * suspend action (hosted OAuth) supplied by the parent — the screen owns only the
+ * in-flight/error view state, keeping business logic out of the view.
+ */
+@Composable
+fun WelcomeScreen(
+    contentRevealed: Boolean,
+    onCreateAccount: () -> Unit,
+    onLogin: () -> Unit,
+    onGoogleSignIn: suspend () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val system = PebblesTheme.colors.system
+    val context = LocalContext.current
+    val reduceMotion = rememberReduceMotion()
+    val inspection = LocalInspectionMode.current
+    val scope = rememberCoroutineScope()
+
+    var isSubmitting by remember { mutableStateOf(false) }
+    var authError by remember { mutableStateOf<String?>(null) }
+    var revealStep by remember { mutableIntStateOf(if (inspection) REVEAL_STEPS else 0) }
+
+    LaunchedEffectReveal(contentRevealed, reduceMotion, revealStep) { revealStep = it }
+
+    Box(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(system.background),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .safeDrawingPadding(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Spacer(modifier = Modifier.weight(1f))
+            RiveLogo(
+                modifier =
+                    Modifier
+                        .fillMaxWidth(0.33f)
+                        .aspectRatio(1f),
+            )
+            Spacer(modifier = Modifier.weight(1f))
+
+            if (revealStep >= 1) {
+                WelcomeRevealedContent(
+                    revealStep = revealStep,
+                    reduceMotion = reduceMotion,
+                    isSubmitting = isSubmitting,
+                    authError = authError,
+                    onCreateAccount = onCreateAccount,
+                    onLogin = onLogin,
+                    onGoogleSignIn = {
+                        if (!isSubmitting) {
+                            scope.launch {
+                                isSubmitting = true
+                                authError = null
+                                try {
+                                    onGoogleSignIn()
+                                } catch (e: Exception) {
+                                    authError = e.message
+                                }
+                                isSubmitting = false
+                            }
+                        }
+                    },
+                    onTermsTap = { openLegalDoc(context, LegalDoc.TERMS) },
+                    onPrivacyTap = { openLegalDoc(context, LegalDoc.PRIVACY) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun WelcomeRevealedContent(
+    revealStep: Int,
+    reduceMotion: Boolean,
+    isSubmitting: Boolean,
+    authError: String?,
+    onCreateAccount: () -> Unit,
+    onLogin: () -> Unit,
+    onGoogleSignIn: () -> Unit,
+    onTermsTap: () -> Unit,
+    onPrivacyTap: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        WelcomeCarousel(
+            reduceMotion = reduceMotion,
+            modifier =
+                Modifier
+                    .revealAlpha(revealStep >= 2)
+                    .padding(bottom = 24.dp),
+        )
+
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp)
+                    .padding(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            PebblesPrimaryButton(
+                text = stringResource(R.string.welcome_create_account),
+                onClick = onCreateAccount,
+                enabled = !isSubmitting,
+                modifier = Modifier.revealAlpha(revealStep >= 3),
+            )
+            WelcomeOutlineButton(
+                text = stringResource(R.string.welcome_log_in),
+                onClick = onLogin,
+                enabled = !isSubmitting,
+                modifier = Modifier.revealAlpha(revealStep >= 4),
+            )
+            GoogleSignInButton(
+                onClick = onGoogleSignIn,
+                enabled = !isSubmitting,
+                modifier = Modifier.revealAlpha(revealStep >= 5),
+            )
+            if (authError != null) {
+                Text(
+                    text = authError,
+                    style = PebblesTypography.subhead.copy(fontSize = 12.sp),
+                    color = ErrorRed,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            LegalDisclaimer(
+                onTermsTap = onTermsTap,
+                onPrivacyTap = onPrivacyTap,
+                modifier =
+                    Modifier
+                        .revealAlpha(revealStep >= 6)
+                        .padding(top = 8.dp)
+                        .fillMaxWidth(),
+            )
+        }
+    }
+}
+
+/** Outlined accent capsule for the secondary "Log in" action. */
+@Composable
+private fun WelcomeOutlineButton(
+    text: String,
+    onClick: () -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val accent = PebblesTheme.colors.accent
+    val shape = RoundedCornerShape(50)
+    Box(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .heightIn(min = 52.dp)
+                .clip(shape)
+                .border(1.dp, accent.primary, shape)
+                .clickable(enabled = enabled) { onClick() },
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(text = text, style = PebblesTypography.buttonLabel, color = accent.primary)
+    }
+}
+
+/** Fades content in as its reveal step is reached. */
+@Composable
+private fun Modifier.revealAlpha(visible: Boolean): Modifier {
+    val target by animateFloatAsState(
+        targetValue = if (visible) 1f else 0f,
+        animationSpec = tween(durationMillis = 300),
+        label = "welcomeReveal",
+    )
+    return this.alpha(target)
+}
+
+/**
+ * Runs the timed reveal cadence once [contentRevealed] flips true. Extracted so
+ * the `LaunchedEffect` keys stay explicit. Under reduced motion, jumps straight
+ * to fully revealed.
+ */
+@Composable
+private fun LaunchedEffectReveal(
+    contentRevealed: Boolean,
+    reduceMotion: Boolean,
+    currentStep: Int,
+    onStep: (Int) -> Unit,
+) {
+    androidx.compose.runtime.LaunchedEffect(contentRevealed, reduceMotion) {
+        if (!contentRevealed || currentStep >= REVEAL_STEPS) return@LaunchedEffect
+        if (reduceMotion) {
+            onStep(REVEAL_STEPS)
+            return@LaunchedEffect
+        }
+        var previous = 0L
+        REVEAL_SCHEDULE_MILLIS.forEachIndexed { index, at ->
+            val wait = at - previous
+            if (wait > 0) delay(wait)
+            onStep(index + 1)
+            previous = at
+        }
+    }
+}
+
+/**
+ * The Android analog of SwiftUI's `accessibilityReduceMotion`. Compose has no
+ * first-class signal, so this reads the system animator duration scale — `0` when
+ * the user disabled animations. In `@Preview`/screenshot rendering
+ * ([LocalInspectionMode]) it returns `true` so the reveal renders fully in one
+ * frame.
+ */
+@Composable
+private fun rememberReduceMotion(): Boolean {
+    if (LocalInspectionMode.current) return true
+    val context = LocalContext.current
+    return remember {
+        Settings.Global.getFloat(
+            context.contentResolver,
+            Settings.Global.ANIMATOR_DURATION_SCALE,
+            1f,
+        ) == 0f
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/welcome/WelcomeSlideView.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/welcome/WelcomeSlideView.kt
@@ -1,0 +1,52 @@
+package app.pbbls.android.features.welcome
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.pbbls.android.theme.PebblesTheme
+import app.pbbls.android.theme.PebblesTypography
+
+/**
+ * A single [WelcomeStep] as a centered title + description — the
+ * `WelcomeSlideView` analog. Title uses the Ysabeau display face (the `title`
+ * token dialed to 22sp) in `system.secondary`; description keeps the body font.
+ * No per-slide illustration — the Rive logo in `WelcomeScreen`'s header fills
+ * that role.
+ */
+@Composable
+fun WelcomeSlideView(
+    step: WelcomeStep,
+    modifier: Modifier = Modifier,
+) {
+    val system = PebblesTheme.colors.system
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = stringResource(step.titleRes),
+            style = PebblesTypography.title.copy(fontSize = 22.sp),
+            color = system.secondary,
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            text = stringResource(step.descriptionRes),
+            style = PebblesTypography.body,
+            color = system.secondary,
+            textAlign = TextAlign.Center,
+        )
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/welcome/WelcomeSteps.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/welcome/WelcomeSteps.kt
@@ -1,0 +1,29 @@
+package app.pbbls.android.features.welcome
+
+import androidx.annotation.StringRes
+import app.pbbls.android.R
+
+/**
+ * Single welcome-carousel slide's content — the `WelcomeStep` analog. No image
+ * field: the Pebbles logo in `WelcomeScreen`'s header plays that role. Copy lives
+ * in `strings.xml`, so titles/descriptions are string-resource ids.
+ */
+data class WelcomeStep(
+    val id: String,
+    @StringRes val titleRes: Int,
+    @StringRes val descriptionRes: Int,
+)
+
+/**
+ * The three slides on the pre-login welcome carousel. Editing copy or reordering
+ * is a single-file change — `WelcomeCarousel` reads `.all` opaquely and
+ * `WelcomeStepsTest` enforces count, unique ids, and id order.
+ */
+object WelcomeSteps {
+    val all: List<WelcomeStep> =
+        listOf(
+            WelcomeStep("record", R.string.welcome_step_record_title, R.string.welcome_step_record_description),
+            WelcomeStep("enrich", R.string.welcome_step_enrich_title, R.string.welcome_step_enrich_description),
+            WelcomeStep("grow", R.string.welcome_step_grow_title, R.string.welcome_step_grow_description),
+        )
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/services/OnboardingPreferences.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/services/OnboardingPreferences.kt
@@ -1,0 +1,26 @@
+package app.pbbls.android.services
+
+import android.content.Context
+
+/**
+ * `hasSeenOnboarding` persistence — the `@AppStorage("hasSeenOnboarding")`
+ * analog (D5). Backed by `SharedPreferences`; DataStore is deferred until real
+ * settings exist. The onboarding overlay reads this once at the session gate and
+ * writes `true` when the flow completes, so it shows once and never again across
+ * restarts.
+ */
+object OnboardingPreferences {
+    private const val PREFS_NAME = "pebbles_prefs"
+    private const val KEY_HAS_SEEN_ONBOARDING = "hasSeenOnboarding"
+
+    fun hasSeenOnboarding(context: Context): Boolean = prefs(context).getBoolean(KEY_HAS_SEEN_ONBOARDING, false)
+
+    fun setHasSeenOnboarding(
+        context: Context,
+        value: Boolean,
+    ) {
+        prefs(context).edit().putBoolean(KEY_HAS_SEEN_ONBOARDING, value).apply()
+    }
+
+    private fun prefs(context: Context) = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/services/SupabaseService.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/services/SupabaseService.kt
@@ -1,0 +1,257 @@
+package app.pbbls.android.services
+
+import android.util.Log
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import app.pbbls.android.AppEnvironment
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.auth.Auth
+import io.github.jan.supabase.auth.FlowType
+import io.github.jan.supabase.auth.auth
+import io.github.jan.supabase.auth.providers.Google
+import io.github.jan.supabase.auth.providers.builtin.Email
+import io.github.jan.supabase.auth.status.SessionStatus
+import io.github.jan.supabase.auth.user.UserSession
+import io.github.jan.supabase.createSupabaseClient
+import io.github.jan.supabase.postgrest.Postgrest
+import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.Columns
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import java.time.Instant
+
+/**
+ * Wraps the supabase-kt client and exposes auth state to Compose. Screens read
+ * this from the [LocalSupabaseService] CompositionLocal (the
+ * `@Environment(SupabaseService.self)` analog) and read [session] to decide what
+ * to render. Actions (`signIn`, `signUp`, `signInWithGoogle`, `signOut`) are
+ * called from the funnel that drives them. Ports
+ * `apps/ios/Pebbles/Services/SupabaseService.swift`.
+ *
+ * The client initializer performs no network I/O, so constructing this during
+ * app launch (`PebblesApp.onCreate`) is safe on the main thread.
+ */
+class SupabaseService {
+    val client: SupabaseClient =
+        createSupabaseClient(
+            supabaseUrl = AppEnvironment.supabaseUrl,
+            supabaseKey = AppEnvironment.supabaseAnonKey,
+        ) {
+            install(Auth) {
+                // Google hosted OAuth returns via the pebbles://auth-callback deep
+                // link; PKCE + this scheme/host are the D15/D16 contract. Shared
+                // with iOS, so the dashboard allowlist is unchanged.
+                flowType = FlowType.PKCE
+                scheme = "pebbles"
+                host = "auth-callback"
+            }
+            install(Postgrest)
+        }
+
+    /** The current Supabase session, or null when signed out. */
+    var session: UserSession? by mutableStateOf(null)
+        private set
+
+    /**
+     * True until the first `sessionStatus` event resolves the persisted session.
+     * `RootScreen` keeps showing the splash/Welcome while this is true so the
+     * user never sees the auth screen flash before Path.
+     */
+    var isInitializing: Boolean by mutableStateOf(true)
+        private set
+
+    /** Guards the OAuth display-name patch so it runs at most once per process. */
+    private var didAttemptNamePatch = false
+
+    // Scope for work that REACTS to a status change (never inline in the
+    // collector — see start()).
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    /**
+     * Collects supabase-kt's auth-status stream and keeps [session] +
+     * [isInitializing] in sync for the lifetime of the app. Call exactly once
+     * from `RootScreen`'s `LaunchedEffect`. Suspends forever under normal
+     * operation.
+     *
+     * CRITICAL (ported verbatim from iOS): do NOT call back into supabase-kt
+     * from inside this collector. The client holds an internal lock while
+     * delivering status events; re-entering it from the callback deadlocks the
+     * auth actor. Mutate state synchronously only — any network call reacting to
+     * a status change is launched in a SEPARATE coroutine ([scope]), not inline.
+     */
+    suspend fun start() {
+        client.auth.sessionStatus.collect { status ->
+            when (status) {
+                is SessionStatus.Authenticated -> {
+                    session = status.session
+                    isInitializing = false
+                    // A brand-new session (OAuth/sign-in/sign-up) may carry a
+                    // provider name claim; patch the trigger-seeded 'Pebbler'
+                    // display name from it — in a separate coroutine, never inline.
+                    if (status.isNew && !didAttemptNamePatch) {
+                        val name = nameFromUserMetadata(status.session.user?.userMetadata)
+                        if (name != null) {
+                            didAttemptNamePatch = true
+                            scope.launch { patchDisplayNameIfDefault(name) }
+                        }
+                    }
+                }
+
+                is SessionStatus.NotAuthenticated -> {
+                    session = null
+                    isInitializing = false
+                }
+
+                is SessionStatus.RefreshFailure -> {
+                    // Keep the last-known session; auth will retry. Initialization
+                    // is nonetheless resolved.
+                    isInitializing = false
+                }
+
+                SessionStatus.Initializing -> {
+                    isInitializing = true
+                }
+            }
+        }
+        Log.e(TAG, "sessionStatus stream ended unexpectedly")
+    }
+
+    /** Sign in with email + password. Success flows back through [start]'s collector. */
+    suspend fun signIn(
+        email: String,
+        password: String,
+    ) {
+        try {
+            client.auth.signInWith(Email) {
+                this.email = email
+                this.password = password
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "signIn failed", e)
+            throw e
+        }
+    }
+
+    /**
+     * Sign up with email + password. Consent timestamps are captured now and
+     * passed through `auth.users.raw_user_meta_data` via the sign-up data block.
+     * Mirrors iOS: the current `handle_new_user` trigger does not copy them into
+     * `public.profiles` — a separate `fix(db)` issue.
+     */
+    suspend fun signUp(
+        email: String,
+        password: String,
+    ) {
+        try {
+            client.auth.signUpWith(Email) {
+                this.email = email
+                this.password = password
+                this.data = consentMetadata(Instant.now().toString())
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "signUp failed", e)
+            throw e
+        }
+    }
+
+    /**
+     * Sign in with Google via Supabase's hosted OAuth flow. supabase-kt opens a
+     * Custom Tab that leaves the app and returns via the pebbles://auth-callback
+     * deep link; the session lands asynchronously through [start]'s collector
+     * (handled in `MainActivity.onNewIntent`). Mirrors the iOS reasoning
+     * (`SupabaseService.swift`) — hosted web OAuth over the native SDK, no Google
+     * Sign-In SDK in v1.
+     */
+    suspend fun signInWithGoogle() {
+        try {
+            client.auth.signInWith(Google)
+        } catch (e: Exception) {
+            Log.e(TAG, "signInWithGoogle failed", e)
+            throw e
+        }
+    }
+
+    /**
+     * Sign out. Failures are logged but never surfaced — the local token is
+     * wiped regardless and the collector emits `NotAuthenticated`.
+     */
+    suspend fun signOut() {
+        try {
+            client.auth.signOut()
+        } catch (e: Exception) {
+            Log.e(TAG, "signOut failed", e)
+        }
+    }
+
+    private fun nameFromUserMetadata(metadata: JsonObject?): String? {
+        if (metadata == null) return null
+        // OIDC `name` claim is preferred; `full_name` is a Supabase alias some
+        // providers populate. Either is fine.
+        for (key in listOf("full_name", "name")) {
+            val value = metadata[key]?.jsonPrimitive?.contentOrNull
+            if (!value.isNullOrEmpty()) return value
+        }
+        return null
+    }
+
+    /**
+     * Replaces `profiles.display_name` with [name] only if the row is still the
+     * trigger default (`'Pebbler'`). Idempotent — safe to call on every new
+     * OAuth session. Runs off the status collector (see [start]).
+     */
+    private suspend fun patchDisplayNameIfDefault(name: String) {
+        val userId = session?.user?.id ?: return
+        try {
+            val row =
+                client
+                    .from("profiles")
+                    .select(Columns.list("display_name")) {
+                        filter { eq("user_id", userId) }
+                    }.decodeSingleOrNull<JsonObject>()
+            val current = row?.get("display_name")?.jsonPrimitive?.contentOrNull
+            if (current != "Pebbler") return
+            client
+                .from("profiles")
+                .update(buildJsonObject { put("display_name", name) }) {
+                    filter { eq("user_id", userId) }
+                }
+        } catch (e: Exception) {
+            Log.e(TAG, "patchDisplayName failed", e)
+        }
+    }
+
+    companion object {
+        private const val TAG = "auth"
+
+        /**
+         * Consent-metadata payload written into user metadata on sign-up. Both
+         * timestamps are the moment of sign-up. Extracted as a pure function so
+         * its shape is unit-tested without a live client.
+         */
+        fun consentMetadata(nowIso: String): JsonObject =
+            buildJsonObject {
+                put("terms_accepted_at", nowIso)
+                put("privacy_accepted_at", nowIso)
+            }
+    }
+}
+
+/**
+ * CompositionLocal for [SupabaseService] — the `@Environment(SupabaseService.self)`
+ * analog (D4). `MainActivity` provides the single instance constructed in
+ * `PebblesApp`; screens read it with `LocalSupabaseService.current`. One
+ * `staticCompositionLocalOf` per service; more land with sub-project D.
+ */
+val LocalSupabaseService =
+    staticCompositionLocalOf<SupabaseService> {
+        error("LocalSupabaseService not provided — wrap the tree in MainActivity's CompositionLocalProvider")
+    }

--- a/apps/android/app/src/main/res/drawable/ic_google_g.xml
+++ b/apps/android/app/src/main/res/drawable/ic_google_g.xml
@@ -1,0 +1,23 @@
+<!--
+  Multi-color Google "G" mark. Vector drawable ported 1:1 from the iOS asset
+  catalog SVG (GoogleGMark.imageset/google.svg) — same 20×20 viewport and path
+  data, so the Android and iOS Google buttons render the identical glyph.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+    <path
+        android:fillColor="#4285F4"
+        android:pathData="M19.6 10.2273C19.6 9.51816 19.5364 8.83636 19.4182 8.18176H10V12.05H15.3818C15.15 13.3 14.4455 14.3591 13.3864 15.0682V17.5773H16.6182C18.5091 15.8364 19.6 13.2727 19.6 10.2273Z" />
+    <path
+        android:fillColor="#34A853"
+        android:pathData="M9.99988 20C12.6999 20 14.9635 19.1045 16.618 17.5773L13.3862 15.0682C12.4908 15.6682 11.3453 16.0227 9.99988 16.0227C7.39528 16.0227 5.19078 14.2636 4.40438 11.9H1.06348V14.4909C2.70898 17.7591 6.09078 20 9.99988 20Z" />
+    <path
+        android:fillColor="#FBBC04"
+        android:pathData="M4.4045 11.9001C4.2045 11.3001 4.0909 10.6592 4.0909 10.0001C4.0909 9.34096 4.2045 8.70006 4.4045 8.10006V5.50916H1.0636C0.3864 6.85916 0 8.38646 0 10.0001C0 11.6137 0.3864 13.141 1.0636 14.491L4.4045 11.9001Z" />
+    <path
+        android:fillColor="#E94235"
+        android:pathData="M9.99988 3.9773C11.468 3.9773 12.7862 4.4818 13.8226 5.4727L16.6908 2.6045C14.959 0.9909 12.6953 0 9.99988 0C6.09078 0 2.70898 2.2409 1.06348 5.5091L4.40438 8.1C5.19078 5.7364 7.39528 3.9773 9.99988 3.9773Z" />
+</vector>

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -1,5 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- ==== Entry funnel (sub-project C) — Welcome ==== -->
+    <string name="welcome_step_record_title">Notez en quelques secondes.</string>
+    <string name="welcome_step_record_description">Capturez les moments quand ils arrivent — pas de page blanche, sans pression.</string>
+    <string name="welcome_step_enrich_title">Enrichissez de sens.</string>
+    <string name="welcome_step_enrich_description">Ajoutez des émotions, des personnes et des réflexions à chaque pebble.</string>
+    <string name="welcome_step_grow_title">Faites grandir votre chemin.</string>
+    <string name="welcome_step_grow_description">Revenez sur votre parcours, à votre rythme.</string>
+    <string name="welcome_create_account">Créer un compte</string>
+    <string name="welcome_log_in">Se connecter</string>
+    <string name="welcome_continue_google">Continuer avec Google</string>
+    <string name="welcome_legal_disclaimer">Lisez nos {terms} et notre {privacy} avant de créer un compte avec Google.</string>
+    <string name="legal_link_terms">Conditions</string>
+    <string name="legal_link_privacy">Confidentialité</string>
+
+    <!-- ==== Entry funnel — Auth ==== -->
+    <string name="auth_mode_login">Connexion</string>
+    <string name="auth_mode_signup">Inscription</string>
+    <string name="auth_email_placeholder">E-mail</string>
+    <string name="auth_password_placeholder">Mot de passe</string>
+    <string name="auth_email_plus_error">Le caractère \'+\' n\'est pas autorisé dans les adresses e-mail.</string>
+    <string name="auth_consent_prefix">J\'accepte </string>
+    <string name="auth_consent_terms_link">les Conditions d\'utilisation</string>
+    <string name="auth_consent_privacy_link">la politique de confidentialité</string>
+    <string name="auth_submit_login">Se connecter</string>
+    <string name="auth_submit_signup">Créer un compte</string>
+
+    <!-- ==== Entry funnel — Onboarding ==== -->
+    <string name="onboarding_intro_title">Votre vie est un chemin.</string>
+    <string name="onboarding_intro_description">Chaque moment compte — les grands comme les plus discrets. Mais la plupart s\'effacent avant même qu\'on les remarque. Pebbles vous aide à les collecter, un par un.</string>
+    <string name="onboarding_concept_title">Posez un pebble, gardez le moment.</string>
+    <string name="onboarding_concept_description">Un café avec un ami. Un concert qui donne des frissons. Une conversation difficile. Notez-le en quelques secondes — pas de page blanche, sans pression, sans audience.</string>
+    <string name="onboarding_qualify_title">Qualifiez et reliez.</string>
+    <string name="onboarding_qualify_description">Associez votre moment à une émotion et un domaine, reliez des personnes et ajoutez votre pebble à une pile ou une collection.</string>
+    <string name="onboarding_carving_title">Obtenez votre pebble.</string>
+    <string name="onboarding_carving_description">Choisissez ou gravez un glyphe pour marquer le moment. Puis révélez une illustration de pebble unique pour vous en souvenir.</string>
+    <string name="onboarding_skip">Passer</string>
+    <string name="onboarding_close">Fermer l\'introduction</string>
+    <string name="onboarding_start">Commencer votre chemin</string>
+
+    <!-- ==== Entry funnel — Path placeholder ==== -->
+    <string name="path_placeholder_title">Votre chemin</string>
+    <string name="path_placeholder_subtitle">Votre journal arrive dans la prochaine mise à jour. Cet écran temporaire permet de tester le parcours de bout en bout.</string>
+    <string name="path_sign_out">Se déconnecter</string>
+
     <!-- French reference-data names — see values/strings.xml for provenance. -->
 
     <!-- Domains (18) -->

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -3,6 +3,52 @@
     <!-- Brand name — never translated (D3/D9). -->
     <string name="app_name" translatable="false">Pebbles</string>
 
+    <!-- ==== Entry funnel (sub-project C) — Welcome ==== -->
+    <string name="welcome_step_record_title">Record in seconds.</string>
+    <string name="welcome_step_record_description">Capture moments as they happen — no blank page, no pressure.</string>
+    <string name="welcome_step_enrich_title">Enrich with meaning.</string>
+    <string name="welcome_step_enrich_description">Add emotions, people, and reflections to each pebble.</string>
+    <string name="welcome_step_grow_title">Grow your path.</string>
+    <string name="welcome_step_grow_description">Look back at your journey, at your own pace.</string>
+    <string name="welcome_create_account">Create an account</string>
+    <string name="welcome_log_in">Log in</string>
+    <string name="welcome_continue_google">Continue with Google</string>
+    <!-- {terms} and {privacy} are replaced in-Compose with tappable links; keep
+         both tokens and let word order follow the translation. -->
+    <string name="welcome_legal_disclaimer">Read our {terms} and {privacy} before creating an account with Google.</string>
+    <string name="legal_link_terms">Terms</string>
+    <string name="legal_link_privacy">Privacy</string>
+
+    <!-- ==== Entry funnel — Auth ==== -->
+    <string name="auth_mode_login">Log In</string>
+    <string name="auth_mode_signup">Sign Up</string>
+    <string name="auth_email_placeholder">Email</string>
+    <string name="auth_password_placeholder">Password</string>
+    <string name="auth_email_plus_error">The \'+\' character is not allowed in email addresses.</string>
+    <string name="auth_consent_prefix">I accept the </string>
+    <string name="auth_consent_terms_link">Terms of Service</string>
+    <string name="auth_consent_privacy_link">Privacy Policy</string>
+    <string name="auth_submit_login">Connect</string>
+    <string name="auth_submit_signup">Create an account</string>
+
+    <!-- ==== Entry funnel — Onboarding ==== -->
+    <string name="onboarding_intro_title">Your life is a path.</string>
+    <string name="onboarding_intro_description">Every moment matters — the big ones and the quiet ones. But most of them slip away before you even notice. Pebbles helps you collect them, one by one.</string>
+    <string name="onboarding_concept_title">Drop a pebble, keep the moment.</string>
+    <string name="onboarding_concept_description">A coffee with a friend. A concert that gave you chills. A tough conversation. Record it in seconds — no blank page, no pressure, no audience.</string>
+    <string name="onboarding_qualify_title">Qualify and relate.</string>
+    <string name="onboarding_qualify_description">Associate your moment with an emotion and a domain, relate with people and add your pebble to a stack or a collection.</string>
+    <string name="onboarding_carving_title">Get your pebble.</string>
+    <string name="onboarding_carving_description">Choose or carve a glyph to mark the moment. Then reveal a unique pebble illustration to remember your moment.</string>
+    <string name="onboarding_skip">Skip</string>
+    <string name="onboarding_close">Close onboarding</string>
+    <string name="onboarding_start">Start your path</string>
+
+    <!-- ==== Entry funnel — Path placeholder (real timeline lands in sub-project D) ==== -->
+    <string name="path_placeholder_title">Your path</string>
+    <string name="path_placeholder_subtitle">Your timeline lands in the next update. This placeholder lets the entry funnel be tested end to end.</string>
+    <string name="path_sign_out">Sign out</string>
+
     <!-- Reference-data names (D9). Resolved via ReferenceStrings, keyed by DB slug —
          never render the DB `name` column directly on a read path. Source: iOS
          Localizable.xcstrings (`emotion.<slug>.name`, `domain.<slug>.name`,

--- a/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/FunnelScreenshots.kt
+++ b/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/FunnelScreenshots.kt
@@ -1,0 +1,83 @@
+package app.pbbls.android
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import app.pbbls.android.features.auth.AuthMode
+import app.pbbls.android.features.auth.AuthScreen
+import app.pbbls.android.features.onboarding.OnboardingScreen
+import app.pbbls.android.features.onboarding.OnboardingSteps
+import app.pbbls.android.features.welcome.WelcomeScreen
+import app.pbbls.android.theme.PebblesTheme
+import com.android.tools.screenshot.PreviewTest
+
+/**
+ * Screenshot-test previews for the entry funnel (sub-project C), rendered to PNGs
+ * in CI so the maintainer can review Welcome/Auth/Onboarding without a device
+ * (see `apps/android/CLAUDE.md`). The screens take plain action lambdas, so no
+ * live `SupabaseService` is needed — previews pass no-ops. `RiveLogo` and the
+ * timed reveal both collapse to their fully-revealed placeholder state under
+ * `LocalInspectionMode`.
+ */
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+fun WelcomeScreenLight() {
+    PebblesTheme {
+        WelcomeScreen(
+            contentRevealed = true,
+            onCreateAccount = {},
+            onLogin = {},
+            onGoogleSignIn = {},
+        )
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun WelcomeScreenDark() {
+    PebblesTheme {
+        WelcomeScreen(
+            contentRevealed = true,
+            onCreateAccount = {},
+            onLogin = {},
+            onGoogleSignIn = {},
+        )
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+fun AuthScreenLogin() {
+    PebblesTheme {
+        AuthScreen(
+            initialMode = AuthMode.LOGIN,
+            onSubmit = { _, _, _ -> },
+            onGoogleSignIn = {},
+        )
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun AuthScreenSignup() {
+    PebblesTheme {
+        AuthScreen(
+            initialMode = AuthMode.SIGNUP,
+            onSubmit = { _, _, _ -> },
+            onGoogleSignIn = {},
+        )
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+fun OnboardingScreenLight() {
+    PebblesTheme {
+        OnboardingScreen(steps = OnboardingSteps.all, onFinish = {})
+    }
+}

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/auth/AuthLogicTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/auth/AuthLogicTest.kt
@@ -1,0 +1,119 @@
+package app.pbbls.android.features.auth
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Ports all 16 iOS `AuthViewLogicTests` cases 1:1
+ * (`apps/ios/PebblesTests/Features/Auth/AuthViewLogicTests.swift`) so the
+ * Android `canSubmit` / `normalizeEmailInput` stay at parity.
+ */
+class AuthLogicTest {
+    @Test
+    fun loginInvalidEmailReturnsFalse() {
+        assertFalse(
+            AuthLogic.canSubmit(AuthMode.LOGIN, "not-an-email", "password", false, false, false),
+        )
+    }
+
+    @Test
+    fun loginShortPasswordReturnsFalse() {
+        assertFalse(
+            AuthLogic.canSubmit(AuthMode.LOGIN, "hello@bohns.design", "abc", false, false, false),
+        )
+    }
+
+    @Test
+    fun loginValidCredentialsReturnTrue() {
+        assertTrue(
+            AuthLogic.canSubmit(AuthMode.LOGIN, "hello@bohns.design", "abcdef", false, false, false),
+        )
+    }
+
+    @Test
+    fun loginIgnoresConsentFlags() {
+        assertTrue(
+            AuthLogic.canSubmit(AuthMode.LOGIN, "hello@bohns.design", "abcdef", true, true, false),
+        )
+    }
+
+    @Test
+    fun signupMissingTermsReturnsFalse() {
+        assertFalse(
+            AuthLogic.canSubmit(AuthMode.SIGNUP, "hello@bohns.design", "abcdef", false, true, false),
+        )
+    }
+
+    @Test
+    fun signupMissingPrivacyReturnsFalse() {
+        assertFalse(
+            AuthLogic.canSubmit(AuthMode.SIGNUP, "hello@bohns.design", "abcdef", true, false, false),
+        )
+    }
+
+    @Test
+    fun signupAllFourConditionsMetReturnsTrue() {
+        assertTrue(
+            AuthLogic.canSubmit(AuthMode.SIGNUP, "hello@bohns.design", "abcdef", true, true, false),
+        )
+    }
+
+    @Test
+    fun isSubmittingTrueReturnsFalseInLogin() {
+        assertFalse(
+            AuthLogic.canSubmit(AuthMode.LOGIN, "hello@bohns.design", "abcdef", false, false, true),
+        )
+    }
+
+    @Test
+    fun isSubmittingTrueReturnsFalseInSignup() {
+        assertFalse(
+            AuthLogic.canSubmit(AuthMode.SIGNUP, "hello@bohns.design", "abcdef", true, true, true),
+        )
+    }
+
+    @Test
+    fun loginEmailMissingDotReturnsFalse() {
+        assertFalse(
+            AuthLogic.canSubmit(AuthMode.LOGIN, "hello@bohns", "abcdef", false, false, false),
+        )
+    }
+
+    @Test
+    fun loginEmailWithPlusReturnsFalse() {
+        assertFalse(
+            AuthLogic.canSubmit(AuthMode.LOGIN, "hello+work@bohns.design", "abcdef", false, false, false),
+        )
+    }
+
+    @Test
+    fun loginWhitespaceOnlyEmailReturnsFalse() {
+        assertFalse(
+            AuthLogic.canSubmit(AuthMode.LOGIN, "   ", "abcdef", false, false, false),
+        )
+    }
+
+    @Test
+    fun loginEmailWithSurroundingWhitespaceIsAccepted() {
+        assertTrue(
+            AuthLogic.canSubmit(AuthMode.LOGIN, "  hello@bohns.design  ", "abcdef", false, false, false),
+        )
+    }
+
+    @Test
+    fun normalizeEmailInputLowercasesUppercaseCharacters() {
+        assertEquals("hello@bohns.design", AuthLogic.normalizeEmailInput("Hello@Bohns.Design"))
+    }
+
+    @Test
+    fun normalizeEmailInputStripsPlusCharacters() {
+        assertEquals("hellowork@bohns.design", AuthLogic.normalizeEmailInput("hello+work@bohns.design"))
+    }
+
+    @Test
+    fun normalizeEmailInputIsIdempotentOnACleanAddress() {
+        assertEquals("hello@bohns.design", AuthLogic.normalizeEmailInput("hello@bohns.design"))
+    }
+}

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/onboarding/OnboardingGateTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/onboarding/OnboardingGateTest.kt
@@ -1,0 +1,31 @@
+package app.pbbls.android.features.onboarding
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Onboarding-flag gating (the `RootView.onChange(of: session?.user.id)` rule):
+ * present only when a user id appears while `hasSeenOnboarding` is still false.
+ */
+class OnboardingGateTest {
+    @Test
+    fun presentsWhenUserAppearsAndFlagUnset() {
+        assertTrue(OnboardingGate.shouldPresent(userId = "user-1", hasSeenOnboarding = false))
+    }
+
+    @Test
+    fun doesNotPresentWhenAlreadySeen() {
+        assertFalse(OnboardingGate.shouldPresent(userId = "user-1", hasSeenOnboarding = true))
+    }
+
+    @Test
+    fun doesNotPresentWithoutAUser() {
+        assertFalse(OnboardingGate.shouldPresent(userId = null, hasSeenOnboarding = false))
+    }
+
+    @Test
+    fun doesNotPresentWithoutAUserEvenIfUnseen() {
+        assertFalse(OnboardingGate.shouldPresent(userId = null, hasSeenOnboarding = true))
+    }
+}

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/onboarding/OnboardingStepsTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/onboarding/OnboardingStepsTest.kt
@@ -1,0 +1,35 @@
+package app.pbbls.android.features.onboarding
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * Ports iOS `OnboardingStepsTests`: count, unique ids, and spec id order. The
+ * "non-empty copy" checks become non-zero string-resource ids.
+ */
+class OnboardingStepsTest {
+    @Test
+    fun containsExactlyFourSteps() {
+        assertEquals(4, OnboardingSteps.all.size)
+    }
+
+    @Test
+    fun stepIdsAreUnique() {
+        val ids = OnboardingSteps.all.map { it.id }
+        assertEquals(ids.size, ids.toSet().size)
+    }
+
+    @Test
+    fun stepIdsMatchSpecOrder() {
+        assertEquals(listOf("intro", "concept", "qualify", "carving"), OnboardingSteps.all.map { it.id })
+    }
+
+    @Test
+    fun everyStepHasTitleAndDescriptionResources() {
+        OnboardingSteps.all.forEach { step ->
+            assertNotEquals("title unset for ${step.id}", 0, step.titleRes)
+            assertNotEquals("description unset for ${step.id}", 0, step.descriptionRes)
+        }
+    }
+}

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/welcome/WelcomeStepsTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/welcome/WelcomeStepsTest.kt
@@ -1,0 +1,36 @@
+package app.pbbls.android.features.welcome
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * Ports iOS `WelcomeStepsTests`: count, unique ids, and spec id order. The
+ * "non-empty copy" checks become non-zero string-resource ids (JVM tests can't
+ * resolve Android string values without Robolectric).
+ */
+class WelcomeStepsTest {
+    @Test
+    fun containsExactlyThreeSteps() {
+        assertEquals(3, WelcomeSteps.all.size)
+    }
+
+    @Test
+    fun stepIdsAreUnique() {
+        val ids = WelcomeSteps.all.map { it.id }
+        assertEquals(ids.size, ids.toSet().size)
+    }
+
+    @Test
+    fun stepIdsMatchSpecOrder() {
+        assertEquals(listOf("record", "enrich", "grow"), WelcomeSteps.all.map { it.id })
+    }
+
+    @Test
+    fun everyStepHasTitleAndDescriptionResources() {
+        WelcomeSteps.all.forEach { step ->
+            assertNotEquals("title unset for ${step.id}", 0, step.titleRes)
+            assertNotEquals("description unset for ${step.id}", 0, step.descriptionRes)
+        }
+    }
+}

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/services/ConsentMetadataTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/services/ConsentMetadataTest.kt
@@ -1,0 +1,22 @@
+package app.pbbls.android.services
+
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Verifies the consent-metadata payload shape written into user metadata on
+ * sign-up (the iOS `signUp` data block). Exercises the pure companion function
+ * without constructing a live client.
+ */
+class ConsentMetadataTest {
+    @Test
+    fun containsExactlyBothConsentTimestamps() {
+        val now = "2026-07-11T12:00:00Z"
+        val payload = SupabaseService.consentMetadata(now)
+
+        assertEquals(setOf("terms_accepted_at", "privacy_accepted_at"), payload.keys)
+        assertEquals(now, payload["terms_accepted_at"]?.jsonPrimitive?.content)
+        assertEquals(now, payload["privacy_accepted_at"]?.jsonPrimitive?.content)
+    }
+}

--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -18,6 +18,17 @@ screenshot = "0.0.1-alpha15"
 # androidx-startup for Rive.init(); see PebblesApp.onCreate().
 rive = "11.7.2"
 androidxStartup = "1.2.0"
+# Entry funnel (sub-project C). supabase-kt is the auth/data client; it needs a
+# Ktor engine on the classpath — supabase-kt 3.1.4 is built against Ktor 3.1.2,
+# so the OkHttp engine is pinned to the same version to avoid Ktor version skew.
+supabase = "3.1.4"
+ktor = "3.1.2"
+kotlinxSerializationJson = "1.8.0"
+# Single-activity NavHost for the unauthenticated Welcome -> Auth flow (D5).
+navigationCompose = "2.9.8"
+# Custom Tabs — the in-app-browser analog of iOS SFSafariViewController, used
+# for the legal document links (D15).
+browser = "1.10.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -34,6 +45,19 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 screenshot-validation-api = { group = "com.android.tools.screenshot", name = "screenshot-validation-api", version.ref = "screenshot" }
 rive-android = { group = "app.rive", name = "rive-android", version.ref = "rive" }
 androidx-startup-runtime = { group = "androidx.startup", name = "startup-runtime", version.ref = "androidxStartup" }
+
+# Compose (BOM-managed; no version here). foundation supplies HorizontalPager.
+androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
+
+# supabase-kt entry-funnel stack (sub-project C).
+supabase-bom = { group = "io.github.jan-tennert.supabase", name = "bom", version.ref = "supabase" }
+supabase-auth = { group = "io.github.jan-tennert.supabase", name = "auth-kt" }
+supabase-postgrest = { group = "io.github.jan-tennert.supabase", name = "postgrest-kt" }
+ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -16,7 +16,7 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Landing",
-      "description": "Public landing page with app branding, login button, and create-account link. Redirects authenticated users to the home view. iOS (PR #281) implements this as WelcomeView: persistent logo header, auto-advancing 3-step carousel, and two CTAs that push AuthView with the correct mode preselected.",
+      "description": "Public landing page with app branding, login button, and create-account link. Redirects authenticated users to the home view. iOS (PR #281) implements this as WelcomeView: persistent logo header, auto-advancing 3-step carousel, and two CTAs that push AuthView with the correct mode preselected. Android (M37 sub-project C) ports this as WelcomeScreen: Rive logo, timed 6-step reveal (honors reduced motion), HorizontalPager carousel, Create/Log in/Google CTAs, and the in-app legal disclaimer (Custom Tabs). No Apple button (settled non-goal).",
       "status": "development",
       "platforms": [
         "web",
@@ -29,7 +29,7 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Login",
-      "description": "Login page with username and password form. Redirects to path or onboarding based on profile completion status.",
+      "description": "Login page with username and password form. Redirects to path or onboarding based on profile completion status. Android (M37 sub-project C) implements this as AuthScreen in login mode (segmented switcher), with live email normalization and Google hosted OAuth.",
       "status": "development",
       "platforms": [
         "web",
@@ -42,7 +42,7 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Register",
-      "description": "Registration page with username, password, confirm password, and consent checkboxes (terms + privacy). Auto-logs in and redirects to onboarding on success.",
+      "description": "Registration page with username, password, confirm password, and consent checkboxes (terms + privacy). Auto-logs in and redirects to onboarding on success. Android (M37 sub-project C) implements this as AuthScreen in signup mode: the two consent checkboxes gate submit and write terms_accepted_at/privacy_accepted_at into user metadata.",
       "status": "development",
       "platforms": [
         "web",
@@ -534,10 +534,11 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Onboarding — Your life is a path",
-      "description": "First onboarding screen introducing the pebble/path metaphor.",
+      "description": "First onboarding screen introducing the pebble/path metaphor. Android (M37 sub-project C) ports this as the first page of OnboardingScreen (HorizontalPager).",
       "status": "development",
       "platforms": [
-        "ios"
+        "ios",
+        "android"
       ]
     },
     {
@@ -545,10 +546,11 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Onboarding — Drop a pebble, keep the moment",
-      "description": "Second onboarding screen framing pebble recording as low-friction.",
+      "description": "Second onboarding screen framing pebble recording as low-friction. Android (M37 sub-project C) ports this as the second page of OnboardingScreen.",
       "status": "development",
       "platforms": [
-        "ios"
+        "ios",
+        "android"
       ]
     },
     {
@@ -556,10 +558,11 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Onboarding — Qualify and relate",
-      "description": "Third onboarding screen explaining emotion, domain, souls, collections.",
+      "description": "Third onboarding screen explaining emotion, domain, souls, collections. Android (M37 sub-project C) ports this as the third page of OnboardingScreen.",
       "status": "development",
       "platforms": [
-        "ios"
+        "ios",
+        "android"
       ]
     },
     {
@@ -567,10 +570,11 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Onboarding — Get your pebble",
-      "description": "Fourth onboarding screen explaining glyph carving and pebble illustration.",
+      "description": "Fourth onboarding screen explaining glyph carving and pebble illustration. Android (M37 sub-project C) ports this as the fourth page of OnboardingScreen, with the 'Start your path' CTA.",
       "status": "development",
       "platforms": [
-        "ios"
+        "ios",
+        "android"
       ]
     },
     {

--- a/docs/decisions/log.md
+++ b/docs/decisions/log.md
@@ -191,3 +191,14 @@ Append-only ledger of **significant** product/engineering decisions. One terse e
 - **Consequences:** Don't "fix" this by hunting for missing `nunito_medium.ttf`/`nunito_semibold.ttf`/etc. — there is no static source to add, and the single-file approach is intentional. If a future weight is needed, add another `Font()` entry with the matching `FontVariation.weight(...)`, not a new file.
 - **Supersedes / Superseded-by:** —
 - **Refs:** #529, `docs/superpowers/plans/2026-07-11-android-design-system.md`, `apps/android/app/src/main/kotlin/app/pbbls/android/theme/PebblesTypography.kt`.
+
+## 2026-07-11 — Android CI bakes Supabase config into the debug APK
+
+- **Status:** taken
+- **Scope:** android, infra
+- **Context:** M37 sub-project C (#530) makes the app construct the supabase-kt auth client at launch (`PebblesApp.onCreate` → `SupabaseService`), so `AppEnvironment` throws on blank keys. The milestone design (D8/D12) built the CI debug APK **secretless**, on the premise that the maintainer would build locally with `secrets.properties` for device testing (risk 4). That premise is false: the maintainer has no Android Studio / local Android toolchain and can only download-and-install the CI artifact — which then crashes instantly on launch, and could not authenticate even if it didn't.
+- **Decision:** CI now injects `SUPABASE_URL` + `SUPABASE_ANON_KEY` from GitHub Actions **repository secrets** into the `assembleDebug` step's environment; `build.gradle.kts`'s `secret()` reads an env var of the same name when `secrets.properties` is absent (a local file still wins when present). The debug-APK artifact is therefore config-baked and functional on-device.
+- **Why:** It is the only way to give the SDK-less maintainer a runnable, authenticating APK. The anon key is a **publishable** key — it already ships in the deployed web bundle and the iOS app — so embedding it in a debug artifact adds no real exposure; row-level security, not key secrecy, protects data.
+- **Consequences:** The maintainer must add the two values as repo Actions secrets (Settings → Secrets and variables → Actions) or the APK stays secretless and fails loud at launch. Reverses only the "no secrets needed in CI / secretless debug APK" aspect of D8/D12; the empty-string build default and the fail-loud-at-launch contract are retained (forks with no secrets still build green and crash at launch). Release/signed builds and Play distribution remain out of scope.
+- **Supersedes / Superseded-by:** Revises the CI-secrets aspect of **D8** and **D12** in the M37 Android bootstrap design (`docs/superpowers/specs/2026-07-10-android-bootstrap-design.md`).
+- **Refs:** #530, #535, `.github/workflows/android.yml`, `apps/android/app/build.gradle.kts`.


### PR DESCRIPTION
Resolves #530 

## Changes

**Core screens & navigation:**
- `RootScreen.kt` — Top-level auth gate with conditional composition (splash hold, session check, onboarding overlay)
- `WelcomeScreen.kt` — Pre-login landing with Rive logo, timed reveal schedule, carousel, and email/Google CTAs
- `AuthScreen.kt` — Email + password auth (Login/Sign-up modes) with live email normalization and consent checkboxes
- `PathScreen.kt` — Authenticated landing placeholder with sign-out button (real timeline lands in sub-project D)
- `OnboardingScreen.kt` — Full-screen paged onboarding overlay (4 steps, auto-dismiss, blocks system back)

**Supporting components & logic:**
- `WelcomeCarousel.kt` — 3-slide auto-advancing carousel with custom pagination dots
- `WelcomeSlideView.kt`, `OnboardingPageView.kt` — Individual slide/page renderers
- `WelcomeSteps.kt`, `OnboardingSteps.kt` — Step data structures and collections
- `AuthLogic.kt` — Pure form validation (email format, password length, consent rules) extracted for unit testing
- `AuthMode.kt` — Login vs Sign-up enum with route and label metadata
- `GoogleSignInButton.kt` — White capsule button with multi-color Google G mark
- `PebblesAuthSwitcher.kt` — Login/Sign-up segmented switcher
- `LegalDisclaimer.kt`, `LegalDocs.kt` — Inline tappable Terms/Privacy links and Custom Tab opener

**Services & persistence:**
- `SupabaseService.kt` — Wraps supabase-kt client, exposes auth state to Compose, handles OAuth deep links (PKCE), patches display names on new sessions, manages initialization flag
- `OnboardingPreferences.kt` — SharedPreferences-backed `hasSeenOnboarding` flag persistence
- `OnboardingGate.kt` — Pure gating logic (present overlay when user id appears and flag is false)

**Tests:**
- `AuthLogicTest.kt` — 16 unit tests ported 1:1 from iOS (`AuthViewLogicTests.swift`)
- `WelcomeStepsTest.kt` — Validates 3 steps, unique ids, spec id order
- `OnboardingStepsTest.kt` — Validates 4 steps, unique ids, spec id order
- `OnboardingGateTest.kt` — Gating logic (present only when user appears and flag unset)
- `ConsentMetadataTest.kt` — Consent payload shape in user metadata

**Localization & resources:**
- `strings.xml` (en) & `strings-fr/strings.xml` (fr) — Welcome carousel, Auth form, Onboarding, Legal, error messages
- `ic_google_g.xml` — Multi-color Google G mark (ported 1:1 from iOS SVG)

**Screenshot tests:**
- `FunnelScreenshots.kt` — Preview tests for Welcome, Auth (Login/Sign-up), Onboarding (light/dark modes)

**Configuration & manifest:**
- `MainActivity.kt` — Wraps `RootScreen` in `LocalSupabaseService` provider, handles OAuth deep links
- `PebblesApp.kt` — Initializes `SupabaseService` singleton on app creation
- `AndroidManifest.xml` — Added `INTERNET` permission for supabase-kt
- `build.gradle.kts` — Added supabase-kt (3.1.4), Ktor OkHttp engine (3.1.2), androidx.browser
- `gradle/libs.versions.toml` — Dependency versions for supabase, Ktor, androidx.browser
- `CLAUDE.md` — Updated scaffolding notes for post sub-project C
- `docs/arkaik/bundle.json` — Updated Landing view description

## Notes

**Architecture & state management:**
- `SupabaseService` is a singleton CompositionLocal, initialized once in

https://claude.ai/code/session_01GHEeL4UVVsBhFFrzeAnVXE