### PR TITLE
docs: milestone-boundary grooming pass after the android bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,4 +21,4 @@ Before writing any Supabase query that touches more than one table, or that does
 - **If no RPC exists but the operation is multi-table or multi-statement:** create a new RPC in a migration rather than stitching multiple client calls together. Client-stitched multi-table writes are not atomic (PostgREST has no client-side transactions), so a partial failure leaves the database in an inconsistent state. RPCs run in a single Postgres transaction and can enforce ownership checks past `security definer`.
 - **If the operation is a single-table, single-statement read or write:** direct client calls are fine. No RPC needed.
 
-This rule applies to both the web app and iOS. When extending an existing RPC, keep its sibling RPCs symmetric (e.g. if you add a payload key to `update_pebble`, add the same key to `create_pebble`) so future readers don't have to hunt down asymmetries.
+This rule applies to every client surface — web, iOS, and Android. When extending an existing RPC, keep its sibling RPCs symmetric (e.g. if you add a payload key to `update_pebble`, add the same key to `create_pebble`) so future readers don't have to hunt down asymmetries.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Treat learnings as living wisdom captured in plans' "Lessons learned" sections. 
 - **Durable** — the constraint will outlive the next refactor, not a quirk of one feature.
 - **Action-guiding** — it tells a future agent what to do or avoid, not a passive observation.
 
-Cadence: promote during the periodic monorepo-audit grooming pass at **milestone boundaries** (folded into the audit's "Doc accuracy" domain — see `docs/superpowers/specs/2026-04-11-monorepo-audit-design.md`). **Never edit CLAUDE.md per-PR for learnings.** Land each promoted rule at the right scope: root `CLAUDE.md` / `AGENTS.md` for cross-cutting rules; workspace `CLAUDE.md` (`apps/web`, `apps/ios`, `apps/admin`, `packages/supabase`) for surface-specific ones.
+Cadence: promote during the periodic monorepo-audit grooming pass at **milestone boundaries** (folded into the audit's "Doc accuracy" domain — see `docs/superpowers/specs/2026-04-11-monorepo-audit-design.md`). **Never edit CLAUDE.md per-PR for learnings.** Land each promoted rule at the right scope: root `CLAUDE.md` / `AGENTS.md` for cross-cutting rules; workspace `CLAUDE.md` (`apps/web`, `apps/ios`, `apps/android`, `apps/admin`, `packages/supabase`) for surface-specific ones.
 
 ## Code conventions
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@ A Turborepo monorepo for **Pebbles**, an app where you record life moments as "p
 pbbls/
   apps/
     web/         ← Next.js PWA (the main application)
-    ios/         ← iOS app (placeholder)
+    ios/         ← Native iOS app (SwiftUI, iOS 17+)
+    android/     ← Native Android app (Kotlin + Jetpack Compose, minSdk 33)
+    admin/       ← Next.js back-office (analytics, Lab logs, glyph moderation)
   packages/
     shared/      ← Shared types & utilities (placeholder)
-    supabase/    ← Supabase client, types & migrations
+    supabase/    ← Supabase types, migrations & edge functions
+    rive/        ← Shared .riv animation assets (consumed by copy per surface)
   turbo.json     ← Turborepo task configuration
   package.json   ← Workspace root
 ```
@@ -25,7 +28,7 @@ npm install
 npm run dev
 ```
 
-Open https://localhost:3000. On first launch, seed data is loaded automatically.
+Open http://localhost:3000.
 
 ## Commands
 
@@ -37,9 +40,9 @@ Open https://localhost:3000. On first launch, seed data is loaded automatically.
 
 ## Web app (`apps/web/`)
 
-The web app is a local-first PWA built with Next.js (App Router), React, Tailwind CSS, and shadcn/ui. Data is stored in localStorage with background sync to Supabase for authenticated users. The DataProvider interface abstracts the storage layer — `LocalProvider` for anonymous/offline use, `SupabaseProvider` for authenticated users.
+The web app is a PWA built with Next.js (App Router), React, Tailwind CSS, and shadcn/ui. Data lives in Supabase (Postgres + RLS); business logic that spans tables lives in Postgres RPCs shared by all client surfaces. The `DataProvider` interface abstracts the data layer — `SupabaseProvider` is its sole implementation.
 
-See [`apps/web/`](apps/web/) for the full web app documentation.
+See [`apps/web/`](apps/web/) for the full web app documentation. The native apps (`apps/ios`, `apps/android`) are independent codebases that mirror each other's architecture and share only the database contract — see the 2026-07-10 entry in `docs/decisions/log.md`.
 
 ### Concepts
 
@@ -74,7 +77,7 @@ apps/web/
   lib/
     types.ts              → Domain entity types (Pebble, Soul, Collection)
     config/               → Static configs (emotions, domains, card types, navigation)
-    data/                 → DataProvider interface, LocalProvider, hooks
+    data/                 → DataProvider interface, SupabaseProvider, hooks
     hooks/                → Reusable hooks (useRecordForm, useStepNavigation)
     utils/                → Utilities (formatters, group-pebbles-by-date)
     seed/                 → Seed data with dev-mode validation
@@ -85,9 +88,9 @@ apps/web/
 ```
 in-memory Store (React context)
 ↕
-LocalProvider (localStorage) ──or── SupabaseProvider (localStorage + Supabase sync)
-↕                                   ↕
-React hooks (usePebbles, etc.)      Background push/pull to Supabase
+SupabaseProvider (PostgREST reads + RPCs for multi-table writes)
+↕
+React hooks (usePebbles, etc.)
 ↕
 Page components → UI
 ```
@@ -98,7 +101,7 @@ Page components → UI
 |-------------|--------|
 | Framework   | Next.js (App Router) |
 | UI          | React + Tailwind CSS + shadcn/ui |
-| Storage     | localStorage + Supabase (local-first) |
+| Storage     | Supabase (Postgres + RLS + RPCs) |
 | Theming     | next-themes |
 | Monorepo    | Turborepo + npm workspaces |
 
@@ -121,7 +124,7 @@ Private — not open source yet.
 **Thesis:** specification-driven, agentic execution. Match ceremony to blast radius. Architecture lives as code-adjacent artifacts, not folklore.
 
 ### 1. Conception
-- GitHub issue: `[Type] Description` + species label (`feat`/`fix`/...) + scope label (`core`/`ui`/`db`/`api`/`auth`/`facility`) + milestone.
+- GitHub issue: `[Type] Description` + species label (`feat`/`fix`/...) + scope label (`core`/`ui`/`db`/`api`/`auth`/`facility`/`android`) + milestone.
 - Living product graph (`docs/arkaik/bundle.json`) — screens, flows, models, APIs as nodes/edges. Updated whenever architecture moves.
 
 ### 2. Spec — `docs/superpowers/specs/<date>-<slug>-design.md`
@@ -174,7 +177,3 @@ Operationalizes the spec. Checkboxable, copy-pasteable.
 4. **Atomicity is a primitive.** RPCs over client-stitching. Strict types over runtime guards.
 5. **Every ship teaches the next one.** Post-ship lessons annotate the plan, not a separate retro.
 
----
-
-### Verification
-After ExitPlanMode I will paste the section above (`# Pebbles — Engineering Paradigm` onward) directly in chat. No files written, no commits.

--- a/apps/android/CLAUDE.md
+++ b/apps/android/CLAUDE.md
@@ -5,12 +5,11 @@ portrait. It mirrors `apps/ios` 1:1 — same architecture, same tokens, same fun
 When this file says "mirror X", read the named iOS file under `apps/ios/Pebbles/`
 and port its structure, not just its behavior.
 
-> This app is built up across milestone **M37** (design:
+> This app was bootstrapped in milestone **M38 · Android App** (design doc:
 > `docs/superpowers/specs/2026-07-10-android-bootstrap-design.md`, decisions
-> D1–D18). Sub-project **A** is the scaffold; B adds the design system, C the
-> entry funnel, D the read-only Path. Much of what this file mandates (services,
-> localization, the deadlock rule) has no code yet — it is the contract B–D work
-> under.
+> D1–D18 — the doc's draft numbering "M37" means this milestone). Sub-project
+> **A** is the scaffold; B adds the design system, C the entry funnel, D the
+> read-only Path. All four have shipped (PRs #533–#536).
 
 ## Source of truth
 
@@ -195,7 +194,7 @@ bundled. Android resource filenames must be lowercase
   change. To adopt visual-regression later, commit the references and switch CI to
   `validateDebugScreenshotTest`. Add a preview per screen/state as real UI lands.
 
-## Current state (post sub-project D — milestone M37 complete)
+## Current state (post sub-project D — bootstrap milestone complete)
 
 - `PebblesApp` constructs the full service graph — `SupabaseService`, then
   `EmotionPaletteService`, `PathService`, `SnapURLCache` (by constructor) —

--- a/apps/ios/CLAUDE.md
+++ b/apps/ios/CLAUDE.md
@@ -38,17 +38,13 @@ Native iOS app for Pebbles. SwiftUI, iOS 17+, iPhone-only.
 
 ```
 Pebbles/
-  PebblesApp.swift          @main entry
-  RootView.swift            Top-level TabView
+  PebblesApp.swift          @main entry — constructs and injects the @Observable service graph
+  RootView.swift            Auth gate (session + splash) + root composition
   Features/<Feature>/       One folder per feature; matches web apps/web/components/<feature>/
-  Services/                 Non-view code (Supabase, environment, future repositories)
-  Resources/                Info.plist, Assets.xcassets, entitlements-adjacent files
+  Services/                 Non-view code (Supabase, environment, palette/reference-data services)
+  Resources/                Info.plist, Assets.xcassets, fonts, Rive/SVG assets
 ```
 
-Features map roughly to the web app's navigation structure: Path (home/timeline), Profile (access to Collections, Glyphs, Souls).
+Features map roughly to the web app's navigation structure: Path (home/timeline), Profile (access to Collections, Glyphs, Souls). The authed root is `PathView` with a custom bottom bar (not a system `TabView`); sheets and full-screen covers do most secondary navigation.
 
-## What's scaffolded but not used yet
-
-- `SupabaseService` is created and injected; no view calls it yet.
-- `Pebbles.entitlements` declares Sign in with Apple; no sign-in UI yet.
-- Asset catalog has an empty `AppIcon` slot — Xcode warns at build time. Expected.
+`apps/android` mirrors this app 1:1 (see `apps/android/CLAUDE.md`) — when changing a schema/RPC contract or a cross-surface behavior here, check whether the Android mirror needs the same change.

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -29,7 +29,7 @@ Native iOS app for Pebbles. SwiftUI, iOS 17+, iPhone-only.
 
 4. Select an iOS 17 iPhone simulator and hit ⌘R.
 
-You should see a two-tab app: Path and Profile.
+You should see the Welcome screen (Rive logo + carousel); after signing in you land on the Path timeline.
 
 ## Project structure
 
@@ -37,12 +37,13 @@ You should see a two-tab app: Path and Profile.
 apps/ios/
   project.yml              XcodeGen source of truth — edit this, not .xcodeproj
   Pebbles/
-    PebblesApp.swift       @main entry
-    RootView.swift         Top-level TabView
-    Features/              Feature folders (placeholder views for now)
-    Services/              SupabaseService, AppEnvironment
-    Resources/             Info.plist, Assets.xcassets
+    PebblesApp.swift       @main entry — constructs and injects the service graph
+    RootView.swift         Auth gate + root composition
+    Features/              One folder per feature (Path, Profile, Auth, Welcome, Onboarding, Glyph, …)
+    Services/              SupabaseService, AppEnvironment, palette/reference-data services
+    Resources/             Info.plist, Assets.xcassets, fonts, Rive/SVG assets
     Pebbles.entitlements   Sign in with Apple
+  PebblesWidget/           Widget extension (Live Activity, retained for future use)
   PebblesTests/            Unit tests (Swift Testing)
   Config/
     Secrets.example.xcconfig  Committed template
@@ -68,4 +69,4 @@ apps/ios/
 
 ## Status
 
-V1 shell. Two empty tabs, Supabase SDK wired but not used. Features will be added in subsequent PRs.
+Full production app: auth (email, Apple, Google), Path timeline with pebble create/edit/detail, Profile (collections, souls, glyphs), glyph carving + marketplace, karma, Lab feed — localized en/fr. Builds on Xcode Cloud (`ci_scripts/ci_post_clone.sh`).

--- a/docs/superpowers/plans/2026-07-11-android-design-system.md
+++ b/docs/superpowers/plans/2026-07-11-android-design-system.md
@@ -81,3 +81,11 @@ Debug composable: swatch grid — **System** (4) + **Accent** (6) sections, adap
 
 ## Delivery
 Merge #533 → branch B off `main` → address issue #529. Branch name suggestion: `claude/issue-529-android-design-system-<suffix>` (or `feat/529-android-design-system`). Standard flow from there: implement, ktlint locally, push, open PR (`Resolves #529`, inherit `feat`/`ui`/`android` labels + M38 milestone), iterate CI to green, hand device checks to the maintainer.
+
+## Lessons learned
+
+_(filled at the M38 milestone-boundary grooming pass, from PR #534)_
+
+- **Google Fonts no longer publishes static per-weight Nunito TTFs** — bundle the single variable-font file and declare weights via `FontVariation.Settings` (see the 2026-07-11 "Android Nunito: one variable-font file" decision-log entry; don't hunt for `nunito_semibold.ttf` files that don't exist).
+- **Compose `TextStyle` has no text-case property** — uppercase tokens go through the `PebblesText` helper, so raw `Text` calls silently lose the case transform. Rule captured in `apps/android/CLAUDE.md`.
+- **The screenshot-test artifact (`ui-screenshots`) is the practical review channel for an SDK-less maintainer** — the token-preview screen doubled as the design-system sign-off surface without a device install.

--- a/docs/superpowers/plans/2026-07-11-android-path-timeline.md
+++ b/docs/superpowers/plans/2026-07-11-android-path-timeline.md
@@ -67,4 +67,10 @@ Screenshot previews (CI `ui-screenshots`): fidelity grid, row variants (sizes/ph
 
 ## Lessons learned
 
-_(filled at completion)_
+_(filled at the M38 milestone-boundary grooming pass, from PR #536)_
+
+- **PostgREST timestamps need `OffsetDateTime`, not `Instant`.** `java.time.Instant.parse` rejects the `+00:00` offset form PostgREST emits; decode timestamptz columns as `OffsetDateTime` via a custom kotlinx serializer.
+- **Palette hexes must be normalized at the model boundary.** `v_emotions_with_palette` returns 8-digit `#RRGGBBAA` strings that may carry stray whitespace; trim + reorder to ARGB when parsing, and truncate to **6-digit** hex before injecting into SVG markup — AndroidSVG misparses 8-digit color literals.
+- **The SVG fidelity spike passed** — AndroidSVG renders the server-composed `render_svg` subset (incl. clipPath and fill-rule cases) faithfully; neither fallback (server-side SVG tweak, custom renderer) was needed. Fixtures generate from the real compositor sources via `apps/android/scripts/gen-pebble-svg-fixtures.ts` — rerun when the engine changes.
+- **Keep leaf composables service-free.** Passing `palette`/data as parameters (with `LocalSnapURLCache` nullable-default) is what lets screenshot tests render without secret-requiring service construction — worth preserving as new screens land.
+- **Requiring a valid Arkaik bundle surfaced a pre-existing defect** (duplicate DM-bounce node had `validate-bundle.js` failing on main); running the validator as part of every Arkaik edit catches drift that otherwise accumulates silently.

--- a/docs/superpowers/specs/2026-07-10-android-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-07-10-android-bootstrap-design.md
@@ -1,6 +1,6 @@
 # Android app bootstrap — scaffold, funnel, and a read-only Path
 
-> Milestone-level design for **M37 · Android app bootstrap** (numbering follows M36 · Pebblestore & Karma Economy; renumber if taken). Four sub-projects **A–D**, each its own issue + spec + plan + PR, per the M36 precedent. Foundation: decision-log entry **2026-07-10 — Android app: native Kotlin + Jetpack Compose, mirroring the iOS architecture** (`docs/decisions/log.md`). Issues: to be created when the milestone is opened.
+> Milestone-level design for the Android bootstrap — drafted as "M37"; created on GitHub as **M38 · Android App** (docs referring to "M37" mean this milestone). Four sub-projects **A–D**, each its own issue + spec + plan + PR, per the M36 precedent. Foundation: decision-log entry **2026-07-10 — Android app: native Kotlin + Jetpack Compose, mirroring the iOS architecture** (`docs/decisions/log.md`). Issues: #528 (A) · #529 (B) · #530 (C) · #531 (D) — all shipped (PRs #533–#536).
 
 ## Goal
 


### PR DESCRIPTION
The milestone-boundary grooming pass mandated by CLAUDE.md's "promote on hardening" cadence, run now that **M38 · Android App** (PRs #533–#536) is complete. Docs-only; does not resolve an issue.

## Changes
- `README.md` — dropped the stale local-first/LocalProvider architecture description (SupabaseProvider has been the sole data source for a while), updated the monorepo layout (android/admin/rive), added the `android` scope label to the paradigm section, removed a leftover plan-output artifact at the tail.
- `apps/ios/README.md` + `apps/ios/CLAUDE.md` — replaced the stale "V1 shell / two empty tabs / scaffolded-but-not-used" text with current reality (flagged as doc drift during the Android tech-choice exploration); added a pointer that `apps/android` mirrors iOS 1:1 so cross-surface changes check both.
- `AGENTS.md` / root `CLAUDE.md` — the RPC rule and the workspace-CLAUDE.md list now name Android.
- `docs/superpowers/plans/2026-07-11-android-{design-system,path-timeline}.md` — filled the "Lessons learned" sections from PRs #534/#536 (OffsetDateTime vs Instant for PostgREST timestamps, palette-hex normalization + 6-digit SVG injection, SVG fidelity spike verdict: passed, variable-font Nunito, screenshot artifact as the SDK-less review channel, Arkaik validator catching pre-existing drift).
- `docs/superpowers/specs/2026-07-10-android-bootstrap-design.md` + `apps/android/CLAUDE.md` — the draft "M37" numbering now points at the actual GitHub milestone (M38 · Android App) with issue/PR references, so future greps land.

## Notes
- CLAUDE.md/AGENTS.md edits here are doc-accuracy fixes and one durable action-guiding pointer (the iOS↔Android mirror note), per the promotion bar — no per-PR learnings were promoted; those stay in the plans' Lessons learned.
- No Lab Note: docs-only, not user-facing. The milestone-level Android Lab Note proposal already lives in #536's body, deferred until a distributable build exists.

## Checklist
- [x] PR title uses conventional commits: `type(scope): description`
- [x] Labels applied (species + scope)
- [x] Milestone assigned
- [x] Docs-only change — no workspace build/lint affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvoHmuZbFhud1DYdUdPzeC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvoHmuZbFhud1DYdUdPzeC)_