### PR TITLE
feat(ui): android petroglyph wobble port (leaky filled outlines)

### DIFF
--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/GlyphImage.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/GlyphImage.kt
@@ -1,11 +1,23 @@
 package app.pbbls.android.features.path.render
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.vector.PathParser
 import app.pbbls.android.features.glyph.models.GlyphStroke
+import app.pbbls.android.features.path.render.wobble.WobbleFlags
+import app.pbbls.android.features.path.render.wobble.WobbleRenderer
+import app.pbbls.android.features.path.render.wobble.wobbleInkPath
 import java.util.Locale
 
 /**
@@ -16,6 +28,12 @@ import java.util.Locale
  * `stroke="currentColor"`, which [PebbleSvg] substitutes with [strokeColor]'s
  * hex before AndroidSVG parses the markup. Reused by C's glyph picker and D's
  * form row.
+ *
+ * Wobble experiment (#555, debug-only via [WobbleFlags]): each committed carve
+ * stroke renders as wobbled filled ink instead (the iOS `GlyphThumbnail`
+ * seam), falling back per-stroke to the plain rounded stroke when a `d`
+ * doesn't parse — and to the [PebbleSvg] pipeline entirely when the viewBox
+ * doesn't.
  */
 @Composable
 fun GlyphImage(
@@ -24,8 +42,82 @@ fun GlyphImage(
     strokeColor: Color,
     modifier: Modifier = Modifier,
 ) {
+    val wobbleStrokes =
+        remember(strokes) {
+            if (WobbleFlags.isEnabled) strokes.map(::buildWobbleStroke) else null
+        }
+    val box = remember(viewBox) { parseGlyphViewBox(viewBox) }
+
+    if (wobbleStrokes != null && box != null) {
+        Canvas(modifier = modifier) {
+            if (box.width <= 0f || box.height <= 0f) return@Canvas
+            // Same aspect-fit + centering contract as SvgCanvas.
+            val fit = minOf(size.width / box.width, size.height / box.height)
+            if (fit <= 0f) return@Canvas
+            val dx = (size.width - box.width * fit) / 2f - box.minX * fit
+            val dy = (size.height - box.height * fit) / 2f - box.minY * fit
+            withTransform({
+                translate(dx, dy)
+                scale(fit, fit, pivot = Offset.Zero)
+            }) {
+                wobbleStrokes.forEach { stroke ->
+                    when (stroke) {
+                        is WobbleStrokeRender.Ink ->
+                            drawPath(path = stroke.path, color = strokeColor, style = Fill)
+                        is WobbleStrokeRender.Plain ->
+                            drawPath(
+                                path = stroke.path,
+                                color = strokeColor,
+                                style =
+                                    Stroke(
+                                        width = stroke.width,
+                                        cap = StrokeCap.Round,
+                                        join = StrokeJoin.Round,
+                                    ),
+                            )
+                    }
+                }
+            }
+        }
+        return
+    }
+
     val markup = remember(strokes, viewBox) { buildGlyphSvg(strokes, viewBox) }
     PebbleSvg(svg = markup, strokeHex = rgbHex(strokeColor), modifier = modifier)
+}
+
+/** One stroke's render mode: wobbled filled ink, or the plain rounded stroke. */
+private sealed interface WobbleStrokeRender {
+    class Ink(
+        val path: Path,
+    ) : WobbleStrokeRender
+
+    class Plain(
+        val path: Path,
+        val width: Float,
+    ) : WobbleStrokeRender
+}
+
+private fun buildWobbleStroke(stroke: GlyphStroke): WobbleStrokeRender {
+    WobbleRenderer.glyphInk(stroke.d, stroke.width)?.let { ink ->
+        return WobbleStrokeRender.Ink(wobbleInkPath(ink))
+    }
+    val plain =
+        try {
+            PathParser().parsePathString(stroke.d).toPath()
+        } catch (e: Exception) {
+            // glyphInk already rejected the d; an empty path draws nothing,
+            // matching AndroidSVG's behavior for the same broken stroke.
+            Path()
+        }
+    return WobbleStrokeRender.Plain(plain, stroke.width.toFloat())
+}
+
+/** Parses `"minX minY width height"`; null falls back to the markup pipeline. */
+private fun parseGlyphViewBox(value: String): PebbleSvgModel.ViewBox? {
+    val parts = value.trim().split(Regex("[,\\s]+")).mapNotNull { it.toFloatOrNull() }
+    if (parts.size != 4) return null
+    return PebbleSvgModel.ViewBox(parts[0], parts[1], parts[2], parts[3])
 }
 
 /** Compose [Color] to 6-digit `"#RRGGBB"` for SVG-text injection (drops alpha; glyph strokes are opaque). */

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/PebbleOutlineBackdrop.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/PebbleOutlineBackdrop.kt
@@ -1,13 +1,22 @@
 package app.pbbls.android.features.path.render
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.platform.LocalContext
 import app.pbbls.android.R
+import app.pbbls.android.features.path.models.EmotionPalette
 import app.pbbls.android.features.path.models.ValencePolarity
 import app.pbbls.android.features.path.models.ValenceSizeGroup
+import app.pbbls.android.features.path.render.wobble.WobbleFlags
+import app.pbbls.android.features.path.render.wobble.WobbleRenderer
+import app.pbbls.android.features.path.render.wobble.wobbleInkPath
 
 /**
  * Explicit (size, polarity) → raw-resource map for the nine bundled outline
@@ -42,6 +51,10 @@ object OutlineAssets {
  * string-replaces the `#FF00FF` sentinel with [fillHex] (6-digit) before
  * parsing, and applies [fillOpacity] as view alpha (the fill color's alpha
  * cannot ride in a 6-digit hex).
+ *
+ * Wobble experiment (#555, debug-only via [WobbleFlags]): natively fills the
+ * displaced silhouette instead of going through AndroidSVG; asset parse
+ * failure or an unreadable fill hex falls through to the [SvgCanvas] branch.
  */
 @Composable
 fun PebbleOutlineBackdrop(
@@ -53,14 +66,49 @@ fun PebbleOutlineBackdrop(
 ) {
     val context = LocalContext.current
     val resId = OutlineAssets.resId(sizeGroup, polarity)
-    val markup =
-        remember(resId, fillHex) {
-            val raw =
-                context.resources
-                    .openRawResource(resId)
-                    .bufferedReader()
-                    .use { it.readText() }
-            SvgColors.injectOutlineFill(raw, fillHex)
+    val raw =
+        remember(resId) {
+            context.resources
+                .openRawResource(resId)
+                .bufferedReader()
+                .use { it.readText() }
         }
+    val wobbleArt =
+        remember(resId) {
+            if (WobbleFlags.isEnabled) {
+                WobbleRenderer.backdropArt("${sizeGroup.key}-${polarity.key}", raw)
+            } else {
+                null
+            }
+        }
+    val fillColor = remember(fillHex) { EmotionPalette.parseColor(fillHex) }
+
+    if (wobbleArt != null && fillColor != null) {
+        val path =
+            remember(resId) {
+                wobbleInkPath(
+                    contours = wobbleArt.contours,
+                    fillType = if (wobbleArt.usesEvenOddFill) PathFillType.EvenOdd else PathFillType.NonZero,
+                )
+            }
+        val viewBox = wobbleArt.viewBox
+        Canvas(modifier = modifier.alpha(fillOpacity)) {
+            if (viewBox.width <= 0f || viewBox.height <= 0f) return@Canvas
+            // Same aspect-fit + centering as SvgCanvas / PebbleStaticRender.
+            val fit = minOf(size.width / viewBox.width, size.height / viewBox.height)
+            if (fit <= 0f) return@Canvas
+            val dx = (size.width - viewBox.width * fit) / 2f - viewBox.minX * fit
+            val dy = (size.height - viewBox.height * fit) / 2f - viewBox.minY * fit
+            withTransform({
+                translate(dx, dy)
+                scale(fit, fit, pivot = Offset.Zero)
+            }) {
+                drawPath(path = path, color = fillColor, style = Fill)
+            }
+        }
+        return
+    }
+
+    val markup = remember(resId, fillHex) { SvgColors.injectOutlineFill(raw, fillHex) }
     SvgCanvas(markup = markup, modifier = modifier.alpha(fillOpacity))
 }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/PebbleStaticRender.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/PebbleStaticRender.kt
@@ -9,10 +9,14 @@ import androidx.compose.ui.graphics.Matrix
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.graphics.vector.PathParser
 import app.pbbls.android.features.path.models.EmotionPalette
+import app.pbbls.android.features.path.render.wobble.WobbleFlags
+import app.pbbls.android.features.path.render.wobble.WobbleRenderer
+import app.pbbls.android.features.path.render.wobble.wobbleInkPath
 
 /**
  * Renders a server-composed pebble SVG by tracing every `layer:*` at a single
@@ -23,6 +27,11 @@ import app.pbbls.android.features.path.models.EmotionPalette
  * glyph, previously drawn at its own (custom-heavy / domain-light) width, now
  * reads at the outline's weight too, so custom and domain glyphs render
  * identically on both the Path and the detail page.
+ *
+ * Wobble experiment (#555, debug-only via [WobbleFlags]): instead of stroking,
+ * fills the wobbled ink — thickness is baked into the leaky outline. The art is
+ * content-keyed by the svg string, both here (`remember(svg)` re-derives on
+ * in-place row updates) and in [WobbleRenderer]'s cross-composable cache.
  *
  * Falls back to [PebbleSvg] (raw AndroidSVG) when the markup can't be parsed
  * into a traceable model or the stroke hex can't be read — the same graceful
@@ -39,6 +48,14 @@ fun PebbleStaticRender(
     val model = remember(svg) { parsePebbleSvg(svg) }
     val renderLayers = remember(model) { model?.let(::buildRenderLayers) }
     val strokeColor = remember(strokeHex) { EmotionPalette.parseColor(strokeHex) }
+    val wobbleLayers =
+        remember(svg) {
+            if (WobbleFlags.isEnabled && model != null && renderLayers != null) {
+                buildWobbleLayers(svg, model)
+            } else {
+                null
+            }
+        }
 
     if (model == null || renderLayers == null || strokeColor == null) {
         PebbleSvg(svg = svg, strokeHex = strokeHex, modifier = modifier)
@@ -59,18 +76,29 @@ fun PebbleStaticRender(
             translate(dx, dy)
             scale(fit, fit, pivot = Offset.Zero)
         }) {
-            renderLayers.forEach { layer ->
-                drawPath(
-                    path = layer.path,
-                    color = strokeColor,
-                    alpha = layer.opacity,
-                    style =
-                        Stroke(
-                            width = PebbleStroke.OUTLINE_WIDTH,
-                            cap = StrokeCap.Round,
-                            join = StrokeJoin.Round,
-                        ),
-                )
+            if (wobbleLayers != null) {
+                wobbleLayers.forEach { layer ->
+                    drawPath(
+                        path = layer.path,
+                        color = strokeColor,
+                        alpha = layer.opacity,
+                        style = Fill,
+                    )
+                }
+            } else {
+                renderLayers.forEach { layer ->
+                    drawPath(
+                        path = layer.path,
+                        color = strokeColor,
+                        alpha = layer.opacity,
+                        style =
+                            Stroke(
+                                width = PebbleStroke.OUTLINE_WIDTH,
+                                cap = StrokeCap.Round,
+                                join = StrokeJoin.Round,
+                            ),
+                    )
+                }
             }
         }
     }
@@ -83,10 +111,10 @@ private class RenderLayer(
 )
 
 /**
- * Builds the per-layer Compose paths from a parsed [PebbleSvgModel], baking each
- * path's flattened `translate`/`scale` transform into viewBox-space geometry.
- * Returns `null` if any path fails to parse, so the caller falls back to
- * [PebbleSvg].
+ * Builds the per-layer Compose paths from a parsed [PebbleSvgModel], baking the
+ * layer's own transform and each path's inner `translate`/`scale` transform
+ * into viewBox-space geometry. Returns `null` if any path fails to parse, so
+ * the caller falls back to [PebbleSvg].
  */
 private fun buildRenderLayers(model: PebbleSvgModel): List<RenderLayer>? =
     try {
@@ -94,7 +122,7 @@ private fun buildRenderLayers(model: PebbleSvgModel): List<RenderLayer>? =
             val combined = Path()
             for (spec in layer.paths) {
                 val parsed = PathParser().parsePathString(spec.d).toPath()
-                parsed.transform(spec.transform.toMatrix())
+                parsed.transform(layer.transform.concat(spec.transform).toMatrix())
                 combined.addPath(parsed)
             }
             RenderLayer(opacity = layer.opacity, path = combined)
@@ -103,6 +131,24 @@ private fun buildRenderLayers(model: PebbleSvgModel): List<RenderLayer>? =
         // A malformed `d` is a data condition, not a crash — fall back.
         null
     }
+
+/**
+ * Per-layer wobbled ink as viewBox-space Compose paths (each glyph layer's ink
+ * is built in its 200-slot space, so the layer transform is baked in here —
+ * the `WobbledPathShape` composition on iOS).
+ */
+private fun buildWobbleLayers(
+    svg: String,
+    model: PebbleSvgModel,
+): List<RenderLayer> {
+    val art = WobbleRenderer.pebbleArt(svg, model)
+    return model.layers.mapIndexed { index, layer ->
+        RenderLayer(
+            opacity = layer.opacity,
+            path = wobbleInkPath(art.layers[index].ink, layer.transform),
+        )
+    }
+}
 
 /**
  * Converts an [Affine] (translate + scale only, no shear/rotation) to a Compose

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/PebbleSvgModel.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/PebbleSvgModel.kt
@@ -8,9 +8,10 @@ import javax.xml.parsers.SAXParserFactory
 
 /**
  * Typed, render-agnostic view of a server-composed pebble SVG: the viewBox plus
- * the ordered `layer:*` groups, each carrying its opacity and its descendant
- * `<path>`s (path data + the flattened `translate`/`scale` transform inherited
- * from every enclosing `<g>`). The Android analog of iOS `PebbleSVGModel`.
+ * the ordered `layer:*` groups, each carrying its kind, own transform and
+ * opacity, and its descendant `<path>`s (path data + the flattened
+ * `translate`/`scale` transform inherited from the non-layer `<g>`s inside the
+ * layer). The Android analog of iOS `PebbleSVGModel`.
  *
  * Deliberately pure — no Compose or `android.graphics` types — so the parse can
  * be unit-tested on the plain JVM (no Robolectric). [PebbleStaticRender] turns
@@ -31,16 +32,29 @@ internal data class PebbleSvgModel(
         val height: Float,
     )
 
-    /** One `layer:*` group. [opacity] is the `<g opacity>` (1 when absent). */
+    /**
+     * One `layer:*` group. [opacity] is the `<g opacity>` (1 when absent).
+     * [kind] is derived from the group id (`layer:shape` / `layer:fossil` /
+     * `layer:glyph`; anything else is [Kind.OTHER]) and [transform] is the
+     * layer `<g>`'s own transform — kept separate from the per-path inner
+     * transforms, mirroring iOS `PebbleSVGModel.Layer`, so the wobble
+     * renderer can work in the glyph's raw 200-slot space.
+     */
     data class Layer(
+        val kind: Kind,
+        val transform: Affine,
         val opacity: Float,
         val paths: List<PathSpec>,
-    )
+    ) {
+        enum class Kind { SHAPE, FOSSIL, GLYPH, OTHER }
+    }
 
     /**
      * One traceable `<path>`: its `d` data and the [transform] flattened from
-     * every enclosing `<g transform>` (identity when none). Stroke width is
-     * deliberately dropped — the renderer overrides it with the outline weight.
+     * the enclosing non-layer `<g transform>`s *inside* the layer (identity
+     * when none) — the layer's own transform lives on [Layer.transform].
+     * Stroke width is deliberately dropped — the renderer overrides it with
+     * the outline weight.
      */
     data class PathSpec(
         val d: String,
@@ -119,11 +133,14 @@ internal fun parsePebbleSvg(svg: String): PebbleSvgModel? {
 // ── SAX handler ─────────────────────────────────────────────
 
 private class MutableLayer(
+    val kind: PebbleSvgModel.Layer.Kind,
+    val transform: Affine,
     val opacity: Float,
 ) {
     val paths = mutableListOf<PebbleSvgModel.PathSpec>()
 
-    fun toLayerOrNull(): PebbleSvgModel.Layer? = if (paths.isEmpty()) null else PebbleSvgModel.Layer(opacity, paths.toList())
+    fun toLayerOrNull(): PebbleSvgModel.Layer? =
+        if (paths.isEmpty()) null else PebbleSvgModel.Layer(kind, transform, opacity, paths.toList())
 }
 
 /** One `<g>` frame: the flattened transform in effect, and the layer it feeds. */
@@ -147,20 +164,21 @@ private class PebbleSvgHandler : DefaultHandler() {
             "svg" -> viewBox = parseViewBox(attributes.getValue("viewBox"))
             "g" -> {
                 val parent = stack.lastOrNull()
-                val parentTransform = parent?.transform ?: Affine.IDENTITY
                 val own = attributes.getValue("transform")?.let(::parseTransform) ?: Affine.IDENTITY
-                val transform = parentTransform.concat(own)
                 val id = attributes.getValue("id")
-                val layer =
-                    if (id != null && id.startsWith("layer:")) {
-                        val opacity = attributes.getValue("opacity")?.toFloatOrNull() ?: 1f
-                        MutableLayer(opacity).also { layers.add(it) }
-                    } else {
-                        // A non-layer group (e.g. the glyph's inner normalization
-                        // <g>) feeds whatever layer its parent belongs to.
-                        parent?.layer
-                    }
-                stack.addLast(GroupFrame(transform, layer))
+                if (id != null && id.startsWith("layer:")) {
+                    val opacity = attributes.getValue("opacity")?.toFloatOrNull() ?: 1f
+                    val layer = MutableLayer(layerKind(id), own, opacity).also { layers.add(it) }
+                    // Paths inside a layer record transforms relative to the
+                    // layer's own <g>; the layer transform is applied by the
+                    // renderer (mirrors iOS `PebbleSVGModel` / `LayerShape`).
+                    stack.addLast(GroupFrame(Affine.IDENTITY, layer))
+                } else {
+                    // A non-layer group (e.g. the glyph's inner normalization
+                    // <g>) feeds whatever layer its parent belongs to.
+                    val parentTransform = parent?.transform ?: Affine.IDENTITY
+                    stack.addLast(GroupFrame(parentTransform.concat(own), parent?.layer))
+                }
             }
             "path" -> {
                 val frame = stack.lastOrNull() ?: return
@@ -184,6 +202,14 @@ private class PebbleSvgHandler : DefaultHandler() {
         if (qName == "g") stack.removeLastOrNull()
     }
 }
+
+private fun layerKind(id: String): PebbleSvgModel.Layer.Kind =
+    when (id) {
+        "layer:shape" -> PebbleSvgModel.Layer.Kind.SHAPE
+        "layer:fossil" -> PebbleSvgModel.Layer.Kind.FOSSIL
+        "layer:glyph" -> PebbleSvgModel.Layer.Kind.GLYPH
+        else -> PebbleSvgModel.Layer.Kind.OTHER
+    }
 
 // ── Attribute parsing ───────────────────────────────────────
 

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/wobble/SVGTurbulence.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/wobble/SVGTurbulence.kt
@@ -1,0 +1,193 @@
+package app.pbbls.android.features.path.render.wobble
+
+import kotlin.math.hypot
+
+/**
+ * Faithful Kotlin port of the SVG 1.1 §15.19 `feTurbulence type="fractalNoise"`
+ * reference implementation — a 1:1 mirror of iOS `SVGTurbulence.swift` (PR
+ * #556). The wobble look was tuned against this exact noise — substituting
+ * another noise changes the approved look (decisions log, 2026-07-13).
+ *
+ * Two structure quirks are deliberate and load-bearing:
+ * - Gradients are generated for all four RGBA channels in the spec's loop
+ *   order even though the wobble only reads channels 0 (R) and 1 (G) — the
+ *   seeded LCG stream position depends on it.
+ * - Integer math follows the spec's Schrage decomposition exactly (in [Long],
+ *   since `randA * (seed % randQ)` grazes `Int.MAX_VALUE`), so the raw LCG
+ *   sequence golden-tests against the shared reference values in
+ *   `src/test/resources/WobbleGolden.json`.
+ */
+internal class SVGTurbulence(
+    seed: Int,
+) {
+    /** Lattice selector, length 2·bSize + 2. */
+    private val lattice = IntArray(B_SIZE + B_SIZE + 2)
+
+    /** Normalized 2-D gradients per channel: `[4][2·bSize + 2][x, y]`. */
+    private val gradient = Array(4) { Array(B_SIZE + B_SIZE + 2) { DoubleArray(2) } }
+
+    init {
+        var seedState = normalizedSeed(seed.toLong())
+
+        for (channel in 0 until 4) {
+            for (i in 0 until B_SIZE) {
+                lattice[i] = i
+                val vector = DoubleArray(2)
+                for (j in 0 until 2) {
+                    seedState = nextRandom(seedState)
+                    vector[j] = ((seedState % (B_SIZE + B_SIZE)) - B_SIZE).toDouble() / B_SIZE
+                }
+                // No zero-length guard, mirroring the reference: 0/0 → NaN on
+                // both sides of the golden test, identically.
+                val length = hypot(vector[0], vector[1])
+                gradient[channel][i][0] = vector[0] / length
+                gradient[channel][i][1] = vector[1] / length
+            }
+        }
+
+        // Fisher–Yates-style lattice shuffle, consuming the same LCG stream.
+        var i = B_SIZE - 1
+        while (i > 0) {
+            val swapped = lattice[i]
+            seedState = nextRandom(seedState)
+            val j = (seedState % B_SIZE).toInt()
+            lattice[i] = lattice[j]
+            lattice[j] = swapped
+            i -= 1
+        }
+
+        // Wrap-around duplication so `lattice[i + by]` never overruns.
+        for (k in 0 until B_SIZE + 2) {
+            lattice[B_SIZE + k] = lattice[k]
+            for (channel in 0 until 4) {
+                gradient[channel][B_SIZE + k][0] = gradient[channel][k][0]
+                gradient[channel][B_SIZE + k][1] = gradient[channel][k][1]
+            }
+        }
+    }
+
+    // ── Noise ───────────────────────────────────────────────────
+
+    /** 2-D gradient noise for one channel at noise-space coordinates, in [−1, 1]. */
+    fun noise2(
+        channel: Int,
+        x: Double,
+        y: Double,
+    ): Double {
+        var t = x + PERLIN_N
+        val bx0 = t.toInt() and B_MASK // (t | 0) truncation, as in the reference
+        val bx1 = (bx0 + 1) and B_MASK
+        val rx0 = t - t.toInt()
+        val rx1 = rx0 - 1
+        t = y + PERLIN_N
+        val by0 = t.toInt() and B_MASK
+        val by1 = (by0 + 1) and B_MASK
+        val ry0 = t - t.toInt()
+        val ry1 = ry0 - 1
+
+        val latticeX0 = lattice[bx0]
+        val latticeX1 = lattice[bx1]
+        val b00 = lattice[latticeX0 + by0]
+        val b10 = lattice[latticeX1 + by0]
+        val b01 = lattice[latticeX0 + by1]
+        val b11 = lattice[latticeX1 + by1]
+
+        val sx = sCurve(rx0)
+        val sy = sCurve(ry0)
+        val grad = gradient[channel]
+
+        var q = grad[b00]
+        val u0 = rx0 * q[0] + ry0 * q[1]
+        q = grad[b10]
+        val v0 = rx1 * q[0] + ry0 * q[1]
+        val a = lerp(sx, u0, v0)
+        q = grad[b01]
+        val u1 = rx0 * q[0] + ry1 * q[1]
+        q = grad[b11]
+        val v1 = rx1 * q[0] + ry1 * q[1]
+        val b = lerp(sx, u1, v1)
+        return lerp(sy, a, b)
+    }
+
+    /** Stitchless fractalNoise sum over [octaves] — signed, unclamped. */
+    fun turbulence(
+        channel: Int,
+        x: Double,
+        y: Double,
+        baseFrequency: Double,
+        octaves: Int,
+    ): Double {
+        var vx = x * baseFrequency
+        var vy = y * baseFrequency
+        var sum = 0.0
+        var ratio = 1.0
+        repeat(octaves) {
+            sum += noise2(channel, vx, vy) / ratio
+            vx *= 2
+            vy *= 2
+            ratio *= 2
+        }
+        return sum
+    }
+
+    // ── Test hooks (internal; consumed by the JVM unit tests) ──
+
+    val latticePrefix16: List<Int> get() = lattice.take(16)
+
+    /** Gradient vector `(x, y)` for one channel/index. */
+    fun gradientSample(
+        channel: Int,
+        index: Int,
+    ): DoubleArray = gradient[channel][index]
+
+    companion object {
+        private const val B_SIZE = 0x100
+        private const val B_MASK = 0xff
+        private const val PERLIN_N = 0x1000
+
+        // Spec LCG constants (§15.19, "RandomNumberSetup").
+        private const val RAND_M = 2147483647L // 2**31 − 1
+        private const val RAND_A = 16807L // 7**5, primitive root of m
+        private const val RAND_Q = 127773L // m / a
+        private const val RAND_R = 2836L // m % a
+
+        // ── Seeded LCG (spec §15.19) ────────────────────────────
+
+        fun nextRandom(seed: Long): Long {
+            var result = RAND_A * (seed % RAND_Q) - RAND_R * (seed / RAND_Q)
+            if (result <= 0) result += RAND_M
+            return result
+        }
+
+        fun normalizedSeed(seed: Long): Long {
+            var normalized = seed
+            if (normalized <= 0) normalized = -(normalized % (RAND_M - 1)) + 1
+            if (normalized > RAND_M - 1) normalized = RAND_M - 1
+            return normalized
+        }
+
+        /** First [count] raw LCG values for [seed] — consumed by the golden test. */
+        fun rawSequence(
+            seed: Long,
+            count: Int,
+        ): List<Long> {
+            val values = ArrayList<Long>(count)
+            var state = normalizedSeed(seed)
+            repeat(count) {
+                state = nextRandom(state)
+                values.add(state)
+            }
+            return values
+        }
+
+        // ── Helpers ─────────────────────────────────────────────
+
+        private fun sCurve(t: Double): Double = t * t * (3 - 2 * t)
+
+        private fun lerp(
+            t: Double,
+            a: Double,
+            b: Double,
+        ): Double = a + t * (b - a)
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/wobble/WobbleFlags.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/wobble/WobbleFlags.kt
@@ -1,0 +1,20 @@
+package app.pbbls.android.features.path.render.wobble
+
+import app.pbbls.android.BuildConfig
+
+/**
+ * Feature gate for the petroglyph wobble experiment (issue #555) — mirrors
+ * iOS `WobbleFlags.swift`.
+ *
+ * Debug-only by construction: the spike evaluates the hand-carved look across
+ * every pebble surface in dev builds, and `BuildConfig.DEBUG` is a constant
+ * `false` in Release (R8 strips the gated branches) so it can never ship by
+ * accident. Deleting the experiment means removing this folder and reverting
+ * the flag-gated call sites ([app.pbbls.android.features.path.render
+ * .PebbleStaticRender], [app.pbbls.android.features.path.render
+ * .PebbleOutlineBackdrop], [app.pbbls.android.features.path.render
+ * .GlyphImage]).
+ */
+internal object WobbleFlags {
+    val isEnabled: Boolean = BuildConfig.DEBUG
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/wobble/WobbleOutlineBuilder.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/wobble/WobbleOutlineBuilder.kt
@@ -1,0 +1,178 @@
+package app.pbbls.android.features.path.render.wobble
+
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.hypot
+import kotlin.math.sin
+
+/**
+ * The wobbled render of one artwork piece, as pure geometry (no Compose or
+ * `android.graphics` types, so the whole pipeline is JVM unit-testable —
+ * same rule as `PebbleSvgModel`). `WobbleShapes.kt` converts it to a Compose
+ * [androidx.compose.ui.graphics.Path] at the view layer.
+ *
+ * [ink] is the leaky filled outline: closed contours, filled together under
+ * the nonzero winding rule. [centerline] is the displaced centerline the
+ * future appear animation's reveal mask must stroke along (fat trimmed
+ * stroke, mirroring iOS `PebbleAnimatedRenderView` — not wired up yet;
+ * Android has no draw-on animation).
+ */
+internal class WobbleArt(
+    val ink: List<List<WobblePoint>>,
+    val centerline: List<WobblePolyline>,
+)
+
+/**
+ * Converts flattened centerline polylines into wobbled filled outlines,
+ * porting iOS `WobbleOutlineBuilder.swift` (itself the playground's
+ * baked-export algorithm): offset both stroke edges from the centerline
+ * first, then displace every contour point independently. The independent
+ * displacement is what makes the width breathe ("leaky") — a stroked wobbled
+ * centerline would stay constant-width.
+ */
+internal object WobbleOutlineBuilder {
+    /**
+     * End caps are semicircles of [CAP_SEGMENTS] arcs (CAP_SEGMENTS − 1
+     * interior points), matching the playground.
+     */
+    private const val CAP_SEGMENTS = 6
+
+    /**
+     * A zero-length polyline (single-tap carve dot) becomes a circle with
+     * this many segments. The playground drops dots; we keep them visible,
+     * matching the current renderer's round-cap dot.
+     */
+    private const val DOT_SEGMENTS = 12
+
+    fun art(
+        polylines: List<WobblePolyline>,
+        halfWidth: Double,
+        params: WobbleParams,
+        noise: SVGTurbulence,
+    ): WobbleArt {
+        val ink = mutableListOf<List<WobblePoint>>()
+        val centerline = mutableListOf<WobblePolyline>()
+        for (polyline in polylines) {
+            for (contour in contours(polyline, halfWidth)) {
+                if (contour.size <= 2) continue
+                ink.add(contour.map { params.displace(it, noise) })
+            }
+            centerline.add(displacedCenterline(polyline, params, noise))
+        }
+        return WobbleArt(ink, centerline)
+    }
+
+    /**
+     * Un-displaced outline contours for one polyline. Internal so tests can
+     * assert point counts and winding without decoding a displaced path.
+     */
+    fun contours(
+        polyline: WobblePolyline,
+        halfWidth: Double,
+    ): List<List<WobblePoint>> {
+        val points = polyline.points
+        val count = points.size
+
+        if (count == 1) {
+            val cx = points[0].x
+            val cy = points[0].y
+            val circle =
+                (0 until DOT_SEGMENTS).map { i ->
+                    val angle = 2 * Math.PI * i / DOT_SEGMENTS
+                    WobblePoint(cx + halfWidth * cos(angle), cy + halfWidth * sin(angle))
+                }
+            return listOf(circle)
+        }
+
+        val normals = normals(points, polyline.isClosed)
+        val left =
+            (0 until count).map { i ->
+                WobblePoint(points[i].x + normals[i].x * halfWidth, points[i].y + normals[i].y * halfWidth)
+            }
+        val right =
+            (0 until count).map { i ->
+                WobblePoint(points[i].x - normals[i].x * halfWidth, points[i].y - normals[i].y * halfWidth)
+            }
+
+        if (polyline.isClosed) {
+            // Outer ring + reversed inner ring: opposite windings make the
+            // pair render as an annulus under nonzero fill.
+            return listOf(left, right.reversed())
+        }
+
+        val contour = left.toMutableList()
+        appendCapArc(
+            contour = contour,
+            center = points[count - 1],
+            from = left[count - 1],
+            halfWidth = halfWidth,
+            tangentX = points[count - 1].x - points[count - 2].x,
+            tangentY = points[count - 1].y - points[count - 2].y,
+        )
+        contour.addAll(right.reversed())
+        appendCapArc(
+            contour = contour,
+            center = points[0],
+            from = right[0],
+            halfWidth = halfWidth,
+            tangentX = points[0].x - points[1].x,
+            tangentY = points[0].y - points[1].y,
+        )
+        return listOf(contour)
+    }
+
+    // ── Pieces ─────────────────────────────────────────────────
+
+    /**
+     * Per-point normals from neighbor tangents; endpoints use their single
+     * adjacent segment, closed rings wrap cyclically.
+     */
+    private fun normals(
+        points: List<WobblePoint>,
+        closed: Boolean,
+    ): List<WobblePoint> {
+        val count = points.size
+        return (0 until count).map { i ->
+            val prev = if (closed) points[(i - 1 + count) % count] else points[maxOf(0, i - 1)]
+            val next = if (closed) points[(i + 1) % count] else points[minOf(count - 1, i + 1)]
+            val tx = next.x - prev.x
+            val ty = next.y - prev.y
+            val rawLength = hypot(tx, ty)
+            val length = if (rawLength == 0.0) 1.0 else rawLength // playground: `|| 1`
+            WobblePoint(-ty / length, tx / length)
+        }
+    }
+
+    /**
+     * Appends the interior points of a semicircular end cap around [center],
+     * starting from [from] and bulging along the tangent direction.
+     */
+    private fun appendCapArc(
+        contour: MutableList<WobblePoint>,
+        center: WobblePoint,
+        from: WobblePoint,
+        halfWidth: Double,
+        tangentX: Double,
+        tangentY: Double,
+    ) {
+        val startAngle = atan2(from.y - center.y, from.x - center.x)
+        val midAngle = startAngle + Math.PI / 2
+        val direction = if (cos(midAngle) * tangentX + sin(midAngle) * tangentY >= 0) 1.0 else -1.0
+        for (step in 1 until CAP_SEGMENTS) {
+            val angle = startAngle + direction * (Math.PI * step / CAP_SEGMENTS)
+            contour.add(WobblePoint(center.x + halfWidth * cos(angle), center.y + halfWidth * sin(angle)))
+        }
+    }
+
+    /**
+     * The displaced centerline mirrors the input subpath structure so a
+     * future reveal mask's trim progresses across subpaths in the same order
+     * as a stroke draw-on would. A one-point polyline stays one point — the
+     * mask stroke's round cap is what will reveal the dot.
+     */
+    private fun displacedCenterline(
+        polyline: WobblePolyline,
+        params: WobbleParams,
+        noise: SVGTurbulence,
+    ): WobblePolyline = WobblePolyline(polyline.points.map { params.displace(it, noise) }, polyline.isClosed)
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/wobble/WobbleParams.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/wobble/WobbleParams.kt
@@ -1,0 +1,76 @@
+package app.pbbls.android.features.path.render.wobble
+
+import kotlin.math.max
+
+/**
+ * Canonical wobble parameters from issue #555 §1, plus the §2.1 rule mapping
+ * them into an arbitrary coordinate space — mirrors iOS `WobbleParams.swift`.
+ * All values are authored for a normalized 200-unit box; [scaled] preserves
+ * the visual density when the geometry lives in a different space (pebble
+ * canvases, backdrop assets).
+ */
+internal data class WobbleParams(
+    /** Max displacement, in the geometry's own units. */
+    val amplitude: Double,
+    /** Noise base frequency, in the geometry's own units. */
+    val frequency: Double,
+    /** Fractal octave count. */
+    val octaves: Int,
+    /** Target chord length when flattening, in the geometry's own units. */
+    val flattenStep: Double,
+) {
+    /**
+     * Displaces one point with the R/G noise channels.
+     *
+     * The sign is MINUS: feDisplacementMap samples source pixels at
+     * p + scale·(noise − 0.5), so geometry must move the opposite way to
+     * reproduce the filter's appearance. Issue #555 §2.3 writes "+", but the
+     * playground bake — the look's source of truth — uses "−" (decisions log,
+     * 2026-07-13). Noise is always sampled at the un-displaced point.
+     */
+    fun displace(
+        point: WobblePoint,
+        noise: SVGTurbulence,
+    ): WobblePoint {
+        val r = unitClamp((noise.turbulence(0, point.x, point.y, frequency, octaves) + 1) / 2) - 0.5
+        val g = unitClamp((noise.turbulence(1, point.x, point.y, frequency, octaves) + 1) / 2) - 0.5
+        return WobblePoint(point.x - amplitude * r, point.y - amplitude * g)
+    }
+
+    companion object {
+        /** The approved look (issue #555 §1) for geometry in the 200-box. */
+        val CANONICAL = WobbleParams(amplitude = 18.0, frequency = 0.024, octaves = 5, flattenStep = 2.0)
+
+        /** The static look's single seed; boil variants would use seed + k later. */
+        const val SEED = 3
+
+        /**
+         * §2.1: for a w×h space, with s = 200 / max(w, h), amplitude and step
+         * scale by 1/s and frequency by s — equivalent to normalizing into the
+         * 200-box, wobbling there, and scaling back.
+         */
+        fun scaled(
+            spaceWidth: Double,
+            spaceHeight: Double,
+        ): WobbleParams {
+            val longestSide = max(spaceWidth, spaceHeight)
+            if (longestSide <= 0) return CANONICAL
+            val normalization = 200 / longestSide
+            return WobbleParams(
+                amplitude = CANONICAL.amplitude / normalization,
+                frequency = CANONICAL.frequency * normalization,
+                octaves = CANONICAL.octaves,
+                flattenStep = CANONICAL.flattenStep / normalization,
+            )
+        }
+
+        private fun unitClamp(value: Double): Double =
+            if (value < 0) {
+                0.0
+            } else if (value > 1) {
+                1.0
+            } else {
+                value
+            }
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/wobble/WobblePathFlattener.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/wobble/WobblePathFlattener.kt
@@ -1,0 +1,432 @@
+package app.pbbls.android.features.path.render.wobble
+
+import androidx.compose.ui.graphics.vector.PathNode
+import app.pbbls.android.features.path.render.Affine
+import kotlin.math.abs
+import kotlin.math.ceil
+import kotlin.math.cos
+import kotlin.math.hypot
+import kotlin.math.max
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/** A 2-D point in the wobble pipeline. Double-precision — the golden fixtures assert to 1e-9. */
+internal data class WobblePoint(
+    val x: Double,
+    val y: Double,
+)
+
+/** A flattened subpath: dense points ready for displacement. */
+internal data class WobblePolyline(
+    val points: List<WobblePoint>,
+    val isClosed: Boolean,
+)
+
+/**
+ * Flattens parsed SVG path nodes into polylines whose chords are ≤ ~`step`
+ * units, so the noise displacement reads as a smooth wobble rather than a
+ * kinked polygon (issue #555 §2.3 step 1) — mirrors iOS
+ * `WobblePathFlattener.swift`. Straight segments are subdivided too — a long
+ * straight line needs interior vertices or it cannot bend.
+ *
+ * Two Android adaptations of the iOS `CGPath` walk:
+ * - Input is Compose's [PathNode] list (`PathParser().parsePathString(d)
+ *   .toNodes()`), so relative/shorthand/arc commands are normalized here to
+ *   the absolute move/line/quad/cubic/close primitives `CGPath` enumeration
+ *   hands iOS.
+ * - An optional [Affine] bakes an enclosing-group transform into the geometry
+ *   before subdivision (chords are measured post-transform), standing in for
+ *   iOS `PebbleSVGModel` pre-transforming its `combinedPath`.
+ */
+internal object WobblePathFlattener {
+    private const val DUPLICATE_EPSILON = 1e-6
+
+    fun flatten(
+        nodes: List<PathNode>,
+        step: Double,
+        transform: Affine = Affine.IDENTITY,
+    ): List<WobblePolyline> {
+        val walker = NodeWalker(step, transform)
+        for (node in nodes) {
+            walker.consume(node)
+        }
+        return walker.finish()
+    }
+
+    /**
+     * Streaming node consumer. `cursor`/control-point state lives in the raw
+     * path space (relative and reflected commands compose there); every point
+     * appended to the output is mapped through [transform] first. Affine maps
+     * of Bézier control points transform the curve exactly, so subdividing
+     * post-transform matches iOS flattening a pre-transformed path.
+     */
+    private class NodeWalker(
+        private val step: Double,
+        private val transform: Affine,
+    ) {
+        private val polylines = mutableListOf<WobblePolyline>()
+        private var current = mutableListOf<WobblePoint>()
+        private var subpathStart = WobblePoint(0.0, 0.0)
+        private var cursor = WobblePoint(0.0, 0.0)
+
+        /** Previous cubic control2 / quad control, for S/T reflection. */
+        private var lastCubicControl: WobblePoint? = null
+        private var lastQuadControl: WobblePoint? = null
+
+        fun consume(node: PathNode) {
+            when (node) {
+                is PathNode.MoveTo -> moveTo(WobblePoint(node.x.toDouble(), node.y.toDouble()))
+                is PathNode.RelativeMoveTo -> moveTo(WobblePoint(cursor.x + node.dx, cursor.y + node.dy))
+                is PathNode.LineTo -> lineTo(WobblePoint(node.x.toDouble(), node.y.toDouble()))
+                is PathNode.RelativeLineTo -> lineTo(WobblePoint(cursor.x + node.dx, cursor.y + node.dy))
+                is PathNode.HorizontalTo -> lineTo(WobblePoint(node.x.toDouble(), cursor.y))
+                is PathNode.RelativeHorizontalTo -> lineTo(WobblePoint(cursor.x + node.dx, cursor.y))
+                is PathNode.VerticalTo -> lineTo(WobblePoint(cursor.x, node.y.toDouble()))
+                is PathNode.RelativeVerticalTo -> lineTo(WobblePoint(cursor.x, cursor.y + node.dy))
+                is PathNode.QuadTo ->
+                    quadTo(
+                        WobblePoint(node.x1.toDouble(), node.y1.toDouble()),
+                        WobblePoint(node.x2.toDouble(), node.y2.toDouble()),
+                    )
+                is PathNode.RelativeQuadTo ->
+                    quadTo(
+                        WobblePoint(cursor.x + node.dx1, cursor.y + node.dy1),
+                        WobblePoint(cursor.x + node.dx2, cursor.y + node.dy2),
+                    )
+                is PathNode.ReflectiveQuadTo -> quadTo(reflectedQuadControl(), WobblePoint(node.x.toDouble(), node.y.toDouble()))
+                is PathNode.RelativeReflectiveQuadTo ->
+                    quadTo(reflectedQuadControl(), WobblePoint(cursor.x + node.dx, cursor.y + node.dy))
+                is PathNode.CurveTo ->
+                    cubicTo(
+                        WobblePoint(node.x1.toDouble(), node.y1.toDouble()),
+                        WobblePoint(node.x2.toDouble(), node.y2.toDouble()),
+                        WobblePoint(node.x3.toDouble(), node.y3.toDouble()),
+                    )
+                is PathNode.RelativeCurveTo ->
+                    cubicTo(
+                        WobblePoint(cursor.x + node.dx1, cursor.y + node.dy1),
+                        WobblePoint(cursor.x + node.dx2, cursor.y + node.dy2),
+                        WobblePoint(cursor.x + node.dx3, cursor.y + node.dy3),
+                    )
+                is PathNode.ReflectiveCurveTo ->
+                    cubicTo(
+                        reflectedCubicControl(),
+                        WobblePoint(node.x1.toDouble(), node.y1.toDouble()),
+                        WobblePoint(node.x2.toDouble(), node.y2.toDouble()),
+                    )
+                is PathNode.RelativeReflectiveCurveTo ->
+                    cubicTo(
+                        reflectedCubicControl(),
+                        WobblePoint(cursor.x + node.dx1, cursor.y + node.dy1),
+                        WobblePoint(cursor.x + node.dx2, cursor.y + node.dy2),
+                    )
+                is PathNode.ArcTo ->
+                    arcTo(
+                        node.horizontalEllipseRadius.toDouble(),
+                        node.verticalEllipseRadius.toDouble(),
+                        node.theta.toDouble(),
+                        node.isMoreThanHalf,
+                        node.isPositiveArc,
+                        WobblePoint(node.arcStartX.toDouble(), node.arcStartY.toDouble()),
+                    )
+                is PathNode.RelativeArcTo ->
+                    arcTo(
+                        node.horizontalEllipseRadius.toDouble(),
+                        node.verticalEllipseRadius.toDouble(),
+                        node.theta.toDouble(),
+                        node.isMoreThanHalf,
+                        node.isPositiveArc,
+                        WobblePoint(cursor.x + node.arcStartDx, cursor.y + node.arcStartDy),
+                    )
+                PathNode.Close -> close()
+            }
+        }
+
+        fun finish(): List<WobblePolyline> {
+            flush(closed = false)
+            return polylines
+        }
+
+        // ── Command primitives (mirror the iOS applyWithBlock cases) ──
+
+        private fun moveTo(point: WobblePoint) {
+            flush(closed = false)
+            cursor = point
+            subpathStart = point
+            current = mutableListOf(map(point))
+            resetReflection()
+        }
+
+        private fun lineTo(end: WobblePoint) {
+            appendLine(end)
+            resetReflection()
+        }
+
+        private fun quadTo(
+            control: WobblePoint,
+            end: WobblePoint,
+        ) {
+            appendQuad(control, end)
+            lastQuadControl = control
+            lastCubicControl = null
+        }
+
+        private fun cubicTo(
+            control1: WobblePoint,
+            control2: WobblePoint,
+            end: WobblePoint,
+        ) {
+            appendCubic(control1, control2, end)
+            lastCubicControl = control2
+            lastQuadControl = null
+        }
+
+        private fun close() {
+            // Subdivide the implicit closing leg, then drop the duplicated
+            // start point: rings are stored without repetition because the
+            // outline builder wraps neighbors cyclically.
+            appendLine(subpathStart)
+            val start = map(subpathStart)
+            val last = current.lastOrNull()
+            if (last != null &&
+                current.size > 1 &&
+                abs(last.x - start.x) < DUPLICATE_EPSILON &&
+                abs(last.y - start.y) < DUPLICATE_EPSILON
+            ) {
+                current.removeAt(current.lastIndex)
+            }
+            flush(closed = true)
+            cursor = subpathStart
+            resetReflection()
+        }
+
+        // ── Subdivision (identical chord math to iOS) ──────────────
+
+        private fun appendLine(end: WobblePoint) {
+            val a = map(cursor)
+            val b = map(end)
+            val distance = hypot(b.x - a.x, b.y - a.y)
+            val count = max(1, ceil(distance / step).toInt())
+            for (i in 1..count) {
+                val t = i.toDouble() / count
+                append(WobblePoint(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t))
+            }
+            cursor = end
+        }
+
+        private fun appendQuad(
+            control: WobblePoint,
+            end: WobblePoint,
+        ) {
+            // Control-polygon length over-estimates arc length, which only
+            // makes chords denser than `step` — never sparser.
+            val start = map(cursor)
+            val c = map(control)
+            val e = map(end)
+            val approxLength = hypot(c.x - start.x, c.y - start.y) + hypot(e.x - c.x, e.y - c.y)
+            val count = max(1, ceil(approxLength / step).toInt())
+            for (i in 1..count) {
+                val t = i.toDouble() / count
+                val mt = 1 - t
+                append(
+                    WobblePoint(
+                        mt * mt * start.x + 2 * mt * t * c.x + t * t * e.x,
+                        mt * mt * start.y + 2 * mt * t * c.y + t * t * e.y,
+                    ),
+                )
+            }
+            cursor = end
+        }
+
+        private fun appendCubic(
+            control1: WobblePoint,
+            control2: WobblePoint,
+            end: WobblePoint,
+        ) {
+            val start = map(cursor)
+            val c1 = map(control1)
+            val c2 = map(control2)
+            val e = map(end)
+            val approxLength =
+                hypot(c1.x - start.x, c1.y - start.y) +
+                    hypot(c2.x - c1.x, c2.y - c1.y) +
+                    hypot(e.x - c2.x, e.y - c2.y)
+            val count = max(1, ceil(approxLength / step).toInt())
+            for (i in 1..count) {
+                val t = i.toDouble() / count
+                val mt = 1 - t
+                val c0 = mt * mt * mt
+                val k1 = 3 * mt * mt * t
+                val k2 = 3 * mt * t * t
+                val k3 = t * t * t
+                append(
+                    WobblePoint(
+                        c0 * start.x + k1 * c1.x + k2 * c2.x + k3 * e.x,
+                        c0 * start.y + k1 * c1.y + k2 * c2.y + k3 * e.y,
+                    ),
+                )
+            }
+            cursor = end
+        }
+
+        /**
+         * SVG arc → cubic segments (W3C endpoint-to-center parameterization,
+         * spec appendix F.6), each ≤ 90° so the standard tangent-length
+         * approximation holds; the cubics then flow through [appendCubic].
+         * iOS gets this conversion from its SVG path parser before flattening,
+         * so cross-platform chords differ slightly here — acceptable per PR
+         * #556 ("vertex-exact overlay is a non-goal"); the parity gates are
+         * the noise/displacement fixtures.
+         */
+        private fun arcTo(
+            radiusX: Double,
+            radiusY: Double,
+            xAxisRotationDegrees: Double,
+            largeArc: Boolean,
+            sweep: Boolean,
+            end: WobblePoint,
+        ) {
+            if (cursor == end) return
+            if (radiusX == 0.0 || radiusY == 0.0) {
+                lineTo(end)
+                return
+            }
+            var rx = abs(radiusX)
+            var ry = abs(radiusY)
+            val phi = Math.toRadians(xAxisRotationDegrees)
+            val cosPhi = cos(phi)
+            val sinPhi = sin(phi)
+
+            // (F.6.5.1) midpoint-relative start in the rotated frame.
+            val dx2 = (cursor.x - end.x) / 2
+            val dy2 = (cursor.y - end.y) / 2
+            val x1p = cosPhi * dx2 + sinPhi * dy2
+            val y1p = -sinPhi * dx2 + cosPhi * dy2
+
+            // (F.6.6) scale radii up if the endpoints can't fit them.
+            val lambda = (x1p * x1p) / (rx * rx) + (y1p * y1p) / (ry * ry)
+            if (lambda > 1) {
+                val s = sqrt(lambda)
+                rx *= s
+                ry *= s
+            }
+
+            // (F.6.5.2) center in the rotated frame.
+            val rxSq = rx * rx
+            val rySq = ry * ry
+            val numerator = rxSq * rySq - rxSq * y1p * y1p - rySq * x1p * x1p
+            val denominator = rxSq * y1p * y1p + rySq * x1p * x1p
+            val radicand = max(0.0, numerator / denominator)
+            val sign = if (largeArc != sweep) 1.0 else -1.0
+            val coefficient = sign * sqrt(radicand)
+            val cxp = coefficient * (rx * y1p / ry)
+            val cyp = coefficient * (-ry * x1p / rx)
+
+            // (F.6.5.3) center + angles in the original frame.
+            val cx = cosPhi * cxp - sinPhi * cyp + (cursor.x + end.x) / 2
+            val cy = sinPhi * cxp + cosPhi * cyp + (cursor.y + end.y) / 2
+            val startAngle = angle((x1p - cxp) / rx, (y1p - cyp) / ry)
+            var sweepAngle = angle((-x1p - cxp) / rx, (-y1p - cyp) / ry) - startAngle
+            if (!sweep && sweepAngle > 0) sweepAngle -= 2 * Math.PI
+            if (sweep && sweepAngle < 0) sweepAngle += 2 * Math.PI
+
+            val segments = max(1, ceil(abs(sweepAngle) / (Math.PI / 2)).toInt())
+            val delta = sweepAngle / segments
+            // Tangent length for a cubic approximating a `delta` elliptical arc.
+            val tangent = 4.0 / 3.0 * kotlin.math.tan(delta / 4)
+            var theta = startAngle
+            for (i in 0 until segments) {
+                val next = theta + delta
+                val from = ellipsePoint(cx, cy, rx, ry, cosPhi, sinPhi, theta)
+                val to = ellipsePoint(cx, cy, rx, ry, cosPhi, sinPhi, next)
+                val fromTangent = ellipseTangent(rx, ry, cosPhi, sinPhi, theta)
+                val toTangent = ellipseTangent(rx, ry, cosPhi, sinPhi, next)
+                cubicTo(
+                    WobblePoint(from.x + tangent * fromTangent.x, from.y + tangent * fromTangent.y),
+                    WobblePoint(to.x - tangent * toTangent.x, to.y - tangent * toTangent.y),
+                    // Land the final segment exactly on the command's endpoint.
+                    if (i == segments - 1) end else to,
+                )
+                theta = next
+            }
+            resetReflection()
+        }
+
+        // ── Helpers ────────────────────────────────────────────────
+
+        private fun flush(closed: Boolean) {
+            if (current.isNotEmpty()) {
+                polylines.add(WobblePolyline(current.toList(), closed))
+            }
+            current = mutableListOf()
+        }
+
+        private fun append(point: WobblePoint) {
+            val last = current.lastOrNull()
+            if (last != null &&
+                abs(last.x - point.x) < DUPLICATE_EPSILON &&
+                abs(last.y - point.y) < DUPLICATE_EPSILON
+            ) {
+                return
+            }
+            current.add(point)
+        }
+
+        private fun map(point: WobblePoint): WobblePoint =
+            if (transform === Affine.IDENTITY) {
+                point
+            } else {
+                WobblePoint(
+                    transform.a * point.x + transform.c * point.y + transform.e,
+                    transform.b * point.x + transform.d * point.y + transform.f,
+                )
+            }
+
+        private fun reflectedQuadControl(): WobblePoint {
+            val last = lastQuadControl ?: return cursor
+            return WobblePoint(2 * cursor.x - last.x, 2 * cursor.y - last.y)
+        }
+
+        private fun reflectedCubicControl(): WobblePoint {
+            val last = lastCubicControl ?: return cursor
+            return WobblePoint(2 * cursor.x - last.x, 2 * cursor.y - last.y)
+        }
+
+        private fun resetReflection() {
+            lastCubicControl = null
+            lastQuadControl = null
+        }
+
+        private fun angle(
+            x: Double,
+            y: Double,
+        ): Double = kotlin.math.atan2(y, x)
+
+        private fun ellipsePoint(
+            cx: Double,
+            cy: Double,
+            rx: Double,
+            ry: Double,
+            cosPhi: Double,
+            sinPhi: Double,
+            theta: Double,
+        ): WobblePoint {
+            val x = rx * cos(theta)
+            val y = ry * sin(theta)
+            return WobblePoint(cx + cosPhi * x - sinPhi * y, cy + sinPhi * x + cosPhi * y)
+        }
+
+        /** Derivative of [ellipsePoint] w.r.t. theta (unscaled direction). */
+        private fun ellipseTangent(
+            rx: Double,
+            ry: Double,
+            cosPhi: Double,
+            sinPhi: Double,
+            theta: Double,
+        ): WobblePoint {
+            val dx = -rx * sin(theta)
+            val dy = ry * cos(theta)
+            return WobblePoint(cosPhi * dx - sinPhi * dy, sinPhi * dx + cosPhi * dy)
+        }
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/wobble/WobbleRenderer.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/wobble/WobbleRenderer.kt
@@ -1,0 +1,207 @@
+package app.pbbls.android.features.path.render.wobble
+
+import androidx.compose.ui.graphics.vector.PathNode
+import androidx.compose.ui.graphics.vector.PathParser
+import app.pbbls.android.features.path.render.PebbleStroke
+import app.pbbls.android.features.path.render.PebbleSvgModel
+
+/**
+ * Per-layer wobbled artwork for a composed pebble SVG, index-aligned with
+ * [PebbleSvgModel.layers].
+ */
+internal class WobblePebbleArt(
+    val layers: List<WobbleArt>,
+)
+
+/**
+ * Wobbled backdrop silhouette, in its asset's viewBox space. [contours] are
+ * closed fill contours (see [WobbleArt.ink]).
+ */
+internal class WobbleBackdropArt(
+    val contours: List<List<WobblePoint>>,
+    val viewBox: PebbleSvgModel.ViewBox,
+    /**
+     * `outline_large_lowlight.svg` carves a hole with `fill-rule="evenodd"`;
+     * the other eight assets fill nonzero.
+     */
+    val usesEvenOddFill: Boolean,
+)
+
+/**
+ * Entry point of the wobble experiment — mirrors iOS `WobbleRenderer.swift`:
+ * derives per-surface parameters (issue #555 §2.1 spaces and half-widths),
+ * runs flatten → outline → displace, and caches results so the cost is paid
+ * once per artwork — never per frame.
+ *
+ * Pure JVM (no Compose/`android.graphics` types beyond the [PathNode]
+ * parser, which is common-Kotlin), so the whole surface unit-tests without
+ * Robolectric. Deliberately log-free for the same reason (`android.util.Log`
+ * throws off-device — same rule as `Valence`); parse failures degrade to
+ * `null`/skips and the calling composable's fallback branch logs.
+ */
+internal object WobbleRenderer {
+    /** One noise field for the whole app: the static look is seed 3 (§1). */
+    private val noise = SVGTurbulence(WobbleParams.SEED)
+
+    // Keys are content strings: collision-proof, and a few KB per key is
+    // negligible next to the cached geometry. Count-bounded LRU — the NSCache
+    // analog minus the memory-pressure hook.
+    private val pebbleCache = LruCache<WobblePebbleArt>(maxSize = 128)
+    private val glyphCache = LruCache<WobbleArt>(maxSize = 512)
+    private val backdropCache = LruCache<WobbleBackdropArt>(maxSize = 16) // 9 assets exist
+
+    // ── Pebble render (layer:shape / layer:fossil / layer:glyph) ──
+
+    fun pebbleArt(
+        svg: String,
+        model: PebbleSvgModel,
+    ): WobblePebbleArt {
+        pebbleCache.get(svg)?.let { return it }
+        val canvasParams = WobbleParams.scaled(model.viewBox.width.toDouble(), model.viewBox.height.toDouble())
+        val layers =
+            model.layers.map { layer ->
+                val params: WobbleParams
+                val halfWidth: Double
+                if (layer.kind == PebbleSvgModel.Layer.Kind.GLYPH && layer.transform.a > 0.01f) {
+                    // Glyph paths live in the engine's 200-box slot space; the
+                    // layer transform scales them onto the canvas. Wobble in the
+                    // raw box with canonical params, and pre-divide the half-width
+                    // so the ink lands at the outline's weight after the
+                    // transform (#509 uniform-weight rule).
+                    params = WobbleParams.CANONICAL
+                    halfWidth = PebbleStroke.OUTLINE_WIDTH.toDouble() / layer.transform.a.toDouble() / 2
+                } else {
+                    // Shape and fossil are authored in canvas space. A glyph layer
+                    // with a degenerate transform (never emitted by the engine)
+                    // also degrades to this treatment rather than dividing by ~0.
+                    params = canvasParams
+                    halfWidth = PebbleStroke.OUTLINE_WIDTH.toDouble() / 2
+                }
+                val polylines =
+                    layer.paths.flatMap { spec ->
+                        WobblePathFlattener.flatten(parseNodes(spec.d), params.flattenStep, spec.transform)
+                    }
+                WobbleOutlineBuilder.art(polylines, halfWidth, params, noise)
+            }
+        val art = WobblePebbleArt(layers)
+        pebbleCache.put(svg, art)
+        return art
+    }
+
+    // ── Backdrop silhouettes (bundled res/raw assets) ──────────
+
+    /**
+     * Wobbled silhouette for one outline asset. [assetName] is the cache key
+     * (`"{size}-{polarity}"`); [raw] is the asset's markup, loaded by the
+     * composable (JVM code can't reach Android resources). Returns null when
+     * the markup can't be parsed — the caller falls back to AndroidSVG.
+     */
+    fun backdropArt(
+        assetName: String,
+        raw: String,
+    ): WobbleBackdropArt? {
+        backdropCache.get(assetName)?.let { return it }
+        val art = backdropArt(raw) ?: return null
+        backdropCache.put(assetName, art)
+        return art
+    }
+
+    /**
+     * Parses one outline asset — a single filled `<path>`, the verified shape
+     * of all nine bundled files — and displaces its contours. No outline
+     * building: the silhouette is already a fill region, so wobbling its edge
+     * is the whole effect.
+     */
+    fun backdropArt(raw: String): WobbleBackdropArt? {
+        val viewBoxAttribute = attribute("viewBox", raw) ?: return null
+        val viewBox = parseViewBox(viewBoxAttribute) ?: return null
+        if (viewBox.width <= 0f || viewBox.height <= 0f) return null
+        val pathData = attribute("d", raw) ?: return null
+        val nodes = parseNodes(pathData)
+        if (nodes.isEmpty()) return null
+
+        val params = WobbleParams.scaled(viewBox.width.toDouble(), viewBox.height.toDouble())
+        val contours =
+            WobblePathFlattener.flatten(nodes, params.flattenStep).mapNotNull { polyline ->
+                val displaced = polyline.points.map { params.displace(it, noise) }
+                // Silhouette contours are fills — treated as closed whether or
+                // not the asset spelled out the trailing `Z`.
+                if (displaced.size > 2) displaced else null
+            }
+        if (contours.isEmpty()) return null
+        return WobbleBackdropArt(
+            contours = contours,
+            viewBox = viewBox,
+            usesEvenOddFill = raw.contains("fill-rule=\"evenodd\""),
+        )
+    }
+
+    // ── Glyph strokes (souls cells, pills, picker, form row) ───
+
+    /**
+     * Wobbled filled ink for one raw glyph stroke in the 200-box space.
+     * Returns null when the `d` string doesn't parse (caller falls back to
+     * the plain stroke).
+     */
+    fun glyphInk(
+        d: String,
+        width: Double,
+    ): List<List<WobblePoint>>? {
+        val key = "$width|$d"
+        glyphCache.get(key)?.let { return it.ink }
+        val nodes = parseNodes(d)
+        if (nodes.isEmpty()) return null
+        val params = WobbleParams.CANONICAL
+        val polylines = WobblePathFlattener.flatten(nodes, params.flattenStep)
+        if (polylines.isEmpty()) return null
+        val art = WobbleOutlineBuilder.art(polylines, width / 2, params, noise)
+        glyphCache.put(key, art)
+        return art.ink
+    }
+
+    // ── Minimal asset scanning ─────────────────────────────────
+
+    /** A malformed `d` is a data condition — empty list, caller degrades. */
+    private fun parseNodes(d: String): List<PathNode> =
+        try {
+            PathParser().parsePathString(d).toNodes()
+        } catch (e: Exception) {
+            emptyList()
+        }
+
+    /**
+     * First `name="…"` attribute value in [svg]. The word boundary keeps
+     * `d=` from matching `id=`.
+     */
+    private fun attribute(
+        name: String,
+        svg: String,
+    ): String? = Regex("(?<![\\w-])${Regex.escape(name)}=\"([^\"]*)\"").find(svg)?.groupValues?.get(1)
+
+    private fun parseViewBox(value: String): PebbleSvgModel.ViewBox? {
+        val parts = value.trim().split(Regex("[,\\s]+")).mapNotNull { it.toFloatOrNull() }
+        if (parts.size != 4) return null
+        return PebbleSvgModel.ViewBox(parts[0], parts[1], parts[2], parts[3])
+    }
+}
+
+/** Tiny synchronized count-bounded LRU (access order) — the NSCache analog. */
+private class LruCache<V>(
+    maxSize: Int,
+) {
+    private val map =
+        object : LinkedHashMap<String, V>(16, 0.75f, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, V>): Boolean = size > maxSize
+        }
+
+    @Synchronized
+    fun get(key: String): V? = map[key]
+
+    @Synchronized
+    fun put(
+        key: String,
+        value: V,
+    ) {
+        map[key] = value
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/wobble/WobbleShapes.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/wobble/WobbleShapes.kt
@@ -1,0 +1,42 @@
+package app.pbbls.android.features.path.render.wobble
+
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathFillType
+import app.pbbls.android.features.path.render.Affine
+
+/*
+ * Compose-side conversion of the pure wobble geometry — the Android analog of
+ * iOS `WobbleShapes.swift`. Kept apart from the pure pipeline so everything
+ * else stays JVM unit-testable, and apart from the render composables so the
+ * module deletes cleanly.
+ *
+ * iOS `WobbleMask` (the appear animation's reveal-mask geometry) has no
+ * counterpart here yet: Android has no draw-on animation. When one lands it
+ * must reveal the filled ink with a fat trimmed stroke along
+ * `WobbleArt.centerline` (the iOS `PebbleAnimatedRenderView` approach) — a
+ * path trim cannot animate a fill directly.
+ */
+
+/**
+ * Builds one filled Compose [Path] from wobbled ink contours, with
+ * [transform] (the owning layer's affine, identity elsewhere) baked in. The
+ * default [PathFillType.NonZero] is what makes a closed ring's
+ * opposite-winding contour pair render as an annulus.
+ */
+internal fun wobbleInkPath(
+    contours: List<List<WobblePoint>>,
+    transform: Affine = Affine.IDENTITY,
+    fillType: PathFillType = PathFillType.NonZero,
+): Path {
+    val path = Path()
+    path.fillType = fillType
+    for (contour in contours) {
+        contour.forEachIndexed { index, point ->
+            val x = (transform.a * point.x + transform.c * point.y + transform.e).toFloat()
+            val y = (transform.b * point.x + transform.d * point.y + transform.f).toFloat()
+            if (index == 0) path.moveTo(x, y) else path.lineTo(x, y)
+        }
+        path.close()
+    }
+    return path
+}

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/render/PebbleSvgModelTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/render/PebbleSvgModelTest.kt
@@ -46,9 +46,12 @@ class PebbleSvgModelTest {
     }
 
     @Test
-    fun `extracts the three layers in document order with their opacity`() {
+    fun `extracts the three layers in document order with their kind and opacity`() {
         val model = parsePebbleSvg(composed)!!
         assertEquals(3, model.layers.size)
+        assertEquals(PebbleSvgModel.Layer.Kind.SHAPE, model.layers[0].kind)
+        assertEquals(PebbleSvgModel.Layer.Kind.FOSSIL, model.layers[1].kind)
+        assertEquals(PebbleSvgModel.Layer.Kind.GLYPH, model.layers[2].kind)
         assertEquals(1f, model.layers[0].opacity, EPS) // shape
         assertEquals(0.3f, model.layers[1].opacity, EPS) // fossil
         assertEquals(1f, model.layers[2].opacity, EPS) // glyph
@@ -64,16 +67,27 @@ class PebbleSvgModelTest {
     }
 
     @Test
-    fun `flattens nested glyph transforms into a single affine`() {
+    fun `splits the glyph transform into the layer's own affine and the inner one`() {
+        // The layer's own <g transform> stays on Layer.transform (the renderer —
+        // and the wobble port, which needs the glyph's raw slot space — applies
+        // it separately); only the inner normalization <g> lands on the path.
         val model = parsePebbleSvg(composed)!!
-        val t =
+        val layer = model.layers[2].transform
+        assertEquals(0.7f, layer.a, EPS)
+        assertEquals(30f, layer.e, EPS)
+        assertEquals(30f, layer.f, EPS)
+        val inner =
             model.layers[2]
                 .paths
                 .single()
                 .transform
-        // outer translate(30,30) scale(0.7) ∘ inner translate(10,20) scale(0.5):
+        assertEquals(0.5f, inner.a, EPS)
+        assertEquals(10f, inner.e, EPS)
+        assertEquals(20f, inner.f, EPS)
+        // Their composition is the flattened transform the renderer bakes in:
         //   scale = 0.7 * 0.5 = 0.35
         //   e = 0.7*10 + 30 = 37 ; f = 0.7*20 + 30 = 44
+        val t = layer.concat(inner)
         assertEquals(0.35f, t.a, EPS)
         assertEquals(0.35f, t.d, EPS)
         assertEquals(0f, t.b, EPS)

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/render/wobble/SVGTurbulenceTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/render/wobble/SVGTurbulenceTest.kt
@@ -1,0 +1,140 @@
+package app.pbbls.android.features.path.render.wobble
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Decoded `WobbleGolden.json` — reference values generated from the issue
+ * #555 design playground's JS implementation of the SVG 1.1 §15.19 noise.
+ * The file is a byte-identical copy of
+ * `apps/ios/PebblesTests/Wobble/WobbleGolden.json`; regenerate with
+ * `node apps/ios/Scripts/generate-wobble-golden.mjs <output>` (once per
+ * platform copy) — never edit by hand.
+ */
+@Serializable
+internal data class WobbleGolden(
+    val seed: Int,
+    val lcg: List<Long>,
+    val latticePrefix: List<Int>,
+    val gradientSamples: List<GradientSample>,
+    val turbulence: List<TurbulenceCase>,
+    val displaced: List<DisplacedCase>,
+) {
+    @Serializable
+    data class GradientSample(
+        val channel: Int,
+        val index: Int,
+        val x: Double,
+        val y: Double,
+    )
+
+    @Serializable
+    data class TurbulenceCase(
+        val channel: Int,
+        val x: Double,
+        val y: Double,
+        val frequency: Double,
+        val octaves: Int,
+        val value: Double,
+    )
+
+    @Serializable
+    data class DisplacedCase(
+        val x: Double,
+        val y: Double,
+        val amplitude: Double,
+        val frequency: Double,
+        val octaves: Int,
+        val xOut: Double,
+        val yOut: Double,
+    )
+
+    companion object {
+        fun load(): WobbleGolden {
+            val stream =
+                checkNotNull(WobbleGolden::class.java.classLoader?.getResourceAsStream("WobbleGolden.json")) {
+                    "WobbleGolden.json not found on the test classpath (src/test/resources)"
+                }
+            val text = stream.bufferedReader().use { it.readText() }
+            // ignoreUnknownKeys: the fixture carries a human-facing "comment".
+            return Json { ignoreUnknownKeys = true }.decodeFromString(text)
+        }
+    }
+}
+
+/**
+ * Golden values vs the playground reference — mirrors iOS
+ * `SVGTurbulenceTests.swift`. LCG is asserted exactly; turbulence and
+ * displacement within 1e-9 (the cross-platform parity gate from the
+ * 2026-07-13 decisions-log entry).
+ */
+class SVGTurbulenceTest {
+    @Test
+    fun `raw LCG sequence matches the reference exactly`() {
+        val golden = WobbleGolden.load()
+        assertEquals(golden.lcg, SVGTurbulence.rawSequence(golden.seed.toLong(), golden.lcg.size))
+    }
+
+    @Test
+    fun `lattice prefix and gradient samples match after init`() {
+        val golden = WobbleGolden.load()
+        val noise = SVGTurbulence(golden.seed)
+        assertEquals(golden.latticePrefix, noise.latticePrefix16)
+        for (sample in golden.gradientSamples) {
+            val vector = noise.gradientSample(sample.channel, sample.index)
+            assertTrue(
+                "gradient[${sample.channel}][${sample.index}] diverged: " +
+                    "got (${vector[0]}, ${vector[1]}), want (${sample.x}, ${sample.y})",
+                kotlin.math.abs(vector[0] - sample.x) < 1e-12 && kotlin.math.abs(vector[1] - sample.y) < 1e-12,
+            )
+        }
+    }
+
+    @Test
+    fun `turbulence values match within 1e-9`() {
+        val golden = WobbleGolden.load()
+        val noise = SVGTurbulence(golden.seed)
+        for (case in golden.turbulence) {
+            val value = noise.turbulence(case.channel, case.x, case.y, case.frequency, case.octaves)
+            assertTrue(
+                "channel ${case.channel} at (${case.x}, ${case.y}) " +
+                    "f=${case.frequency} o=${case.octaves}: got $value, want ${case.value}",
+                kotlin.math.abs(value - case.value) < 1e-9,
+            )
+        }
+    }
+
+    @Test
+    fun `displacement matches the playground bake within 1e-9`() {
+        val golden = WobbleGolden.load()
+        val noise = SVGTurbulence(golden.seed)
+        for (case in golden.displaced) {
+            val params =
+                WobbleParams(
+                    amplitude = case.amplitude,
+                    frequency = case.frequency,
+                    octaves = case.octaves,
+                    flattenStep = 2.0,
+                )
+            val out = params.displace(WobblePoint(case.x, case.y), noise)
+            assertTrue(
+                "displace(${case.x}, ${case.y}) diverged: got $out, want (${case.xOut}, ${case.yOut})",
+                kotlin.math.abs(out.x - case.xOut) < 1e-9 && kotlin.math.abs(out.y - case.yOut) < 1e-9,
+            )
+        }
+    }
+
+    @Test
+    fun `determinism - two instances produce identical values`() {
+        val first = SVGTurbulence(WobbleParams.SEED)
+        val second = SVGTurbulence(WobbleParams.SEED)
+        for ((x, y) in listOf(0.0 to 0.0, 12.3 to 45.6, 199.0 to 3.0)) {
+            val a = first.turbulence(0, x, y, 0.024, 5)
+            val b = second.turbulence(0, x, y, 0.024, 5)
+            assertEquals(a, b, 0.0)
+        }
+    }
+}

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/render/wobble/WobbleOutlineBuilderTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/render/wobble/WobbleOutlineBuilderTest.kt
@@ -1,0 +1,150 @@
+package app.pbbls.android.features.path.render.wobble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.hypot
+import kotlin.math.sin
+
+/** Mirrors iOS `WobbleOutlineBuilderTests.swift`. */
+class WobbleOutlineBuilderTest {
+    /** Params that displace nothing — isolates outline construction from noise. */
+    private val identityParams = WobbleParams(amplitude = 0.0, frequency = 0.024, octaves = 1, flattenStep = 2.0)
+    private val noise = SVGTurbulence(WobbleParams.SEED)
+
+    @Test
+    fun `open polyline yields one capped contour`() {
+        val polyline = WobblePolyline(listOf(WobblePoint(0.0, 0.0), WobblePoint(10.0, 0.0)), isClosed = false)
+        val contours = WobbleOutlineBuilder.contours(polyline, halfWidth = 3.0)
+        assertEquals(1, contours.size)
+        // 2n side points + 2 caps × 5 interior points (6-segment semicircles).
+        assertEquals(2 * 2 + 2 * 5, contours[0].size)
+    }
+
+    @Test
+    fun `closed polyline yields two opposite-winding rings`() {
+        val square =
+            listOf(
+                WobblePoint(0.0, 0.0),
+                WobblePoint(10.0, 0.0),
+                WobblePoint(10.0, 10.0),
+                WobblePoint(0.0, 10.0),
+            )
+        val contours = WobbleOutlineBuilder.contours(WobblePolyline(square, isClosed = true), halfWidth = 2.0)
+        assertEquals(2, contours.size)
+        assertTrue(signedArea(contours[0]) * signedArea(contours[1]) < 0)
+    }
+
+    @Test
+    fun `dot becomes a filled circle of halfWidth radius`() {
+        val contours =
+            WobbleOutlineBuilder.contours(
+                WobblePolyline(listOf(WobblePoint(5.0, 5.0)), isClosed = false),
+                halfWidth = 3.0,
+            )
+        assertEquals(1, contours.size)
+        assertEquals(12, contours[0].size)
+        for (point in contours[0]) {
+            assertTrue(abs(hypot(point.x - 5, point.y - 5) - 3) < 1e-9)
+        }
+    }
+
+    @Test
+    fun `undisplaced ink contains the centerline and excludes the outside`() {
+        val polyline =
+            WobblePolyline((0..10).map { WobblePoint(it * 2.0, 5.0) }, isClosed = false)
+        val art = WobbleOutlineBuilder.art(listOf(polyline), halfWidth = 3.0, params = identityParams, noise = noise)
+        assertTrue(windingContains(art.ink, 10.0, 5.0))
+        assertFalse(windingContains(art.ink, 10.0, 20.0))
+    }
+
+    @Test
+    fun `closed ring ink is an annulus - band is full, hole is empty`() {
+        val circle =
+            (0 until 60).map { i ->
+                val angle = 2 * Math.PI * i / 60
+                WobblePoint(10 * cos(angle), 10 * sin(angle))
+            }
+        val art =
+            WobbleOutlineBuilder.art(
+                listOf(WobblePolyline(circle, isClosed = true)),
+                halfWidth = 2.0,
+                params = identityParams,
+                noise = noise,
+            )
+        assertTrue(windingContains(art.ink, 10.0, 0.0))
+        assertFalse(windingContains(art.ink, 0.0, 0.0))
+    }
+
+    @Test
+    fun `wobbled ink actually breathes - contour diverges from constant offset`() {
+        // A long horizontal centerline through the 200-box, canonical params:
+        // displaced contour points must not all sit at a constant ±hw offset,
+        // otherwise the "leaky" quality is lost.
+        val polyline =
+            WobblePolyline((0..100).map { WobblePoint(it * 2.0, 100.0) }, isClosed = false)
+        val art =
+            WobbleOutlineBuilder.art(
+                listOf(polyline),
+                halfWidth = 3.0,
+                params = WobbleParams.CANONICAL,
+                noise = noise,
+            )
+        val ys = art.ink.flatten().map { it.y }
+        val height = ys.max() - ys.min()
+        // With amplitude 18, the ink's vertical extent must clearly exceed the
+        // rigid 6-unit band a constant-width stroke would produce.
+        assertTrue("ink bounding box height $height — wobble looks inert", height > 8)
+    }
+
+    @Test
+    fun `determinism - same input, identical geometry`() {
+        val polyline =
+            WobblePolyline(
+                listOf(WobblePoint(0.0, 0.0), WobblePoint(20.0, 14.0), WobblePoint(40.0, 3.0)),
+                isClosed = false,
+            )
+        val first = WobbleOutlineBuilder.art(listOf(polyline), 3.0, WobbleParams.CANONICAL, noise)
+        val second = WobbleOutlineBuilder.art(listOf(polyline), 3.0, WobbleParams.CANONICAL, noise)
+        assertEquals(first.ink, second.ink)
+        assertEquals(first.centerline, second.centerline)
+    }
+
+    private fun signedArea(points: List<WobblePoint>): Double {
+        var sum = 0.0
+        for (i in points.indices) {
+            val a = points[i]
+            val b = points[(i + 1) % points.size]
+            sum += a.x * b.y - b.x * a.y
+        }
+        return sum / 2
+    }
+
+    /**
+     * Nonzero-winding point-in-polygon over the ink's closed contours — the
+     * JVM stand-in for iOS `CGPath.contains(_:using: .winding)`.
+     */
+    private fun windingContains(
+        contours: List<List<WobblePoint>>,
+        x: Double,
+        y: Double,
+    ): Boolean {
+        var winding = 0
+        for (contour in contours) {
+            for (i in contour.indices) {
+                val a = contour[i]
+                val b = contour[(i + 1) % contour.size]
+                val cross = (b.x - a.x) * (y - a.y) - (x - a.x) * (b.y - a.y)
+                if (a.y <= y) {
+                    if (b.y > y && cross > 0) winding += 1
+                } else {
+                    if (b.y <= y && cross < 0) winding -= 1
+                }
+            }
+        }
+        return winding != 0
+    }
+}

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/render/wobble/WobblePathFlattenerTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/render/wobble/WobblePathFlattenerTest.kt
@@ -1,0 +1,90 @@
+package app.pbbls.android.features.path.render.wobble
+
+import androidx.compose.ui.graphics.vector.PathNode
+import androidx.compose.ui.graphics.vector.PathParser
+import app.pbbls.android.features.path.render.Affine
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+import kotlin.math.hypot
+
+/** Mirrors iOS `WobblePathFlattenerTests.swift`. */
+class WobblePathFlattenerTest {
+    private fun nodes(d: String): List<PathNode> = PathParser().parsePathString(d).toNodes()
+
+    @Test
+    fun `straight lines gain interior vertices so they can bend`() {
+        val polylines = WobblePathFlattener.flatten(nodes("M0,0 L10,0"), step = 2.0)
+        assertEquals(1, polylines.size)
+        val points = polylines[0].points
+        assertEquals(6, points.size) // 0, 2, 4, 6, 8, 10
+        assertEquals(WobblePoint(0.0, 0.0), points.first())
+        assertEquals(WobblePoint(10.0, 0.0), points.last())
+        assertFalse(polylines[0].isClosed)
+    }
+
+    @Test
+    fun `cubic chords stay near the step`() {
+        val polylines = WobblePathFlattener.flatten(nodes("M0,0 C30,60 70,60 100,0"), step = 2.0)
+        val points = polylines[0].points
+        assertTrue(points.size > 10)
+        for (i in 1 until points.size) {
+            val chord = hypot(points[i].x - points[i - 1].x, points[i].y - points[i - 1].y)
+            assertTrue("chord $i too long: $chord", chord <= 3) // step × 1.5 headroom
+        }
+        assertEquals(WobblePoint(100.0, 0.0), points.last())
+    }
+
+    @Test
+    fun `Z closes the ring without duplicating the start point`() {
+        val polylines = WobblePathFlattener.flatten(nodes("M0,0 L10,0 L10,10 L0,10 Z"), step = 2.0)
+        assertEquals(1, polylines.size)
+        val polyline = polylines[0]
+        assertTrue(polyline.isClosed)
+        assertEquals(WobblePoint(0.0, 0.0), polyline.points.first())
+        assertTrue(polyline.points.last() != polyline.points.first())
+        // 4 sides × 5 chords, minus the deduplicated ring-closing point.
+        assertEquals(20, polyline.points.size)
+    }
+
+    @Test
+    fun `multiple subpaths flatten to multiple polylines`() {
+        val polylines = WobblePathFlattener.flatten(nodes("M0,0 L4,0 M0,10 L4,10"), step = 2.0)
+        assertEquals(2, polylines.size)
+        assertFalse(polylines[0].isClosed)
+        assertFalse(polylines[1].isClosed)
+    }
+
+    @Test
+    fun `a single-tap carve dot survives as a one-point polyline`() {
+        // Carve dots serialize as "M p L p" (one-point stroke).
+        val polylines = WobblePathFlattener.flatten(nodes("M5,5 L5,5"), step = 2.0)
+        assertEquals(1, polylines.size)
+        assertEquals(listOf(WobblePoint(5.0, 5.0)), polylines[0].points)
+    }
+
+    @Test
+    fun `quad curves flatten through the control point's pull`() {
+        val polylines = WobblePathFlattener.flatten(nodes("M0,0 Q10,10 20,0"), step = 2.0)
+        val points = polylines[0].points
+        assertTrue(points.size > 5)
+        // The curve's apex (t = 0.5) passes through y = 5.
+        val apexY = points.maxOf { it.y }
+        assertTrue("apex $apexY too far from 5", abs(apexY - 5) < 1)
+    }
+
+    @Test
+    fun `a transform is baked in before subdivision`() {
+        // Android adaptation: iOS pre-transforms the CGPath in the model; here
+        // the affine rides into flatten(). scale(2) doubles the geometry, so
+        // the 10-unit line becomes 20 units → 11 points at step 2.
+        val transform = Affine(2f, 0f, 0f, 2f, 1f, 0f)
+        val polylines = WobblePathFlattener.flatten(nodes("M0,0 L10,0"), step = 2.0, transform = transform)
+        val points = polylines[0].points
+        assertEquals(11, points.size)
+        assertEquals(WobblePoint(1.0, 0.0), points.first())
+        assertEquals(WobblePoint(21.0, 0.0), points.last())
+    }
+}

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/render/wobble/WobbleRendererTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/render/wobble/WobbleRendererTest.kt
@@ -1,0 +1,142 @@
+// Inlined SVG markup lines are machine-shaped and cannot wrap.
+@file:Suppress("ktlint:standard:max-line-length")
+
+package app.pbbls.android.features.path.render.wobble
+
+import app.pbbls.android.features.path.models.ValencePolarity
+import app.pbbls.android.features.path.models.ValenceSizeGroup
+import app.pbbls.android.features.path.render.PebbleSvgModel
+import app.pbbls.android.features.path.render.parsePebbleSvg
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Mirrors iOS `WobbleRendererTests.swift`. The backdrop-assets case reads the
+ * nine `res/raw` files straight from disk (the Gradle test task's working
+ * directory is the module root, same trick as `LocalizationParityTest` — JVM
+ * tests can't reach Android resources), which doubles as an asset regression
+ * test.
+ */
+class WobbleRendererTest {
+    private val composedSvg =
+        """
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 260" width="260" height="260">
+          <g id="layer:shape">
+            <path d="M 20 130 C 20 70 70 20 130 20 C 190 20 240 70 240 130 C 240 190 190 240 130 240 C 70 240 20 190 20 130 Z" fill="none" stroke="currentColor"/>
+          </g>
+          <g id="layer:glyph" transform="translate(55, 55) scale(0.75)">
+            <path d="M 0 0 L 200 200 M 0 200 L 200 0" fill="none" stroke="currentColor"/>
+          </g>
+        </svg>
+        """.trimIndent()
+
+    @Test
+    fun `pebble art is cached by svg content and index-aligned with layers`() {
+        val model = requireNotNull(parsePebbleSvg(composedSvg))
+        val first = WobbleRenderer.pebbleArt(composedSvg, model)
+        val second = WobbleRenderer.pebbleArt(composedSvg, model)
+        assertSame(first, second)
+        assertEquals(model.layers.size, first.layers.size)
+        for (layer in first.layers) {
+            assertTrue(layer.ink.isNotEmpty())
+            assertTrue(layer.centerline.isNotEmpty())
+        }
+    }
+
+    @Test
+    fun `glyph layers wobble in slot space with the pre-divided half-width`() {
+        val model = requireNotNull(parsePebbleSvg(composedSvg))
+        assertEquals(PebbleSvgModel.Layer.Kind.GLYPH, model.layers[1].kind)
+        val art = WobbleRenderer.pebbleArt(composedSvg, model)
+        // The glyph's ink is in the raw 200-box (pre-transform): its extent
+        // must be ~200 units, not the 150 the 0.75 layer scale would give.
+        val xs =
+            art.layers[1]
+                .ink
+                .flatten()
+                .map { it.x }
+        assertTrue("glyph ink looks canvas-spaced: ${xs.max() - xs.min()}", xs.max() - xs.min() > 170)
+    }
+
+    @Test
+    fun `space rule scales amplitude, frequency and step`() {
+        val params = WobbleParams.scaled(260.0, 310.0)
+        val normalization = 200.0 / 310.0
+        assertEquals(18 / normalization, params.amplitude, 1e-12)
+        assertEquals(0.024 * normalization, params.frequency, 1e-12)
+        assertEquals(2 / normalization, params.flattenStep, 1e-12)
+        assertEquals(5, params.octaves)
+    }
+
+    @Test
+    fun `degenerate space falls back to canonical params`() {
+        val params = WobbleParams.scaled(0.0, 0.0)
+        assertEquals(WobbleParams.CANONICAL.amplitude, params.amplitude, 0.0)
+        assertEquals(WobbleParams.CANONICAL.frequency, params.frequency, 0.0)
+    }
+
+    @Test
+    fun `all nine backdrop assets parse and wobble`() {
+        for (size in ValenceSizeGroup.entries) {
+            for (polarity in ValencePolarity.entries) {
+                val name = "${size.key}-${polarity.key}"
+                val art =
+                    requireNotNull(WobbleRenderer.backdropArt(name, backdropAsset(size, polarity))) {
+                        "backdrop art failed for $name"
+                    }
+                assertTrue(art.contours.isNotEmpty())
+                assertTrue(art.viewBox.width > 0)
+                assertTrue(art.viewBox.height > 0)
+            }
+        }
+        // The only evenodd asset is large-lowlight (it carves a hole).
+        val lowlight = WobbleRenderer.backdropArt(backdropAsset(ValenceSizeGroup.LARGE, ValencePolarity.LOWLIGHT))
+        assertEquals(true, lowlight?.usesEvenOddFill)
+        val neutral = WobbleRenderer.backdropArt(backdropAsset(ValenceSizeGroup.MEDIUM, ValencePolarity.NEUTRAL))
+        assertEquals(false, neutral?.usesEvenOddFill)
+    }
+
+    @Test
+    fun `asset parsing survives on synthetic markup and rejects garbage`() {
+        val asset =
+            """
+            <svg width="200" height="100" viewBox="0 0 200 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M10 50 C 10 10, 190 10, 190 50 C 190 90, 10 90, 10 50 Z" fill="#FF00FF"/>
+            </svg>
+            """.trimIndent()
+        val art = WobbleRenderer.backdropArt(asset)
+        assertNotNull(art)
+        assertEquals(PebbleSvgModel.ViewBox(0f, 0f, 200f, 100f), art?.viewBox)
+        assertEquals(false, art?.usesEvenOddFill)
+        assertNull(WobbleRenderer.backdropArt("<svg></svg>"))
+    }
+
+    @Test
+    fun `glyph ink parses carve strokes and caches by content`() {
+        val d = "M30,30 Q60,80 100,100 L170,170"
+        val first = WobbleRenderer.glyphInk(d, width = 6.0)
+        val second = WobbleRenderer.glyphInk(d, width = 6.0)
+        assertNotNull(first)
+        assertSame(first, second)
+        // A different width is different ink.
+        val wider = WobbleRenderer.glyphInk(d, width = 10.0)
+        assertNotSame(wider, first)
+        // Unparseable input falls back to null (caller strokes plainly).
+        assertNull(WobbleRenderer.glyphInk("not a path", width = 6.0))
+    }
+
+    private fun backdropAsset(
+        size: ValenceSizeGroup,
+        polarity: ValencePolarity,
+    ): String {
+        val file = File("src/main/res/raw/outline_${size.key}_${polarity.key}.svg")
+        check(file.exists()) { "Missing outline asset: ${file.absolutePath}" }
+        return file.readText()
+    }
+}

--- a/apps/android/app/src/test/resources/WobbleGolden.json
+++ b/apps/android/app/src/test/resources/WobbleGolden.json
@@ -1,0 +1,406 @@
+{
+  "comment": "Golden values for the SVG 1.1 §15.19 fractalNoise port (issue #555 wobble). Generated from the design playground's reference JS. Regenerate with the script in the PR description if the algorithm ever changes.",
+  "seed": 3,
+  "lcg": [
+    50421,
+    847425747,
+    572982925,
+    807347327,
+    1284843143,
+    1410633816,
+    303082632,
+    78585340,
+    81366475,
+    1726745833
+  ],
+  "latticePrefix": [
+    153,
+    245,
+    237,
+    129,
+    190,
+    122,
+    232,
+    177,
+    142,
+    97,
+    223,
+    234,
+    158,
+    233,
+    98,
+    53
+  ],
+  "gradientSamples": [
+    {
+      "channel": 0,
+      "index": 0,
+      "x": -0.23745309047699006,
+      "y": -0.9713990064967775
+    },
+    {
+      "channel": 1,
+      "index": 0,
+      "x": -0.9596285438852137,
+      "y": 0.28127043527670054
+    },
+    {
+      "channel": 0,
+      "index": 255,
+      "x": 0.6933422110959913,
+      "y": 0.7206084778244853
+    },
+    {
+      "channel": 1,
+      "index": 511,
+      "x": 0.8918272423909417,
+      "y": -0.4523761374446806
+    }
+  ],
+  "turbulence": [
+    {
+      "channel": 0,
+      "x": 0,
+      "y": 0,
+      "frequency": 0.024,
+      "octaves": 5,
+      "value": 0
+    },
+    {
+      "channel": 0,
+      "x": 10.5,
+      "y": 20.25,
+      "frequency": 0.024,
+      "octaves": 5,
+      "value": 0.18838218822234745
+    },
+    {
+      "channel": 0,
+      "x": 50,
+      "y": 50,
+      "frequency": 0.024,
+      "octaves": 5,
+      "value": 0.08299357848410477
+    },
+    {
+      "channel": 0,
+      "x": 123.456,
+      "y": 78.9,
+      "frequency": 0.024,
+      "octaves": 5,
+      "value": -0.02899392361449355
+    },
+    {
+      "channel": 0,
+      "x": 199,
+      "y": 3.75,
+      "frequency": 0.024,
+      "octaves": 5,
+      "value": 0.2232306418680975
+    },
+    {
+      "channel": 0,
+      "x": 260,
+      "y": 310,
+      "frequency": 0.024,
+      "octaves": 5,
+      "value": -0.0723071624679829
+    },
+    {
+      "channel": 1,
+      "x": 0,
+      "y": 0,
+      "frequency": 0.024,
+      "octaves": 5,
+      "value": 0
+    },
+    {
+      "channel": 1,
+      "x": 10.5,
+      "y": 20.25,
+      "frequency": 0.024,
+      "octaves": 5,
+      "value": 0.04551141080019032
+    },
+    {
+      "channel": 1,
+      "x": 50,
+      "y": 50,
+      "frequency": 0.024,
+      "octaves": 5,
+      "value": 0.36949423792173397
+    },
+    {
+      "channel": 1,
+      "x": 123.456,
+      "y": 78.9,
+      "frequency": 0.024,
+      "octaves": 5,
+      "value": 0.06305283995791416
+    },
+    {
+      "channel": 1,
+      "x": 199,
+      "y": 3.75,
+      "frequency": 0.024,
+      "octaves": 5,
+      "value": -0.1398656166041451
+    },
+    {
+      "channel": 1,
+      "x": 260,
+      "y": 310,
+      "frequency": 0.024,
+      "octaves": 5,
+      "value": 0.08156449977271564
+    },
+    {
+      "channel": 0,
+      "x": 0,
+      "y": 0,
+      "frequency": 0.024,
+      "octaves": 1,
+      "value": 0
+    },
+    {
+      "channel": 0,
+      "x": 10.5,
+      "y": 20.25,
+      "frequency": 0.024,
+      "octaves": 1,
+      "value": -0.0009228992146396026
+    },
+    {
+      "channel": 0,
+      "x": 50,
+      "y": 50,
+      "frequency": 0.024,
+      "octaves": 1,
+      "value": 0.04375626049253826
+    },
+    {
+      "channel": 0,
+      "x": 123.456,
+      "y": 78.9,
+      "frequency": 0.024,
+      "octaves": 1,
+      "value": -0.06831204223238257
+    },
+    {
+      "channel": 0,
+      "x": 199,
+      "y": 3.75,
+      "frequency": 0.024,
+      "octaves": 1,
+      "value": 0.21747182058393044
+    },
+    {
+      "channel": 0,
+      "x": 260,
+      "y": 310,
+      "frequency": 0.024,
+      "octaves": 1,
+      "value": 0.20324762266163648
+    },
+    {
+      "channel": 1,
+      "x": 0,
+      "y": 0,
+      "frequency": 0.024,
+      "octaves": 1,
+      "value": 0
+    },
+    {
+      "channel": 1,
+      "x": 10.5,
+      "y": 20.25,
+      "frequency": 0.024,
+      "octaves": 1,
+      "value": 0.10795596163599738
+    },
+    {
+      "channel": 1,
+      "x": 50,
+      "y": 50,
+      "frequency": 0.024,
+      "octaves": 1,
+      "value": 0.25191707396817964
+    },
+    {
+      "channel": 1,
+      "x": 123.456,
+      "y": 78.9,
+      "frequency": 0.024,
+      "octaves": 1,
+      "value": 0.13842217802614254
+    },
+    {
+      "channel": 1,
+      "x": 199,
+      "y": 3.75,
+      "frequency": 0.024,
+      "octaves": 1,
+      "value": -0.0715833518117924
+    },
+    {
+      "channel": 1,
+      "x": 260,
+      "y": 310,
+      "frequency": 0.024,
+      "octaves": 1,
+      "value": 0.07869911812015118
+    },
+    {
+      "channel": 0,
+      "x": 0,
+      "y": 0,
+      "frequency": 0.05,
+      "octaves": 3,
+      "value": 0
+    },
+    {
+      "channel": 0,
+      "x": 10.5,
+      "y": 20.25,
+      "frequency": 0.05,
+      "octaves": 3,
+      "value": 0.34596219673827633
+    },
+    {
+      "channel": 0,
+      "x": 50,
+      "y": 50,
+      "frequency": 0.05,
+      "octaves": 3,
+      "value": 0.23825661504920304
+    },
+    {
+      "channel": 0,
+      "x": 123.456,
+      "y": 78.9,
+      "frequency": 0.05,
+      "octaves": 3,
+      "value": 0.2805668878765744
+    },
+    {
+      "channel": 0,
+      "x": 199,
+      "y": 3.75,
+      "frequency": 0.05,
+      "octaves": 3,
+      "value": -0.1779311079461383
+    },
+    {
+      "channel": 0,
+      "x": 260,
+      "y": 310,
+      "frequency": 0.05,
+      "octaves": 3,
+      "value": -0.12108509786251015
+    },
+    {
+      "channel": 1,
+      "x": 0,
+      "y": 0,
+      "frequency": 0.05,
+      "octaves": 3,
+      "value": 0
+    },
+    {
+      "channel": 1,
+      "x": 10.5,
+      "y": 20.25,
+      "frequency": 0.05,
+      "octaves": 3,
+      "value": -0.06492939427224079
+    },
+    {
+      "channel": 1,
+      "x": 50,
+      "y": 50,
+      "frequency": 0.05,
+      "octaves": 3,
+      "value": 0.2403259677200646
+    },
+    {
+      "channel": 1,
+      "x": 123.456,
+      "y": 78.9,
+      "frequency": 0.05,
+      "octaves": 3,
+      "value": -0.019156743237803496
+    },
+    {
+      "channel": 1,
+      "x": 199,
+      "y": 3.75,
+      "frequency": 0.05,
+      "octaves": 3,
+      "value": 0.11171485078176954
+    },
+    {
+      "channel": 1,
+      "x": 260,
+      "y": 310,
+      "frequency": 0.05,
+      "octaves": 3,
+      "value": 0.03479009424787066
+    }
+  ],
+  "displaced": [
+    {
+      "x": 10,
+      "y": 10,
+      "amplitude": 18,
+      "frequency": 0.024,
+      "octaves": 5,
+      "xOut": 9.750638084807921,
+      "yOut": 11.343723348810332
+    },
+    {
+      "x": 100,
+      "y": 100,
+      "amplitude": 18,
+      "frequency": 0.024,
+      "octaves": 5,
+      "xOut": 99.56741289200951,
+      "yOut": 97.90535533528978
+    },
+    {
+      "x": 150.5,
+      "y": 42.25,
+      "amplitude": 18,
+      "frequency": 0.024,
+      "octaves": 5,
+      "xOut": 147.9840260570191,
+      "yOut": 41.67115151705082
+    },
+    {
+      "x": 199,
+      "y": 199,
+      "amplitude": 18,
+      "frequency": 0.024,
+      "octaves": 5,
+      "xOut": 200.84898144369353,
+      "yOut": 199.0452463683827
+    },
+    {
+      "x": 130,
+      "y": 155,
+      "amplitude": 27.900000000000002,
+      "frequency": 0.015483870967741935,
+      "octaves": 5,
+      "xOut": 122.57984429447768,
+      "yOut": 158.4086809277309
+    },
+    {
+      "x": 42.5,
+      "y": 297.75,
+      "amplitude": 27.900000000000002,
+      "frequency": 0.015483870967741935,
+      "octaves": 5,
+      "xOut": 41.74204120998505,
+      "yOut": 296.58008636449443
+    }
+  ]
+}


### PR DESCRIPTION
Part of #555 — the Android port of the iOS wobble spike (PR #556), wobble axis only. Boil and the web port remain tracked on the issue; **merging this must not close it**.

## Changes

**Wobble module — `apps/android/app/src/main/kotlin/app/pbbls/android/features/path/render/wobble/` (isolated, deletable, 1:1 mirror of the iOS module):**
- `SVGTurbulence.kt` — faithful Kotlin port of the SVG 1.1 §15.19 `feTurbulence type="fractalNoise"` reference implementation. Spec LCG via Schrage decomposition **in `Long`** (the `randA · (seed % randQ)` product grazes `Int.MAX_VALUE`); gradients generated for **all four RGBA channels in spec loop order** (the seeded stream position depends on it, even though wobble only reads R/G).
- `WobbleParams.kt` — canonical look (amplitude 18 / frequency 0.024 / octaves 5 / seed 3) + the §2.1 space rule. Displacement keeps the **minus** sign — matching the playground bake / feDisplacementMap inverse sampling per the 2026-07-13 decisions-log entry; issue §2.3's "+" stays superseded.
- `WobblePathFlattener.kt` — polylines with ~2-unit chords. Two Android adaptations of the iOS `CGPath` walk: input is Compose `PathNode`s, so relative/shorthand/arc commands are normalized here to the absolute move/line/quad/cubic/close primitives `CGPath` enumeration hands iOS; and an optional `Affine` bakes the enclosing-group transform in before subdivision (chords measured post-transform), standing in for iOS pre-transforming `combinedPath`.
- `WobbleOutlineBuilder.kt` — the leaky ink: offset both stroke edges (6-segment cap arcs for open paths, dual opposite-winding rings for closed ones, circles for dots), then displace every contour point independently so the width breathes. Emits the displaced centerline too, for the future draw-on mask.
- `WobbleRenderer.kt` — per-surface params/half-width derivation (same table as PR #556: canvas-scaled for `layer:shape`/`fossil` and backdrop assets, canonical in slot space with pre-divided half-width for `layer:glyph`, canonical + authored width/2 for glyph strokes) + three content-keyed LRU caches (pebbles by svg string, glyph strokes by `width|d`, backdrops by asset name).
- `WobbleShapes.kt` — Compose `Path` conversion of the pure geometry, kept separate so the pipeline stays JVM-testable and the module deletes cleanly.
- `WobbleFlags.kt` — the gate: `BuildConfig.DEBUG`, a compile-time constant `false` in Release (R8 strips the branches). Unshippable by construction, like iOS.

**Integration seams (three flag-gated call sites):**
- `PebbleStaticRender` — fills the wobbled ink instead of stroking; `remember(svg)` content-keys the per-composable conversion (the reactivity iOS needed commit 850009b for).
- `PebbleOutlineBackdrop` — native fill of the displaced silhouette for all nine bundled assets (evenodd honored for `outline_large_lowlight`); AndroidSVG fallback on parse failure.
- `GlyphImage` — committed carve strokes render as wobbled filled ink, with per-stroke fallback to the plain rounded stroke (souls cells, pills, picker, form row — Android has no carve canvas yet).
- `PebbleSvgModel` — now records each layer's **kind** and **own transform** (path transforms became layer-relative), mirroring iOS `PebbleSVGModel.Layer`, so glyph layers wobble in their raw 200-slot space. `PebbleStaticRender`'s stroke path composes `layer ∘ inner` back, so the non-wobble render is unchanged.

**No appear animation on Android yet**, so no mask reveal in this PR. `WobbleArt.centerline` and comments in `WobbleShapes.kt` pin the contract: a future draw-on must reveal the fill with a fat trimmed **mask** stroking along the wobbled centerline (the iOS `PebbleAnimatedRenderView` approach) — a trim cannot animate a fill.

**Tests — `apps/android/app/src/test/.../wobble/` (JVM, no Robolectric):**
- `WobbleGolden.json` — **byte-identical copy** of `apps/ios/PebblesTests/Wobble/WobbleGolden.json` in `src/test/resources/`. Regenerable only via `node apps/ios/Scripts/generate-wobble-golden.mjs <output>`; never hand-edited.
- `SVGTurbulenceTest` — raw LCG asserted **exactly**; lattice/gradients, turbulence and displacement within **1e-9** (the cross-platform parity gate from the decisions log).
- `WobblePathFlattenerTest` / `WobbleOutlineBuilderTest` / `WobbleRendererTest` — chord bounds, ring closure/dedup, winding/containment (pure-Kotlin winding-number stand-in for `CGPath.contains`), breathing check, cache identity, §2.1 scaling, slot-space guard for glyph layers, and a parse+wobble pass over all nine `res/raw` outline assets (read from disk, `LocalizationParityTest`-style).

All 208 JVM unit tests pass locally (26 new); ktlint clean.

## Notes

- Screenshot previews (debug variant) will now show the wobbled look — same review channel as the rest of the Android UI, useful for the visual sign-off against the #555 samples.
- Vertex-exact overlay with iOS is a non-goal for arcs (different arc→cubic conversion than iOS's SVG parser); parity is anchored by the noise/displacement fixtures, per PR #556.
- Labels/milestone mirror PR #556 (`feat`, `ui`, `android`, M40) — flagging per the PR checklist since I set them without a confirmation round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p1vjLiHmqEmN35cBQNdTn