### PR TITLE
feat(ui): port petroglyph wobble to web (dev-only spike)

### DIFF
--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -2,3 +2,9 @@
 # Get these from: Supabase Dashboard > Project Settings > API
 NEXT_PUBLIC_SUPABASE_URL=https://<project-ref>.supabase.co
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<your-anon-key>
+
+# Petroglyph wobble spike (#555) — dev-only. "1" forces the hand-drawn wobble
+# on (set it in a Vercel *Preview* deployment to review the look), "0" forces
+# it off. Unset = on for local dev and non-production deploys, off on the
+# production domain. Never set "1" on the production scope.
+# NEXT_PUBLIC_WOBBLE=1

--- a/apps/web/components/carve/StrokeRenderer.tsx
+++ b/apps/web/components/carve/StrokeRenderer.tsx
@@ -1,4 +1,5 @@
 import type { MarkStroke } from "@/lib/types"
+import { WOBBLE_ENABLED, wobbleGlyphInk } from "@/lib/wobble"
 
 type StrokeRendererProps = {
   strokes: MarkStroke[]
@@ -6,20 +7,31 @@ type StrokeRendererProps = {
 }
 
 export function StrokeRenderer({ strokes, className }: StrokeRendererProps) {
+  const strokeClass = className ?? "text-foreground"
   return (
     <>
-      {strokes.map((stroke, i) => (
-        <path
-          key={i}
-          d={stroke.d}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={stroke.width}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className={className ?? "text-foreground"}
-        />
-      ))}
+      {strokes.map((stroke, i) => {
+        // Petroglyph wobble (#555): dev-only. Committed strokes render as leaky
+        // filled ink (canonical params, content-cached); the in-progress carve
+        // stroke is a separate ActiveStroke, so drag latency is untouched.
+        // Falls back to the plain stroked path when the `d` doesn't parse.
+        const ink = WOBBLE_ENABLED ? wobbleGlyphInk(stroke.d, stroke.width) : null
+        if (ink) {
+          return <path key={i} d={ink} fill="currentColor" className={strokeClass} />
+        }
+        return (
+          <path
+            key={i}
+            d={stroke.d}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={stroke.width}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={strokeClass}
+          />
+        )
+      })}
     </>
   )
 }

--- a/apps/web/components/pebble/PebbleOutlineBackdrop.tsx
+++ b/apps/web/components/pebble/PebbleOutlineBackdrop.tsx
@@ -1,5 +1,6 @@
 import { getOutline } from "@/lib/config/pebble-outlines"
 import type { Size, Polarity } from "@/lib/config/pebble-geometry"
+import { WOBBLE_ENABLED, wobbleBackdrop } from "@/lib/wobble"
 import { cn } from "@/lib/utils"
 
 type PebbleOutlineBackdropProps = {
@@ -29,6 +30,10 @@ export function PebbleOutlineBackdrop({
   className,
 }: PebbleOutlineBackdropProps) {
   const { path, width, height, fillRule } = getOutline(size, polarity)
+  // Petroglyph wobble (#555): dev-only closed-contour displacement of the
+  // silhouette. `fillRule` is untouched, so the evenodd `large-lowlight` hole
+  // still carves. Falls back to the flat path on parse failure.
+  const wobbled = WOBBLE_ENABLED ? wobbleBackdrop(path, width, height) : null
   return (
     <svg
       aria-hidden
@@ -37,7 +42,7 @@ export function PebbleOutlineBackdrop({
       className={cn("size-full", className)}
       style={{ opacity: fillOpacity }}
     >
-      <path d={path} fill={fillColor} fillRule={fillRule} />
+      <path d={wobbled ?? path} fill={fillColor} fillRule={fillRule} />
     </svg>
   )
 }

--- a/apps/web/components/pebble/PebbleVisual.tsx
+++ b/apps/web/components/pebble/PebbleVisual.tsx
@@ -9,6 +9,7 @@ import { EMOTIONS } from "@/lib/config/emotions"
 import { useEmotionLocalized } from "@/lib/i18n"
 import { useEmotionPalettes } from "@/lib/data/useEmotionPalettes"
 import { usePebbleVisual } from "@/lib/hooks/usePebbleVisual"
+import { WOBBLE_ENABLED, wobblePebbleSvg } from "@/lib/wobble"
 import { cn } from "@/lib/utils"
 
 type PebbleVisualProps = {
@@ -35,7 +36,10 @@ export function PebbleVisual({
   // seed pebbles) where no render exists yet.
   const fallback = usePebbleVisual(pebble, mark, tier)
   const isServerRender = pebble.render_svg !== null
-  const svg = pebble.render_svg ?? fallback.svg
+  const rawSvg = pebble.render_svg ?? fallback.svg
+  // Petroglyph wobble (#555): dev-only, content-cached. Rewrites the composed
+  // SVG's stroked paths into leaky filled ink; compiled out in production.
+  const svg = WOBBLE_ENABLED ? wobblePebbleSvg(rawSvg) : rawSvg
 
   const t = useTranslations("pebble")
   const tCommon = useTranslations("common")

--- a/apps/web/lib/wobble/flags.ts
+++ b/apps/web/lib/wobble/flags.ts
@@ -1,7 +1,22 @@
-// Dev-only gate for the petroglyph wobble experiment (issue #555), mirroring
-// iOS's `#if DEBUG` stance (`WobbleFlags`). On in dev, dead-code-eliminated to
-// a constant `false` in production builds (Next.js inlines `NODE_ENV`), so the
-// spike can never ship by accident. Deleting the experiment means removing this
-// folder and reverting the flag-gated call sites (PebbleVisual, StrokeRenderer,
-// PebbleOutlineBackdrop).
-export const WOBBLE_ENABLED = process.env.NODE_ENV !== "production"
+// Dev-only gate for the petroglyph wobble experiment (issue #555), the web
+// analogue of iOS's `#if DEBUG` (`WobbleFlags`).
+//
+// The catch: the spike has to be reviewable on a Vercel *preview*/branch
+// deploy, but there `NODE_ENV` is "production" exactly like the live site — so
+// gating on `NODE_ENV` alone compiles the wobble out of every deploy (which is
+// why it looked perfectly straight on the branch URL). Instead:
+//
+//   - explicit override wins: NEXT_PUBLIC_WOBBLE="1" forces on, "0" forces off;
+//   - otherwise on for local dev and any non-production deploy env
+//     (NEXT_PUBLIC_VERCEL_ENV — "preview"/"development"), off on the production
+//     domain.
+//
+// Every input is a build-time-inlined `NODE_ENV` / `NEXT_PUBLIC_*` literal, so
+// the value is identical on server and client (no hydration mismatch) and the
+// production domain never ships the spike by accident. Delete the experiment by
+// removing `lib/wobble/` and reverting the flag-gated call sites (PebbleVisual,
+// StrokeRenderer, PebbleOutlineBackdrop).
+const override = process.env.NEXT_PUBLIC_WOBBLE
+const deployEnv = process.env.NEXT_PUBLIC_VERCEL_ENV ?? process.env.NODE_ENV
+
+export const WOBBLE_ENABLED = override === "1" || (override !== "0" && deployEnv !== "production")

--- a/apps/web/lib/wobble/flags.ts
+++ b/apps/web/lib/wobble/flags.ts
@@ -1,0 +1,7 @@
+// Dev-only gate for the petroglyph wobble experiment (issue #555), mirroring
+// iOS's `#if DEBUG` stance (`WobbleFlags`). On in dev, dead-code-eliminated to
+// a constant `false` in production builds (Next.js inlines `NODE_ENV`), so the
+// spike can never ship by accident. Deleting the experiment means removing this
+// folder and reverting the flag-gated call sites (PebbleVisual, StrokeRenderer,
+// PebbleOutlineBackdrop).
+export const WOBBLE_ENABLED = process.env.NODE_ENV !== "production"

--- a/apps/web/lib/wobble/flatten.ts
+++ b/apps/web/lib/wobble/flatten.ts
@@ -1,0 +1,131 @@
+// Flattens parsed path elements into polylines whose chords are ≤ ~`step`
+// units, so the noise displacement reads as a smooth wobble rather than a
+// kinked polygon (issue #555 §2.3 step 1). Straight segments are subdivided
+// too — a long straight line needs interior vertices or it cannot bend.
+// Faithful port of the iOS `WobblePathFlattener`.
+
+import type { Point } from "./types"
+import type { PathElement } from "./path-parser"
+
+/** A flattened subpath: dense points ready for displacement. */
+export type Polyline = {
+  points: Point[]
+  isClosed: boolean
+}
+
+const DUPLICATE_EPSILON = 1e-6
+
+export function flatten(elements: PathElement[], step: number): Polyline[] {
+  const polylines: Polyline[] = []
+  let current: Point[] = []
+  let subpathStart: Point = { x: 0, y: 0 }
+  let cursor: Point = { x: 0, y: 0 }
+
+  const flush = (closed: boolean): void => {
+    if (current.length > 0) polylines.push({ points: current, isClosed: closed })
+    current = []
+  }
+
+  const append = (point: Point): void => {
+    const last = current[current.length - 1]
+    if (
+      last &&
+      Math.abs(last.x - point.x) < DUPLICATE_EPSILON &&
+      Math.abs(last.y - point.y) < DUPLICATE_EPSILON
+    ) {
+      return
+    }
+    current.push(point)
+  }
+
+  const appendLine = (end: Point): void => {
+    const distance = Math.hypot(end.x - cursor.x, end.y - cursor.y)
+    const count = Math.max(1, Math.ceil(distance / step))
+    for (let i = 1; i <= count; i++) {
+      const t = i / count
+      append({ x: cursor.x + (end.x - cursor.x) * t, y: cursor.y + (end.y - cursor.y) * t })
+    }
+    cursor = end
+  }
+
+  const appendQuad = (control: Point, end: Point): void => {
+    // Control-polygon length over-estimates arc length, which only makes chords
+    // denser than `step` — never sparser.
+    const approxLength =
+      Math.hypot(control.x - cursor.x, control.y - cursor.y) +
+      Math.hypot(end.x - control.x, end.y - control.y)
+    const count = Math.max(1, Math.ceil(approxLength / step))
+    const start = cursor
+    for (let i = 1; i <= count; i++) {
+      const t = i / count
+      const mt = 1 - t
+      append({
+        x: mt * mt * start.x + 2 * mt * t * control.x + t * t * end.x,
+        y: mt * mt * start.y + 2 * mt * t * control.y + t * t * end.y,
+      })
+    }
+    cursor = end
+  }
+
+  const appendCubic = (control1: Point, control2: Point, end: Point): void => {
+    const approxLength =
+      Math.hypot(control1.x - cursor.x, control1.y - cursor.y) +
+      Math.hypot(control2.x - control1.x, control2.y - control1.y) +
+      Math.hypot(end.x - control2.x, end.y - control2.y)
+    const count = Math.max(1, Math.ceil(approxLength / step))
+    const start = cursor
+    for (let i = 1; i <= count; i++) {
+      const t = i / count
+      const mt = 1 - t
+      const c0 = mt * mt * mt
+      const c1 = 3 * mt * mt * t
+      const c2 = 3 * mt * t * t
+      const c3 = t * t * t
+      append({
+        x: c0 * start.x + c1 * control1.x + c2 * control2.x + c3 * end.x,
+        y: c0 * start.y + c1 * control1.y + c2 * control2.y + c3 * end.y,
+      })
+    }
+    cursor = end
+  }
+
+  for (const element of elements) {
+    switch (element.type) {
+      case "move":
+        flush(false)
+        cursor = element.to
+        subpathStart = cursor
+        current = [cursor]
+        break
+      case "line":
+        appendLine(element.to)
+        break
+      case "quad":
+        appendQuad(element.control, element.to)
+        break
+      case "cubic":
+        appendCubic(element.control1, element.control2, element.to)
+        break
+      case "close": {
+        // Subdivide the implicit closing leg, then drop the duplicated start
+        // point: rings are stored without repetition because the outline
+        // builder wraps neighbors cyclically.
+        appendLine(subpathStart)
+        const last = current[current.length - 1]
+        if (
+          last &&
+          current.length > 1 &&
+          Math.abs(last.x - subpathStart.x) < DUPLICATE_EPSILON &&
+          Math.abs(last.y - subpathStart.y) < DUPLICATE_EPSILON
+        ) {
+          current.pop()
+        }
+        flush(true)
+        cursor = subpathStart
+        break
+      }
+    }
+  }
+  flush(false)
+  return polylines
+}

--- a/apps/web/lib/wobble/index.ts
+++ b/apps/web/lib/wobble/index.ts
@@ -1,0 +1,7 @@
+// Petroglyph wobble (issue #555, wobble only) — pure-TS, SSR-safe web port of
+// the iOS spike (`apps/ios/Pebbles/Features/Path/Render/Wobble/`, PR #556).
+// Dev-only experiment: see `flags.ts`. Deleting it means removing this folder
+// and reverting the three flag-gated call sites.
+
+export { WOBBLE_ENABLED } from "./flags"
+export { wobblePebbleSvg, wobbleGlyphInk, wobbleBackdrop } from "./renderer"

--- a/apps/web/lib/wobble/outline.ts
+++ b/apps/web/lib/wobble/outline.ts
@@ -1,0 +1,161 @@
+// Converts flattened centerline polylines into wobbled filled outlines, and
+// displaces already-filled silhouettes. Faithful port of the iOS
+// `WobbleOutlineBuilder`, but emitting SVG `d` strings instead of CGPaths.
+//
+// The leaky ink: offset both stroke edges from the centerline first, then
+// displace every contour point independently. The independent displacement is
+// what makes the width breathe ("leaky") — a stroked wobbled centerline would
+// stay constant-width.
+
+import type { Point } from "./types"
+import type { Polyline } from "./flatten"
+import { displace, type WobbleParams } from "./params"
+import type { SVGTurbulence } from "./turbulence"
+
+// End caps are semicircles of `CAP_SEGMENTS` arcs (CAP_SEGMENTS − 1 interior
+// points), matching the playground.
+const CAP_SEGMENTS = 6
+// A zero-length polyline (single-tap carve dot) becomes a circle with this many
+// segments — the current renderer's round-cap dot, kept visible.
+const DOT_SEGMENTS = 12
+
+/** Per-point normals from neighbor tangents; endpoints use their single
+ * adjacent segment, closed rings wrap cyclically. */
+function normals(points: Point[], closed: boolean): Point[] {
+  const count = points.length
+  const result: Point[] = []
+  for (let i = 0; i < count; i++) {
+    const prev = closed ? points[(i - 1 + count) % count] : points[Math.max(0, i - 1)]
+    const next = closed ? points[(i + 1) % count] : points[Math.min(count - 1, i + 1)]
+    const tx = next.x - prev.x
+    const ty = next.y - prev.y
+    const rawLength = Math.hypot(tx, ty)
+    const length = rawLength === 0 ? 1 : rawLength // playground: `|| 1`
+    result.push({ x: -ty / length, y: tx / length })
+  }
+  return result
+}
+
+/** Appends the interior points of a semicircular end cap around `center`,
+ * starting from `from` and bulging along the tangent direction. */
+function appendCapArc(
+  contour: Point[],
+  center: Point,
+  from: Point,
+  halfWidth: number,
+  tangentX: number,
+  tangentY: number,
+): void {
+  const cx = center.x
+  const cy = center.y
+  const startAngle = Math.atan2(from.y - cy, from.x - cx)
+  const midAngle = startAngle + Math.PI / 2
+  const direction = Math.cos(midAngle) * tangentX + Math.sin(midAngle) * tangentY >= 0 ? 1 : -1
+  for (let step = 1; step < CAP_SEGMENTS; step++) {
+    const angle = startAngle + direction * ((Math.PI * step) / CAP_SEGMENTS)
+    contour.push({ x: cx + halfWidth * Math.cos(angle), y: cy + halfWidth * Math.sin(angle) })
+  }
+}
+
+/** Un-displaced outline contours for one polyline. */
+export function contours(polyline: Polyline, halfWidth: number): Point[][] {
+  const points = polyline.points
+  const count = points.length
+
+  if (count === 1) {
+    const { x: cx, y: cy } = points[0]
+    const circle: Point[] = []
+    for (let i = 0; i < DOT_SEGMENTS; i++) {
+      const angle = (2 * Math.PI * i) / DOT_SEGMENTS
+      circle.push({ x: cx + halfWidth * Math.cos(angle), y: cy + halfWidth * Math.sin(angle) })
+    }
+    return [circle]
+  }
+
+  const norms = normals(points, polyline.isClosed)
+  const left = points.map((p, i) => ({ x: p.x + norms[i].x * halfWidth, y: p.y + norms[i].y * halfWidth }))
+  const right = points.map((p, i) => ({ x: p.x - norms[i].x * halfWidth, y: p.y - norms[i].y * halfWidth }))
+
+  if (polyline.isClosed) {
+    // Outer ring + reversed inner ring: opposite windings make the pair render
+    // as an annulus under nonzero fill.
+    return [left, [...right].reverse()]
+  }
+
+  const contour = [...left]
+  appendCapArc(
+    contour,
+    points[count - 1],
+    left[count - 1],
+    halfWidth,
+    points[count - 1].x - points[count - 2].x,
+    points[count - 1].y - points[count - 2].y,
+  )
+  contour.push(...[...right].reverse())
+  appendCapArc(
+    contour,
+    points[0],
+    right[0],
+    halfWidth,
+    points[0].x - points[1].x,
+    points[0].y - points[1].y,
+  )
+  return [contour]
+}
+
+// ── Serialization ───────────────────────────────────────────────────
+
+function fmt(n: number): string {
+  // 3 decimals is well under a sub-pixel at display scale and keeps the emitted
+  // `d` compact. Avoids `-0` and trailing zeros.
+  const r = Math.round(n * 1000) / 1000
+  return Object.is(r, -0) ? "0" : String(r)
+}
+
+function closedPolygonToD(points: Point[]): string {
+  if (points.length === 0) return ""
+  let d = `M${fmt(points[0].x)} ${fmt(points[0].y)}`
+  for (let i = 1; i < points.length; i++) d += `L${fmt(points[i].x)} ${fmt(points[i].y)}`
+  return d + "Z"
+}
+
+/**
+ * The leaky filled ink for a set of stroke centerlines: build outline contours,
+ * displace every point independently, emit as closed subpaths. Returns "" when
+ * nothing renders.
+ */
+export function buildInk(
+  polylines: Polyline[],
+  halfWidth: number,
+  noise: SVGTurbulence,
+  params: WobbleParams,
+): string {
+  let d = ""
+  for (const polyline of polylines) {
+    for (const contour of contours(polyline, halfWidth)) {
+      if (contour.length <= 2) continue
+      d += closedPolygonToD(contour.map((p) => displace(p, noise, params)))
+    }
+  }
+  return d
+}
+
+/**
+ * Displaces already-filled silhouette contours (backdrops, fossils) — no
+ * outline building: the region is already a fill, so wobbling its edge is the
+ * whole effect. Each subpath is displaced and closed. Returns "" when nothing
+ * renders.
+ */
+export function displaceFilledContours(
+  polylines: Polyline[],
+  noise: SVGTurbulence,
+  params: WobbleParams,
+): string {
+  let d = ""
+  for (const polyline of polylines) {
+    const displaced = polyline.points.map((p) => displace(p, noise, params))
+    if (displaced.length <= 2) continue
+    d += closedPolygonToD(displaced)
+  }
+  return d
+}

--- a/apps/web/lib/wobble/params.ts
+++ b/apps/web/lib/wobble/params.ts
@@ -1,0 +1,67 @@
+// Canonical wobble parameters (issue #555 §1) plus the §2.1 rule mapping them
+// into an arbitrary coordinate space. Authored for a normalized 200-unit box;
+// `scaledParams` preserves the visual density when the geometry lives in a
+// different space (pebble canvases, backdrop assets).
+
+import type { Point } from "./types"
+import type { SVGTurbulence } from "./turbulence"
+
+export type WobbleParams = {
+  /** Max displacement, in the geometry's own units. */
+  amplitude: number
+  /** Noise base frequency, in the geometry's own units. */
+  frequency: number
+  /** Fractal octave count. */
+  octaves: number
+  /** Target chord length when flattening, in the geometry's own units. */
+  flattenStep: number
+}
+
+/** The static look's single seed; boil variants would use seed + k later. */
+export const SEED = 3
+
+/** The approved look (issue #555 §1) for geometry in the 200-box. */
+export const CANONICAL: WobbleParams = {
+  amplitude: 18,
+  frequency: 0.024,
+  octaves: 5,
+  flattenStep: 2,
+}
+
+/**
+ * §2.1: for a w×h space, with s = 200 / max(w, h), amplitude and step scale by
+ * 1/s and frequency by s — equivalent to normalizing into the 200-box,
+ * wobbling there, and scaling back.
+ */
+export function scaledParams(spaceWidth: number, spaceHeight: number): WobbleParams {
+  const longestSide = Math.max(spaceWidth, spaceHeight)
+  if (!(longestSide > 0)) return CANONICAL
+  const normalization = 200 / longestSide
+  return {
+    amplitude: CANONICAL.amplitude / normalization,
+    frequency: CANONICAL.frequency * normalization,
+    octaves: CANONICAL.octaves,
+    flattenStep: CANONICAL.flattenStep / normalization,
+  }
+}
+
+function unitClamp(value: number): number {
+  return value < 0 ? 0 : value > 1 ? 1 : value
+}
+
+/**
+ * Displaces one point with the R/G noise channels.
+ *
+ * The sign is MINUS: feDisplacementMap samples source pixels at
+ * p + scale·(noise − 0.5), so geometry must move the opposite way to reproduce
+ * the filter's appearance. Issue #555 §2.3 writes "+", but the playground bake
+ * — the look's source of truth — uses "−". Noise is always sampled at the
+ * un-displaced point.
+ */
+export function displace(point: Point, noise: SVGTurbulence, params: WobbleParams): Point {
+  const r =
+    unitClamp((noise.turbulence(0, point.x, point.y, params.frequency, params.octaves) + 1) / 2) - 0.5
+  const g =
+    unitClamp((noise.turbulence(1, point.x, point.y, params.frequency, params.octaves) + 1) / 2) - 0.5
+  return { x: point.x - params.amplitude * r, y: point.y - params.amplitude * g }
+}

--- a/apps/web/lib/wobble/path-parser.ts
+++ b/apps/web/lib/wobble/path-parser.ts
@@ -1,0 +1,407 @@
+// Own SVG path-`d` parser, mirroring the iOS `SVGPathParser` (which builds a
+// CGPath) but emitting normalized path elements the flattener consumes. Pure,
+// no DOM: SSR-safe. Supports `M m L l H h V v C c S s Q q T t A a Z z` with
+// implicit-command continuation and S/T smoothing; arcs are decomposed into
+// cubic Béziers (the shape CGPath stores internally, so the flattener sees the
+// same element stream on both platforms).
+
+import type { Point } from "./types"
+
+export type PathElement =
+  | { type: "move"; to: Point }
+  | { type: "line"; to: Point }
+  | { type: "quad"; control: Point; to: Point }
+  | { type: "cubic"; control1: Point; control2: Point; to: Point }
+  | { type: "close" }
+
+type Token = { kind: "command"; char: string } | { kind: "number"; value: number }
+
+const COMMAND_CHARS = new Set("MmLlHhVvCcSsQqTtAaZz".split(""))
+
+function isDigit(c: string): boolean {
+  return c >= "0" && c <= "9"
+}
+
+function tokenize(d: string): Token[] {
+  const tokens: Token[] = []
+  const n = d.length
+  let i = 0
+  while (i < n) {
+    const c = d[i]
+    if (COMMAND_CHARS.has(c)) {
+      tokens.push({ kind: "command", char: c })
+      i += 1
+    } else if (c === " " || c === "\t" || c === "\n" || c === "\r" || c === ",") {
+      i += 1
+    } else if (c === "+" || c === "-" || c === "." || isDigit(c)) {
+      // Number — read until the next non-numeric character.
+      const start = i
+      if (c === "+" || c === "-") i += 1
+      let seenDot = false
+      let seenExp = false
+      while (i < n) {
+        const ch = d[i]
+        if (isDigit(ch)) {
+          i += 1
+        } else if (ch === "." && !seenDot && !seenExp) {
+          seenDot = true
+          i += 1
+        } else if ((ch === "e" || ch === "E") && !seenExp) {
+          seenExp = true
+          i += 1
+          if (i < n && (d[i] === "+" || d[i] === "-")) i += 1
+        } else {
+          break
+        }
+      }
+      const value = Number(d.slice(start, i))
+      if (Number.isNaN(value)) return []
+      tokens.push({ kind: "number", value })
+    } else {
+      // Unknown character — abort.
+      return []
+    }
+  }
+  return tokens
+}
+
+/** S/s reflects only after C/c/S/s; T/t only after Q/q/T/t. */
+function reflectedControl(
+  current: Point,
+  lastControl: Point | null,
+  lastCommand: string,
+  cubicLike: boolean,
+): Point {
+  const qualifies = cubicLike ? "CcSs".includes(lastCommand) : "QqTt".includes(lastCommand)
+  if (!qualifies || !lastControl) return { ...current }
+  return { x: 2 * current.x - lastControl.x, y: 2 * current.y - lastControl.y }
+}
+
+/**
+ * Parses an SVG path `d` string into normalized elements, or null when it
+ * contains no recognizable command or cannot be tokenized.
+ */
+export function parsePath(d: string): PathElement[] | null {
+  const tokens = tokenize(d)
+  if (tokens.length === 0) return null
+
+  const out: PathElement[] = []
+  let current: Point = { x: 0, y: 0 }
+  let subpathStart: Point = { x: 0, y: 0 }
+  let lastControl: Point | null = null
+  let lastCommand = "M"
+
+  let i = 0
+  while (i < tokens.length) {
+    const head = tokens[i]
+    if (head.kind !== "command") return null
+    const cmdChar = head.char
+    i += 1
+
+    const args: number[] = []
+    while (i < tokens.length) {
+      const tok = tokens[i]
+      if (tok.kind !== "number") break
+      args.push(tok.value)
+      i += 1
+    }
+
+    let argIndex = 0
+    let firstIteration = true
+
+    do {
+      let activeCmd: string
+      if (firstIteration) {
+        activeCmd = cmdChar
+        firstIteration = false
+      } else {
+        // Implicit M continues as L; m continues as l. Others repeat.
+        activeCmd = cmdChar === "M" ? "L" : cmdChar === "m" ? "l" : cmdChar
+      }
+
+      switch (activeCmd) {
+        case "M": {
+          if (argIndex + 1 >= args.length) return null
+          current = { x: args[argIndex], y: args[argIndex + 1] }
+          subpathStart = current
+          out.push({ type: "move", to: current })
+          argIndex += 2
+          break
+        }
+        case "m": {
+          if (argIndex + 1 >= args.length) return null
+          current = { x: current.x + args[argIndex], y: current.y + args[argIndex + 1] }
+          subpathStart = current
+          out.push({ type: "move", to: current })
+          argIndex += 2
+          break
+        }
+        case "L": {
+          if (argIndex + 1 >= args.length) return null
+          current = { x: args[argIndex], y: args[argIndex + 1] }
+          out.push({ type: "line", to: current })
+          argIndex += 2
+          break
+        }
+        case "l": {
+          if (argIndex + 1 >= args.length) return null
+          current = { x: current.x + args[argIndex], y: current.y + args[argIndex + 1] }
+          out.push({ type: "line", to: current })
+          argIndex += 2
+          break
+        }
+        case "H": {
+          if (argIndex >= args.length) return null
+          current = { x: args[argIndex], y: current.y }
+          out.push({ type: "line", to: current })
+          argIndex += 1
+          break
+        }
+        case "h": {
+          if (argIndex >= args.length) return null
+          current = { x: current.x + args[argIndex], y: current.y }
+          out.push({ type: "line", to: current })
+          argIndex += 1
+          break
+        }
+        case "V": {
+          if (argIndex >= args.length) return null
+          current = { x: current.x, y: args[argIndex] }
+          out.push({ type: "line", to: current })
+          argIndex += 1
+          break
+        }
+        case "v": {
+          if (argIndex >= args.length) return null
+          current = { x: current.x, y: current.y + args[argIndex] }
+          out.push({ type: "line", to: current })
+          argIndex += 1
+          break
+        }
+        case "C": {
+          if (argIndex + 5 >= args.length) return null
+          const c1 = { x: args[argIndex], y: args[argIndex + 1] }
+          const c2 = { x: args[argIndex + 2], y: args[argIndex + 3] }
+          current = { x: args[argIndex + 4], y: args[argIndex + 5] }
+          out.push({ type: "cubic", control1: c1, control2: c2, to: current })
+          lastControl = c2
+          argIndex += 6
+          break
+        }
+        case "c": {
+          if (argIndex + 5 >= args.length) return null
+          const c1 = { x: current.x + args[argIndex], y: current.y + args[argIndex + 1] }
+          const c2 = { x: current.x + args[argIndex + 2], y: current.y + args[argIndex + 3] }
+          current = { x: current.x + args[argIndex + 4], y: current.y + args[argIndex + 5] }
+          out.push({ type: "cubic", control1: c1, control2: c2, to: current })
+          lastControl = c2
+          argIndex += 6
+          break
+        }
+        case "S": {
+          if (argIndex + 3 >= args.length) return null
+          const c1 = reflectedControl(current, lastControl, lastCommand, true)
+          const c2 = { x: args[argIndex], y: args[argIndex + 1] }
+          current = { x: args[argIndex + 2], y: args[argIndex + 3] }
+          out.push({ type: "cubic", control1: c1, control2: c2, to: current })
+          lastControl = c2
+          argIndex += 4
+          break
+        }
+        case "s": {
+          if (argIndex + 3 >= args.length) return null
+          const c1 = reflectedControl(current, lastControl, lastCommand, true)
+          const c2 = { x: current.x + args[argIndex], y: current.y + args[argIndex + 1] }
+          current = { x: current.x + args[argIndex + 2], y: current.y + args[argIndex + 3] }
+          out.push({ type: "cubic", control1: c1, control2: c2, to: current })
+          lastControl = c2
+          argIndex += 4
+          break
+        }
+        case "Q": {
+          if (argIndex + 3 >= args.length) return null
+          const c = { x: args[argIndex], y: args[argIndex + 1] }
+          current = { x: args[argIndex + 2], y: args[argIndex + 3] }
+          out.push({ type: "quad", control: c, to: current })
+          lastControl = c
+          argIndex += 4
+          break
+        }
+        case "q": {
+          if (argIndex + 3 >= args.length) return null
+          const c = { x: current.x + args[argIndex], y: current.y + args[argIndex + 1] }
+          current = { x: current.x + args[argIndex + 2], y: current.y + args[argIndex + 3] }
+          out.push({ type: "quad", control: c, to: current })
+          lastControl = c
+          argIndex += 4
+          break
+        }
+        case "T": {
+          if (argIndex + 1 >= args.length) return null
+          const c = reflectedControl(current, lastControl, lastCommand, false)
+          current = { x: args[argIndex], y: args[argIndex + 1] }
+          out.push({ type: "quad", control: c, to: current })
+          lastControl = c
+          argIndex += 2
+          break
+        }
+        case "t": {
+          if (argIndex + 1 >= args.length) return null
+          const c = reflectedControl(current, lastControl, lastCommand, false)
+          current = { x: current.x + args[argIndex], y: current.y + args[argIndex + 1] }
+          out.push({ type: "quad", control: c, to: current })
+          lastControl = c
+          argIndex += 2
+          break
+        }
+        case "A": {
+          if (argIndex + 6 >= args.length) return null
+          const end = { x: args[argIndex + 5], y: args[argIndex + 6] }
+          appendArc(out, current, end, {
+            rx: args[argIndex],
+            ry: args[argIndex + 1],
+            xAxisRotationDeg: args[argIndex + 2],
+            largeArc: args[argIndex + 3] !== 0,
+            sweep: args[argIndex + 4] !== 0,
+          })
+          current = end
+          lastControl = null
+          argIndex += 7
+          break
+        }
+        case "a": {
+          if (argIndex + 6 >= args.length) return null
+          const end = { x: current.x + args[argIndex + 5], y: current.y + args[argIndex + 6] }
+          appendArc(out, current, end, {
+            rx: args[argIndex],
+            ry: args[argIndex + 1],
+            xAxisRotationDeg: args[argIndex + 2],
+            largeArc: args[argIndex + 3] !== 0,
+            sweep: args[argIndex + 4] !== 0,
+          })
+          current = end
+          lastControl = null
+          argIndex += 7
+          break
+        }
+        case "Z":
+        case "z": {
+          out.push({ type: "close" })
+          current = subpathStart
+          lastControl = null
+          break
+        }
+        default:
+          return null
+      }
+
+      lastCommand = activeCmd
+      if (activeCmd === "Z" || activeCmd === "z") break
+    } while (argIndex < args.length)
+  }
+
+  return out
+}
+
+// ── Arc → cubic Bézier decomposition (SVG 1.1 F.6) ──────────────────
+
+type ArcSpec = {
+  rx: number
+  ry: number
+  xAxisRotationDeg: number
+  largeArc: boolean
+  sweep: boolean
+}
+
+function appendArc(out: PathElement[], from: Point, to: Point, spec: ArcSpec): void {
+  if (Math.abs(from.x - to.x) < 1e-6 && Math.abs(from.y - to.y) < 1e-6) return
+
+  // Zero radius → straight line, per spec.
+  if (spec.rx === 0 || spec.ry === 0) {
+    out.push({ type: "line", to })
+    return
+  }
+
+  const phi = (spec.xAxisRotationDeg * Math.PI) / 180
+  let rx = Math.abs(spec.rx)
+  let ry = Math.abs(spec.ry)
+
+  // F.6.5 step 1
+  const dx2 = (from.x - to.x) / 2
+  const dy2 = (from.y - to.y) / 2
+  const cosPhi = Math.cos(phi)
+  const sinPhi = Math.sin(phi)
+  const x1p = cosPhi * dx2 + sinPhi * dy2
+  const y1p = -sinPhi * dx2 + cosPhi * dy2
+
+  // F.6.6 — ensure radii large enough.
+  const lambda = (x1p * x1p) / (rx * rx) + (y1p * y1p) / (ry * ry)
+  if (lambda > 1) {
+    const s = Math.sqrt(lambda)
+    rx *= s
+    ry *= s
+  }
+
+  // F.6.5 step 2 — center in primed coords.
+  const signFactor = spec.largeArc === spec.sweep ? -1 : 1
+  const num = rx * rx * ry * ry - rx * rx * y1p * y1p - ry * ry * x1p * x1p
+  const denom = rx * rx * y1p * y1p + ry * ry * x1p * x1p
+  const coeff = signFactor * Math.sqrt(Math.max(0, num / denom))
+  const cxp = coeff * ((rx * y1p) / ry)
+  const cyp = -coeff * ((ry * x1p) / rx)
+
+  // Center back in user coords.
+  const cx = cosPhi * cxp - sinPhi * cyp + (from.x + to.x) / 2
+  const cy = sinPhi * cxp + cosPhi * cyp + (from.y + to.y) / 2
+
+  const angle = (ux: number, uy: number, vx: number, vy: number): number => {
+    const dot = ux * vx + uy * vy
+    const len = Math.sqrt(ux * ux + uy * uy) * Math.sqrt(vx * vx + vy * vy)
+    let v = dot / len
+    v = Math.max(-1, Math.min(1, v))
+    const sign = ux * vy - uy * vx < 0 ? -1 : 1
+    return sign * Math.acos(v)
+  }
+
+  const theta1 = angle(1, 0, (x1p - cxp) / rx, (y1p - cyp) / ry)
+  let deltaTheta = angle((x1p - cxp) / rx, (y1p - cyp) / ry, (-x1p - cxp) / rx, (-y1p - cyp) / ry)
+  if (!spec.sweep && deltaTheta > 0) deltaTheta -= 2 * Math.PI
+  if (spec.sweep && deltaTheta < 0) deltaTheta += 2 * Math.PI
+
+  // Split into ≤ 90° arcs; each becomes one cubic (the standard κ tangent
+  // approximation), transformed by the ellipse rotation/scale about the center.
+  const segments = Math.max(1, Math.ceil(Math.abs(deltaTheta) / (Math.PI / 2)))
+  const delta = deltaTheta / segments
+  const t = (4 / 3) * Math.tan(delta / 4)
+
+  const onEllipse = (ang: number): Point => {
+    const cosA = Math.cos(ang)
+    const sinA = Math.sin(ang)
+    return {
+      x: cx + cosPhi * rx * cosA - sinPhi * ry * sinA,
+      y: cy + sinPhi * rx * cosA + cosPhi * ry * sinA,
+    }
+  }
+  const derivative = (ang: number): Point => {
+    const cosA = Math.cos(ang)
+    const sinA = Math.sin(ang)
+    return {
+      x: -cosPhi * rx * sinA - sinPhi * ry * cosA,
+      y: -sinPhi * rx * sinA + cosPhi * ry * cosA,
+    }
+  }
+
+  let angleStart = theta1
+  let p0 = onEllipse(angleStart)
+  for (let seg = 0; seg < segments; seg++) {
+    const angleEnd = angleStart + delta
+    const p3 = onEllipse(angleEnd)
+    const d0 = derivative(angleStart)
+    const d3 = derivative(angleEnd)
+    const c1 = { x: p0.x + t * d0.x, y: p0.y + t * d0.y }
+    const c2 = { x: p3.x - t * d3.x, y: p3.y - t * d3.y }
+    out.push({ type: "cubic", control1: c1, control2: c2, to: p3 })
+    angleStart = angleEnd
+    p0 = p3
+  }
+}

--- a/apps/web/lib/wobble/renderer.ts
+++ b/apps/web/lib/wobble/renderer.ts
@@ -1,0 +1,205 @@
+// Per-surface entry points for the wobble experiment. Derives per-surface
+// params/half-widths, runs parse → flatten → outline/displace, and memoizes the
+// result content-keyed by the source string — the whole flatten/outline/
+// displace cost is paid once per artwork, never per render. Pure and SSR-safe
+// (no DOM): the SVG rewrite is regex/string surgery, mirroring the iOS
+// `WobbleRenderer`'s minimal asset scanning rather than a DOM parser.
+
+import { buildInk, displaceFilledContours } from "./outline"
+import { flatten } from "./flatten"
+import { parsePath } from "./path-parser"
+import { CANONICAL, SEED, scaledParams, type WobbleParams } from "./params"
+import { SVGTurbulence } from "./turbulence"
+
+// One noise field for the whole app: the static look is seed 3 (§1).
+const noise = new SVGTurbulence(SEED)
+
+// ── Content-keyed caches ────────────────────────────────────────────
+
+type Cache<T> = {
+  get(key: string): T | undefined
+  set(key: string, value: T): void
+}
+
+// Bounded, insertion-ordered LRU. Keys are content strings: collision-proof,
+// and a few KB per key is negligible next to the cached output.
+function makeCache<T>(limit: number): Cache<T> {
+  const map = new Map<string, T>()
+  return {
+    get(key) {
+      const value = map.get(key)
+      if (value !== undefined) {
+        map.delete(key)
+        map.set(key, value)
+      }
+      return value
+    },
+    set(key, value) {
+      if (map.has(key)) map.delete(key)
+      map.set(key, value)
+      if (map.size > limit) {
+        const oldest = map.keys().next().value
+        if (oldest !== undefined) map.delete(oldest)
+      }
+    },
+  }
+}
+
+const pebbleCache = makeCache<string>(128)
+const glyphCache = makeCache<string | null>(512)
+const backdropCache = makeCache<string | null>(32)
+
+// ── Minimal SVG attribute scanning ──────────────────────────────────
+
+/** First `name="…"` attribute value in `source`. The boundary lookbehind keeps
+ * `d=` from matching `id=`, `fill=` from `fill-rule=`, etc. */
+function attr(source: string, name: string): string | null {
+  const match = new RegExp(`(?<![\\w-])${name}="([^"]*)"`).exec(source)
+  return match ? match[1] : null
+}
+
+function parseViewBox(value: string | null): { w: number; h: number } | null {
+  if (!value) return null
+  const parts = value.split(/[\s,]+/).map(Number)
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n))) return null
+  return { w: parts[2], h: parts[3] }
+}
+
+// ── Glyph strokes (thumbnails, carve committed strokes, pills) ──────
+
+/**
+ * Wobbled filled ink for one raw glyph stroke in the 200-box space. Returns
+ * null when the `d` doesn't parse or nothing renders (caller falls back to the
+ * plain stroke).
+ */
+export function wobbleGlyphInk(d: string, width: number): string | null {
+  const key = `${width}|${d}`
+  const cached = glyphCache.get(key)
+  if (cached !== undefined) return cached
+
+  let ink: string | null = null
+  const elements = parsePath(d)
+  if (elements) {
+    const polylines = flatten(elements, CANONICAL.flattenStep)
+    if (polylines.length > 0) {
+      ink = buildInk(polylines, width / 2, noise, CANONICAL) || null
+    }
+  }
+  glyphCache.set(key, ink)
+  return ink
+}
+
+// ── Backdrop silhouettes (pebble-outlines.ts) ───────────────────────
+
+/**
+ * Wobbled backdrop silhouette `d`: closed-contour displacement only (the
+ * silhouette is already a fill region). Multi-subpath assets (the evenodd
+ * `large-lowlight` hole) displace every subpath, so evenodd still carves the
+ * hole. Returns null on parse failure (caller falls back to the flat path).
+ */
+export function wobbleBackdrop(path: string, width: number, height: number): string | null {
+  const key = `${width}x${height}|${path}`
+  const cached = backdropCache.get(key)
+  if (cached !== undefined) return cached
+
+  let out: string | null = null
+  const elements = parsePath(path)
+  if (elements) {
+    const params = scaledParams(width, height)
+    const polylines = flatten(elements, params.flattenStep)
+    out = displaceFilledContours(polylines, noise, params) || null
+  }
+  backdropCache.set(key, out)
+  return out
+}
+
+// ── Composed pebble SVG (PebbleVisual render_svg) ───────────────────
+
+/**
+ * Rewrites a composed pebble SVG string, replacing each drawn `<path>` with its
+ * wobbled form: stroked paths become leaky filled ink, filled regions (fossil)
+ * get closed-contour displacement. The glyph subtree (`<g id="glyph">`) wobbles
+ * with canonical params in its own slot space (matching iOS's glyph rule); all
+ * other geometry uses §2.1-scaled canvas params. Falls back to the original SVG
+ * on any failure. Content-keyed by the whole SVG string.
+ */
+export function wobblePebbleSvg(svg: string): string {
+  const cached = pebbleCache.get(svg)
+  if (cached !== undefined) return cached
+
+  let result: string
+  try {
+    result = rewritePebbleSvg(svg)
+  } catch {
+    result = svg
+  }
+  pebbleCache.set(svg, result)
+  return result
+}
+
+function rewritePebbleSvg(svg: string): string {
+  const viewBox = parseViewBox(attr(svg, "viewBox"))
+  const canvasParams = viewBox ? scaledParams(viewBox.w, viewBox.h) : CANONICAL
+
+  const tagRe = /<g\b[^>]*>|<\/g\s*>|<path\b[^>]*>/g
+  let out = ""
+  let lastIndex = 0
+  let depth = 0
+  let glyphDepth = -1
+  let match: RegExpExecArray | null
+
+  while ((match = tagRe.exec(svg)) !== null) {
+    out += svg.slice(lastIndex, match.index)
+    const tag = match[0]
+    if (tag.startsWith("</g")) {
+      if (depth === glyphDepth) glyphDepth = -1
+      depth -= 1
+      out += tag
+    } else if (tag.startsWith("<g")) {
+      depth += 1
+      if (glyphDepth < 0 && /(?<![\w-])id="glyph"/.test(tag)) glyphDepth = depth
+      out += tag
+    } else {
+      out += wobblePathElement(tag, glyphDepth >= 0, canvasParams)
+    }
+    lastIndex = match.index + tag.length
+  }
+  out += svg.slice(lastIndex)
+  return out
+}
+
+function wobblePathElement(tag: string, inGlyph: boolean, canvasParams: WobbleParams): string {
+  const d = attr(tag, "d")
+  if (!d) return tag
+  const elements = parsePath(d)
+  if (!elements) return tag
+
+  const id = attr(tag, "id")
+  const idAttr = id ? `id="${id}" ` : ""
+  const stroke = attr(tag, "stroke")
+  const strokeWidth = attr(tag, "stroke-width")
+  const fill = attr(tag, "fill")
+
+  const isStroke = stroke !== null && stroke !== "none" && strokeWidth !== null
+  if (isStroke) {
+    const width = Number(strokeWidth)
+    if (!Number.isFinite(width) || width <= 0) return tag
+    const params = inGlyph ? CANONICAL : canvasParams
+    const polylines = flatten(elements, params.flattenStep)
+    const ink = buildInk(polylines, width / 2, noise, params)
+    if (!ink) return tag
+    return `<path ${idAttr}d="${ink}" fill="${stroke}" stroke="none"/>`
+  }
+
+  const isFill = fill !== null && fill !== "none"
+  if (isFill) {
+    const polylines = flatten(elements, canvasParams.flattenStep)
+    const displaced = displaceFilledContours(polylines, noise, canvasParams)
+    if (!displaced) return tag
+    const fillRule = attr(tag, "fill-rule")
+    const fillRuleAttr = fillRule ? ` fill-rule="${fillRule}"` : ""
+    return `<path ${idAttr}d="${displaced}" fill="${fill}"${fillRuleAttr}/>`
+  }
+
+  return tag
+}

--- a/apps/web/lib/wobble/renderer.ts
+++ b/apps/web/lib/wobble/renderer.ts
@@ -14,6 +14,14 @@ import { SVGTurbulence } from "./turbulence"
 // One noise field for the whole app: the static look is seed 3 (§1).
 const noise = new SVGTurbulence(SEED)
 
+// The single weight every composed-pebble layer is traced at, in canvas units —
+// mirrors the `6` on every shape path in the engine templates (and iOS
+// `PebbleStroke.outlineWidth` / Android `PebbleStroke.OUTLINE_WIDTH`). Custom
+// carved glyphs are authored heavier than the outline, so honoring each layer's
+// own stroke-width renders the glyph too thick (iOS PR #511 / Android #552);
+// tracing every layer at this weight makes glyph == outline everywhere.
+const OUTLINE_WIDTH = 6
+
 // ── Content-keyed caches ────────────────────────────────────────────
 
 type Cache<T> = {
@@ -117,11 +125,13 @@ export function wobbleBackdrop(path: string, width: number, height: number): str
 
 /**
  * Rewrites a composed pebble SVG string, replacing each drawn `<path>` with its
- * wobbled form: stroked paths become leaky filled ink, filled regions (fossil)
- * get closed-contour displacement. The glyph subtree (`<g id="glyph">`) wobbles
- * with canonical params in its own slot space (matching iOS's glyph rule); all
- * other geometry uses §2.1-scaled canvas params. Falls back to the original SVG
- * on any failure. Content-keyed by the whole SVG string.
+ * wobbled form: stroked paths become leaky filled ink at the uniform outline
+ * weight (OUTLINE_WIDTH, ignoring each layer's authored stroke-width so custom
+ * glyphs stop rendering too thick — iOS PR #511 / Android #552), filled regions
+ * (fossil) get closed-contour displacement. The glyph subtree (`<g id="glyph">`)
+ * wobbles with canonical params in its own slot space (matching iOS's glyph
+ * rule); all other geometry uses §2.1-scaled canvas params. Falls back to the
+ * original SVG on any failure. Content-keyed by the whole SVG string.
  */
 export function wobblePebbleSvg(svg: string): string {
   const cached = pebbleCache.get(svg)
@@ -146,6 +156,10 @@ function rewritePebbleSvg(svg: string): string {
   let lastIndex = 0
   let depth = 0
   let glyphDepth = -1
+  // Accumulated uniform scale of the enclosing `<g transform>` stack, so the
+  // outline weight can be expressed in the layer's own (pre-transform) units.
+  let scale = 1
+  const scaleStack: number[] = []
   let match: RegExpExecArray | null
 
   while ((match = tagRe.exec(svg)) !== null) {
@@ -154,13 +168,16 @@ function rewritePebbleSvg(svg: string): string {
     if (tag.startsWith("</g")) {
       if (depth === glyphDepth) glyphDepth = -1
       depth -= 1
+      scale = scaleStack.pop() ?? 1
       out += tag
     } else if (tag.startsWith("<g")) {
       depth += 1
       if (glyphDepth < 0 && /(?<![\w-])id="glyph"/.test(tag)) glyphDepth = depth
+      scaleStack.push(scale)
+      scale *= groupScale(tag)
       out += tag
     } else {
-      out += wobblePathElement(tag, glyphDepth >= 0, canvasParams)
+      out += wobblePathElement(tag, glyphDepth >= 0, scale, canvasParams)
     }
     lastIndex = match.index + tag.length
   }
@@ -168,7 +185,23 @@ function rewritePebbleSvg(svg: string): string {
   return out
 }
 
-function wobblePathElement(tag: string, inGlyph: boolean, canvasParams: WobbleParams): string {
+/** Uniform scale factor of a `<g transform="… scale(s) …">`, 1 when absent. The
+ * engine only emits translate + uniform scale, matching Android's Affine
+ * assumption; a degenerate/zero scale degrades to 1. */
+function groupScale(tag: string): number {
+  const transform = attr(tag, "transform")
+  if (!transform) return 1
+  const match = /scale\(\s*([-\d.eE]+)/.exec(transform)
+  const s = match ? Number(match[1]) : 1
+  return Number.isFinite(s) && s > 0 ? s : 1
+}
+
+function wobblePathElement(
+  tag: string,
+  inGlyph: boolean,
+  scale: number,
+  canvasParams: WobbleParams,
+): string {
   const d = attr(tag, "d")
   if (!d) return tag
   const elements = parsePath(d)
@@ -177,16 +210,17 @@ function wobblePathElement(tag: string, inGlyph: boolean, canvasParams: WobblePa
   const id = attr(tag, "id")
   const idAttr = id ? `id="${id}" ` : ""
   const stroke = attr(tag, "stroke")
-  const strokeWidth = attr(tag, "stroke-width")
   const fill = attr(tag, "fill")
 
-  const isStroke = stroke !== null && stroke !== "none" && strokeWidth !== null
+  const isStroke = stroke !== null && stroke !== "none"
   if (isStroke) {
-    const width = Number(strokeWidth)
-    if (!Number.isFinite(width) || width <= 0) return tag
     const params = inGlyph ? CANONICAL : canvasParams
+    // Uniform outline weight, ignoring the layer's authored stroke-width (which
+    // is heavy for custom glyphs). OUTLINE_WIDTH is a canvas-space weight; divide
+    // by the group's accumulated scale so it lands at 6 after the transform.
+    const halfWidth = OUTLINE_WIDTH / 2 / scale
     const polylines = flatten(elements, params.flattenStep)
-    const ink = buildInk(polylines, width / 2, noise, params)
+    const ink = buildInk(polylines, halfWidth, noise, params)
     if (!ink) return tag
     return `<path ${idAttr}d="${ink}" fill="${stroke}" stroke="none"/>`
   }

--- a/apps/web/lib/wobble/turbulence.ts
+++ b/apps/web/lib/wobble/turbulence.ts
@@ -1,0 +1,169 @@
+// Faithful TypeScript port of the SVG 1.1 §15.19 `feTurbulence type="fractalNoise"`
+// reference implementation. Transliterated from the design playground's JS
+// (`apps/ios/Scripts/generate-wobble-golden.mjs`) — the exact source the iOS
+// `SVGTurbulence` port and the `WobbleGolden.json` fixture both derive from.
+// The wobble look was tuned against this exact noise; substituting another
+// noise (simplex, hash-based) changes the approved look.
+//
+// Two structure quirks are deliberate and load-bearing — do NOT "clean up":
+//  - Gradients are generated for all four RGBA channels in the spec's loop
+//    order even though the wobble only reads channels 0 (R) and 1 (G): the
+//    seeded LCG stream position depends on it.
+//  - Integer math follows the spec's Schrage decomposition exactly, so the raw
+//    LCG sequence golden-tests against `PebblesTests/Wobble/WobbleGolden.json`.
+
+import type { Point } from "./types"
+
+const B_SIZE = 0x100
+const BM = 0xff
+const PERLIN_N = 0x1000
+
+// Spec LCG constants (§15.19, "RandomNumberSetup").
+const RAND_M = 2147483647 // 2**31 − 1
+const RAND_A = 16807 // 7**5, primitive root of m
+const RAND_Q = 127773 // m / a
+const RAND_R = 2836 // m % a
+
+/** One step of the spec's seeded LCG (Schrage decomposition). */
+function nextRandom(seed: number): number {
+  let result = RAND_A * (seed % RAND_Q) - RAND_R * Math.floor(seed / RAND_Q)
+  if (result <= 0) result += RAND_M
+  return result
+}
+
+function normalizedSeed(seed: number): number {
+  let s = Math.floor(seed)
+  if (s <= 0) s = -(s % (RAND_M - 1)) + 1
+  if (s > RAND_M - 1) s = RAND_M - 1
+  return s
+}
+
+/** First `count` raw LCG values for `seed` — consumed by the golden test. */
+export function rawSequence(seed: number, count: number): number[] {
+  const values: number[] = []
+  let state = normalizedSeed(seed)
+  for (let i = 0; i < count; i++) {
+    state = nextRandom(state)
+    values.push(state)
+  }
+  return values
+}
+
+const sCurve = (t: number): number => t * t * (3 - 2 * t)
+const lerp = (t: number, a: number, b: number): number => a + t * (b - a)
+
+export class SVGTurbulence {
+  /** Lattice selector, length 2·B_SIZE + 2. */
+  private readonly lattice: number[]
+  /** Normalized 2-D gradients per channel: [4][2·B_SIZE + 2]. */
+  private readonly gradient: Point[][]
+
+  constructor(seed: number) {
+    const lattice = new Array<number>(B_SIZE + B_SIZE + 2).fill(0)
+    const gradient: Point[][] = [0, 1, 2, 3].map(() => {
+      const row = new Array<Point>(B_SIZE + B_SIZE + 2)
+      for (let i = 0; i < row.length; i++) row[i] = { x: 0, y: 0 }
+      return row
+    })
+    let s = normalizedSeed(seed)
+
+    for (let channel = 0; channel < 4; channel++) {
+      for (let i = 0; i < B_SIZE; i++) {
+        lattice[i] = i
+        const v: [number, number] = [0, 0]
+        for (let j = 0; j < 2; j++) {
+          s = nextRandom(s)
+          v[j] = ((s % (B_SIZE + B_SIZE)) - B_SIZE) / B_SIZE
+        }
+        // No zero-length guard, mirroring the reference: 0/0 → NaN on both
+        // sides of the golden test, identically.
+        const len = Math.hypot(v[0], v[1])
+        gradient[channel][i] = { x: v[0] / len, y: v[1] / len }
+      }
+    }
+
+    // Fisher–Yates-style lattice shuffle, consuming the same LCG stream.
+    let i = B_SIZE - 1
+    while (i > 0) {
+      const swapped = lattice[i]
+      s = nextRandom(s)
+      const j = s % B_SIZE
+      lattice[i] = lattice[j]
+      lattice[j] = swapped
+      i -= 1
+    }
+
+    // Wrap-around duplication so `lattice[i + by]` never overruns.
+    for (let k = 0; k < B_SIZE + 2; k++) {
+      lattice[B_SIZE + k] = lattice[k]
+      for (let channel = 0; channel < 4; channel++) {
+        gradient[channel][B_SIZE + k] = gradient[channel][k]
+      }
+    }
+
+    this.lattice = lattice
+    this.gradient = gradient
+  }
+
+  /** 2-D gradient noise for one channel at noise-space coordinates, in [−1, 1]. */
+  noise2(channel: number, x: number, y: number): number {
+    let t = x + PERLIN_N
+    const bx0 = (t | 0) & BM // (t | 0) truncation, as in the reference
+    const bx1 = (bx0 + 1) & BM
+    const rx0 = t - (t | 0)
+    const rx1 = rx0 - 1
+    t = y + PERLIN_N
+    const by0 = (t | 0) & BM
+    const by1 = (by0 + 1) & BM
+    const ry0 = t - (t | 0)
+    const ry1 = ry0 - 1
+
+    const latticeX0 = this.lattice[bx0]
+    const latticeX1 = this.lattice[bx1]
+    const b00 = this.lattice[latticeX0 + by0]
+    const b10 = this.lattice[latticeX1 + by0]
+    const b01 = this.lattice[latticeX0 + by1]
+    const b11 = this.lattice[latticeX1 + by1]
+
+    const sx = sCurve(rx0)
+    const sy = sCurve(ry0)
+    const grad = this.gradient[channel]
+
+    let q = grad[b00]
+    const u0 = rx0 * q.x + ry0 * q.y
+    q = grad[b10]
+    const v0 = rx1 * q.x + ry0 * q.y
+    const a = lerp(sx, u0, v0)
+    q = grad[b01]
+    const u1 = rx0 * q.x + ry1 * q.y
+    q = grad[b11]
+    const v1 = rx1 * q.x + ry1 * q.y
+    const b = lerp(sx, u1, v1)
+    return lerp(sy, a, b)
+  }
+
+  /** Stitchless fractalNoise sum over `octaves` — signed, unclamped. */
+  turbulence(channel: number, x: number, y: number, baseFrequency: number, octaves: number): number {
+    let vx = x * baseFrequency
+    let vy = y * baseFrequency
+    let sum = 0
+    let ratio = 1
+    for (let o = 0; o < octaves; o++) {
+      sum += this.noise2(channel, vx, vy) / ratio
+      vx *= 2
+      vy *= 2
+      ratio *= 2
+    }
+    return sum
+  }
+
+  // ── Test hooks (consumed by the golden test) ──────────────────────
+
+  latticePrefix(count: number): number[] {
+    return this.lattice.slice(0, count)
+  }
+
+  gradientSample(channel: number, index: number): Point {
+    return this.gradient[channel][index]
+  }
+}

--- a/apps/web/lib/wobble/types.ts
+++ b/apps/web/lib/wobble/types.ts
@@ -1,0 +1,4 @@
+// Shared geometry primitives for the wobble module. Kept local to the folder
+// so the whole experiment deletes cleanly (see `flags.ts`).
+
+export type Point = { x: number; y: number }

--- a/apps/web/lib/wobble/wobble.golden.test.ts
+++ b/apps/web/lib/wobble/wobble.golden.test.ts
@@ -1,0 +1,83 @@
+// Hard gate for the wobble port: the noise + displacement must reproduce the
+// cross-platform golden fixture the iOS spike pinned (issue #555, PR #556),
+// `apps/ios/PebblesTests/Wobble/WobbleGolden.json` — LCG exact, everything
+// else within 1e-9. The fixture is the shared parity anchor for the Kotlin/TS
+// ports; regenerate it ONLY via `apps/ios/Scripts/generate-wobble-golden.mjs`.
+
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+import { SVGTurbulence, rawSequence } from "./turbulence"
+import { displace, type WobbleParams } from "./params"
+
+type Golden = {
+  seed: number
+  lcg: number[]
+  latticePrefix: number[]
+  gradientSamples: { channel: number; index: number; x: number; y: number }[]
+  turbulence: { channel: number; x: number; y: number; frequency: number; octaves: number; value: number }[]
+  displaced: {
+    x: number
+    y: number
+    amplitude: number
+    frequency: number
+    octaves: number
+    xOut: number
+    yOut: number
+  }[]
+}
+
+const goldenPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../apps/ios/PebblesTests/Wobble/WobbleGolden.json",
+)
+const golden = JSON.parse(readFileSync(goldenPath, "utf8")) as Golden
+
+const TOLERANCE = 1e-9
+
+describe("SVGTurbulence golden parity", () => {
+  it("reproduces the raw LCG sequence exactly", () => {
+    expect(rawSequence(golden.seed, golden.lcg.length)).toEqual(golden.lcg)
+  })
+
+  it("reproduces the lattice prefix exactly", () => {
+    const noise = new SVGTurbulence(golden.seed)
+    expect(noise.latticePrefix(golden.latticePrefix.length)).toEqual(golden.latticePrefix)
+  })
+
+  it("reproduces the gradient samples", () => {
+    const noise = new SVGTurbulence(golden.seed)
+    for (const sample of golden.gradientSamples) {
+      const g = noise.gradientSample(sample.channel, sample.index)
+      expect(g.x).toBeCloseTo(sample.x, 9)
+      expect(g.y).toBeCloseTo(sample.y, 9)
+      expect(Math.abs(g.x - sample.x)).toBeLessThanOrEqual(TOLERANCE)
+      expect(Math.abs(g.y - sample.y)).toBeLessThanOrEqual(TOLERANCE)
+    }
+  })
+
+  it("reproduces turbulence values within 1e-9", () => {
+    const noise = new SVGTurbulence(golden.seed)
+    for (const c of golden.turbulence) {
+      const value = noise.turbulence(c.channel, c.x, c.y, c.frequency, c.octaves)
+      expect(Math.abs(value - c.value)).toBeLessThanOrEqual(TOLERANCE)
+    }
+  })
+
+  it("reproduces displaced points within 1e-9", () => {
+    const noise = new SVGTurbulence(golden.seed)
+    for (const c of golden.displaced) {
+      const params: WobbleParams = {
+        amplitude: c.amplitude,
+        frequency: c.frequency,
+        octaves: c.octaves,
+        flattenStep: 0, // unused by displace()
+      }
+      const out = displace({ x: c.x, y: c.y }, noise, params)
+      expect(Math.abs(out.x - c.xOut)).toBeLessThanOrEqual(TOLERANCE)
+      expect(Math.abs(out.y - c.yOut)).toBeLessThanOrEqual(TOLERANCE)
+    }
+  })
+})

--- a/apps/web/lib/wobble/wobble.pipeline.test.ts
+++ b/apps/web/lib/wobble/wobble.pipeline.test.ts
@@ -147,4 +147,26 @@ describe("composed pebble SVG rewrite", () => {
     const plain = `<svg viewBox="0 0 10 10"><g id="x"></g></svg>`
     expect(wobblePebbleSvg(plain)).toBe(plain)
   })
+
+  it("traces glyph strokes at the outline weight regardless of authored width", () => {
+    // Custom glyphs are authored heavier than the outline; the wobble must
+    // ignore the authored stroke-width and trace at OUTLINE_WIDTH (iOS #511 /
+    // Android #552), so varying only the authored width leaves the ink identical.
+    const make = (w: number) =>
+      `<svg viewBox="0 0 200 200"><g id="glyph"><g transform="translate(10, 10) scale(0.5)"><path id="g" d="M20 20 L180 180" stroke="currentColor" stroke-width="${w}" stroke-linecap="round"/></g></g></svg>`
+    const thin = /id="g" d="([^"]+)"/.exec(wobblePebbleSvg(make(6)))![1]
+    const heavy = /id="g" d="([^"]+)"/.exec(wobblePebbleSvg(make(24)))![1]
+    expect(heavy).toBe(thin)
+  })
+
+  it("divides the outline weight by the group scale (transform-aware)", () => {
+    // Same glyph path and canonical params at two transform scales differ only
+    // in half-width (OUTLINE_WIDTH/2/scale), so the ink must differ — proving the
+    // scale is applied rather than ignored.
+    const at = (s: number) =>
+      `<svg viewBox="0 0 200 200"><g id="glyph"><g transform="scale(${s})"><path id="g" d="M0 100 L200 100" stroke="currentColor" stroke-width="6"/></g></g></svg>`
+    const half = /id="g" d="([^"]+)"/.exec(wobblePebbleSvg(at(0.5)))![1]
+    const full = /id="g" d="([^"]+)"/.exec(wobblePebbleSvg(at(1)))![1]
+    expect(half).not.toBe(full)
+  })
 })

--- a/apps/web/lib/wobble/wobble.pipeline.test.ts
+++ b/apps/web/lib/wobble/wobble.pipeline.test.ts
@@ -1,0 +1,150 @@
+// Non-golden regression coverage for the parse → flatten → outline/displace
+// pipeline and the per-surface entry points. The cross-platform parity gate
+// lives in `wobble.golden.test.ts`; this file guards the web-only plumbing
+// (SVG rewrite, caching, fallbacks) that has no iOS golden.
+
+import { describe, expect, it } from "vitest"
+
+import { parsePath } from "./path-parser"
+import { flatten } from "./flatten"
+import { contours } from "./outline"
+import { CANONICAL } from "./params"
+import { wobbleBackdrop, wobbleGlyphInk, wobblePebbleSvg } from "./renderer"
+import { getOutline } from "../config/pebble-outlines"
+
+describe("path parser", () => {
+  it("returns null for unparseable input", () => {
+    expect(parsePath("not a path")).toBeNull()
+    expect(parsePath("")).toBeNull()
+  })
+
+  it("expands H/V into line elements and closes", () => {
+    const els = parsePath("M0 0 H10 V10 Z")
+    expect(els).not.toBeNull()
+    expect(els!.map((e) => e.type)).toEqual(["move", "line", "line", "close"])
+  })
+
+  it("handles implicit line continuation after M", () => {
+    const els = parsePath("M0 0 10 10 20 20")
+    expect(els!.map((e) => e.type)).toEqual(["move", "line", "line"])
+  })
+
+  it("decomposes arcs into cubic segments", () => {
+    const els = parsePath("M0 0 A10 10 0 0 1 20 0")
+    expect(els!.some((e) => e.type === "cubic")).toBe(true)
+  })
+})
+
+describe("flattener", () => {
+  it("subdivides long straight lines below the step", () => {
+    const els = parsePath("M0 0 L100 0")!
+    const [poly] = flatten(els, 2)
+    // ~50 chords of ≤2 units, plus interior vertices so the line can bend.
+    expect(poly.points.length).toBeGreaterThan(40)
+    for (let i = 1; i < poly.points.length; i++) {
+      const dx = poly.points[i].x - poly.points[i - 1].x
+      expect(Math.abs(dx)).toBeLessThanOrEqual(2 + 1e-6)
+    }
+  })
+
+  it("marks closed subpaths and drops the duplicated start", () => {
+    const els = parsePath("M0 0 L10 0 L10 10 L0 10 Z")!
+    const [poly] = flatten(els, 100)
+    expect(poly.isClosed).toBe(true)
+    const first = poly.points[0]
+    const last = poly.points[poly.points.length - 1]
+    expect(first.x === last.x && first.y === last.y).toBe(false)
+  })
+})
+
+describe("outline builder", () => {
+  it("makes a dual-ring annulus for closed polylines", () => {
+    const els = parsePath("M0 0 L10 0 L10 10 L0 10 Z")!
+    const [poly] = flatten(els, 100)
+    expect(contours(poly, 3)).toHaveLength(2) // outer + reversed inner
+  })
+
+  it("makes a single capped contour for open polylines", () => {
+    const els = parsePath("M0 0 L100 0")!
+    const [poly] = flatten(els, 2)
+    const cs = contours(poly, 3)
+    expect(cs).toHaveLength(1)
+    expect(cs[0].length).toBeGreaterThan(poly.points.length) // + cap arc points
+  })
+
+  it("makes a circle for a single-point dot", () => {
+    const els = parsePath("M50 50")!
+    const [poly] = flatten(els, 2)
+    expect(poly.points).toHaveLength(1)
+    expect(contours(poly, 3)[0]).toHaveLength(12) // DOT_SEGMENTS
+  })
+})
+
+describe("glyph ink entry point", () => {
+  it("emits a closed filled path and is content-cached", () => {
+    const ink = wobbleGlyphInk("M20 20 L80 80 L140 40", CANONICAL.flattenStep === 2 ? 6 : 6)
+    expect(ink).not.toBeNull()
+    expect(ink!.startsWith("M")).toBe(true)
+    expect(ink!.endsWith("Z")).toBe(true)
+    expect(wobbleGlyphInk("M20 20 L80 80 L140 40", 6)).toBe(ink) // cache identity
+  })
+
+  it("returns null on unparseable d (caller falls back to raw stroke)", () => {
+    expect(wobbleGlyphInk("garbage", 6)).toBeNull()
+  })
+})
+
+describe("backdrop entry point", () => {
+  it("displaces every bundled outline, preserving subpath count for evenodd", () => {
+    for (const size of ["small", "medium", "large"] as const) {
+      for (const polarity of ["neutral", "lowlight", "highlight"] as const) {
+        const o = getOutline(size, polarity)
+        const wobbled = wobbleBackdrop(o.path, o.width, o.height)
+        expect(wobbled).not.toBeNull()
+        expect(wobbled!.startsWith("M")).toBe(true)
+      }
+    }
+  })
+
+  it("keeps both subpaths of the evenodd large-lowlight hole", () => {
+    const o = getOutline("large", "lowlight")
+    expect(o.fillRule).toBe("evenodd")
+    const wobbled = wobbleBackdrop(o.path, o.width, o.height)!
+    // Two source subpaths (silhouette + hole) → two displaced closed contours.
+    expect((wobbled.match(/M/g) ?? []).length).toBeGreaterThanOrEqual(2)
+  })
+})
+
+describe("composed pebble SVG rewrite", () => {
+  const svg = `<svg viewBox="0 0 242 283" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="high-negative">
+<path id="pebble-outline" d="M19.67 233.24C2.50 223.06 -5.75 43.48 16.49 6.83L60.77 22.82L64.29 21.94Z" stroke="currentColor" stroke-width="6" stroke-linecap="round"/>
+<g id="glyph-wrapper"><g id="glyph"><g transform="translate(14, 56) scale(0.8)"><path id="Vector" d="M43.08 106.03C35.02 112.47 30.54 117.93 29.64 122.42L45.82 146.76" stroke="currentColor" stroke-width="7.5" stroke-linecap="round" stroke-linejoin="round"/></g></g></g>
+<path id="fossil" fill-rule="evenodd" clip-rule="evenodd" d="M178.02 105.92C179.87 98.38 186.64 91.60 194.31 90.03L227.29 116.62L216.93 142.78Z" fill="currentColor"/>
+</g></svg>`
+
+  it("converts stroke paths to filled ink and drops stroke width", () => {
+    const wob = wobblePebbleSvg(svg)
+    expect(/stroke-width/.test(wob)).toBe(false)
+    expect(/id="pebble-outline" d="[^"]+" fill="currentColor" stroke="none"/.test(wob)).toBe(true)
+  })
+
+  it("preserves the glyph transform group and the fossil evenodd fill-rule", () => {
+    const wob = wobblePebbleSvg(svg)
+    expect(/transform="translate\(14, 56\) scale\(0\.8\)"/.test(wob)).toBe(true)
+    expect(/id="Vector"/.test(wob)).toBe(true)
+    expect(/id="fossil"[^>]*fill-rule="evenodd"/.test(wob)).toBe(true)
+  })
+
+  it("preserves the root svg wrapper and is content-cached", () => {
+    const wob = wobblePebbleSvg(svg)
+    expect(wob.startsWith(`<svg viewBox="0 0 242 283"`)).toBe(true)
+    expect(wob.endsWith("</svg>")).toBe(true)
+    expect(wobblePebbleSvg(svg)).toBe(wob)
+  })
+
+  it("returns the original string unchanged when there are no paths", () => {
+    const plain = `<svg viewBox="0 0 10 10"><g id="x"></g></svg>`
+    expect(wobblePebbleSvg(plain)).toBe(plain)
+  })
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "vitest run",
     "test:week-roll": "tsx scripts/test-week-roll.ts",
     "generate:splash": "tsx scripts/generate-splash-screens.ts"
   },
@@ -51,6 +52,7 @@
     "sharp": "^0.34.5",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config"
+
+// Vitest covers the pure-TS `lib/wobble` module (SSR-safe, no DOM). Kept minimal
+// and node-environment: the wobble golden test needs no jsdom or path aliases.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["lib/**/*.test.ts"],
+  },
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,10 @@
         "typescript": "^5"
       }
     },
+    "apps/android": {
+      "name": "@pbbls/android",
+      "version": "0.0.0"
+    },
     "apps/ios": {
       "name": "@pbbls/ios",
       "version": "0.0.0"
@@ -93,7 +97,8 @@
         "sharp": "^0.34.5",
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -861,21 +866,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -884,9 +889,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2691,6 +2696,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@parcel/watcher": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
@@ -3002,6 +3017,10 @@
       "resolved": "apps/admin",
       "link": true
     },
+    "node_modules/@pbbls/android": {
+      "resolved": "apps/android",
+      "link": true
+    },
     "node_modules/@pbbls/ios": {
       "resolved": "apps/ios",
       "link": true
@@ -3081,6 +3100,289 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -4001,14 +4303,25 @@
       ]
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-array": {
@@ -4082,6 +4395,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -4824,6 +5144,119 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -5134,6 +5567,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -5440,6 +5883,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -6525,6 +6978,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -7117,6 +7577,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -7191,6 +7661,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -10913,9 +11393,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -11346,6 +11826,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -11709,6 +12203,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -11755,9 +12256,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -11775,7 +12276,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -12572,6 +13073,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -13094,6 +13629,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -13168,6 +13710,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -13177,6 +13726,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -13615,10 +14171,27 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13661,6 +14234,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -14373,6 +14956,200 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -14512,6 +15289,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {


### PR DESCRIPTION
Web port of the iOS wobble spike (#555, wobble only; PR #556), following the
same four anchors and the runtime-on-device / minus-sign / golden-parity
decision (decisions-log 2026-07-13).

Pure-TS, SSR-safe module (`apps/web/lib/wobble/`, no DOM APIs):
- turbulence.ts — SVG 1.1 §15.19 fractalNoise port (all 4 RGBA channels in
  spec loop order; Schrage LCG), transliterated from the reference JS.
- params.ts — canonical look + §2.1 space rule + MINUS-sign displacement.
- path-parser.ts — own d-string parser (M/L/H/V/C/S/Q/T/A/Z, implicit
  continuation, S/T reflection, arc→cubic), mirroring iOS SVGPathParser.
- flatten.ts / outline.ts — same flattening rules and leaky dual-edge outline
  builder, emitting d-strings.
- renderer.ts — per-surface entry points, content-keyed memoization.
- flags.ts — dev-only gate (compiled out in production), mirroring iOS DEBUG.

Flag-gated integration:
- PebbleVisual — rewrites the injected render_svg's stroked paths into leaky
  filled ink; glyph subtree uses canonical params, canvas geometry §2.1-scaled.
- PebbleOutlineBackdrop — closed-contour displacement, evenodd preserved.
- StrokeRenderer — committed glyph strokes wobble; the in-progress carve stroke
  (ActiveStroke) stays raw. Web's Framer Motion appear animation is untouched
  (no mask work).

Hard gate: vitest against apps/ios/PebblesTests/Wobble/WobbleGolden.json — LCG
exact, turbulence/displacement within 1e-9. Plus pipeline regression coverage.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YJ4jt6wMbQaX7MoHXjWVww