### PR TITLE
feat(android): redesign pebble read view with snap frame overlay (#599)

### DIFF
--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/models/EmotionPalette.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/models/EmotionPalette.kt
@@ -3,22 +3,29 @@ package app.pbbls.android.features.path.models
 import androidx.compose.ui.graphics.Color
 
 /**
- * The four colors of an emotion category palette — mirrors iOS
- * `EmotionPalette.swift`. Initialized from the 8-digit `#RRGGBBAA` hex
- * strings stored on `emotion_categories` (hand-entered in Supabase Studio —
- * may carry stray whitespace, trimmed at this boundary). [fromHex] returns
- * `null` if any hex fails to parse; callers treat the palette as unavailable
- * and fall back to the brand accent.
+ * The colors of an emotion category palette — mirrors iOS `EmotionPalette.swift`.
+ * Initialized from the 8-digit `#RRGGBBAA` hex strings stored on
+ * `emotion_categories` (hand-entered in Supabase Studio — may carry stray
+ * whitespace, trimmed at this boundary). [fromHex] returns `null` if any hex
+ * fails to parse; callers treat the palette as unavailable and fall back to the
+ * brand accent.
+ *
+ * [dark] is the #599 addition: the small/medium Petroglyph backfill in dark
+ * mode (the "palette.dark" role). The sibling `shaded_color` column also exists
+ * on the view but has no Android consumer yet, so it is intentionally not
+ * modelled here.
  */
 data class EmotionPalette(
     val primary: Color,
     val secondary: Color,
     val light: Color,
     val surface: Color,
+    val dark: Color,
     val primaryHex: String,
     val secondaryHex: String,
     val lightHex: String,
     val surfaceHex: String,
+    val darkHex: String,
 ) {
     /** Pebble stroke color: `primary` in light mode, `secondary` in dark. */
     fun stroke(isDark: Boolean): Color = if (isDark) secondary else primary
@@ -53,26 +60,30 @@ data class EmotionPalette(
         }
 
     companion object {
-        /** Builds a palette from the four DB hex columns; null if any fails. */
+        /** Builds a palette from the DB hex columns; null if any fails. */
         fun fromHex(
             primaryHex: String,
             secondaryHex: String,
             lightHex: String,
             surfaceHex: String,
+            darkHex: String,
         ): EmotionPalette? {
             val trimmedPrimary = primaryHex.trim()
             val trimmedSecondary = secondaryHex.trim()
             val trimmedLight = lightHex.trim()
             val trimmedSurface = surfaceHex.trim()
+            val trimmedDark = darkHex.trim()
             return EmotionPalette(
                 primary = parseColor(trimmedPrimary) ?: return null,
                 secondary = parseColor(trimmedSecondary) ?: return null,
                 light = parseColor(trimmedLight) ?: return null,
                 surface = parseColor(trimmedSurface) ?: return null,
+                dark = parseColor(trimmedDark) ?: return null,
                 primaryHex = trimmedPrimary,
                 secondaryHex = trimmedSecondary,
                 lightHex = trimmedLight,
                 surfaceHex = trimmedSurface,
+                darkHex = trimmedDark,
             )
         }
 

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/models/EmotionWithPalette.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/models/EmotionWithPalette.kt
@@ -31,6 +31,8 @@ data class EmotionWithPaletteRow(
     val lightColor: String? = null,
     @SerialName("surface_color")
     val surfaceColor: String? = null,
+    @SerialName("dark_color")
+    val darkColor: String? = null,
 ) {
     fun toEmotionWithPalette(): EmotionWithPalette? {
         val palette =
@@ -39,6 +41,7 @@ data class EmotionWithPaletteRow(
                 secondaryHex = secondaryColor ?: return null,
                 lightHex = lightColor ?: return null,
                 surfaceHex = surfaceColor ?: return null,
+                darkHex = darkColor ?: return null,
             ) ?: return null
         return EmotionWithPalette(
             id = id ?: return null,

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/read/BannerAspect.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/read/BannerAspect.kt
@@ -3,27 +3,33 @@ package app.pbbls.android.features.path.read
 import kotlin.math.abs
 
 /**
- * Banner aspect-ratio bucket chosen for a source image — ports iOS
- * `BannerAspect.swift`. The pebble read banner snaps the source's
- * width/height ratio to the nearest of three fixed buckets — 16:9, 4:3, 1:1 —
- * so portrait or near-square uploads don't get cropped to a forced landscape
- * strip. Pure value type; trivially unit-testable.
+ * Aspect-ratio bucket chosen for a pebble's snap on the read view — ports iOS
+ * `BannerAspect.swift`. The snap's width/height ratio snaps to the nearest of
+ * three fixed buckets — 4:3 (landscape), 1:1, 3:4 (portrait) — so the imported
+ * photo reads at a natural shape instead of a forced strip (issue #599).
+ *
+ * These buckets replace the earlier 16:9/4:3/1:1 set: the redesigned page
+ * frames the whole picture (portrait included) with the Petroglyph overlapping
+ * its top-right, so a tall 3:4 crop is now first-class and the wide 16:9 strip
+ * is gone.
+ *
+ * Pure value type; trivially unit-testable.
  */
 enum class BannerAspect(
     /** Width / height for the bucket. */
     val ratio: Float,
 ) {
-    SIXTEEN_NINE(16f / 9f),
     FOUR_THREE(4f / 3f),
     SQUARE(1f),
+    THREE_FOUR(3f / 4f),
     ;
 
     companion object {
         /**
          * The bucket whose ratio is closest to [ratio] (absolute distance).
-         * Portrait sources (`ratio < 1`) always bucket to [SQUARE] since 1.0
-         * is the smallest candidate — no special case.
+         * Very wide sources collapse to [FOUR_THREE] and very tall ones to
+         * [THREE_FOUR] since those are the extreme candidates — no special case.
          */
-        fun nearest(ratio: Float): BannerAspect = entries.minByOrNull { abs(it.ratio - ratio) } ?: SIXTEEN_NINE
+        fun nearest(ratio: Float): BannerAspect = entries.minByOrNull { abs(it.ratio - ratio) } ?: SQUARE
     }
 }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/read/PebbleReadBanner.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/read/PebbleReadBanner.kt
@@ -1,21 +1,9 @@
 package app.pbbls.android.features.path.read
 
-import android.provider.Settings
 import android.util.Log
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.slideInVertically
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -24,18 +12,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import app.pbbls.android.features.path.models.EmotionPalette
 import app.pbbls.android.features.path.models.Valence
-import app.pbbls.android.features.path.models.ValenceSizeGroup
-import app.pbbls.android.features.path.render.PebbleStaticRender
 import app.pbbls.android.services.LocalSnapURLCache
-import app.pbbls.android.theme.PebblesTheme
 import coil3.SingletonImageLoader
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
@@ -43,28 +27,29 @@ import coil3.toBitmap
 
 private const val TAG = "pebble-read-banner"
 
-/** The decoded photo + its bucketed frame, resolved before layout (design D7). */
+/** Slot for the Petroglyph when it is the page heading (no snap). */
+private val HEADING_PETROGLYPH = 150.dp
+
+/** The decoded snap plus its bucketed frame, resolved before layout. */
 private data class BannerPhoto(
     val bitmap: ImageBitmap,
     val aspect: BannerAspect,
 )
 
 /**
- * Render banner for the detail sheet — ports iOS `PebbleReadBanner.swift`,
- * now with the two-phase photo reveal (M42 #582):
+ * Top zone of the pebble read view — the #599 redesign.
  *
- * 1. Phase 1 — the pebble render in its fixed 120dp slot, snap or not.
- * 2. Phase 2 — once the ORIGINAL rendition is signed + decoded, the photo
- *    slides in above the pebble in the [BannerAspect] bucket nearest its
- *    intrinsic ratio, bottom-padded by half the slot so the pebble overlaps
- *    its lower edge; the slot gains a rounded system-background backdrop.
+ * - **No snap** (or one that hasn't loaded / failed to load): the framed
+ *   [PebbleReadPetroglyph] centred as the page heading.
+ * - **Snap present**: once the ORIGINAL rendition is signed + decoded, the whole
+ *   picture shows at its nearest [BannerAspect] bucket with the Petroglyph
+ *   overlapping its top-right ([PebbleSnapFrame]).
  *
- * Android's pebble render is static, so iOS's animation-finished gate is
- * trivially satisfied (its own static-pebble branch) — the reveal fires as
- * soon as the photo is ready. Any failure (null path, null cache in
- * previews, sign/download/decode) just leaves Phase 1 — no error UI. The
- * pebble slot stays structurally stable across the reveal, and the photo is
- * hidden from accessibility (iOS parity).
+ * This replaces the previous two-phase reveal (the snap sliding in over the
+ * pebble after the stroke animation, M42 #582): the page now frames the picture
+ * outright, so there is no mask/slide. A failed load simply stays on the
+ * Petroglyph heading — no error UI — and the pebble render is static on Android,
+ * so nothing gates the swap but the decode itself.
  */
 @Composable
 fun PebbleReadBanner(
@@ -74,25 +59,9 @@ fun PebbleReadBanner(
     modifier: Modifier = Modifier,
     snapStoragePath: String? = null,
 ) {
-    val system = PebblesTheme.colors.system
-    val accentHex = PebblesTheme.colors.accent.primaryHex
-    val strokeHex = palette?.pebbleFrameColors(valence.intensity)?.strokeHex ?: accentHex
-    val heightDp =
-        when (valence.sizeGroup) {
-            ValenceSizeGroup.SMALL -> 80.dp
-            ValenceSizeGroup.MEDIUM -> 100.dp
-            ValenceSizeGroup.LARGE -> 116.dp
-        }
-
     val context = LocalContext.current
     val snapUrls = LocalSnapURLCache.current
     var photo by remember(snapStoragePath) { mutableStateOf<BannerPhoto?>(null) }
-    // Reveal timing honors the platform's remove-animations setting (the iOS
-    // reduce-motion analog): shorter fade, no slide.
-    val reduceMotion =
-        remember(context) {
-            Settings.Global.getFloat(context.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f) == 0f
-        }
 
     LaunchedEffect(snapStoragePath, snapUrls) {
         photo = null
@@ -115,58 +84,24 @@ fun PebbleReadBanner(
         }
     }
 
-    val revealPhoto = photo != null
-    Box(
-        modifier = modifier.fillMaxWidth().heightIn(min = 120.dp),
-        contentAlignment = Alignment.BottomCenter,
-    ) {
-        AnimatedVisibility(
-            visible = revealPhoto,
-            enter =
-                if (reduceMotion) {
-                    fadeIn(tween(durationMillis = 250))
-                } else {
-                    fadeIn(tween(durationMillis = 450)) +
-                        slideInVertically(tween(durationMillis = 450)) { fullHeight -> -fullHeight / 3 }
-                },
-        ) {
-            photo?.let { loaded ->
-                Image(
-                    bitmap = loaded.bitmap,
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(bottom = 60.dp)
-                            .aspectRatio(loaded.aspect.ratio)
-                            .clip(RoundedCornerShape(24.dp)),
-                )
-            }
+    val loaded = photo
+    if (loaded == null) {
+        Box(modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+            PebbleReadPetroglyph(
+                renderSvg = renderSvg,
+                valence = valence,
+                palette = palette,
+                modifier = Modifier.size(HEADING_PETROGLYPH),
+            )
         }
-        // The pebble slot keeps composition identity across the reveal.
-        Box(
-            modifier =
-                Modifier
-                    .size(120.dp)
-                    .then(
-                        if (revealPhoto) {
-                            Modifier.background(system.background, RoundedCornerShape(24.dp))
-                        } else {
-                            Modifier
-                        },
-                    ),
-            contentAlignment = Alignment.Center,
-        ) {
-            if (renderSvg != null) {
-                // PebbleStaticRender fit-scales + centers within the slot (the
-                // iOS 120pt pebbleStableSlot), the pebble sized by valence.
-                PebbleStaticRender(
-                    svg = renderSvg,
-                    strokeHex = strokeHex,
-                    modifier = Modifier.fillMaxWidth().height(heightDp),
-                )
-            }
-        }
+    } else {
+        PebbleSnapFrame(
+            photo = remember(loaded.bitmap) { BitmapPainter(loaded.bitmap) },
+            aspect = loaded.aspect,
+            renderSvg = renderSvg,
+            valence = valence,
+            palette = palette,
+            modifier = modifier,
+        )
     }
 }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/read/PebbleReadPetroglyph.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/read/PebbleReadPetroglyph.kt
@@ -1,0 +1,69 @@
+package app.pbbls.android.features.path.read
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import app.pbbls.android.features.path.models.EmotionPalette
+import app.pbbls.android.features.path.models.Valence
+import app.pbbls.android.features.path.render.PebbleOutlineBackdrop
+import app.pbbls.android.features.path.render.PebbleOutlineGeometry
+import app.pbbls.android.features.path.render.PebbleStaticRender
+import app.pbbls.android.theme.PebblesTheme
+
+/**
+ * The read-view "Petroglyph" (issue #599): the outline silhouette backfill with
+ * the server-composed render (outline + glyph) traced on top, down-scaled per
+ * [PebbleOutlineGeometry] to sit inside the silhouette. Same composite the Path
+ * rows draw via `PebbleThumbnail`, but coloured through [petroglyphColors] so
+ * the read page follows #599's per-size, per-theme table instead of the shared
+ * theme-neutral `pebbleFrameColors`.
+ *
+ * Sized by the caller's [modifier]: the heading treatment gives it a large
+ * square slot, the snap overlay a smaller one. A missing [palette] (cache cold,
+ * unknown or absent emotion) falls back to the brand accent, mirroring
+ * `PebbleThumbnail`. [palette] and the valence data arrive as parameters so
+ * screenshot previews drive it without a live client.
+ */
+@Composable
+fun PebbleReadPetroglyph(
+    renderSvg: String?,
+    valence: Valence,
+    palette: EmotionPalette?,
+    modifier: Modifier = Modifier,
+) {
+    val accentHex = PebblesTheme.colors.accent.primaryHex
+    val sizeGroup = valence.sizeGroup
+    val colors =
+        palette?.let { petroglyphColors(it, sizeGroup, isSystemInDarkTheme()) }
+            ?: PetroglyphColors(strokeHex = accentHex, fillHex = accentHex, fillOpacity = 1f)
+
+    Box(modifier, contentAlignment = Alignment.Center) {
+        Box(
+            modifier = Modifier.aspectRatio(PebbleOutlineGeometry.aspectRatio(sizeGroup)),
+            contentAlignment = Alignment.Center,
+        ) {
+            PebbleOutlineBackdrop(
+                sizeGroup = sizeGroup,
+                polarity = valence.polarity,
+                fillHex = colors.fillHex,
+                fillOpacity = colors.fillOpacity,
+                modifier = Modifier.fillMaxSize(),
+            )
+            if (renderSvg != null) {
+                PebbleStaticRender(
+                    svg = renderSvg,
+                    strokeHex = colors.strokeHex,
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .scale(PebbleOutlineGeometry.pebbleScale(sizeGroup)),
+                )
+            }
+        }
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/read/PebbleSnapFrame.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/read/PebbleSnapFrame.kt
@@ -1,0 +1,102 @@
+package app.pbbls.android.features.path.read
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import app.pbbls.android.features.path.models.EmotionPalette
+import app.pbbls.android.features.path.models.Valence
+
+/**
+ * The snap-present heading of the read view (issue #599): the whole picture at
+ * its nearest [BannerAspect] bucket, tilted slightly, with the [PebbleReadPetroglyph]
+ * overlapping its top-right corner and tilted the other way. Ports the web
+ * `PebbleDetail` snap+pebble bundle.
+ *
+ * Stateless — the caller resolves the [photo] painter (a decoded snap in the app,
+ * a flat colour in previews) and its [aspect], so this whole overlay is
+ * screenshot-previewable without a network load. Kept separate from
+ * `PebbleReadBanner`'s loader precisely so the same frame can back the edit
+ * view's placeholder in the #599 follow-up.
+ *
+ * The photo is inset from the cluster's top and right edges (the poke insets) so
+ * the top-end-aligned Petroglyph pokes out past the corner while overlapping the
+ * picture; the tilt is draw-only (`rotate`), so the rounded rectangle turns with
+ * the image. The snap is hidden from accessibility (iOS/web parity).
+ */
+@Composable
+fun PebbleSnapFrame(
+    photo: Painter,
+    aspect: BannerAspect,
+    renderSvg: String?,
+    valence: Valence,
+    palette: EmotionPalette?,
+    modifier: Modifier = Modifier,
+) {
+    val (photoWidth, photoHeight) =
+        when (aspect) {
+            BannerAspect.SQUARE -> PHOTO_MINOR to PHOTO_MINOR
+            BannerAspect.FOUR_THREE -> PHOTO_MAJOR to PHOTO_MINOR
+            BannerAspect.THREE_FOUR -> PHOTO_MINOR to PHOTO_MAJOR
+        }
+    Box(modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+        // The cluster wraps the photo (plus its poke insets); the Petroglyph
+        // aligns to the cluster's top-right so it lands on the photo corner. The
+        // insets are asymmetric — it pokes above the photo more than past its
+        // right edge, matching the design.
+        Box {
+            Image(
+                painter = photo,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier =
+                    Modifier
+                        .padding(top = PHOTO_POKE_TOP, end = PHOTO_POKE_END)
+                        .size(width = photoWidth, height = photoHeight)
+                        .rotate(PHOTO_TILT)
+                        .clip(RoundedCornerShape(PHOTO_CORNER)),
+            )
+            PebbleReadPetroglyph(
+                renderSvg = renderSvg,
+                valence = valence,
+                palette = palette,
+                modifier =
+                    Modifier
+                        .align(Alignment.TopEnd)
+                        .size(OVERLAY_PETROGLYPH)
+                        .rotate(PETROGLYPH_TILT),
+            )
+        }
+    }
+}
+
+/** Shorter photo edge; the longer edge grows to [PHOTO_MAJOR] for non-square snaps. */
+private val PHOTO_MINOR = 150.dp
+
+/** Longer photo edge for 4:3 / 3:4 snaps (150 × 4/3). */
+private val PHOTO_MAJOR = 200.dp
+
+/** Top inset of the photo — how far the Petroglyph pokes above it. */
+private val PHOTO_POKE_TOP = 40.dp
+
+/** Right inset of the photo — how far the Petroglyph pokes past its right edge. */
+private val PHOTO_POKE_END = 28.dp
+
+/** Layout slot for the overlapping Petroglyph (its tilt bounding runs a touch larger). */
+private val OVERLAY_PETROGLYPH = 96.dp
+
+private val PHOTO_CORNER = 18.dp
+
+/** Counter-clockwise photo tilt, clockwise Petroglyph tilt — the web `-rotate-4` / `rotate-7`. */
+private const val PHOTO_TILT = -5f
+private const val PETROGLYPH_TILT = 7.5f

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/read/PetroglyphColors.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/read/PetroglyphColors.kt
@@ -15,16 +15,18 @@ import app.pbbls.android.features.path.models.ValenceSizeGroup
  * | large strokes         | palette.light     | palette.light       |
  * | large backfill        | palette.primary   | palette.primary     |
  *
- * "palette.dark" in the spec is the DB `surface_color` — the fourth palette
- * slot (seeded as primary at ~10% alpha), the only dark-mode backfill
- * candidate in the four-color palette. Its low alpha rides in [fillOpacity]
- * because a 6-digit hex can't carry it.
+ * "palette.dark" is the dedicated `dark_color` column (added for #599), not the
+ * faint `surface_color` wash — so the dark-mode backfill is a solid dark tint,
+ * mirroring the solid `light` backfill in light mode. Any alpha still rides in
+ * [fillOpacity] because a 6-digit hex can't carry it.
  *
  * This is deliberately distinct from the shared, theme-neutral
- * [EmotionPalette.pebbleFrameColors] used by the Path rows: #599 scopes the new
- * theme-dependent coloring to the read view. Large is identical to
- * `pebbleFrameColors` (light stroke + opaque primary fill); only small/medium
- * diverges, and only in light mode (primary stroke + solid `light` backfill).
+ * [EmotionPalette.pebbleFrameColors] used by the Path rows (which still washes
+ * small/medium with `surface_color`): #599 scopes the new theme-dependent
+ * coloring to the read view. Large is identical to `pebbleFrameColors` (light
+ * stroke + opaque primary fill); small/medium diverges — light mode uses a
+ * primary stroke over a solid `light` backfill, dark a secondary stroke over
+ * `dark`.
  */
 data class PetroglyphColors(
     /** 6-digit `#RRGGBB` for the outline + glyph strokes. */
@@ -54,15 +56,15 @@ fun petroglyphColors(
                 fillHex = EmotionPalette.rgbHex(palette.primaryHex),
                 fillOpacity = EmotionPalette.alphaComponent(palette.primaryHex),
             )
-        // Small / medium: theme-dependent. Dark keeps the current secondary
-        // stroke + faint `surface` wash; light switches to a primary stroke over
-        // a solid `light` backfill.
+        // Small / medium: theme-dependent. Dark uses a secondary stroke over a
+        // solid `dark` backfill; light a primary stroke over a solid `light`
+        // backfill.
         else ->
             if (isDark) {
                 PetroglyphColors(
                     strokeHex = EmotionPalette.rgbHex(palette.secondaryHex),
-                    fillHex = EmotionPalette.rgbHex(palette.surfaceHex),
-                    fillOpacity = EmotionPalette.alphaComponent(palette.surfaceHex),
+                    fillHex = EmotionPalette.rgbHex(palette.darkHex),
+                    fillOpacity = EmotionPalette.alphaComponent(palette.darkHex),
                 )
             } else {
                 PetroglyphColors(

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/read/PetroglyphColors.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/read/PetroglyphColors.kt
@@ -1,0 +1,74 @@
+package app.pbbls.android.features.path.read
+
+import app.pbbls.android.features.path.models.EmotionPalette
+import app.pbbls.android.features.path.models.ValenceSizeGroup
+
+/**
+ * Render-ready colors for the read-view Petroglyph (issue #599) — the framed
+ * pebble (backfill + outline + glyph) shown as the page heading, or overlapping
+ * the snap's top-right. Resolved per size group AND theme, per the issue table:
+ *
+ * | layer                 | light             | dark                |
+ * | --------------------- | ----------------- | ------------------- |
+ * | small/medium strokes  | palette.primary   | palette.secondary   |
+ * | small/medium backfill | palette.light     | palette.dark        |
+ * | large strokes         | palette.light     | palette.light       |
+ * | large backfill        | palette.primary   | palette.primary     |
+ *
+ * "palette.dark" in the spec is the DB `surface_color` — the fourth palette
+ * slot (seeded as primary at ~10% alpha), the only dark-mode backfill
+ * candidate in the four-color palette. Its low alpha rides in [fillOpacity]
+ * because a 6-digit hex can't carry it.
+ *
+ * This is deliberately distinct from the shared, theme-neutral
+ * [EmotionPalette.pebbleFrameColors] used by the Path rows: #599 scopes the new
+ * theme-dependent coloring to the read view. Large is identical to
+ * `pebbleFrameColors` (light stroke + opaque primary fill); only small/medium
+ * diverges, and only in light mode (primary stroke + solid `light` backfill).
+ */
+data class PetroglyphColors(
+    /** 6-digit `#RRGGBB` for the outline + glyph strokes. */
+    val strokeHex: String,
+    /** 6-digit `#RRGGBB` for the backfill silhouette. */
+    val fillHex: String,
+    /** The backfill fill color's alpha (0..1), applied as backdrop view alpha. */
+    val fillOpacity: Float,
+)
+
+/**
+ * Resolves [PetroglyphColors] from a [palette] for the given [sizeGroup] and
+ * theme ([isDark]). Pure — no Compose or Android dependency, so it unit-tests
+ * directly.
+ */
+fun petroglyphColors(
+    palette: EmotionPalette,
+    sizeGroup: ValenceSizeGroup,
+    isDark: Boolean,
+): PetroglyphColors =
+    when (sizeGroup) {
+        // Large: pale `light` stroke over an opaque `primary` silhouette, both
+        // themes — the same hero treatment `pebbleFrameColors(3)` already gives.
+        ValenceSizeGroup.LARGE ->
+            PetroglyphColors(
+                strokeHex = EmotionPalette.rgbHex(palette.lightHex),
+                fillHex = EmotionPalette.rgbHex(palette.primaryHex),
+                fillOpacity = EmotionPalette.alphaComponent(palette.primaryHex),
+            )
+        // Small / medium: theme-dependent. Dark keeps the current secondary
+        // stroke + faint `surface` wash; light switches to a primary stroke over
+        // a solid `light` backfill.
+        else ->
+            if (isDark) {
+                PetroglyphColors(
+                    strokeHex = EmotionPalette.rgbHex(palette.secondaryHex),
+                    fillHex = EmotionPalette.rgbHex(palette.surfaceHex),
+                    fillOpacity = EmotionPalette.alphaComponent(palette.surfaceHex),
+                )
+            } else {
+                PetroglyphColors(
+                    strokeHex = EmotionPalette.rgbHex(palette.primaryHex),
+                    fillHex = EmotionPalette.rgbHex(palette.lightHex),
+                    fillOpacity = EmotionPalette.alphaComponent(palette.lightHex),
+                )
+            }
+    }

--- a/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/CreateScreenshots.kt
+++ b/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/CreateScreenshots.kt
@@ -47,6 +47,7 @@ private fun palette(
     secondary: String,
     light: String,
     surface: String,
+    dark: String = "#2A2138FF",
 ): EmotionPalette =
     requireNotNull(
         EmotionPalette.fromHex(
@@ -54,6 +55,7 @@ private fun palette(
             secondaryHex = secondary,
             lightHex = light,
             surfaceHex = surface,
+            darkHex = dark,
         ),
     )
 

--- a/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/EditPebbleScreenshots.kt
+++ b/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/EditPebbleScreenshots.kt
@@ -35,6 +35,7 @@ private fun palette(
     secondary: String,
     light: String,
     surface: String,
+    dark: String = "#2A2138FF",
 ): EmotionPalette =
     requireNotNull(
         EmotionPalette.fromHex(
@@ -42,6 +43,7 @@ private fun palette(
             secondaryHex = secondary,
             lightHex = light,
             surfaceHex = surface,
+            darkHex = dark,
         ),
     )
 

--- a/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/PathRowScreenshots.kt
+++ b/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/PathRowScreenshots.kt
@@ -30,6 +30,7 @@ private val previewPalette: EmotionPalette =
             secondaryHex = "#AE91CCFF",
             lightHex = "#F2EFF5FF",
             surfaceHex = "#7B5E991A",
+            darkHex = "#2A2138FF",
         ),
     )
 

--- a/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/PathScreenScreenshots.kt
+++ b/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/PathScreenScreenshots.kt
@@ -29,6 +29,7 @@ private val screenPalette: EmotionPalette =
             secondaryHex = "#AE91CCFF",
             lightHex = "#F2EFF5FF",
             surfaceHex = "#7B5E991A",
+            darkHex = "#2A2138FF",
         ),
     )
 

--- a/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/PebbleDetailScreenshots.kt
+++ b/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/PebbleDetailScreenshots.kt
@@ -3,9 +3,14 @@ package app.pbbls.android
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import app.pbbls.android.features.glyph.models.Glyph
 import app.pbbls.android.features.glyph.models.GlyphStroke
 import app.pbbls.android.features.path.DeleteConfirmDialog
@@ -14,8 +19,11 @@ import app.pbbls.android.features.path.models.EmotionPalette
 import app.pbbls.android.features.path.models.EmotionRef
 import app.pbbls.android.features.path.models.PebbleCollection
 import app.pbbls.android.features.path.models.PebbleDetail
+import app.pbbls.android.features.path.models.Valence
 import app.pbbls.android.features.path.models.Visibility
+import app.pbbls.android.features.path.read.BannerAspect
 import app.pbbls.android.features.path.read.PebbleReadView
+import app.pbbls.android.features.path.read.PebbleSnapFrame
 import app.pbbls.android.features.profile.models.SoulRow
 import app.pbbls.android.theme.PebblesTheme
 import com.android.tools.screenshot.PreviewTest
@@ -28,6 +36,11 @@ import java.time.OffsetDateTime
  * [DeleteConfirmDialog]. Light and dark, driven with fixture [PebbleDetail]s so
  * no services are needed. The stateful `PebbleDetailScreen` (service-backed) is
  * deliberately not previewed.
+ *
+ * The #599 snap-overlay frame is covered separately via [PebbleSnapFrame] with a
+ * flat [ColorPainter] standing in for the decoded snap (a real photo needs a
+ * network load the screenshot renderer can't do) — square / landscape / portrait
+ * across light and dark.
  */
 private val previewPalette: EmotionPalette =
     requireNotNull(
@@ -247,4 +260,64 @@ fun PebbleDeleteDialogDark() {
             onDismiss = {},
         )
     }
+}
+
+// A neutral fill stands in for the decoded snap — the screenshot renderer has no
+// network, so a real rendition can't load in a preview.
+private val previewSnap = ColorPainter(Color(0xFF6B7A8F))
+
+@Composable
+private fun SnapFramePreview(
+    aspect: BannerAspect,
+    valence: Valence,
+    renderSvg: String,
+) {
+    val system = PebblesTheme.colors.system
+    PebbleSnapFrame(
+        photo = previewSnap,
+        aspect = aspect,
+        renderSvg = renderSvg,
+        valence = valence,
+        palette = previewPalette,
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .background(system.background)
+                .padding(vertical = 24.dp),
+    )
+}
+
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+fun PebbleSnapSquareLight() {
+    PebblesTheme { SnapFramePreview(BannerAspect.SQUARE, Valence.NEUTRAL_MEDIUM, PebbleSvgFixtures.mediumNeutral) }
+}
+
+@PreviewTest
+@Preview(showBackground = true, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun PebbleSnapSquareDark() {
+    PebblesTheme { SnapFramePreview(BannerAspect.SQUARE, Valence.NEUTRAL_MEDIUM, PebbleSvgFixtures.mediumNeutral) }
+}
+
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+fun PebbleSnapLandscapeLight() {
+    PebblesTheme { SnapFramePreview(BannerAspect.FOUR_THREE, Valence.NEUTRAL_MEDIUM, PebbleSvgFixtures.mediumNeutral) }
+}
+
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+fun PebbleSnapPortraitLargeLight() {
+    PebblesTheme { SnapFramePreview(BannerAspect.THREE_FOUR, Valence.HIGHLIGHT_LARGE, PebbleSvgFixtures.largeHighlight) }
+}
+
+@PreviewTest
+@Preview(showBackground = true, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun PebbleSnapPortraitLargeDark() {
+    PebblesTheme { SnapFramePreview(BannerAspect.THREE_FOUR, Valence.HIGHLIGHT_LARGE, PebbleSvgFixtures.largeHighlight) }
 }

--- a/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/PebbleDetailScreenshots.kt
+++ b/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/PebbleDetailScreenshots.kt
@@ -49,6 +49,7 @@ private val previewPalette: EmotionPalette =
             secondaryHex = "#AE91CCFF",
             lightHex = "#F2EFF5FF",
             surfaceHex = "#7B5E991A",
+            darkHex = "#2A2138FF",
         ),
     )
 

--- a/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/PebbleRowScreenshots.kt
+++ b/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/PebbleRowScreenshots.kt
@@ -30,6 +30,7 @@ private val previewPalette: EmotionPalette =
             secondaryHex = "#AE91CCFF",
             lightHex = "#F2EFF5FF",
             surfaceHex = "#7B5E991A",
+            darkHex = "#2A2138FF",
         ),
     )
 

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/create/EmotionPickerGroupingTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/create/EmotionPickerGroupingTest.kt
@@ -23,6 +23,7 @@ class EmotionPickerGroupingTest {
                 secondaryHex = "#AE91CCFF",
                 lightHex = "#F2EFF5FF",
                 surfaceHex = "#7B5E991A",
+                darkHex = "#2A2138FF",
             ),
         )
 

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/models/EmotionPaletteTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/models/EmotionPaletteTest.kt
@@ -17,6 +17,7 @@ class EmotionPaletteTest {
             secondaryHex = "#AE91CCFF",
             lightHex = "#F2EFF5FF",
             surfaceHex = "#7B5E991A",
+            darkHex = "#2A2138FF",
         )
 
     // parseColor
@@ -62,6 +63,7 @@ class EmotionPaletteTest {
                 secondaryHex = "#AE91CCFF",
                 lightHex = "#F2EFF5FF",
                 surfaceHex = "#7B5E991A",
+                darkHex = "#2A2138FF",
             ),
         )
     }
@@ -74,10 +76,26 @@ class EmotionPaletteTest {
                 secondaryHex = "  #AE91CCFF",
                 lightHex = "#F2EFF5FF\n",
                 surfaceHex = "#7B5E991A ",
+                darkHex = "  #2A2138FF ",
             )
         assertEquals("#7B5E99FF", palette?.primaryHex)
         assertEquals("#7B5E991A", palette?.surfaceHex)
+        assertEquals("#2A2138FF", palette?.darkHex)
         assertEquals("#7B5E99", palette?.strokeHex(isDark = false))
+    }
+
+    @Test
+    fun `fromHex captures the dark slot and rejects a malformed one`() {
+        assertEquals("#2A2138FF", makePalette()?.darkHex)
+        assertNull(
+            EmotionPalette.fromHex(
+                primaryHex = "#7B5E99FF",
+                secondaryHex = "#AE91CCFF",
+                lightHex = "#F2EFF5FF",
+                surfaceHex = "#7B5E991A",
+                darkHex = "not-hex",
+            ),
+        )
     }
 
     // strokeHex

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/models/PebbleDecodingTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/models/PebbleDecodingTest.kt
@@ -104,7 +104,8 @@ class PebbleDecodingTest {
                   "id": "e1", "slug": "joyful", "name": "Joyful", "emoji": "😊",
                   "category_id": "c1", "category_slug": "joy", "category_name": "Joy",
                   "primary_color": "#7B5E99FF", "secondary_color": "#AE91CCFF",
-                  "light_color": "#F2EFF5FF", "surface_color": "#7B5E991A"
+                  "light_color": "#F2EFF5FF", "surface_color": "#7B5E991A",
+                  "dark_color": "#2A2138FF"
                 }
                 """.trimIndent(),
             )
@@ -114,6 +115,8 @@ class PebbleDecodingTest {
 
         // A null column (view types are all-nullable) drops the row.
         assertNull(goodRow.copy(name = null).toEmotionWithPalette())
+        // The dark_color slot (#599) is required like the rest of the palette.
+        assertNull(goodRow.copy(darkColor = null).toEmotionWithPalette())
         // An unparseable hex drops the row.
         assertNull(goodRow.copy(primaryColor = "oops").toEmotionWithPalette())
     }

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/read/BannerAspectTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/read/BannerAspectTest.kt
@@ -3,18 +3,18 @@ package app.pbbls.android.features.path.read
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-/** [BannerAspect.nearest] — the three-bucket snap (M42 #582), mirroring iOS `BannerAspectTests`. */
+/** [BannerAspect.nearest] — the #599 three-bucket snap (4:3 / 1:1 / 3:4), mirroring iOS `BannerAspectTests`. */
 class BannerAspectTest {
     @Test
-    fun `wide sources bucket to sixteen-nine`() {
-        assertEquals(BannerAspect.SIXTEEN_NINE, BannerAspect.nearest(16f / 9f))
-        assertEquals(BannerAspect.SIXTEEN_NINE, BannerAspect.nearest(2.4f))
+    fun `landscape sources bucket to four-three`() {
+        assertEquals(BannerAspect.FOUR_THREE, BannerAspect.nearest(4f / 3f))
+        assertEquals(BannerAspect.FOUR_THREE, BannerAspect.nearest(1.4f))
     }
 
     @Test
-    fun `mid-landscape sources bucket to four-three`() {
-        assertEquals(BannerAspect.FOUR_THREE, BannerAspect.nearest(4f / 3f))
-        assertEquals(BannerAspect.FOUR_THREE, BannerAspect.nearest(1.4f))
+    fun `very wide sources still bucket to four-three`() {
+        assertEquals(BannerAspect.FOUR_THREE, BannerAspect.nearest(16f / 9f))
+        assertEquals(BannerAspect.FOUR_THREE, BannerAspect.nearest(2.4f))
     }
 
     @Test
@@ -24,17 +24,22 @@ class BannerAspectTest {
     }
 
     @Test
-    fun `portrait always buckets to square`() {
-        assertEquals(BannerAspect.SQUARE, BannerAspect.nearest(0.75f))
-        assertEquals(BannerAspect.SQUARE, BannerAspect.nearest(0.1f))
+    fun `portrait sources bucket to three-four`() {
+        assertEquals(BannerAspect.THREE_FOUR, BannerAspect.nearest(3f / 4f))
+        assertEquals(BannerAspect.THREE_FOUR, BannerAspect.nearest(0.8f))
+    }
+
+    @Test
+    fun `very tall sources still bucket to three-four`() {
+        assertEquals(BannerAspect.THREE_FOUR, BannerAspect.nearest(0.1f))
     }
 
     @Test
     fun `boundaries split at the midpoints`() {
-        // Midpoint between 1.0 and 4/3 is ~1.1667; between 4/3 and 16/9 is ~1.5556.
+        // Midpoint between 3/4 and 1.0 is 0.875; between 1.0 and 4/3 is ~1.1667.
+        assertEquals(BannerAspect.THREE_FOUR, BannerAspect.nearest(0.87f))
+        assertEquals(BannerAspect.SQUARE, BannerAspect.nearest(0.88f))
         assertEquals(BannerAspect.SQUARE, BannerAspect.nearest(1.16f))
         assertEquals(BannerAspect.FOUR_THREE, BannerAspect.nearest(1.17f))
-        assertEquals(BannerAspect.FOUR_THREE, BannerAspect.nearest(1.55f))
-        assertEquals(BannerAspect.SIXTEEN_NINE, BannerAspect.nearest(1.56f))
     }
 }

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/read/PetroglyphColorsTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/read/PetroglyphColorsTest.kt
@@ -1,0 +1,54 @@
+package app.pbbls.android.features.path.read
+
+import app.pbbls.android.features.path.models.EmotionPalette
+import app.pbbls.android.features.path.models.ValenceSizeGroup
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * [petroglyphColors] — the #599 per-size, per-theme colour table. Fixture hex
+ * matches the shared `EmotionPaletteTest` palette (opaque primary/secondary/
+ * light, 10%-alpha surface).
+ */
+class PetroglyphColorsTest {
+    private val palette: EmotionPalette =
+        requireNotNull(
+            EmotionPalette.fromHex(
+                primaryHex = "#7B5E99FF",
+                secondaryHex = "#AE91CCFF",
+                lightHex = "#F2EFF5FF",
+                surfaceHex = "#7B5E991A",
+            ),
+        )
+
+    @Test
+    fun `large is light stroke over opaque primary backfill in both themes`() {
+        for (isDark in listOf(false, true)) {
+            val colors = petroglyphColors(palette, ValenceSizeGroup.LARGE, isDark)
+            assertEquals("#F2EFF5", colors.strokeHex)
+            assertEquals("#7B5E99", colors.fillHex)
+            assertEquals(1f, colors.fillOpacity, 0.001f)
+        }
+    }
+
+    @Test
+    fun `small and medium in light mode use primary stroke over solid light backfill`() {
+        for (size in listOf(ValenceSizeGroup.SMALL, ValenceSizeGroup.MEDIUM)) {
+            val colors = petroglyphColors(palette, size, isDark = false)
+            assertEquals("#7B5E99", colors.strokeHex)
+            assertEquals("#F2EFF5", colors.fillHex)
+            assertEquals(1f, colors.fillOpacity, 0.001f)
+        }
+    }
+
+    @Test
+    fun `small and medium in dark mode use secondary stroke over the surface wash`() {
+        for (size in listOf(ValenceSizeGroup.SMALL, ValenceSizeGroup.MEDIUM)) {
+            val colors = petroglyphColors(palette, size, isDark = true)
+            assertEquals("#AE91CC", colors.strokeHex)
+            // "palette.dark" == the DB surface slot: primary rgb at 10% alpha.
+            assertEquals("#7B5E99", colors.fillHex)
+            assertEquals(0x1A / 255f, colors.fillOpacity, 0.001f)
+        }
+    }
+}

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/read/PetroglyphColorsTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/read/PetroglyphColorsTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 /**
  * [petroglyphColors] — the #599 per-size, per-theme colour table. Fixture hex
  * matches the shared `EmotionPaletteTest` palette (opaque primary/secondary/
- * light, 10%-alpha surface).
+ * light/dark, 10%-alpha surface).
  */
 class PetroglyphColorsTest {
     private val palette: EmotionPalette =
@@ -18,6 +18,7 @@ class PetroglyphColorsTest {
                 secondaryHex = "#AE91CCFF",
                 lightHex = "#F2EFF5FF",
                 surfaceHex = "#7B5E991A",
+                darkHex = "#2A2138FF",
             ),
         )
 
@@ -42,13 +43,13 @@ class PetroglyphColorsTest {
     }
 
     @Test
-    fun `small and medium in dark mode use secondary stroke over the surface wash`() {
+    fun `small and medium in dark mode use secondary stroke over the solid dark backfill`() {
         for (size in listOf(ValenceSizeGroup.SMALL, ValenceSizeGroup.MEDIUM)) {
             val colors = petroglyphColors(palette, size, isDark = true)
             assertEquals("#AE91CC", colors.strokeHex)
-            // "palette.dark" == the DB surface slot: primary rgb at 10% alpha.
-            assertEquals("#7B5E99", colors.fillHex)
-            assertEquals(0x1A / 255f, colors.fillOpacity, 0.001f)
+            // "palette.dark" == the dedicated opaque dark_color slot.
+            assertEquals("#2A2138", colors.fillHex)
+            assertEquals(1f, colors.fillOpacity, 0.001f)
         }
     }
 }

--- a/packages/supabase/supabase/migrations/20260717000000_emotion_categories_shaded_dark.sql
+++ b/packages/supabase/supabase/migrations/20260717000000_emotion_categories_shaded_dark.sql
@@ -1,0 +1,35 @@
+-- Migration: emotion category palette — shaded + dark colors (#599)
+--
+-- Adds two palette slots to public.emotion_categories and surfaces them on
+-- public.v_emotions_with_palette:
+--   - dark_color: the small/medium Petroglyph backfill in dark mode (the
+--     "palette.dark" role in the #599 read-view colour table).
+--   - shaded_color: a deeper tint (e.g. the pebble-page title), not yet
+--     consumed by a client — surfaced now so the palette view is complete.
+--
+-- Schema-only, like the original four palette columns: values are 8-digit hex
+-- (#RRGGBBAA) hand-entered per category in Supabase Studio, not seeded here.
+-- `add column if not exists` because the columns were added live in Studio
+-- ahead of this migration; on a fresh DB the emotion_categories table is empty,
+-- so the not-null columns land without a default.
+--
+-- The view appends the two columns AT THE END of the select list — Postgres
+-- CREATE OR REPLACE VIEW can only add trailing columns (mid-list insertion is
+-- read as a rename and rejected with SQLSTATE 42P16). Clients look columns up
+-- by name, so position doesn't matter.
+
+alter table public.emotion_categories
+  add column if not exists shaded_color text not null,
+  add column if not exists dark_color text not null;
+
+create or replace view public.v_emotions_with_palette as
+select
+  e.id, e.slug, e.name, e.color,
+  c.id              as category_id,
+  c.slug            as category_slug,
+  c.name            as category_name,
+  c.primary_color, c.secondary_color, c.light_color, c.surface_color,
+  e.emoji,
+  c.shaded_color, c.dark_color
+from public.emotions e
+join public.emotion_categories c on c.id = e.category_id;

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -227,29 +227,35 @@ export type Database = {
       }
       emotion_categories: {
         Row: {
+          dark_color: string
           id: string
           light_color: string
           name: string
           primary_color: string
           secondary_color: string
+          shaded_color: string
           slug: string
           surface_color: string
         }
         Insert: {
+          dark_color: string
           id?: string
           light_color: string
           name: string
           primary_color: string
           secondary_color: string
+          shaded_color: string
           slug: string
           surface_color: string
         }
         Update: {
+          dark_color?: string
           id?: string
           light_color?: string
           name?: string
           primary_color?: string
           secondary_color?: string
+          shaded_color?: string
           slug?: string
           surface_color?: string
         }
@@ -1387,12 +1393,14 @@ export type Database = {
           category_name: string | null
           category_slug: string | null
           color: string | null
+          dark_color: string | null
           emoji: string | null
           id: string | null
           light_color: string | null
           name: string | null
           primary_color: string | null
           secondary_color: string | null
+          shaded_color: string | null
           slug: string | null
           surface_color: string | null
         }


### PR DESCRIPTION
Resolves #599

## Changes

**Core redesign:**
- `PebbleReadBanner.kt`: Replaced two-phase photo reveal with conditional layout — no snap shows the Petroglyph as page heading; snap present shows `PebbleSnapFrame` with overlay.
- `PebbleSnapFrame.kt` (new): Frames the decoded snap at its nearest aspect bucket (4:3 / 1:1 / 3:4) with the Petroglyph overlapping its top-right corner, both tilted slightly.
- `PebbleReadPetroglyph.kt` (new): The framed pebble render (outline silhouette + glyph) — sized by caller, colored via `petroglyphColors` per size group and theme.
- `PetroglyphColors.kt` (new): Per-size, per-theme color table for the Petroglyph (issue #599 design spec) — large uses light stroke over opaque primary; small/medium use primary/secondary stroke over solid light/dark backfill depending on theme.

**Data model:**
- `EmotionPalette.kt`: Added `dark` color and `darkHex` field (the #599 small/medium dark-mode backfill).
- `BannerAspect.kt`: Replaced 16:9/4:3/1:1 buckets with 4:3/1:1/3:4 to support portrait snaps as first-class layout.
- `EmotionWithPalette.kt`: Mapped `dark_color` from the Supabase view.

**Database:**
- `20260717000000_emotion_categories_shaded_dark.sql` (new): Added `dark_color` and `shaded_color` columns to `emotion_categories`; updated `v_emotions_with_palette` view.
- `database.ts`: Reflected new columns in Supabase types.

**Tests & previews:**
- `PetroglyphColorsTest.kt` (new): Unit tests for the color resolution logic (large vs. small/medium, light vs. dark theme).
- `BannerAspectTest.kt`: Updated test names and boundaries to reflect 4:3/1:1/3:4 buckets.
- `EmotionPaletteTest.kt`: Added `darkHex` to fixture and test coverage.
- `PebbleDetailScreenshots.kt`: Added `PebbleSnapFrame` preview suite (square/landscape/portrait, light/dark).
- Screenshot test fixtures updated to include `darkHex` parameter.

## Notes

- **Animation removed**: The earlier two-phase reveal (snap sliding in over the pebble after stroke animation) is gone. The page now frames the picture outright, so there is no mask/slide — a failed load simply stays on the Petroglyph heading.
- **Static render**: Android's pebble render is static, so the reveal fires as soon as the photo decodes (no animation-finished gate like iOS).
- **Aspect buckets**: The new 3:4 bucket accommodates portrait snaps; 16:9 is gone because the redesigned page frames the whole picture instead of forcing a landscape strip.
- **Color table**: The `petroglyphColors` function is pure (no Compose/Android dependency), so it unit-tests directly and can be reused by the edit view's placeholder in the #599 follow-up.
- **Stateless frame**: `PebbleSnapFrame` is stateless — the caller resolves the photo painter and aspect — so it's screenshot-previewable without a network load and can back multiple views.

## Lab Note (EN/FR)

**EN**
- **Title:** Pebble detail redesign — snap frames the page
- **Summary:** The pebble read view now frames your snap at its natural shape (landscape, square, or portrait) with the pebble overlapping the top-right corner. No snap? The pebble sits centered as the page heading.

**FR**
- **Titre :** Redesign de la page pebble — le snap encadre la page
- **Résumé :** La page de lecture du pebble enc

https://claude.ai/code/session_01KFobG5XKVSU5HwriLjygaA