### PR TITLE
feat(ui): rebuild iOS glyph picker as mine/owned/community tabs

### DIFF
--- a/apps/ios/Pebbles/Features/Glyph/Views/GlyphPickerSheet.swift
+++ b/apps/ios/Pebbles/Features/Glyph/Views/GlyphPickerSheet.swift
@@ -1,24 +1,38 @@
 import SwiftUI
 import os
 
-/// Sheet that lists the user's glyphs and offers to carve a new one.
-/// Presented from `PebbleFormView`'s "Glyph" row.
+/// Sheet to choose a glyph for a pebble or soul. Three tabs (Mine / Owned /
+/// Commu) mirroring the Glyphs store (`GlyphsListView`): Mine + Owned are
+/// directly pickable; Commu glyphs are bought inline via `GlyphDetailDrawer`
+/// and auto-selected on purchase. Carve-new lives on the Mine tab.
+///
+/// Before #547 this listed `GlyphService.list()` — an unfiltered `glyphs` read
+/// that, under the browse-friendly `glyphs_select` RLS, surfaced every approved
+/// community glyph as pickable (including unbought ones). The server guard
+/// (`can_use_glyph`, #545) now rejects attaching an unowned glyph, so the picker
+/// must only offer usable glyphs (Mine ∪ Owned) and route Commu through a buy.
 struct GlyphPickerSheet: View {
     let currentGlyphId: UUID?
     let onSelected: (Glyph) -> Void
 
     @Environment(SupabaseService.self) private var supabase
+    @Environment(PathStatsService.self) private var stats
     @Environment(\.dismiss) private var dismiss
 
-    @State private var glyphs: [Glyph] = []
-    @State private var isLoading = true
+    @State private var tab: GlyphTab = .mine
+    @State private var itemsByTab: [GlyphTab: [GlyphGridItem]] = [:]
+    @State private var isLoading = false
     @State private var loadError: String?
     @State private var showCarveSheet = false
+    /// Commu glyph pending purchase — drives the buy drawer.
+    @State private var buying: GlyphGridItem?
 
     private let logger = Logger(subsystem: "app.pbbls.ios", category: "glyph-picker")
-    private var service: GlyphService { GlyphService(supabase: supabase) }
+    private var market: GlyphMarketService { GlyphMarketService(supabase: supabase) }
 
     private let columns = [GridItem(.adaptive(minimum: 96), spacing: 12)]
+
+    private var items: [GlyphGridItem] { itemsByTab[tab] ?? [] }
 
     var body: some View {
         NavigationStack {
@@ -29,21 +43,32 @@ struct GlyphPickerSheet: View {
                         PebbleToolbarButton("Close") { dismiss() }
                     }
                 }
+                .safeAreaInset(edge: .bottom) {
+                    GlyphTabBar(selection: $tab)
+                }
                 .pebblesScreen()
-                .task { await load() }
+                .task { await stats.load() }
+                .task(id: tab) { await load(tab) }
                 .fullScreenCover(isPresented: $showCarveSheet) {
                     GlyphCarveSheet(onSaved: { glyph in
-                        glyphs.insert(glyph, at: 0)
                         onSelected(glyph)
                         dismiss()
                     })
+                }
+                .sheet(item: $buying) { item in
+                    GlyphDetailDrawer(item: item, balance: stats.karma ?? 0) { _ in
+                        // Bought → the glyph is now usable; select it and close
+                        // the picker (the drawer dismisses with it).
+                        onSelected(item.glyph)
+                        dismiss()
+                    }
                 }
         }
     }
 
     @ViewBuilder
     private var content: some View {
-        if isLoading {
+        if isLoading && items.isEmpty {
             ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let loadError {
             ContentUnavailableView(
@@ -52,38 +77,53 @@ struct GlyphPickerSheet: View {
                 description: Text(loadError)
             )
             .overlay(alignment: .bottom) {
-                Button("Retry") { Task { await load() } }
+                Button("Retry") { Task { await load(tab) } }
                     .padding()
             }
         } else {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    carveNewRow
+                    // Mine keeps the carve entry point; it also serves as the
+                    // empty-state CTA, so Mine shows no ContentUnavailableView.
+                    if tab == .mine {
+                        carveNewRow
+                    }
 
-                    if !glyphs.isEmpty {
-                        Text("Your glyphs")
-                            .font(.headline)
-                            .padding(.top)
-
+                    if items.isEmpty {
+                        // Mine's empty state is EmptyView — its carve row is the CTA.
+                        emptyState
+                    } else {
                         LazyVGrid(columns: columns, spacing: 12) {
-                            ForEach(glyphs) { glyph in
-                                Button {
-                                    onSelected(glyph)
-                                    dismiss()
-                                } label: {
-                                    GlyphView(
-                                        case: glyph.id == currentGlyphId ? .selected : .default,
-                                        strokes: glyph.strokes,
-                                        side: 96
-                                    )
-                                }
-                                .accessibilityLabel(glyph.name ?? "Untitled glyph")
+                            ForEach(items) { item in
+                                cell(for: item)
                             }
                         }
                     }
                 }
                 .padding()
             }
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        switch tab {
+        case .mine:
+            EmptyView()
+        case .owned:
+            ContentUnavailableView(
+                "Nothing owned yet",
+                systemImage: "checkmark.seal",
+                description: Text("Swap a community glyph to see it here.")
+            )
+            .frame(maxWidth: .infinity)
+        case .commu:
+            ContentUnavailableView(
+                "No community glyphs",
+                systemImage: "person.3",
+                description: Text("Check back soon.")
+            )
+            .frame(maxWidth: .infinity)
         }
     }
 
@@ -106,20 +146,66 @@ struct GlyphPickerSheet: View {
         .buttonStyle(.plain)
     }
 
-    private func load() async {
+    @ViewBuilder
+    private func cell(for item: GlyphGridItem) -> some View {
+        Button {
+            switch tab {
+            case .mine, .owned:
+                onSelected(item.glyph)
+                dismiss()
+            case .commu:
+                buying = item
+            }
+        } label: {
+            VStack(spacing: 4) {
+                GlyphView(
+                    case: item.glyph.id == currentGlyphId ? .selected : .default,
+                    strokes: item.glyph.strokes,
+                    side: 96
+                )
+                if let name = item.glyph.name {
+                    Text(name).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                }
+                if tab == .commu, item.price > 0 {
+                    HStack(spacing: 2) {
+                        Image(systemName: "sparkle")
+                        Text("\(item.price)")
+                    }
+                    .font(.caption2)
+                    .foregroundStyle(Color.system.muted)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(item.glyph.name ?? "Untitled glyph")
+    }
+
+    // MARK: - Loading
+
+    private func load(_ which: GlyphTab) async {
         isLoading = true
         loadError = nil
         do {
-            self.glyphs = try await service.list()
+            let result: [GlyphGridItem]
+            switch which {
+            case .mine:  result = try await market.listMine()
+            case .owned: result = try await market.listOwned()
+            // Owned community glyphs live under the Owned tab; Commu only offers
+            // what's still buyable.
+            case .commu: result = try await market.listCommunity().filter { !$0.owned }
+            }
+            itemsByTab[which] = result
         } catch {
-            logger.error("glyphs list failed: \(error.localizedDescription, privacy: .private)")
-            self.loadError = "Please try again."
+            let reason = error.localizedDescription
+            logger.error("glyphs fetch failed (\(which.rawValue, privacy: .public)): \(reason, privacy: .private)")
+            if (itemsByTab[which] ?? []).isEmpty { loadError = "Please try again." }
         }
-        self.isLoading = false
+        isLoading = false
     }
 }
 
 #Preview {
     GlyphPickerSheet(currentGlyphId: nil, onSelected: { _ in })
         .environment(SupabaseService())
+        .environment(PathStatsService(supabase: SupabaseService()))
 }


### PR DESCRIPTION
Resolves #547

## What & why

On iOS, the glyph picker (`GlyphPickerSheet`) loaded from `GlyphService.list()` — an **unfiltered** `select` on `public.glyphs`. Under the browse-friendly `glyphs_select` RLS (which exposes `own ∪ system-default ∪ every approved community glyph ∪ entitled`), the picker showed **community glyphs the user hadn't bought** and let them pick one. This is the iOS counterpart of the web fix in #545, and it's the surface where the bug was actually observed. With the #545 server guard now live, the old picker would also make pebble/soul saves **fail** (SQLSTATE 42501) whenever an unowned glyph was chosen.

## Change

Rebuilt `GlyphPickerSheet` as a 3-tab sheet (**Mine · Owned · Commu**) mirroring the store (`GlyphsListView`):
- **Mine** (`listMine`) and **Owned** (`listOwned`) glyphs are directly selectable.
- **Commu** (`listCommunity`, filtered to `!owned`) routes through `GlyphDetailDrawer` to buy; on a successful purchase the glyph is **auto-selected and the sheet closes**.
- Carve-new stays on the Mine tab.
- Reuses the existing `GlyphMarketService` / `GlyphTabBar` / `GlyphDetailDrawer` — no new services, no RPC changes.
- Public contract unchanged (`currentGlyphId` + `onSelected`), so the 5 call sites (pebble form, soul create/edit, settings) need no edits.

## Verification
- `xcodebuild -scheme Pebbles -destination 'generic/platform=iOS Simulator' build` → **BUILD SUCCEEDED**.
- `swiftlint` → 0 violations.
- No new localization entries (reuses existing catalog strings).

## Follow-up
`apps/android` mirrors iOS 1:1 and will want the same picker change once its pebble-creation surface exists.

## Lab Note (EN/FR) — proposal
- **EN — _Pick from what's yours, buy the rest._** The glyph picker on iOS now has **Mine · Owned · Commu** tabs: choose a glyph you own, or buy a community one right there — it's applied the moment you buy it.
- **FR — _Choisissez les vôtres, achetez le reste._** Le sélecteur de glyphes sur iOS propose maintenant les onglets **Mes glyphes · Achetés · Commu** : choisissez un glyphe que vous possédez, ou achetez-en un de la communauté sur place — il est appliqué dès l'achat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)