### PR TITLE
refactor(carve): reuse StrokeRenderer in saved preview

### DIFF
--- a/apps/web/components/carve/CarveEditor.tsx
+++ b/apps/web/components/carve/CarveEditor.tsx
@@ -8,6 +8,7 @@ import { useMarks } from "@/lib/data/useMarks"
 import { useHaptics } from "@/lib/hooks/useHaptics"
 import type { MarkStroke } from "@/lib/types"
 import { DrawingCanvas } from "@/components/carve/DrawingCanvas"
+import { StrokeRenderer } from "@/components/carve/StrokeRenderer"
 import { CarveToolbar } from "@/components/carve/CarveToolbar"
 import { StampPicker } from "@/components/carve/StampPicker"
 import { Input } from "@/components/ui/input"
@@ -90,23 +91,15 @@ export function CarveEditor({ onSaved }: CarveEditorProps) {
         <p className="text-lg font-medium" aria-live="polite">
           {name.trim() ? t("savedNamed", { name: name.trim() }) : t("saved")}
         </p>
+        {/* Reuse StrokeRenderer (like the live DrawingCanvas) so the saved
+            preview matches the canvas — including the petroglyph wobble (#555)
+            when enabled; it falls back to the plain stroke in production. */}
         <svg
           viewBox={GLYPH_VIEWBOX}
           className="w-full max-w-[200px] aspect-square"
           aria-hidden="true"
         >
-          {strokes.map((s, i) => (
-            <path
-              key={i}
-              d={s.d}
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={s.width}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="text-foreground"
-            />
-          ))}
+          <StrokeRenderer strokes={strokes} />
         </svg>
         <button
           onClick={handleNewMark}


### PR DESCRIPTION
Resolves #555

## Changes

**apps/web/components/carve/CarveEditor.tsx**
- Replaced inline SVG path rendering in the saved preview with `<StrokeRenderer>` component
- Removed 10 lines of duplicated stroke rendering logic
- Added explanatory comment noting that this ensures the preview matches the live canvas, including petroglyph wobble effects when enabled

## Notes

This change consolidates stroke rendering logic by reusing the existing `StrokeRenderer` component in the saved preview section. Previously, the preview rendered strokes inline with hardcoded SVG attributes, which could diverge from the live canvas rendering (especially when petroglyph wobble is enabled). Now both use the same component, guaranteeing visual consistency.

The `StrokeRenderer` component already handles the wobble effect gracefully — it applies it in development/preview but falls back to plain strokes in production, so this change is safe across all environments.

## Checklist
- [x] Branch name follows `type/issueNumber-description`
- [x] PR title uses conventional commits: `type(scope): description`
- [x] `npm run lint --workspace=apps/web` passes

https://claude.ai/code/session_01LPpNGSfSWbMUG5WoqTkzCR