### PR TITLE
docs(android): android port parity audit and M40 profile milestone design

### DIFF
--- a/docs/superpowers/specs/2026-07-16-android-parity-audit.md
+++ b/docs/superpowers/specs/2026-07-16-android-parity-audit.md
@@ -1,0 +1,179 @@
+# Android port — parity audit & roadmap
+
+> Full-source audit of `apps/android` against the iOS reference (`apps/ios/Pebbles`), taken after milestones **M38 · Android App** (bootstrap) and **M39 · Android Record Flow** both shipped. Ten feature areas were audited file-by-file and the findings adversarially verified: every headline "missing on Android" claim was attacked with full-tree greps (all 12 confirmed, zero false gaps), every DB object named below was verified to exist in `packages/supabase/supabase/migrations/`, and every deferral classification was checked against the two milestone design docs and the decisions log. This doc is the planning input for the next Android milestones; the first of them is specced in `2026-07-16-android-profile-design.md`.
+
+## 1. Where the port stands
+
+Shipped and verified working (M38 + M39 + follow-ons, PRs #533–#536, #538–#543, #550, #552–#553, #558–#559):
+
+- **Entry funnel** — Welcome (Rive splash, timed reveal, carousel), email/password auth with iOS-parity validation + consent metadata, Google hosted OAuth (PKCE, `pebbles://auth-callback`), session gate, 4-page onboarding with SharedPreferences gate. No Apple sign-in (M38 non-goal); onboarding illustrations are placeholders (risk 6).
+- **Path timeline** — `path_pebbles()` → week roll (static cairn) + header + pager, refocus rule, rows with outline + `render_svg` + rotated snap thumbs, long-press delete.
+- **Record flow** — create/edit/delete + detail read screen, shared `PebbleForm`, all four pickers (emotion/valence/soul/glyph), inline soul creation (with the D11 cache fix iOS doesn't have), karma flash pastille (D9/D10), `PebbleWriteService` with soft-success handling, snaps round-tripped on edit (risk 5 resolved as round-trip — an iOS-attached photo survives an Android edit).
+- **Render stack** — layer-tracing static renderer (#552), full wobble port with golden-fixture parity (#558), valence picker SVGs.
+- **Infra** — first repo CI, screenshot render-to-view artifact, Play internal-testing release pipeline (signed AAB, `versionCode` from run number), config-baked debug APK, ktlint, 38 JVM test files, en/fr localization with parity gate.
+
+Remaining to port: **~7,500–8,000 iOS-LOC equivalent** — roughly the back half of the app. **None of it needs DB work**: every view, RPC, table, bucket, and edge function the gaps depend on already exists, built for web/iOS.
+
+## 2. Verified defects in shipped code ([Fix] candidates, pre-flight)
+
+1. **`GlyphService.list()` excludes marketplace-entitled glyphs** (`features/glyph/services/GlyphService.kt` filters `userId == null || userId == me`). The M39 design explicitly put entitled-glyph selection **in scope** ("own, system, or marketplace-entitled … IS in scope", non-goals §), but the shipped filter narrows it with only a code comment as authority. Consequence: a user who bought glyphs on web/iOS **cannot attach them on Android** even though `can_use_glyph` permits it. Right-sized fix: union one `glyph_entitlements` read into `list()` — do **not** wait for the tabbed-picker port (#549).
+2. **Soul picker renders permanent zero counts** — `ReferenceDataService.fetchSouls` selects `id, name, glyph_id, glyphs(…)` without the `pebbles_count:pebble_souls(count)` aggregate, while `SoulTile` renders `soul.pebblesCount`; the wire model's default decodes to 0 for every soul. iOS fetches the aggregate. ~2-line select fix (mirror it in the `createSoul` select-back).
+3. **Missed M39 grooming pass** — PR #550 added screens but made zero Arkaik edits, violating the repo rule. Stale: `V-timeline` description ("no dock, stats, create or detail yet"), `V-pebble-detail` `platformStatuses.android: "idea"`, `V-karma-flash` still `platforms: ["ios"]` (the M39 doc explicitly instructed adding `android`), `V-profile` has a **null title** (schema violation the validator misses). `apps/android/CLAUDE.md` is equally stale: "No create / edit / delete / detail / stats yet" and the valence-picker "port when the create flow lands" note both predate M39. One retroactive grooming PR fixes all of it (docs-only).
+
+## 3. Parity matrix
+
+Classification: **DD** = deliberately deferred by a named design-doc decision (now unowned/coming due); **gap** = absent with no doc authority; **n/a** = does not translate to Android. Sizes are measured iOS LOC (`wc -l`), not guesses.
+
+### Profile surface (~1,125 LOC in-area + ~600 shared) — nothing exists on Android
+
+| Feature | iOS refs | Size | Class |
+|---|---|---|---|
+| PathBottomBar + Profile nav entry | `PathBottomBar.swift`, `PathView.swift` | ~107 | DD (M39 non-goal) |
+| PathStatsService + stats models | `PathStatsService.swift`, `KarmaSummary`, `ProfileEngagement`, `RippleSummary` | ~154 | DD |
+| RippleBadge stroke system (6 hand-ported beziers, tone table) | `Shared/Ripples/{RippleBadge,RippleStrokes,RippleStrokeColor}` | ~209 | DD (named in M39 "ripple on the timeline") |
+| ProfileView shell (banner, fetch, logout, card chrome) | `ProfileView`, `ProfileBanner`, `ProfileLogoutButton`, `Theme/ProfileCard`, `GlyphBanner`, `GlyphView` | ~412 | DD (M38 blanket non-goal) |
+| Stats card cluster (RipplesRow, AssiduityGrid, counters, DataTile) | `Profile/Components/*` | ~196 | DD |
+| Shortcuts row (Collections/Souls/Glyphs tiles) | `ProfileShortcutsRow`, `ProfileShortcutTile` | ~41 (+560 destinations) | DD |
+| Collections carousel card + `Collection` model (mode + count) | `ProfileCollectionsCard`, `ProfileCollectionCard`, `Collection`, `CollectionModeBadge` | ~296 | DD |
+| SettingsSheet (name, glyph swap, password/providers branch, legal) | `SettingsSheet.swift` + `PebblesList.swift` chrome | ~439 | DD |
+| Remove temporary Path sign-out | — | ~15 Android LOC | rides Profile |
+
+DB: `profiles(+glyph_id)`, `v_karma_summary` (latest def `20260411000005:405`), `v_ripple` (thresholds [1,5,9,13,17,21]), `get_profile_engagement(p_tz)` (`20260516104231:73`), `update_profile` (`:33` — null = keep; **cannot clear `glyph_id`** by design), `collections + collection_pebbles` aggregate — **all exist**.
+
+### Souls & collections CRUD (~1,700 LOC) — only the M39 picker fragments exist
+
+| Feature | Size | Class |
+|---|---|---|
+| Souls list (grid + SoulItem + delete) | ~286 | DD |
+| Collections list (+ mode badge, swipe-delete on iOS) | ~233 | DD |
+| Soul detail (pebbles via `pebble_souls!inner`, shared PebbleRow) | ~323 | DD |
+| Collection detail (+ `groupPebblesByMonth` util + test) | ~232 | DD |
+| Create/Edit soul with glyph row (M39 D12 pre-assigned "to a Profile milestone") | ~403 | DD |
+| Create/Edit collection (segmented mode, explicit-null encoder + tests) | ~257 | DD |
+
+DB: all owner-scoped RLS single-table writes (sanctioned pattern, no RPCs), `souls.glyph_id` NOT NULL with system default `4759c37c-…` and the server-side `souls_glyph_usable` trigger — **all exist**. ⚠️ Junction-naming trap: it's `pebble_souls` but `collection_pebbles` (not `pebble_collections`) — mind PostgREST embed strings.
+
+### Pebble media / snaps (~1,230 LOC) — read side shipped, write side absent
+
+| Feature | Size | Class |
+|---|---|---|
+| Photo attach + upload write path (picker, pipeline 1024px/≤1MB + 420px/≤300KB, `SnapUploadCoordinator` state machine with retry/compensating deletes, form Photo section, `ExistingSnapRow` + eager `delete_pebble_media`) | ~950 (+286 tests) | DD ("own milestone") |
+| Detail read-banner photo reveal (two-phase, `BannerAspect` 16:9/4:3/1:1 buckets) | ~280 | DD (D7 "drives no UI") |
+| Write/delete half of `PebbleSnapRepository` | ~90 | DD |
+
+DB: `pebbles-media` bucket (private, 1.5 MB, `image/jpeg` only, owner-scoped on first path segment, **no UPDATE policy** — delete + re-upload), `snaps` table, quota-raising `create_pebble`/`update_pebble`, `delete_pebble_media(p_snap_id) returns text` — **all exist**. ⚠️ `update_pebble` snaps semantics: replace-on-key-present, `[]` deletes all — Android's always-echo round-trip must stay. Android translation is friendlier than iOS: `PickVisualMedia` needs **no runtime permission** on minSdk 33, and `Bitmap.compress` strips EXIF inherently.
+
+### Glyph feature (~2,090 LOC) — models + flat picker + renderer only
+
+| Feature | Size | Class |
+|---|---|---|
+| Carve stack (canvas capture → RDP simplification ε1.5 → quadratic-midpoint SVG serializer, byte-parity with web/iOS) | ~565 (+175 tests) | DD (M39 non-goal) |
+| Glyph naming at carve + rename in store list | ~75 | gap |
+| Store surface (GlyphsListView Mine/Owned/Commu + GlyphTabBar) | ~300 | DD (M38 blanket) |
+| Market data layer (`GlyphMarketService`, models, `buy_glyph`) | ~270 | DD |
+| Detail drawer + SlideToConfirm + swap feedback (haptics/audio) | ~380 (+~100 service slices) | DD |
+| Tabbed picker harmonization (**= open issue #549**, inline buy, carve row) | ~211 rework | gap (server guard live; Android picker is pre-harmonization flat) |
+| GlyphView case-based chrome wrapper | ~122 | gap |
+| GlyphBanner (profile header + drawer) | ~74 | gap |
+
+DB: `v_glyph_market` (latest `20260701114205:405`), `buy_glyph` (error contract: `not_authenticated`, `not_in_market`, `cannot_buy_own`, `already_owned`, + `insufficient_karma` from `spend_karma`, returns jsonb `{entitlement_id, balance}`), `glyph_submissions`/`glyph_entitlements`, `can_use_glyph` + souls trigger — **all exist**. ⚠️ `refund_karma` is **service-role-only** since `20260629194418` — never plan it as a client call. iOS deliberately omits submit-to-market and favourites (web-only) — not Android gaps.
+
+### Lab / changelog (~1,025 LOC) — literally zero Android code
+
+| Feature | Size | Class |
+|---|---|---|
+| Log model + LogsService + lossy decode (4 feeds over `v_logs_with_counts`, reactions on `log_reactions` — deliberately no RPC) | ~317 (+249 tests) | DD (M38 blanket) |
+| Lab main screen (5 concurrent feeds, WhatsApp card, optimistic reactions) | ~254 | DD |
+| LogTimeline + ReactionButton | ~148 | DD |
+| AnnouncementRow + detail (V1 markdown subset — match, don't exceed) | ~183 | DD |
+| LogListView (see-all changelog/backlog) | ~123 | DD |
+| Entry point (ProfileLabCard) | ~36 | DD, blocked on Profile |
+
+⚠️ `logs.platform` check allows `project`/`infra`; iOS's strict enum silently drops those rows via lossy decode — Android must pick a matching behavior (decide in the Lab milestone spec).
+
+### Path completion & polish
+
+| Feature | Size | Class |
+|---|---|---|
+| Pebble draw-on/appear animation (`PebbleAnimatedRenderView` + `PebbleAnimationTimings`, keyed on `render_version`, settle pulse, reduce-motion static) | ~315 | **gap** — the only substantial iOS behavior inside M39's own scope dropped without a named decision |
+| Animated cairn week-roll (Rive `pbbls-cairn-states.riv`, `isSelected` + `strokeColor` data binding) | ~101 + asset | DD (documented fast-follow) — verify rive-android data-binding color support first; `packages/rive/pbbls-cairn-states` is missing its `.riv` extension |
+| Week-list reveal cascade + bottom gradient fade | ~50 | gap (code-comment-only skip) |
+| Week-roll initial centering + snap-to-cell | ~30 | gap |
+| Detail nav title + serif description font | ~15 | gap (serif face = maintainer asset decision) |
+
+### Entry funnel & auth completion
+
+| Feature | Size | Class |
+|---|---|---|
+| **Apple sign-in** via hosted web OAuth — supabase-kt ships an `Apple` provider; same Custom-Tab/PKCE/deep-link path as Google; **no nonce/native service needed**; provider already dashboard-configured (web uses `signInWithOAuth({provider:'apple'})`); Android's generic display-name patch already covers it | ~100–150 Android LOC | DD — highest-value auth item: iOS Apple-SSO accounts are hard-locked out of Android today |
+| Onboarding illustrations — **the four 720×720 PNGs exist in-repo** (iOS asset catalog); copy to `drawable-nodpi` + flip `OnboardingSteps` from `Placeholder` to `Asset` (~10 LOC). Risk 6's "needs maintainer design sources" only applies to crisper exports | ~10 LOC + 4 assets | DD, now trivially closable |
+| Welcome reveal layout animation (content slide-in + logo push-up) | ~30 | gap |
+| Carousel parity (crossfade vs pager wrap-around artifact, swipe timer reset) | ~60 | gap |
+
+Not gaps (absent on **every** surface, product decisions, not ports): password reset, email change, account deletion — see §5.
+
+### Karma & ripples
+
+| Feature | Size | Class |
+|---|---|---|
+| Ceramic sound on earn (`AudioService`, ambient/mix-with-others etiquette) | ~48 + 1 asset | DD (D9) — silent-mode policy needs a named Android decision |
+| Waveform-envelope haptic (`HapticsService` → `VibrationEffect.createWaveform`; precompute the ~20-point envelope offline) | ~150 | DD (D9) |
+| Karma Live Activity / Dynamic Island | ~129 retained-unused | **n/a** (Apple-only; abandoned even on iOS per 2026-07-01 decision) |
+| Web `/wallet` history page | — | **n/a** (iOS doesn't have it; iOS is the reference) |
+
+⚠️ `v_ripple.active_today` is UTC; iOS overrides client-side (`rippleWithLocalActiveToday`, "M22 follow-up"). Android should port the workaround; a server-side `p_tz` fix is a separate cross-surface decision.
+
+### Platform services, theme idioms, infra
+
+| Feature | Size | Class |
+|---|---|---|
+| Screen scaffold + toolbar idioms (`pebblesScreen`/`pebblesToolbarTitle`/`PebbleToolbarButton`) | ~140 | gap — consumed by ~38 iOS files; without it every new screen hand-rolls chrome |
+| List/form chrome (`pebblesList`/`pebblesListRow` segmented borders/`pebblesSectionHeader`) | ~132 | gap — prerequisite for Settings + all CRUD sheets |
+| `profileCard()` modifier | ~24 | gap |
+| Icon size tokens + per-icon vector-drawable pipeline (no SF Symbols on Android) | ~36 + assets | gap |
+| Shared `PebbleRow` (souls/collections detail lists) | ~108 | gap |
+| App icon + themed/monochrome icon + Android-12 splash theming | config + assets | gap — **default system icon is live on the Play internal track**; blocked on maintainer's layered design source |
+| Predictive back not actually enabled (`android:enableOnBackInvokedCallback` unset despite being a stated minSdk-33 rationale) | 1 attr + 5-site BackHandler audit | gap |
+| `rememberSaveable` draft persistence | small Saver | DD (D4/risk 7) — costlier on Android than the iOS-parity framing suggests |
+| Crash reporting (Play vitals vs SDK) | decision | DD — needs a decisions-log entry, symmetric with iOS |
+| Screenshot tests as regression gate | config | DD (adoption path documented) |
+| `UUID+Identifiable`, widgets/Glance | — | n/a |
+
+## 4. Cross-cutting findings (no area owned these)
+
+1. **Google Play compliance beyond the icon** — the Data Safety form, a privacy-policy URL, and store-listing assets gate any promotion past internal testing. **Account deletion is a Play policy hard blocker** for production: no surface has it, no delete-account RPC/edge function exists — it needs a cross-surface design (cascade over pebbles, karma ledger, storage, glyphs with entitlements), not an Android-first port.
+2. **Auth session lifecycle** — expired/revoked refresh-token behavior, token storage location/encryption, and re-auth UX are untested on Android beyond the initial gate.
+3. **Reference-slug catalog sync** — adding an emotion/domain server-side now requires touching iOS (`ReferenceSlugs` + xcstrings) **and** Android (`ReferenceSlugs.kt` + both `strings.xml`) in lockstep; each platform's parity test only covers itself. Process note for `packages/supabase` PRs.
+4. **Font-scaling a11y** — several Android layouts pin dp heights (e.g. the 110.dp carousel pager) under sp-scaled text; no pass has been done on either platform. TalkBack has never been validated on-device (no instrumented tests, SDK-less maintainer loop).
+5. **Rendering performance** — AndroidSVG re-parse per row bind, Coil cache sizing, and cairn-Rive per-cell allocation are unmeasured; watch when the timeline grows.
+6. **Offline is a non-goal on every surface** but recorded nowhere — worth one decisions-log line so it stops being re-litigated.
+7. **Wobble experiment** — `WOBBLE_ENABLED` is baked into internal-testing releases; **flip to `'false'` in `android-release.yml` before any public-track promotion** (2026-07-14 decision).
+8. **Uncaptured expired deferral** — M38 D5 deferred DataStore "until real settings exist"; the Settings port is that moment. (Resolution proposed in the M40 spec: still not needed — settings live in Postgres, not local prefs.)
+
+## 5. Roadmap
+
+Proposed sequence. Every milestone is pure client work (zero migrations). Sizes are the measured iOS-LOC scope being ported.
+
+| Order | Milestone / batch | Contents | Size |
+|---|---|---|---|
+| now | **Pre-flight batch** (independent small PRs) | [Fix] entitled-glyph union in `GlyphService.list()` · [Fix] soul-picker `pebbles_count` aggregate · [Docs] retroactive M39 grooming (Arkaik + `apps/android/CLAUDE.md`) · [Feat] Apple sign-in (web OAuth) · [Feat] onboarding artwork (in-repo PNGs) | ~200 |
+| M40 | **Android Profile** (specced: `2026-07-16-android-profile-design.md`) | design-idiom kit → stats stack + bottom bar → profile shell + settings → souls management → collections management; retires the temporary sign-out | ~3,900 |
+| M41 | **Android Snaps** | photo attach/upload write path + form Photo section + existing-snap removal; detail-banner photo reveal (`BannerAspect`) | ~1,250 |
+| M42 | **Android Glyph studio & store** | carve stack + naming; GlyphView chrome; market data layer; store page (hosted by Profile shortcuts); detail drawer + slide-to-confirm (reduced feedback per the D9 precedent); tabbed picker — **closes #549**; rename; AudioService/HapticsService scaffolds | ~2,100 |
+| M43 | **Android Lab** | Log model/service, Lab screen, timeline components, announcement detail, see-all lists, reactions; Profile Lab card un-hides | ~1,060 |
+| rolling | **Polish bucket** (schedulable into milestone gaps) | pebble appear animation (the one undocumented in-scope drop — highest polish priority) · cairn Rive · reveal cascade + fade · roll centering/snap · welcome reveal + carousel parity · karma sound + waveform haptic · predictive-back flag · `rememberSaveable` Saver · detail title/serif | ~900 |
+| cross-surface | **Not Android-only** | account deletion (Play blocker — own design) · password reset · `v_ripple` timezone server fix · crash-reporting decision · app icon/splash (maintainer assets) · Play listing/Data Safety | — |
+
+**Why Profile first:** five of the six other work streams dead-end into it — souls/collections lists are unreachable without the shortcuts row, the Lab card and glyph store page need the shell, the bottom bar's three tap targets need a Profile destination, the M39 D12 soul-glyph debt was pre-assigned to it, and the temporary Path sign-out only retires with it. It also carries the design-idiom kit (toolbar/list/card chrome) that every later screen consumes — porting Lab or the store first would hand-roll chrome that immediately drifts.
+
+**M41 vs M42 order is swappable.** Snaps-first favors content parity (photos already exist cross-surface and are invisible in Android's detail view); glyphs-first favors creation parity (Android users cannot create glyphs at all) and closes #549 sooner. Snaps has zero dependency on M40; glyphs needs M40's stats service (karma balance) and Profile host. Recommendation stands: snaps first. #549 should be re-homed from M39 into the glyph milestone (maintainer call) — the pre-flight entitled-glyph [Fix] removes its urgency.
+
+**Issue/label conventions carried forward:** one species label per issue, `android` scope label, sub-projects A–E each own issue + spec + plan + PR, milestone naming `M4x · Android <name>` (GitHub numbering may drift from draft numbering, per the M38/M39 precedent).
+
+## 6. Corrections to prior doc claims (found during verification)
+
+- The junction table is `collection_pebbles` (not `pebble_collections`); its sibling is `pebble_souls` — the two are named in opposite orders.
+- `delete_pebble`'s latest definition is `20260411000005:361` (the `20260426000002` migration touches `update_pebble` + `delete_pebble_media` only).
+- `v_karma_summary`'s latest definition is `20260411000005:405`; `20260629194621` created `v_wallet_summary`, it did not revise `v_karma_summary`.
+- `handle_new_user` still does not copy consent timestamps into `profiles` — the open fix(db) both mobile clients' comments reference remains open.
+- iOS `SnapImageView.swift` is dead code (zero call sites) — do not port it. `PebbleMetaPill`/`PebblePillFlow` are legacy and unused — Android correctly ported the SurfaceTile-era read view.

--- a/docs/superpowers/specs/2026-07-16-android-profile-design.md
+++ b/docs/superpowers/specs/2026-07-16-android-profile-design.md
@@ -1,0 +1,134 @@
+# Android Profile — profile surface, stats, settings, souls & collections management
+
+> Milestone-level design drafted as **"M40 · Android Profile"** — GitHub milestone numbering may differ, as it did for M38/M39 (docs referring to "M40" mean this milestone). Seven PRs: a small pre-flight batch (two `[Fix]` + one `[Docs]` grooming PR, shared with the parity audit's roadmap) plus five sub-projects **A–E**, each its own issue + spec + plan + PR, per the M38/M39 precedent. Foundation: the parity audit (`docs/superpowers/specs/2026-07-16-android-parity-audit.md`), the M38 bootstrap, and the M39 record flow. Every DB object this milestone touches already exists — it is a pure client milestone.
+
+## Goal
+
+Give the Android app its Profile hemisphere, 1:1 with iOS: a Path bottom bar (profile entry + karma count + ripple badge, live-refreshed after every write), the Profile screen (glyph identity banner, shortcuts row, stats card with ripple level/assiduity grid/counters, collections carousel, logout), a Settings surface (display name, profile glyph swap, password-or-providers branch, legal links), and full souls & collections management (lists, detail views with their tagged pebbles, create/edit — including the soul glyph row that M39 D12 explicitly parked "to a Profile milestone"). The milestone retires the temporary sign-out button on PathScreen and ends with the on-device round-trip: record a pebble → watch karma/ripple move on the bar → open Profile → manage a soul's glyph and a collection's mode → change display name + profile glyph in Settings → sign out from Profile.
+
+The finished iOS app is the reference implementation. Where this design says "mirror X", read the named iOS file under `apps/ios/Pebbles/` and port its structure, not just its behavior (`apps/android/CLAUDE.md` rule).
+
+## Non-goals
+
+- **Lab.** `ProfileLabCard` does not ship — the card is omitted (not stubbed) until the Lab milestone; ProfileView composes without it.
+- **Glyph store / marketplace / carving.** The shortcuts row ships **two tiles** (Collections, Souls); the Glyphs tile lands with the glyph milestone. The soul glyph row and Settings glyph swap use the existing picker (own + system + entitled after pre-flight Fix-1) — selection-only, no tabs, no buy. #549 stays out of scope here.
+- **Karma sound + waveform haptics** (D9 stands), **wallet history** (web-only; iOS is the reference), **ripples explainer sheet** (#446, iOS-first).
+- **Account deletion, password reset, email change.** Absent on every surface; cross-surface product decisions, not ports (audit §4/§5). Settings shows email read-only, exactly like iOS.
+- **Assiduity/ripple server-side timezone fix.** Android ports the iOS client-side `active_today` override verbatim (D3 below); fixing `v_ripple` server-side is a separate cross-surface decision.
+- **Swipe-to-delete, tablet layouts, Play distribution changes.**
+
+## Background: what exists today
+
+- **iOS shape to mirror** — `PathView` pins `PathBottomBar` (62 LOC) under the New-pebble button; all three tap targets push `ProfileView` (136 LOC) via NavigationStack. `PathStatsService` (80 LOC) loads `v_karma_summary`, `v_ripple`, and `get_profile_engagement(p_tz)` in parallel with per-source error isolation, shared by PathView and ProfileView, `refresh()`ed after every create/edit/delete. ProfileView composes `ProfileBanner` (GlyphBanner: 96pt glyph or dashed carve placeholder + hand-font name + "Member since"), `ProfileShortcutsRow`, `ProfileStatsCard` (RipplesRow = RippleBadge + level headline + "X more pebbles to level Y" + 28-cell AssiduityGrid; then Days/Pebbles/Karma DataTiles), `ProfileCollectionsCard` (140pt tile carousel with `collection_pebbles(count)` aggregate), `ProfileLogoutButton`, and a gear button presenting `SettingsSheet` (307 LOC + 132 LOC of `PebblesList` grouped-row chrome). Lists/details/sheets: `SoulsListView`/`CollectionsListView`, `SoulDetailView`/`CollectionDetailView` (+ `GroupPebblesByMonth`), `Create/EditSoulSheet` (glyph row → GlyphPickerSheet), `Create/EditCollectionSheet` (segmented mode, explicit-null encoder), shared `PebbleRow` (108 LOC) for detail pebble lists.
+- **Android already owns** (shrinks the port materially): `GlyphPickerSheet` with the exact API Settings/soul-edit need (`currentGlyphId` + `onSelected(Glyph)`), `GlyphImage` stroke renderer, `SurfaceTile`, `LegalDocs` Custom-Tab launcher, Reenie Beanie hand-font tokens, `SoulWithGlyph` model + `SoulRow` count-aggregate decode pattern, `EditPebbleScreen`/`PebbleDetailScreen`/`PebbleWriteService.delete` for the detail screens' pebble rows, `ReferenceDataService.createSoul/refreshSouls/refreshCollections`, and the sign-out plumbing itself (only its Profile home is missing).
+- **DB contract (verified, all existing):** `v_karma_summary` (`20260411000005:405`), `v_ripple` (`20260516000001`; level thresholds [1,5,9,13,17,21]; `active_today` is UTC), `get_profile_engagement(p_tz text)` (`20260516104231:73`), `update_profile(p_display_name, p_glyph_id)` (`:33`; null = don't change; **cannot clear glyph_id** — a future "remove glyph" needs a dedicated flag, do not improvise), `profiles.glyph_id`, `souls` + `souls_glyph_usable` trigger, `collections` (mode check `stack/pack/track`, nullable) + owner RLS CRUD, junctions `pebble_souls` / **`collection_pebbles`** (opposite name orders — mind embed strings), `delete_pebble` (`20260411000005:361`). Souls/collections writes are sanctioned direct single-table calls; no new RPCs anywhere.
+
+## Milestone-level settled choices
+
+- **Scope:** bottom bar + stats stack + profile shell + settings + souls & collections management, in five sub-projects. If the milestone balloons, the pre-agreed slice is **D/E (souls, collections) slip to a follow-on milestone** with their shortcut tiles hidden — A–C stay one unit.
+- **iOS is the reference; deviations are named decisions** (D1, D5, D7, D11–D13); everything else ports structurally.
+- **Two shipped-defect fixes ride as pre-flight** (audit §2): entitled-glyph union in `GlyphService.list()`, soul-picker `pebbles_count` aggregate — plus the retroactive M39 grooming `[Docs]` PR (Arkaik + `apps/android/CLAUDE.md`).
+
+## Sub-project decomposition
+
+Five sub-projects, sequenced **A → B → C → (D ∥ E)**. Pre-flight fixes land first (independent).
+
+### A — Design-system pass 2: screen/toolbar/list/card idioms, icon tokens, shared components
+
+The idiom kit ~38 iOS files consume; porting Profile screens without it guarantees hand-rolled drift. Mirrors how sub-project B preceded C/D in the bootstrap.
+
+- `PebblesScreen` scaffold + `PebblesTopBar` (centered meta-token title, leading/trailing text-button slots; semantics `heading()` for TalkBack) — refactor M39's hand-rolled `CreateTopBar` onto it (mirror `Theme/{PebblesScreen,PebblesToolbarTitle,PebbleToolbarButton}.swift`).
+- `PebblesListSection` / row-position segmented 1pt borders / `pebblesSectionHeader` (mirror `Theme/PebblesList.swift` — per-corner radii by row position; explicit divider between rows).
+- `Modifier.profileCard()` (mirror `Theme/ProfileCard.swift`).
+- `PebblesIcon` size tokens + this milestone's vector-drawable batch (gear, person, sparkle, calendar, fossil-shell, alternating-current, chevron-right, stack, person-pair, scribble, plus) — hand-traced, no icon library (established convention).
+- Shared `PebbleRow` composable (mirror `Components/PebbleRow.swift`: outline backdrop + render_svg thumb + name/date + long-press delete slot) and `GlyphView` case wrapper + `GlyphBanner` (mirror `Features/Glyph/Views/{GlyphView,GlyphBanner}.swift`; extract PebbleForm's private `DashedPlaceholder` into it).
+- Screenshot previews for every idiom.
+
+Issue title: `[Feat] Android design-system pass 2: screen/toolbar/list/card idioms, icon tokens, shared glyph & pebble rows` — labels: `feat`, `android`, `ui`.
+
+### B — Stats stack: PathStatsService, ripple badge, bottom bar
+
+- **`PathStatsService`** analog (D2): plain class per D4-bootstrap, three parallel loads with per-source error isolation, idempotent `load()` + `refresh()`, new CompositionLocal; models `KarmaSummary`, `ProfileEngagement`, `RippleSummary` (port the [1,5,9,13,17,21] thresholds with the migration-pointing comment; `pebblesToNextLevel`/`nextLevel`).
+- **RippleBadge stack** (D4): six bezier ring shapes into Compose `Path` (44×44 viewBox scale), layered opacities 0.33/0.66/1.0, digit overlay, a11y label; `rippleStrokeTone` pure function unit-tested against the iOS truth table; screenshot preview grid (7 levels × active/inactive).
+- **`PathBottomBar`** under NewPebbleButton: profile button, karma stat, ripple badge; `rippleWithLocalActiveToday` override ported verbatim (D3); `stats.refresh()` wired into PathScreen's create/edit/delete success paths; profile tap target lands stubbed (wired in C).
+- `chunkAssiduity` pure helper + test.
+- Unit tests: decoding (incl. `boolean[]` RPC row), thresholds, tone table, chunking.
+
+Issue title: `[Feat] Android path stats: PathStatsService, ripple badge, bottom bar` — labels: `feat`, `android`, `ui`, `core`.
+
+### C — Profile shell + settings + authed navigation
+
+- **Authed NavHost** (D1): `path` (start) → `profile` → `souls`/`collections` list/detail routes; predictive back enabled and the five existing BackHandler sites re-verified.
+- **ProfileScreen** (mirror `ProfileView.swift`): profiles single-row fetch + glyph strokes fetch, `GlyphBanner` header (carve placeholder when glyph-less), two-tile shortcuts row (D11), stats card cluster (RipplesRow + AssiduityGrid + counters over B's service), collections carousel card + `Collection` model with mode/count (D10), logout button; load/error/retry treatment (D13).
+- **SettingsScreen** (D5, mirror `SettingsSheet.swift`): tappable 120pt glyph header → existing GlyphPickerSheet; Name field + read-only Email; SSO-vs-email branch from session identities (providers list vs new-password field); inline save error; Legal section → `openLegalDoc`. Save sends only changed fields: `update_profile` then `auth.updateUser { password }`; `onSaved` patches ProfileScreen state.
+- **Retire the temporary sign-out**: remove PathScreen's TextButton + `onSignOut` threading; sign-out lives on Profile.
+- Screenshot previews: profile (loading/loaded/glyph-less), settings (email vs SSO account, dirty/error states).
+
+Issue title: `[Feat] Android profile screen, settings, authed navigation` — labels: `feat`, `android`, `ui`, `core`.
+
+### D — Souls management
+
+- Shared `SoulItem` (lift/replace the private `SoulTile` in SoulPickerSheet; 4-case styling per the #459 contract), `SoulsListView` grid (+ create entry, long-press delete per D7), `SoulDetailView` (header + `pebble_souls!inner` pebble list on shared PebbleRow, tap → EditPebbleScreen, delete → `delete_pebble`), `CreateSoul`/`EditSoul` full forms with the glyph row (D8/D9) + `SoulDraft`/payloads, `SystemGlyph` const; `refreshSouls()` after mutations.
+- Plural resources for pebble counts (en/fr).
+
+Issue title: `[Feat] Android souls management: list, detail, create/edit with glyph row` — labels: `feat`, `android`, `ui`, `core`.
+
+### E — Collections management
+
+- `Collection` model consolidation (mode + `[{count}]` unwrap — SoulRow pattern), `CollectionModeBadge`, `CollectionsListView` (long-press delete per D7, pull-to-refresh), `CollectionDetailView` + `groupPebblesByMonth` (java.time `YearMonth`, locale-aware headers, JVM test mirroring `GroupPebblesByMonthTests`), `CreateCollection`/`EditCollection` forms (segmented mode picker, explicit-null mode encoder + exact-keyset unit tests mirroring the iOS encoding suites); carousel wiring back into ProfileScreen.
+- FR labels for Stack/Pack/Track confirmed with the maintainer (product vocabulary — no machine translation).
+
+Issue title: `[Feat] Android collections management: list, detail, create/edit` — labels: `feat`, `android`, `ui`, `core`.
+
+**Dependencies:** pre-flight fixes are independent; A blocks B–E (idioms); B blocks C (bar + stats card); C blocks D and E (navigation entry + carousel host); D and E are independent of each other.
+
+## Core design decisions (settled)
+
+- **D1 — Authed navigation: pushes become a real NavHost; modals stay conditional composition.** iOS distinguishes *pushes* (Profile, lists, details — NavigationStack) from *modals* (create/detail/edit pebble — sheets/covers). M39's D5 cover pattern mapped the modals honestly; Profile's multi-level pushes (profile → list → detail → edit) would strain it. So: an authed `NavHost` (`path` start destination; profile/souls/collections routes) for pushes, while the pebble create/detail/edit covers inside PathScreen stay exactly as shipped. The auth gate itself remains conditional composition (RootScreen unchanged in shape). `android:enableOnBackInvokedCallback="true"` lands here — the navigation pass is the moment to re-verify all BackHandler sites (onboarding's unconditional consume, the save-guards).
+- **D2 — One shared `PathStatsService`; display-only, never a flash source.** Constructed in `PebblesApp`, provided by CompositionLocal, shared by the bar and Profile (a refresh from either is visible to both, iOS parity). Amounts on the karma pastille continue to come exclusively from edge-function `karma_delta` (M39 D10) — the stats service must never feed the flash.
+- **D3 — `active_today`: port the iOS client-side local-day override verbatim.** `v_ripple` compares against UTC `current_date`; iOS recomputes from loaded pebbles in the device calendar (`rippleWithLocalActiveToday`, "M22 follow-up"). Android mirrors the workaround, comment included. Fixing `v_ripple` server-side (e.g. a `p_tz` param) is a deliberate cross-surface follow-up — not this milestone's only DB change.
+- **D4 — RippleBadge paths are transcribed, tone table is unit-tested.** Transcribe the six cubics from `RippleStrokes.swift` into Compose `Path` (44-unit viewBox, DrawScope scale) — same approach as prior hand-ported shapes. `rippleStrokeTone(strokeId, level, activeToday)` ports as a pure function with a test asserting the full iOS truth table; screenshot grid is the visual gate.
+- **D5 — Settings is a full-screen route, not a sheet.** iOS stacks SettingsSheet → GlyphPickerSheet; per the never-stack-sheets rule, Settings becomes a pushed route (its text fields also avoid the ModalBottomSheet+IME caveat) and the glyph picker is its single ModalBottomSheet level. Save semantics mirror iOS exactly: dirty-check enabled Save, trimmed name, only-changed fields, `update_profile` (null = keep) then password update, stay-open-on-error.
+- **D6 — Souls/collections writes stay direct single-table client calls.** The sanctioned cross-surface pattern (AGENTS.md single-table exemption; iOS comments it). Glyph ownership on souls is enforced server-side by `souls_glyph_usable` — client filtering is defense-in-depth only. Pebble deletion inside detail views goes through the existing `delete_pebble` RPC path in `PebbleWriteService`.
+- **D7 — Delete affordance unifies on long-press `DropdownMenu` + confirm `AlertDialog` for both lists.** iOS is inconsistent (swipe for collections, context menu for souls); Android standardizes on the M39 D8 idiom everywhere. Named deviation; revisit only with the D8 discoverability trigger.
+- **D8 — Soul glyph row and Settings glyph swap use the existing flat picker (post-Fix-1: own + system + entitled).** The tabbed store picker (#549) belongs to the glyph milestone; the picker API (`currentGlyphId` + `onSelected`) already matches, so upgrading later is a drop-in.
+- **D9 — Detail → edit is a surface swap; edit forms are full-screen.** Edit-soul needs the glyph picker as its sheet level and both edit forms carry text fields, so they follow the Detail→Edit surface-swap pattern from M39 D5 rather than sheets.
+- **D10 — `Collection` gains mode + pebble_count; list screens fetch their own rows.** Extend the model with `CollectionMode` (mirroring the check constraint) and the `[{count: N}]` aggregate unwrap. iOS keeps list fetches in the views and uses ReferenceDataService only for the form's reference lists — mirror that; don't widen the cache contract.
+- **D11 — Shortcuts row ships two tiles; the Lab card is omitted.** Glyphs tile arrives with the glyph milestone, Lab card with the Lab milestone. Dead chrome is worse than temporarily-narrower parity. Named temporary deviation, reversed by those milestones.
+- **D12 — DataStore stays deferred (M38 D5 window closes: answer is "still no").** The Settings this milestone adds live in Postgres (`update_profile`), not local prefs; `hasSeenOnboarding` remains the only local flag and stays in SharedPreferences. Recording this here prevents re-litigation.
+- **D13 — Profile fetch gets Android's standard load/error/retry treatment.** iOS silently swallows a failed profiles fetch into an empty banner; Android's established screens (picker, path, detail) all have retry states — porting the silent swallow would be a regression against the port's own bar. Named deviation; a companion iOS quality issue may be filed rather than porting the gap.
+- **D14 — Member-since and month headers format via the active locale** (`java.time` + locale-aware patterns; never pinned — repo rule), counters use tabular figures (`FontFeatureSettings "tnum"` or the counter token).
+
+## Risks and open questions
+
+1. **Navigation refactor regression risk** — introducing the authed NavHost touches RootScreen/PathScreen wiring; the funnel gate must stay conditional composition. Mitigation: C's plan starts with a no-behavior-change refactor commit (PathScreen mounted as start destination) before any new route; on-device funnel pass is C's first checkpoint.
+2. **RippleBadge fidelity** — hand-transcribed cubics can drift subtly. Mitigation: the screenshot preview grid compared side-by-side with the iOS `RipplePreviewGrid` before B merges.
+3. **Predictive back** — flipping the manifest flag changes system-back visuals for all five existing BackHandler sites. Mitigation: explicit on-device back-flow pass (onboarding, create-with-dirty-draft, detail, edit) on the Play internal track.
+4. **Providers rendering for cross-platform accounts** — an account created on iOS with Apple SSO carries an `apple` identity; Apple branding on Android has usage rules. v1: text-only provider labels ("Apple", "Google") with no logo commitments; maintainer taste-check on device.
+5. **Asset dependency** — ~11 hand-traced vector drawables (A) and the Stack/Pack/Track FR vocabulary (E) need maintainer sign-off; neither blocks other sub-projects.
+6. **Milestone size** — ~3,900 iOS-LOC of scope vs M39's ~2,900. The pre-agreed slice (settled above): D/E split off with hidden tiles if A–C consume the budget.
+7. **`update_profile` cannot clear `glyph_id`** — the Settings glyph row must not offer "remove glyph" (iOS doesn't either); doing so would require a new RPC flag and is out of scope.
+8. **Stats freshness** — iOS refreshes stats after every write; Android's M39 reload paths currently reload only the timeline. B wires `refresh()` into all three write paths; verification includes watching the bar move after each.
+
+## Verification strategy
+
+Per repo reality: **CI green → unit tests → screenshot artifact → maintainer on device** (Play internal track).
+
+- **Pre-flight:** entitled glyph (bought on web) appears in the Android picker and attaches to a pebble + a soul (server trigger accepts); soul picker shows live counts; Arkaik validator green.
+- **A:** screenshot previews of every idiom; CreateTopBar refactor pixel-compares against the shipped M39 screenshots (no visual drift).
+- **B:** tone-table/threshold/chunking/decoding tests green; badge preview grid matches iOS side-by-side; on device: bar shows real karma/ripple; create a pebble → karma count and ripple state update without app restart; `active_today` flips correctly near local midnight vs UTC (the override's whole point).
+- **C:** on device: Profile round-trip (banner with real glyph + member-since; glyph-less account shows the carve placeholder), Settings — rename + glyph swap persist (verify `profiles` row), password change on an email account, providers list on an SSO account, legal links open; sign-out from Profile returns to Welcome; the temporary Path button is gone; back gestures behave at every level with predictive back on; fr pass.
+- **D:** on device: souls grid with live counts → detail lists the right pebbles → edit a soul's name + glyph (glyph visible on its pebble rows after) → delete a soul ("linked pebbles stay" verified — pebbles survive, links gone) → inline-create still works from the pebble form.
+- **E:** on device: collections list with mode badges → detail groups by month with localized headers → create with mode, edit clearing the mode (explicit-null actually clears the column — verify in dashboard) → delete; carousel on Profile reflects changes; **milestone exit round-trip** as stated in the Goal.
+
+## Arkaik
+
+As sub-projects land, update `docs/arkaik/bundle.json`: fix `V-profile`'s null title and mark it implemented on Android; update `V-souls-list`/`V-soul-detail`/`V-soul-create`/`V-soul-edit`, `V-collections-list`/`V-collection-detail`/`V-collection-create`/`V-collection-edit`, `F-manage-souls`/`F-manage-collections`; refresh `V-home`/`V-timeline` for the bottom bar (and consider the open question of merging them — maintainer call); `V-settings` platforms gains `android` when C lands. The pre-flight `[Docs]` grooming PR handles the M39 backlog (`V-karma-flash` platforms, `V-timeline` description, `V-pebble-detail` platformStatuses, `apps/android/CLAUDE.md` staleness). Run `node .claude/skills/arkaik/scripts/validate-bundle.js` on every bundle edit. **Lab Note:** a distributable build now exists (Play internal testing), so propose the single milestone-level bilingual note when E lands, per the M38/M39 rule — a human publishes it via the Lab admin; never write to `logs` from the dev loop.
+
+## Open questions deferred (not blocking)
+
+- Tabbed glyph picker + store (#549 → glyph milestone); Lab card + Lab milestone; Glyphs shortcut tile.
+- `v_ripple` server-side timezone fix (cross-surface; would supersede D3's ported workaround on all three clients).
+- Ripples explainer sheet (#446) / `V-mechanic-sheet` platform claims.
+- Whether `V-home` and `V-timeline` merge in Arkaik post-bottom-bar.
+- Companion iOS quality issue for D13 (silent profile-fetch swallow) — file, don't port.


### PR DESCRIPTION
No tracking issue — planning docs produced directly in-session (audit → spec → plan for the Android port's next steps).

## Changes

Two specification documents for the Android port's next development phase, following the M38/M39 milestone-doc conventions:

1. **`docs/superpowers/specs/2026-07-16-android-parity-audit.md`** (179 lines)
   - Full-source audit of `apps/android` against the iOS reference (`apps/ios/Pebbles`), taken post-M38/M39 — ten feature areas, adversarially verified (all 12 headline "missing" claims grep-confirmed against the full Android tree; every named DB object verified in migrations)
   - Parity matrix with measured iOS LOC per gap, classified deliberately-deferred / gap / platform-n/a
   - Two shipped-defect `[Fix]` candidates (entitled-glyph filter in `GlyphService.list()`, soul-picker `pebbles_count` aggregate) plus the missed M39 Arkaik/CLAUDE.md grooming pass
   - Cross-cutting findings: Play compliance incl. the account-deletion policy blocker, auth session lifecycle, reference-slug catalog sync, font-scaling a11y, rendering performance, offline non-goal, wobble release gate
   - Roadmap: pre-flight batch → Profile → Snaps → Glyph studio & store (closes #549) → Lab → rolling polish + cross-surface buckets — with the finding that **zero DB work is needed anywhere** (~7,500–8,000 iOS-LOC of pure client work remains)
   - Corrections to prior doc claims (junction naming `collection_pebbles` vs `pebble_souls`, `delete_pebble`/`v_karma_summary` latest-definition citations)

2. **`docs/superpowers/specs/2026-07-16-android-profile-design.md`** (134 lines)
   - Milestone-level design for the **Android Profile** milestone (drafted "M40"; created on GitHub as **M41 · Android Profile** — docs referring to "M40" mean this milestone, per the M38/M39 renumbering precedent): bottom bar + stats stack, profile shell, settings, souls & collections management; retires the temporary Path sign-out and closes the M39 D12 soul-glyph debt
   - Five sub-projects (A design-system pass 2 → B stats/ripple/bottom-bar → C profile shell + settings + authed NavHost → D souls ∥ E collections) plus the pre-flight `[Fix]`/`[Docs]` batch — issues #562–#569
   - 14 named design decisions (navigation model, `active_today` override, ripple-badge port strategy, settings-as-route, unified delete affordance, DataStore still-deferred resolution, etc.), risks, per-sub-project verification ladder, Arkaik update guidance

## Notes

- Docs-only: no code changes, no lint/build required (per task-size triage).
- Not user-facing → no Lab Note section.
- The pre-agreed slice if the milestone balloons: D/E split off with hidden shortcut tiles; A–C stay one unit.

## Checklist

- [x] PR title in conventional-commits format
- [x] Labels: `docs`, `android`
- [x] Milestone: **M41 · Android Profile** (created post-merge; the umbrella-spec PR rides the milestone it defines, per the #544/M39 precedent)
- [ ] Branch is UI-assigned (`claude/android-port-audit-plan-q1t8rh`), not `type/issueNumber-description` — noted for transparency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7ZRJbBPw65HQdW74p2Zi5