### PR TITLE
docs(android): document the Play internal-testing release pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Page components → UI
 
 ## Deployment
 
+### Web (`apps/web/`)
+
 The web app deploys to **Vercel**. After the monorepo migration, the Vercel project's **Root Directory** must be set to `apps/web` in the dashboard. This makes Vercel:
 
 1. Install dependencies at the repo root (respecting npm workspaces)
@@ -114,6 +116,10 @@ The web app deploys to **Vercel**. After the monorepo migration, the Vercel proj
 3. Serve output from `apps/web/.next`
 
 Preview URLs remain unchanged.
+
+### Android (`apps/android/`)
+
+The native Android app ships to **Google Play internal testing** from CI: merges to `main` touching `apps/android/**` build a signed release AAB and publish it via `.github/workflows/android-release.yml`, and a PR labelled `deploy-beta` deploys that branch on demand. The pipeline and its one-time console setup are documented in [`docs/android-play-deploy.md`](docs/android-play-deploy.md).
 
 ## License
 

--- a/apps/android/CLAUDE.md
+++ b/apps/android/CLAUDE.md
@@ -194,6 +194,26 @@ bundled. Android resource filenames must be lowercase
   change. To adopt visual-regression later, commit the references and switch CI to
   `validateDebugScreenshotTest`. Add a preview per screen/state as real UI lands.
 
+## Release & distribution (Play internal testing)
+
+- **The app auto-ships to Play internal testing from CI.**
+  `.github/workflows/android-release.yml` builds a **signed release AAB**
+  (`bundleRelease`) and publishes it on every push to `main`, on a PR labelled
+  `deploy-beta`, or via manual dispatch. It is separate from `android.yml`, which
+  stays the debug / lint / test / screenshot CI. Full setup + troubleshooting:
+  the [`docs/android-play-deploy.md`](../../docs/android-play-deploy.md) runbook.
+- **`versionCode` derives from `GITHUB_RUN_NUMBER`** (`build.gradle.kts`) — Play
+  requires every upload to strictly increase, so never pin it to a constant.
+  Re-running a release run reuses its number, which only matters once a publish
+  has actually reached Play (a failed publish leaves the code unused).
+- **Release signing flows like the Supabase secrets (D8).** The `release`
+  `signingConfig` reads the upload keystore + passwords from `KEYSTORE_FILE` /
+  `KEYSTORE_PASSWORD` / `KEY_ALIAS` / `KEY_PASSWORD` — env vars in CI (decoded
+  from the `KEYSTORE_BASE64` secret), or `secrets.properties` locally. With no
+  keystore the release build stays **unsigned** rather than failing — the same
+  fail-soft contract as the config secrets. Never commit a keystore (`*.jks` is
+  git-ignored).
+
 ## Current state (post sub-project D — bootstrap milestone complete)
 
 - `PebblesApp` constructs the full service graph — `SupabaseService`, then

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -6,9 +6,9 @@ backend. See `CLAUDE.md` for conventions and
 `docs/superpowers/specs/2026-07-10-android-bootstrap-design.md` for the milestone
 design.
 
-At this stage the app builds, lints, unit-tests, and launches to a debug preview
-of the design system (theme tokens, typography, components, the Rive logo). The
-auth funnel and Path timeline arrive in later sub-projects.
+The bootstrap milestone (M38) has shipped: the app builds, lints, unit-tests, and
+runs the entry funnel (Welcome → Auth → Onboarding) and the read-only Path
+timeline against live Supabase. Create / edit / detail / stats are not built yet.
 
 ## Prerequisites
 
@@ -52,8 +52,25 @@ Run on a device/emulator from Android Studio (Run ▶), or:
 ./gradlew installDebug         # install on a connected device
 ```
 
+## Releasing to Google Play (internal testing)
+
+Merges to `main` that touch `apps/android/**` are built into a **signed release
+AAB** and published to the **Play internal testing** track automatically by
+`.github/workflows/android-release.yml` — the maintainer's phone then updates via
+the Play Store, no manual steps. To push a branch to the phone before merging,
+label its PR **`deploy-beta`**; for an ad-hoc build use the workflow's **Run
+workflow** button.
+
+Release signing reads the upload keystore from CI secrets via the same
+env-var / `secrets.properties` chain as the Supabase config, and `versionCode`
+derives from the CI run number. The one-time console setup (upload keystore, Play
+service account, seeding the first release by hand) lives in the
+[`docs/android-play-deploy.md`](../../docs/android-play-deploy.md) runbook.
+
 ## Installing without a local SDK (CI artifact)
 
+The **debug** APK below is for quick PR-time side-loading and UI review; the Play
+internal-testing track above is the day-to-day path for the maintainer's device.
 The shared dev container has no Android SDK, so the debug APK is produced by CI.
 On every pull request touching `apps/android/**`, the **Android** workflow
 (`.github/workflows/android.yml`) runs ktlint + unit tests + `assembleDebug` and

--- a/docs/android-play-deploy.md
+++ b/docs/android-play-deploy.md
@@ -118,10 +118,15 @@ This is the credential CI uses to publish.
 2. Google Cloud Console → **IAM & Admin → Service Accounts → Create service
    account** (e.g. `github-play-publisher`). No project-level roles needed.
    Then **Keys → Add key → JSON** and download the file.
-3. Back in Play Console → **Users and permissions → Invite new users** → enter
+3. **Enable the Play API in that project:** Google Cloud Console → **APIs &
+   Services → Library** → search **"Google Play Android Developer API"** →
+   **Enable**. Miss this and the publish step fails with *"…API has not been used
+   in project … or it is disabled"* — reusing an existing Cloud project (e.g. your
+   Supabase one) does *not* enable it for you.
+4. Back in Play Console → **Users and permissions → Invite new users** → enter
    the service account's email → grant **app access to `app.pbbls.android`**
    with permission to **Release to testing tracks** (Release manager is fine).
-4. Add the **entire JSON file contents** as a repo secret named
+5. Add the **entire JSON file contents** as a repo secret named
    **`PLAY_SERVICE_ACCOUNT_JSON`**.
 
 Give it a few minutes to propagate.
@@ -141,9 +146,10 @@ Give it a few minutes to propagate.
 | Symptom | Cause / fix |
 |---|---|
 | Upload rejected: "not signed" / "unsigned" | A `KEYSTORE_*` secret is missing or mistyped — check the run's *Decode upload keystore* and *Assemble signed release AAB* steps ran. |
-| "Version code N has already been used" | Don't **re-run** a release run (same `run_number` → same `versionCode`). Push a new commit instead — a fresh run gets a higher code. |
+| "Version code N has already been used" | That `versionCode` already reached Play. Re-running a run reuses its `run_number`, so push a new commit for a higher one. (Re-running a run whose publish *failed* before it reached Play is fine — the code was never consumed.) |
+| Publish step: "Google Play Android Developer API has not been used in project … or it is disabled" | Enable the **Google Play Android Developer API** in the Cloud project the service account belongs to (the error links straight to it), wait a few minutes, then re-run. See step 5.3. |
 | First upload errors about "existing users can't upgrade" | The manual seed (step 4) hasn't happened yet — the API can't create the first release. |
-| Publish step: "caller does not have permission" | Service account not granted app access in Play Console (step 5.3), or still propagating — wait a few minutes. |
+| Publish step: "caller does not have permission" | Service account not granted app access in Play Console (step 5.4), or still propagating — wait a few minutes. |
 | Nothing publishes, job green | `PLAY_SERVICE_ACCOUNT_JSON` not set yet — the publish step self-skips by design. |
 
 ## Security notes


### PR DESCRIPTION
Follow-up to #553 (Play internal-testing release pipeline) — no issue. The pipeline shipped, but the descriptive docs lagged; this aligns them.

## Changes
- **`apps/android/README.md`** — fixed the stale intro (the entry funnel and read-only Path have **shipped**; they were still described as "later sub-projects"); added a **Releasing to Google Play (internal testing)** section; noted the debug-APK artifact is now the PR-review / side-load fallback rather than the primary on-device path.
- **`README.md`** (root) — added an **Android** subsection under Deployment (was web / Vercel only).
- **`apps/android/CLAUDE.md`** — added a **Release & distribution** section capturing the durable contracts for future agents: `versionCode ← GITHUB_RUN_NUMBER`, the secrets-fed release `signingConfig`, the fail-soft unsigned-build behavior, and a pointer to the runbook.
- **`docs/android-play-deploy.md`** — added the "enable the Google Play Android Developer API" step (the gotcha that blocked the first automated publish) and refined the versionCode / re-run troubleshooting note.

## Notes
- **Docs-only** — no code, build, or CI changes.
- Not user-facing → **Lab Note section omitted** per the template gate.
- `apps/android/CLAUDE.md` normally receives learning-promotions at milestone boundaries; this entry documents a shipped subsystem's **durable contracts** (not a transient learning), added now at the maintainer's request.

## Checklist
- [x] Branch: designated agent working branch (`claude/magical-faraday-f7mqav`), restarted from `main` since #553 already merged
- [x] PR title uses conventional commits: `type(scope): description`
- [x] Labels applied (species + scope): `docs`, `android`
- [ ] Milestone assigned — awaiting maintainer (docs follow-up; happy to add one if you'd like)
- [x] Docs-only — no `npm run build` / `npm run lint` impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5h9qpbAPh2gcGbaw7CpWd)_