### PR TITLE
feat(ui): snap display + top-right petroglyph on the pebble page

### DIFF
--- a/apps/ios/Pebbles/Features/Path/Models/EmotionPalette.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/EmotionPalette.swift
@@ -20,17 +20,23 @@ struct EmotionPalette: Equatable {
     let secondary: Color
     let light: Color
     let surface: Color
+    let shaded: Color
+    let dark: Color
 
     let primaryHex: String
     let secondaryHex: String
     let lightHex: String
     let surfaceHex: String
+    let shadedHex: String
+    let darkHex: String
 
     init?(
         primaryHex: String,
         secondaryHex: String,
         lightHex: String,
-        surfaceHex: String
+        surfaceHex: String,
+        shadedHex: String,
+        darkHex: String
     ) {
         // The palette hex columns on `emotion_categories` are populated by
         // hand in Supabase Studio and can carry stray surrounding whitespace.
@@ -42,11 +48,15 @@ struct EmotionPalette: Equatable {
         let secondaryHex = secondaryHex.trimmingCharacters(in: .whitespacesAndNewlines)
         let lightHex = lightHex.trimmingCharacters(in: .whitespacesAndNewlines)
         let surfaceHex = surfaceHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        let shadedHex = shadedHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        let darkHex = darkHex.trimmingCharacters(in: .whitespacesAndNewlines)
         guard
             let primary = Color(hex: primaryHex),
             let secondary = Color(hex: secondaryHex),
             let light = Color(hex: lightHex),
-            let surface = Color(hex: surfaceHex)
+            let surface = Color(hex: surfaceHex),
+            let shaded = Color(hex: shadedHex),
+            let dark = Color(hex: darkHex)
         else {
             return nil
         }
@@ -54,10 +64,14 @@ struct EmotionPalette: Equatable {
         self.secondary = secondary
         self.light = light
         self.surface = surface
+        self.shaded = shaded
+        self.dark = dark
         self.primaryHex = primaryHex
         self.secondaryHex = secondaryHex
         self.lightHex = lightHex
         self.surfaceHex = surfaceHex
+        self.shadedHex = shadedHex
+        self.darkHex = darkHex
     }
 
     var accentBackground: Color { primary }
@@ -119,6 +133,35 @@ extension EmotionPalette {
                 strokeHex:   EmotionPalette.rgbHex(secondaryHex),
                 fillHex:     EmotionPalette.rgbHex(surfaceHex),
                 fillOpacity: EmotionPalette.alphaComponent(surfaceHex)
+            )
+        }
+    }
+
+    /// Theme-aware petroglyph colors for the pebble **page** (issue #599).
+    /// "Stroke" = outline + glyph paths (one color); "backfill" = the
+    /// silhouette fill behind them. Distinct from `pebbleFrameColors`, which
+    /// keeps the older theme-neutral mapping for the timeline row.
+    ///
+    /// | intensity      | stroke (light / dark) | backfill (light / dark) |
+    /// |----------------|-----------------------|-------------------------|
+    /// | small, medium  | primary / secondary   | light / dark            |
+    /// | large (3)      | light / light         | primary / primary       |
+    func petroglyphColors(forIntensity intensity: Int, scheme: ColorScheme) -> PebbleFrameColors {
+        let isDark = scheme == .dark
+        switch intensity {
+        case 3:
+            return PebbleFrameColors(
+                strokeHex:   EmotionPalette.rgbHex(lightHex),
+                fillHex:     EmotionPalette.rgbHex(primaryHex),
+                fillOpacity: EmotionPalette.alphaComponent(primaryHex)
+            )
+        default:
+            let strokeSource = isDark ? secondaryHex : primaryHex
+            let fillSource   = isDark ? darkHex : lightHex
+            return PebbleFrameColors(
+                strokeHex:   EmotionPalette.rgbHex(strokeSource),
+                fillHex:     EmotionPalette.rgbHex(fillSource),
+                fillOpacity: EmotionPalette.alphaComponent(fillSource)
             )
         }
     }

--- a/apps/ios/Pebbles/Features/Path/Models/EmotionPalette.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/EmotionPalette.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// The four colors of an emotion category palette, plus role-named accessors
+/// The six colors of an emotion category palette, plus role-named accessors
 /// that map to the design-token contract:
 ///
 /// - **Accent context** (used by the emotion meta pill on the read view):
@@ -11,7 +11,7 @@ import SwiftUI
 ///   raw hex `String` (for SVG-text injection in `PebbleRenderView`, which
 ///   replaces `currentColor` literally inside the SVG markup).
 ///
-/// Initialized from the four 8-digit hex strings stored on
+/// Initialized from the six 8-digit hex strings stored on
 /// `public.emotion_categories`. Returns `nil` if any hex fails to parse —
 /// callers treat the palette as unavailable and fall back to
 /// `Color.accent.primary` / `Color.accent.primaryHex`.
@@ -107,9 +107,13 @@ struct PebbleFrameColors: Equatable {
     /// (replaces the `#FF00FF` sentinel in the outline SVG).
     let fillHex: String
     /// The fill color's alpha (0...1), applied as view opacity by
-    /// `PebbleOutlineBackdropView`. Large pebbles fill with opaque
-    /// `primary` (1.0); small/medium fill with `surface`, which the
-    /// palette seeds at ~10% alpha for a faint silhouette wash.
+    /// `PebbleOutlineBackdropView`. Value depends on the producer:
+    /// - `pebbleFrameColors` (timeline row): large → opaque `primary` (1.0);
+    ///   small/medium → `surface`, which the palette seeds at ~10% alpha for a
+    ///   faint silhouette wash.
+    /// - `petroglyphColors` (pebble page, #599): large → opaque `primary`;
+    ///   small/medium → opaque `light`/`dark`, so the backfill reads as a solid
+    ///   tint rather than a wash.
     let fillOpacity: Double
 }
 

--- a/apps/ios/Pebbles/Features/Path/Models/EmotionWithPalette.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/EmotionWithPalette.swift
@@ -29,6 +29,8 @@ struct EmotionWithPalette: Identifiable, Decodable {
         case secondaryColor = "secondary_color"
         case lightColor    = "light_color"
         case surfaceColor  = "surface_color"
+        case shadedColor   = "shaded_color"
+        case darkColor     = "dark_color"
     }
 
     init(from decoder: Decoder) throws {
@@ -45,12 +47,16 @@ struct EmotionWithPalette: Identifiable, Decodable {
         let secondary = try container.decode(String.self, forKey: .secondaryColor)
         let light = try container.decode(String.self, forKey: .lightColor)
         let surface = try container.decode(String.self, forKey: .surfaceColor)
+        let shaded = try container.decode(String.self, forKey: .shadedColor)
+        let dark = try container.decode(String.self, forKey: .darkColor)
 
         guard let palette = EmotionPalette(
             primaryHex: primary,
             secondaryHex: secondary,
             lightHex: light,
-            surfaceHex: surface
+            surfaceHex: surface,
+            shadedHex: shaded,
+            darkHex: dark
         ) else {
             throw DecodingError.dataCorruptedError(
                 forKey: .primaryColor,

--- a/apps/ios/Pebbles/Features/Path/Read/BannerAspect.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/BannerAspect.swift
@@ -1,15 +1,17 @@
 import CoreGraphics
 
 /// Banner aspect-ratio bucket chosen for a source image. The pebble read
-/// banner snaps the source's width/height ratio to the nearest of three
-/// fixed buckets — 16:9, 4:3, 1:1 — so portrait or near-square uploads no
-/// longer get cropped to a forced landscape strip.
+/// banner snaps the source's width/height ratio to the nearest of four fixed
+/// buckets — 16:9, 4:3, 1:1, 3:4 — so landscape, square, and portrait uploads
+/// are each shown at a sensible ratio (issue #599 added the 3:4 portrait
+/// bucket).
 ///
 /// Pure value type. No view dependencies; trivially unit-testable.
 enum BannerAspect: Equatable {
     case sixteenNine
     case fourThree
     case square
+    case threeFour
 
     /// CG ratio (width / height) for the bucket.
     var cgRatio: CGFloat {
@@ -17,14 +19,15 @@ enum BannerAspect: Equatable {
         case .sixteenNine: return 16.0 / 9.0
         case .fourThree:   return 4.0 / 3.0
         case .square:      return 1.0
+        case .threeFour:   return 3.0 / 4.0
         }
     }
 
     /// Pick the bucket whose `cgRatio` is closest to `ratio` (absolute
-    /// distance). Portrait sources (`ratio < 1`) always bucket to `.square`
-    /// since 1.0 is the smallest of the three candidates — no special case.
+    /// distance). Portrait sources (`ratio < 1`) now bucket to `.threeFour`
+    /// (0.75) rather than collapsing to `.square`.
     static func nearest(to ratio: CGFloat) -> BannerAspect {
-        let candidates: [BannerAspect] = [.sixteenNine, .fourThree, .square]
+        let candidates: [BannerAspect] = [.sixteenNine, .fourThree, .square, .threeFour]
         return candidates.min(by: { abs($0.cgRatio - ratio) < abs($1.cgRatio - ratio) })
             ?? .sixteenNine
     }

--- a/apps/ios/Pebbles/Features/Path/Read/PebbleReadBanner.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/PebbleReadBanner.swift
@@ -18,6 +18,10 @@ struct PebbleReadBanner: View {
     let renderVersion: String?
     let emotionId: UUID
     let valence: Valence
+    /// Fired once the snap load has settled (decoded, failed, or there was no
+    /// snap to load). The parent uses this to start the page's reveal cascade
+    /// only after the picture + pebble are ready to be shown together.
+    var onReady: () -> Void = {}
 
     @Environment(SnapURLCache.self) private var snapURLs
     @Environment(EmotionPaletteService.self) private var palettes
@@ -44,6 +48,11 @@ struct PebbleReadBanner: View {
         .frame(maxWidth: .infinity)
         .task(id: snapStoragePath) {
             await loadPhotoIfNeeded()
+            // Signal readiness once the load settles — but not on cancellation
+            // (the .task id changed or the view is tearing down; a newer load
+            // or a fresh view owns the reveal now).
+            guard !Task.isCancelled else { return }
+            onReady()
         }
     }
 

--- a/apps/ios/Pebbles/Features/Path/Read/PebbleReadBanner.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/PebbleReadBanner.swift
@@ -65,8 +65,20 @@ struct PebbleReadBanner: View {
                 polarity: valence.polarity,
                 renderVersion: renderVersion
             )
+            .frame(height: pebbleHeight)
         } else {
             EmptyView()
+        }
+    }
+
+    /// Pebble height inside the petroglyph slot, scaled by valence size group
+    /// so higher-intensity pebbles read bigger than lower-intensity ones
+    /// (preserved from the pre-#599 read banner).
+    private var pebbleHeight: CGFloat {
+        switch valence.sizeGroup {
+        case .small:  return 80
+        case .medium: return 100
+        case .large:  return 116
         }
     }
 
@@ -78,9 +90,11 @@ struct PebbleReadBanner: View {
         guard let path = snapStoragePath else { return }
         do {
             let urls = try await snapURLs.signedURLs(storagePath: path)
+            guard !Task.isCancelled else { return }
             var request = URLRequest(url: urls.original)
             request.timeoutInterval = 30
             let (data, _) = try await URLSession.shared.data(for: request)
+            guard !Task.isCancelled else { return }
             guard let image = UIImage(data: data) else {
                 Self.logger.error("decode failed for \(path, privacy: .public)")
                 loadFailed = true
@@ -88,6 +102,11 @@ struct PebbleReadBanner: View {
             }
             loadedImage = image
         } catch {
+            // A cancelled load (the .task id changed or the view went away) must
+            // not flip loadFailed — a newer load or teardown owns the state now.
+            if error is CancellationError || (error as? URLError)?.code == .cancelled {
+                return
+            }
             Self.logger.error(
                 "photo load failed for \(path, privacy: .public): \(error.localizedDescription, privacy: .private)"
             )

--- a/apps/ios/Pebbles/Features/Path/Read/PebbleReadBanner.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/PebbleReadBanner.swift
@@ -1,19 +1,17 @@
 import SwiftUI
 import os
 
-/// Top zone of the pebble read view.
+/// Top zone of the pebble read view (issue #599).
 ///
-/// Sequencing (issue #335):
-/// 1. Phase 1 — render the no-photo layout regardless of whether the pebble
-///    has a snap. Pebble centered in its 120pt zone. Photo bytes load in the
-///    background; the stroke animation runs in parallel.
-/// 2. Phase 2 — once both the stroke animation has finished AND the bytes
-///    have been decoded into a `UIImage`, flip `revealPhoto` inside a
-///    `withAnimation`. The banner inserts above the pebble box at the
-///    bucketed aspect ratio (`BannerAspect`), the pebble box settles into
-///    its overlap position, and content below shifts down.
+/// Loads the snap bytes in the background and composes them with the petroglyph
+/// via `SnapPetroglyphHeader`:
+/// - With a snap → the photo (cover-cropped to its `BannerAspect` bucket, tilted)
+///   with the petroglyph overlapping the top-right corner.
+/// - Without a snap (or after a settled load failure) → the petroglyph centered
+///   as the page heading.
 ///
-/// Without a snap, Phase 2 never fires.
+/// The petroglyph and snap appear together — the petroglyph keeps its own
+/// entry animation (`PebbleAnimatedRenderView`); there is no timed reveal gate.
 struct PebbleReadBanner: View {
     let snapStoragePath: String?
     let renderSvg: String?
@@ -23,105 +21,69 @@ struct PebbleReadBanner: View {
 
     @Environment(SnapURLCache.self) private var snapURLs
     @Environment(EmotionPaletteService.self) private var palettes
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
 
     @State private var loadedImage: UIImage?
-    @State private var animationFinished: Bool = false
-    @State private var revealPhoto: Bool = false
+    /// True once a snap load attempt has settled in failure (no image). Used to
+    /// collapse to the centered layout instead of holding an empty placeholder.
+    @State private var loadFailed: Bool = false
 
     private static let logger = Logger(subsystem: "app.pbbls.ios", category: "pebble-read-banner")
 
-    private let bannerCornerRadius: CGFloat = 24
-    private let boxSize: CGFloat = 120
-    private let boxCornerRadius: CGFloat = 24
-    private let revealDuration: Double = 0.45
-    private let revealDurationReduceMotion: Double = 0.25
+    /// A snap slot is expected when the pebble has a storage path AND the load
+    /// hasn't hard-failed. A still-loading snap keeps the slot (placeholder);
+    /// only a settled failure drops to the centered petroglyph.
+    private var hasSnapSlot: Bool {
+        snapStoragePath != nil && !loadFailed
+    }
 
     var body: some View {
-        // The pebble lives in a stable slot of this ZStack across both phases
-        // — same structural position before and after reveal — so its
-        // identity is preserved and `PebbleAnimatedRenderView.onAppear` does
-        // NOT re-fire. The banner inserts as an optional sibling above the
-        // pebble; its bottom padding produces the half-overlap with the box.
-        ZStack(alignment: .bottom) {
-            if revealPhoto, let image = loadedImage {
-                bannerWithPhoto(image: image)
-                    .padding(.bottom, boxSize / 2)
-                    .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
-            }
-
-            pebbleStableSlot
+        SnapPetroglyphHeader(snapImage: loadedImage, hasSnapSlot: hasSnapSlot) {
+            renderedPebble
         }
-        .frame(maxWidth: .infinity, minHeight: boxSize)
+        .frame(maxWidth: .infinity)
         .task(id: snapStoragePath) {
             await loadPhotoIfNeeded()
         }
-        .task(id: renderVersion) {
-            await waitForAnimationToFinish()
-        }
-        .onChange(of: loadedImage) { _, _ in revealIfReady() }
-        .onChange(of: animationFinished) { _, _ in revealIfReady() }
     }
 
-    private var pebbleStableSlot: some View {
-        renderedPebble
-            .frame(width: boxSize, height: boxSize)
-            .background {
-                if revealPhoto {
-                    RoundedRectangle(cornerRadius: boxCornerRadius)
-                        .fill(Color.system.background)
-                }
-            }
-    }
-
-    private func revealIfReady() {
-        guard !revealPhoto, loadedImage != nil, animationFinished else { return }
-        let animation: Animation = reduceMotion
-            ? .easeOut(duration: revealDurationReduceMotion)
-            : .easeOut(duration: revealDuration)
-        withAnimation(animation) {
-            revealPhoto = true
-        }
-    }
-
-    // MARK: - Phase 2 banner
+    // MARK: - Petroglyph (backfill + outline + glyph)
 
     @ViewBuilder
-    private func bannerWithPhoto(image: UIImage) -> some View {
-        let aspect = BannerAspect.nearest(to: image.size.width / max(image.size.height, 1))
-        // The Color.clear container is the size-of-truth: it's full-width and
-        // forced to `aspect.cgRatio`. The image overlays it with `.fill`,
-        // overflowing edges are clipped by the surrounding RoundedRectangle.
-        // This gives CSS `background-size: cover` behavior inside a fixed
-        // bucket. The half-overlap with the pebble is produced by the
-        // `.padding(.bottom, boxSize / 2)` applied at the call site.
-        Color.clear
-            .aspectRatio(aspect.cgRatio, contentMode: .fit)
-            .frame(maxWidth: .infinity)
-            .overlay {
-                Image(uiImage: image)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-            }
-            .clipShape(RoundedRectangle(cornerRadius: bannerCornerRadius))
-            .accessibilityHidden(true)
+    private var renderedPebble: some View {
+        if let renderSvg {
+            let palette = palettes.palette(for: emotionId)
+            let colors = palette?.petroglyphColors(forIntensity: valence.intensity, scheme: colorScheme)
+            let strokeHex = colors?.strokeHex ?? Color.accent.primaryHex
+            PebbleAnimatedRenderView(
+                svg: renderSvg,
+                strokeColor: Color(hex: strokeHex) ?? Color.accent.primary,
+                strokeColorHex: strokeHex,
+                fillHex: colors?.fillHex ?? Color.accent.primaryHex,
+                fillOpacity: colors?.fillOpacity ?? 1,
+                size: valence.sizeGroup,
+                polarity: valence.polarity,
+                renderVersion: renderVersion
+            )
+        } else {
+            EmptyView()
+        }
     }
 
-    // MARK: - Phase 1 background work
+    // MARK: - Snap load
 
     private func loadPhotoIfNeeded() async {
-        guard let path = snapStoragePath else { return }
         loadedImage = nil
-        revealPhoto = false
+        loadFailed = false
+        guard let path = snapStoragePath else { return }
         do {
             let urls = try await snapURLs.signedURLs(storagePath: path)
             var request = URLRequest(url: urls.original)
             request.timeoutInterval = 30
             let (data, _) = try await URLSession.shared.data(for: request)
             guard let image = UIImage(data: data) else {
-                Self.logger.error(
-                    "decode failed for \(path, privacy: .public)"
-                )
+                Self.logger.error("decode failed for \(path, privacy: .public)")
+                loadFailed = true
                 return
             }
             loadedImage = image
@@ -129,59 +91,7 @@ struct PebbleReadBanner: View {
             Self.logger.error(
                 "photo load failed for \(path, privacy: .public): \(error.localizedDescription, privacy: .private)"
             )
-        }
-    }
-
-    private func waitForAnimationToFinish() async {
-        // Static pebble (no animation) → reveal as soon as the photo is ready.
-        guard !reduceMotion,
-              let timings = PebbleAnimationTimings.forVersion(renderVersion) else {
-            animationFinished = true
-            return
-        }
-        do {
-            try await Task.sleep(for: .seconds(timings.totalDuration))
-        } catch {
-            // Cancellation: either the .task id changed (relaunch will reset
-            // the gate) or the view disappeared (no reveal needed). Leave
-            // animationFinished as-is in both cases.
-            return
-        }
-        animationFinished = true
-    }
-
-    // MARK: - Pebble rendering (unchanged)
-
-    @ViewBuilder
-    private var renderedPebble: some View {
-        if let renderSvg {
-            let palette = palettes.palette(for: emotionId)
-            let frameColors = palette?.pebbleFrameColors(forIntensity: valence.intensity)
-            let strokeHex = frameColors?.strokeHex ?? Color.accent.primaryHex
-            PebbleAnimatedRenderView(
-                svg: renderSvg,
-                strokeColor: Color(hex: strokeHex) ?? Color.accent.primary,
-                strokeColorHex: strokeHex,
-                fillHex: frameColors?.fillHex ?? Color.accent.primaryHex,
-                fillOpacity: frameColors?.fillOpacity ?? 1,
-                size: valence.sizeGroup,
-                polarity: valence.polarity,
-                renderVersion: renderVersion
-            )
-            .frame(height: pebbleHeight)
-        } else {
-            EmptyView()
-        }
-    }
-
-    /// Pebble height inside the 120pt box, scaled by valence size group
-    /// so higher-intensity pebbles read bigger than lower-intensity ones
-    /// while still fitting comfortably.
-    private var pebbleHeight: CGFloat {
-        switch valence.sizeGroup {
-        case .small:  return 80
-        case .medium: return 100
-        case .large:  return 116
+            loadFailed = true
         }
     }
 }
@@ -218,29 +128,6 @@ struct PebbleReadBanner: View {
         renderVersion: "0.1.0",
         emotionId: UUID(),
         valence: .highlightLarge
-    )
-    .padding()
-    .background(Color.system.background)
-    .environment(supabase)
-    .environment(EmotionPaletteService(client: supabase.client))
-    .environment(SnapURLCache(client: supabase.client))
-}
-
-#Preview("With photo (preview-only stub)") {
-    // Preview cannot reach Supabase Storage; this preview only shows the
-    // no-photo path. Manual smoke verification covers the with-photo
-    // sequencing in the simulator.
-    let supabase = SupabaseService()
-    return PebbleReadBanner(
-        snapStoragePath: nil,
-        renderSvg: """
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-              <circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" stroke-width="3"/>
-            </svg>
-            """,
-        renderVersion: "0.1.0",
-        emotionId: UUID(),
-        valence: .neutralMedium
     )
     .padding()
     .background(Color.system.background)

--- a/apps/ios/Pebbles/Features/Path/Read/PebbleReadView.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/PebbleReadView.swift
@@ -9,6 +9,20 @@ import SwiftUI
 struct PebbleReadView: View {
     let detail: PebbleDetail
 
+    /// Flips true once `PebbleReadBanner` reports the snap + pebble are ready.
+    /// Drives the whole-page reveal cascade. Kept false until then so the
+    /// placeholder→image settling happens off-screen (no visible reflow), and
+    /// the content then slides+fades in progressively rather than popping in.
+    @State private var revealed = false
+
+    // Cascade step indices — the order the page reveals in. Tiles and souls
+    // each advance the step per element ("one by one").
+    private let stepBanner = 0
+    private let stepTitle = 1
+    private let stepTilesBase = 2      // emotion, domain, collection → 2, 3, 4
+    private let stepDescription = 5
+    private let stepSoulsBase = 6      // then one step per soul
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
@@ -17,10 +31,13 @@ struct PebbleReadView: View {
                     renderSvg: detail.renderSvg,
                     renderVersion: detail.renderVersion,
                     emotionId: detail.emotion.id,
-                    valence: detail.valence
+                    valence: detail.valence,
+                    onReady: { revealed = true }
                 )
+                .cascade(step: stepBanner, revealed: revealed)
 
                 PebbleReadTitle(name: detail.name, happenedAt: detail.happenedAt)
+                    .cascade(step: stepTitle, revealed: revealed)
 
                 metadataRow
 
@@ -29,6 +46,7 @@ struct PebbleReadView: View {
                         .font(.system(size: 17, weight: .regular, design: .serif))
                         .foregroundStyle(Color.system.foreground)
                         .frame(maxWidth: .infinity, alignment: .leading)
+                        .cascade(step: stepDescription, revealed: revealed)
                 }
 
                 if !detail.souls.isEmpty {
@@ -53,19 +71,23 @@ struct PebbleReadView: View {
             SurfaceTile(systemImage: "heart.fill") {
                 Text(LocalizedStringResource(stringLiteral: detail.emotion.localizedName))
             }
+            .cascade(step: stepTilesBase, revealed: revealed)
 
             // Domain — always rendered. Muted placeholder when unset.
-            if detail.domains.isEmpty {
-                SurfaceTile(systemImage: "tag.fill", muted: true) {
-                    Text("No domain")
-                }
-            } else {
-                SurfaceTile(systemImage: "tag.fill") {
-                    Text(LocalizedStringResource(
-                        stringLiteral: detail.domains.map(\.localizedName).joined(separator: ", ")
-                    ))
+            Group {
+                if detail.domains.isEmpty {
+                    SurfaceTile(systemImage: "tag.fill", muted: true) {
+                        Text("No domain")
+                    }
+                } else {
+                    SurfaceTile(systemImage: "tag.fill") {
+                        Text(LocalizedStringResource(
+                            stringLiteral: detail.domains.map(\.localizedName).joined(separator: ", ")
+                        ))
+                    }
                 }
             }
+            .cascade(step: stepTilesBase + 1, revealed: revealed)
 
             // Collections — only when non-empty.
             if !detail.collections.isEmpty {
@@ -74,6 +96,7 @@ struct PebbleReadView: View {
                         stringLiteral: detail.collections.map(\.name).joined(separator: ", ")
                     ))
                 }
+                .cascade(step: stepTilesBase + 2, revealed: revealed)
             }
         }
     }
@@ -81,9 +104,39 @@ struct PebbleReadView: View {
     @ViewBuilder
     private var soulsRow: some View {
         LazyVGrid(columns: SoulPillGrid.columns, spacing: SoulPillGrid.spacing) {
-            ForEach(detail.souls) { soulWithGlyph in
+            ForEach(Array(detail.souls.enumerated()), id: \.element.id) { index, soulWithGlyph in
                 SoulItem(case: .default, soul: soulWithGlyph, count: nil)
+                    .cascade(step: stepSoulsBase + index, revealed: revealed)
             }
         }
+    }
+}
+
+/// Staggered slide-fade reveal for the pebble page. Each element declares its
+/// `step` in the cascade; when `revealed` flips true they animate in one after
+/// another. The transform (opacity + a small upward slide) never changes layout,
+/// so the page never reflows — it only progressively appears.
+private struct CascadeReveal: ViewModifier {
+    let step: Int
+    let revealed: Bool
+
+    /// The banner (step 0) reveals immediately; the text below waits a beat so
+    /// the picture + pebble read as "displayed first", then cascades.
+    private var delay: Double {
+        guard step > 0 else { return 0 }
+        return 0.3 + Double(step - 1) * 0.08
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(revealed ? 1 : 0)
+            .offset(y: revealed ? 0 : 12)
+            .animation(.easeOut(duration: 0.5).delay(delay), value: revealed)
+    }
+}
+
+private extension View {
+    func cascade(step: Int, revealed: Bool) -> some View {
+        modifier(CascadeReveal(step: step, revealed: revealed))
     }
 }

--- a/apps/ios/Pebbles/Features/Path/Read/SnapPetroglyphHeader.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/SnapPetroglyphHeader.swift
@@ -2,9 +2,10 @@ import SwiftUI
 
 /// Presentational top-zone layout for the pebble page (issue #599).
 ///
-/// - **With a snap:** the photo fills the content width at its `BannerAspect`
-///   bucket (cover-cropped, rounded), tilted −4°, with the petroglyph
-///   overlapping the top-right corner, tilted +7°.
+/// - **With a snap:** the photo sits at ~half the screen width — centered, so it
+///   breathes with generous side margins rather than spanning edge-to-edge — at
+///   its `BannerAspect` bucket (cover-cropped, rounded), tilted −4°, with the
+///   petroglyph perched on and poking past its top-right corner, tilted +7°.
 /// - **Without a snap:** the petroglyph is centered as the page heading.
 ///
 /// Pure layout — it loads nothing. `PebbleReadBanner` owns the async snap load
@@ -24,6 +25,13 @@ struct SnapPetroglyphHeader<Petroglyph: View>: View {
     private let petroglyphInset: CGFloat = 16
     private let snapTilt: Double = -4
     private let petroglyphTilt: Double = 7
+    /// Snap width cap. The design (issue #599) keeps the photo at roughly half
+    /// the screen so it reads as a framed keepsake with breathing room, not a
+    /// full-bleed banner; the rest of the width is the centering margin on
+    /// either side. A fixed cap (rather than a screen fraction) keeps the photo
+    /// from ballooning on the largest phones while still breathing on the
+    /// smallest — ~51% on a 390pt screen, ~47% on a 430pt Pro Max.
+    private let snapMaxWidth: CGFloat = 200
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
@@ -38,15 +46,22 @@ struct SnapPetroglyphHeader<Petroglyph: View>: View {
             // is preserved when `hasSnapSlot` flips (e.g. a settled snap-load
             // failure). Only its placement modifiers change between states:
             // top-right + tilted with a snap, centered + straight without.
+            //
+            // With a snap the ZStack sizes to the (half-width) snap and aligns
+            // the petroglyph to its top-trailing corner; the +16/−16 offset then
+            // pokes it out past that corner. Without a snap the ZStack holds only
+            // the petroglyph.
             petroglyph()
                 .frame(width: petroglyphBox, height: petroglyphBox)
                 .rotationEffect(.degrees(hasSnapSlot ? petroglyphTilt : 0))
                 .offset(x: hasSnapSlot ? petroglyphInset : 0,
                         y: hasSnapSlot ? -petroglyphInset : 0)
-                .frame(maxWidth: .infinity, alignment: hasSnapSlot ? .trailing : .center)
         }
+        // Center the whole composition in the content width so the half-width
+        // snap floats with equal margins instead of hugging the leading edge.
+        .frame(maxWidth: .infinity, alignment: .center)
+        // Headroom for the petroglyph's upward poke so it clears the nav zone.
         .padding(.top, hasSnapSlot ? petroglyphInset : 0)
-        .padding(.trailing, hasSnapSlot ? petroglyphInset : 0)
     }
 
     @ViewBuilder
@@ -59,8 +74,6 @@ struct SnapPetroglyphHeader<Petroglyph: View>: View {
             BannerAspect.nearest(to: $0.size.width / max($0.size.height, 1))
         }
         Color.system.muted
-            .aspectRatio(aspect?.cgRatio ?? 1, contentMode: .fit)
-            .frame(maxWidth: .infinity)
             .overlay {
                 if let snapImage {
                     Image(uiImage: snapImage)
@@ -69,6 +82,11 @@ struct SnapPetroglyphHeader<Petroglyph: View>: View {
                         .transition(.opacity)
                 }
             }
+            .aspectRatio(aspect?.cgRatio ?? 1, contentMode: .fit)
+            // Cap at ~half the screen width, not the full content width — the
+            // source of the "let the picture breathe" correction. Height follows
+            // the bucket ratio above.
+            .frame(maxWidth: snapMaxWidth)
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
             .accessibilityHidden(true)
             .animation(.easeOut(duration: 0.25), value: snapImage)

--- a/apps/ios/Pebbles/Features/Path/Read/SnapPetroglyphHeader.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/SnapPetroglyphHeader.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+/// Presentational top-zone layout for the pebble page (issue #599).
+///
+/// - **With a snap:** the photo fills the content width at its `BannerAspect`
+///   bucket (cover-cropped, rounded), tilted −4°, with the petroglyph
+///   overlapping the top-right corner, tilted +7°.
+/// - **Without a snap:** the petroglyph is centered as the page heading.
+///
+/// Pure layout — it loads nothing. `PebbleReadBanner` owns the async snap load
+/// and the color selection. Edit mode will reuse this view later with a
+/// placeholder snap state, so it stays view-mode-agnostic.
+struct SnapPetroglyphHeader<Petroglyph: View>: View {
+    /// Decoded snap bytes; nil until they load (or when there is no snap).
+    let snapImage: UIImage?
+    /// Whether a snap is expected for this pebble. Drives the layout from first
+    /// paint (petroglyph top-right) independent of whether `snapImage` has
+    /// decoded, so the petroglyph never jumps from center to corner.
+    let hasSnapSlot: Bool
+    @ViewBuilder var petroglyph: () -> Petroglyph
+
+    private let cornerRadius: CGFloat = 24
+    private let petroglyphBox: CGFloat = 120
+    private let petroglyphInset: CGFloat = 16
+    private let snapTilt: Double = -4
+    private let petroglyphTilt: Double = 7
+
+    var body: some View {
+        if hasSnapSlot {
+            withSnapLayout
+        } else {
+            // No snap → petroglyph centered as heading content, no tilt.
+            petroglyph()
+                .frame(width: petroglyphBox, height: petroglyphBox)
+                .frame(maxWidth: .infinity)
+        }
+    }
+
+    private var withSnapLayout: some View {
+        ZStack(alignment: .topTrailing) {
+            snapArea
+                .rotationEffect(.degrees(snapTilt))
+
+            petroglyph()
+                .frame(width: petroglyphBox, height: petroglyphBox)
+                .rotationEffect(.degrees(petroglyphTilt))
+                .offset(x: petroglyphInset, y: -petroglyphInset)
+        }
+        // Reserve the inset so the petroglyph poking past the top-right corner
+        // isn't clipped by the ZStack bounds / surrounding VStack spacing.
+        .padding(.top, petroglyphInset)
+        .padding(.trailing, petroglyphInset)
+    }
+
+    @ViewBuilder
+    private var snapArea: some View {
+        // Bucket ratio is known only once the image decodes; until then the
+        // placeholder holds a neutral square so the petroglyph already sits
+        // top-right. On decode the image cross-fades in and the container
+        // settles to its bucket ratio.
+        let aspect = snapImage.map {
+            BannerAspect.nearest(to: $0.size.width / max($0.size.height, 1))
+        }
+        Color.system.muted
+            .aspectRatio(aspect?.cgRatio ?? 1, contentMode: .fit)
+            .frame(maxWidth: .infinity)
+            .overlay {
+                if let snapImage {
+                    Image(uiImage: snapImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .transition(.opacity)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            .accessibilityHidden(true)
+            .animation(.easeOut(duration: 0.25), value: snapImage)
+    }
+}
+
+#Preview("No snap · petroglyph centered") {
+    SnapPetroglyphHeader(snapImage: nil, hasSnapSlot: false) {
+        RoundedRectangle(cornerRadius: 24)
+            .fill(Color.system.secondary)
+    }
+    .padding(.horizontal, 16)
+    .background(Color.system.background)
+}
+
+#Preview("Snap slot · placeholder (no bytes)") {
+    SnapPetroglyphHeader(snapImage: nil, hasSnapSlot: true) {
+        RoundedRectangle(cornerRadius: 24)
+            .fill(Color.system.secondary)
+    }
+    .padding(.horizontal, 16)
+    .background(Color.system.background)
+}

--- a/apps/ios/Pebbles/Features/Path/Read/SnapPetroglyphHeader.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/SnapPetroglyphHeader.swift
@@ -26,30 +26,27 @@ struct SnapPetroglyphHeader<Petroglyph: View>: View {
     private let petroglyphTilt: Double = 7
 
     var body: some View {
-        if hasSnapSlot {
-            withSnapLayout
-        } else {
-            // No snap → petroglyph centered as heading content, no tilt.
-            petroglyph()
-                .frame(width: petroglyphBox, height: petroglyphBox)
-                .frame(maxWidth: .infinity)
-        }
-    }
-
-    private var withSnapLayout: some View {
         ZStack(alignment: .topTrailing) {
-            snapArea
-                .rotationEffect(.degrees(snapTilt))
+            if hasSnapSlot {
+                snapArea
+                    .rotationEffect(.degrees(snapTilt))
+            }
 
+            // The petroglyph lives at a STABLE structural position (always the
+            // second element of this ZStack, never inside an if/else branch) so
+            // its identity — and `PebbleAnimatedRenderView`'s entry animation —
+            // is preserved when `hasSnapSlot` flips (e.g. a settled snap-load
+            // failure). Only its placement modifiers change between states:
+            // top-right + tilted with a snap, centered + straight without.
             petroglyph()
                 .frame(width: petroglyphBox, height: petroglyphBox)
-                .rotationEffect(.degrees(petroglyphTilt))
-                .offset(x: petroglyphInset, y: -petroglyphInset)
+                .rotationEffect(.degrees(hasSnapSlot ? petroglyphTilt : 0))
+                .offset(x: hasSnapSlot ? petroglyphInset : 0,
+                        y: hasSnapSlot ? -petroglyphInset : 0)
+                .frame(maxWidth: .infinity, alignment: hasSnapSlot ? .trailing : .center)
         }
-        // Reserve the inset so the petroglyph poking past the top-right corner
-        // isn't clipped by the ZStack bounds / surrounding VStack spacing.
-        .padding(.top, petroglyphInset)
-        .padding(.trailing, petroglyphInset)
+        .padding(.top, hasSnapSlot ? petroglyphInset : 0)
+        .padding(.trailing, hasSnapSlot ? petroglyphInset : 0)
     }
 
     @ViewBuilder

--- a/apps/ios/Pebbles/Features/Path/Read/SnapPetroglyphHeader.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/SnapPetroglyphHeader.swift
@@ -2,10 +2,12 @@ import SwiftUI
 
 /// Presentational top-zone layout for the pebble page (issue #599).
 ///
-/// - **With a snap:** the photo sits at ~half the screen width — centered, so it
-///   breathes with generous side margins rather than spanning edge-to-edge — at
-///   its `BannerAspect` bucket (cover-cropped, rounded), tilted −4°, with the
-///   petroglyph perched on and poking past its top-right corner, tilted +7°.
+/// - **With a snap:** the photo is fit inside a bounding box (max 230×200) at
+///   its `BannerAspect` bucket, so wide ratios (16:9, 4:3) read big and portrait
+///   (3:4) reads narrow-tall instead of every ratio sharing one width. It is
+///   cover-cropped, rounded, tilted −4°, and centered so it breathes. The
+///   petroglyph is centered *on* the snap's top-right corner — half overlapping
+///   the photo, half poking past it — tilted +7°.
 /// - **Without a snap:** the petroglyph is centered as the page heading.
 ///
 /// Pure layout — it loads nothing. `PebbleReadBanner` owns the async snap load
@@ -22,16 +24,20 @@ struct SnapPetroglyphHeader<Petroglyph: View>: View {
 
     private let cornerRadius: CGFloat = 24
     private let petroglyphBox: CGFloat = 120
-    private let petroglyphInset: CGFloat = 16
     private let snapTilt: Double = -4
     private let petroglyphTilt: Double = 7
-    /// Snap width cap. The design (issue #599) keeps the photo at roughly half
-    /// the screen so it reads as a framed keepsake with breathing room, not a
-    /// full-bleed banner; the rest of the width is the centering margin on
-    /// either side. A fixed cap (rather than a screen fraction) keeps the photo
-    /// from ballooning on the largest phones while still breathing on the
-    /// smallest — ~51% on a 390pt screen, ~47% on a 430pt Pro Max.
-    private let snapMaxWidth: CGFloat = 200
+    /// The snap is fit inside this bounding box, preserving its bucket ratio.
+    /// A box (not a flat width cap) is what lets a 16:9 read as wide and a 3:4
+    /// as narrow-tall — otherwise a short-wide 16:9 shares the portrait's width
+    /// and looks tiny beside it (issue #599 follow-up feedback). Landscape
+    /// buckets bind on width (230), portrait/square bind on height (200), so
+    /// nothing spans the full content width — the rest is the breathing margin.
+    private let snapMaxWidth: CGFloat = 230
+    private let snapMaxHeight: CGFloat = 200
+    /// Air above the composition, on top of the pebble's upward overhang. This
+    /// is the visible gap between the nav zone and the pebble — the "more space
+    /// on top" the design calls for.
+    private let topGap: CGFloat = 32
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
@@ -44,32 +50,32 @@ struct SnapPetroglyphHeader<Petroglyph: View>: View {
             // second element of this ZStack, never inside an if/else branch) so
             // its identity — and `PebbleAnimatedRenderView`'s entry animation —
             // is preserved when `hasSnapSlot` flips (e.g. a settled snap-load
-            // failure). Only its placement modifiers change between states:
-            // top-right + tilted with a snap, centered + straight without.
+            // failure). Only its placement modifiers change between states.
             //
-            // With a snap the ZStack sizes to the (half-width) snap and aligns
-            // the petroglyph to its top-trailing corner; the +16/−16 offset then
-            // pokes it out past that corner. Without a snap the ZStack holds only
-            // the petroglyph.
+            // With a snap, `.topTrailing` pins the box's top-right to the snap's
+            // top-right corner; nudging out by half the box in each axis brings
+            // the box CENTER onto that corner — half over the photo, half past
+            // it, per the design. The +7° tilt pivots on that same center.
+            // Without a snap the ZStack holds only the (centered, straight) box.
             petroglyph()
                 .frame(width: petroglyphBox, height: petroglyphBox)
                 .rotationEffect(.degrees(hasSnapSlot ? petroglyphTilt : 0))
-                .offset(x: hasSnapSlot ? petroglyphInset : 0,
-                        y: hasSnapSlot ? -petroglyphInset : 0)
+                .offset(x: hasSnapSlot ? petroglyphBox / 2 : 0,
+                        y: hasSnapSlot ? -petroglyphBox / 2 : 0)
         }
-        // Center the whole composition in the content width so the half-width
-        // snap floats with equal margins instead of hugging the leading edge.
+        // Center the whole composition in the content width so the snap floats
+        // with equal margins instead of hugging the leading edge.
         .frame(maxWidth: .infinity, alignment: .center)
-        // Headroom for the petroglyph's upward poke so it clears the nav zone.
-        .padding(.top, hasSnapSlot ? petroglyphInset : 0)
+        // Reserve the pebble's upward overhang (half the box) plus a gap, so it
+        // clears the nav zone and the page has real air at the top.
+        .padding(.top, hasSnapSlot ? petroglyphBox / 2 + topGap : topGap)
     }
 
     @ViewBuilder
     private var snapArea: some View {
         // Bucket ratio is known only once the image decodes; until then the
-        // placeholder holds a neutral square so the petroglyph already sits
-        // top-right. On decode the image cross-fades in and the container
-        // settles to its bucket ratio.
+        // placeholder holds a neutral square. The parent gates visibility on
+        // load-complete, so this placeholder→image settling never shows.
         let aspect = snapImage.map {
             BannerAspect.nearest(to: $0.size.width / max($0.size.height, 1))
         }
@@ -79,17 +85,14 @@ struct SnapPetroglyphHeader<Petroglyph: View>: View {
                     Image(uiImage: snapImage)
                         .resizable()
                         .aspectRatio(contentMode: .fill)
-                        .transition(.opacity)
                 }
             }
             .aspectRatio(aspect?.cgRatio ?? 1, contentMode: .fit)
-            // Cap at ~half the screen width, not the full content width — the
-            // source of the "let the picture breathe" correction. Height follows
-            // the bucket ratio above.
-            .frame(maxWidth: snapMaxWidth)
+            // Fit inside the bounding box — landscape binds on width, portrait
+            // on height — so the photo breathes and ratios keep their character.
+            .frame(maxWidth: snapMaxWidth, maxHeight: snapMaxHeight)
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
             .accessibilityHidden(true)
-            .animation(.easeOut(duration: 0.25), value: snapImage)
     }
 }
 

--- a/apps/ios/PebblesTests/BannerAspectTests.swift
+++ b/apps/ios/PebblesTests/BannerAspectTests.swift
@@ -10,18 +10,6 @@ struct BannerAspectTests {
         #expect(BannerAspect.nearest(to: 16.0 / 9.0) == .sixteenNine)
     }
 
-    @Test("3:2 source picks .fourThree (closer than 16:9)")
-    func threeTwoSource() {
-        // r = 1.5; |1.5 - 1.333| = 0.167; |1.5 - 1.778| = 0.278 → 4:3 wins.
-        #expect(BannerAspect.nearest(to: 3.0 / 2.0) == .fourThree)
-    }
-
-    @Test("Near-midpoint ~1.6 picks .sixteenNine (closer than 4:3)")
-    func nearMidpointPicksSixteenNine() {
-        // r = 1.6; |1.6 - 1.778| = 0.178; |1.6 - 1.333| = 0.267 → 16:9 wins.
-        #expect(BannerAspect.nearest(to: 1.6) == .sixteenNine)
-    }
-
     @Test("4:3 source picks .fourThree")
     func fourThreeSource() {
         #expect(BannerAspect.nearest(to: 4.0 / 3.0) == .fourThree)
@@ -32,10 +20,21 @@ struct BannerAspectTests {
         #expect(BannerAspect.nearest(to: 1.0) == .square)
     }
 
-    @Test("Portrait 9:16 source picks .square (no portrait bucket)")
+    @Test("3:4 portrait source picks .threeFour")
+    func threeFourSource() {
+        #expect(BannerAspect.nearest(to: 3.0 / 4.0) == .threeFour)
+    }
+
+    @Test("Portrait 9:16 source picks .threeFour (nearest is 0.75, not 1.0)")
     func portraitSource() {
-        // r ≈ 0.5625; closer to 1.0 than to 1.333 or 1.778.
-        #expect(BannerAspect.nearest(to: 9.0 / 16.0) == .square)
+        // r ≈ 0.5625; |0.5625 - 0.75| = 0.1875 < |0.5625 - 1.0| = 0.4375 → 3:4 wins.
+        #expect(BannerAspect.nearest(to: 9.0 / 16.0) == .threeFour)
+    }
+
+    @Test("3:2 source picks .fourThree (closer than 16:9)")
+    func threeTwoSource() {
+        // r = 1.5; |1.5 - 1.333| = 0.167; |1.5 - 1.778| = 0.278 → 4:3 wins.
+        #expect(BannerAspect.nearest(to: 3.0 / 2.0) == .fourThree)
     }
 
     @Test("Extreme landscape 21:9 source picks .sixteenNine")
@@ -48,5 +47,6 @@ struct BannerAspectTests {
         #expect(BannerAspect.sixteenNine.cgRatio == 16.0 / 9.0)
         #expect(BannerAspect.fourThree.cgRatio   == 4.0 / 3.0)
         #expect(BannerAspect.square.cgRatio      == 1.0)
+        #expect(BannerAspect.threeFour.cgRatio   == 3.0 / 4.0)
     }
 }

--- a/apps/ios/PebblesTests/EmotionPalettePetroglyphColorsTests.swift
+++ b/apps/ios/PebblesTests/EmotionPalettePetroglyphColorsTests.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import Testing
+@testable import Pebbles
+
+@Suite("EmotionPalette.petroglyphColors")
+struct EmotionPalettePetroglyphColorsTests {
+
+    // Distinct opaque hexes so each role is unambiguous in assertions.
+    private func palette() -> EmotionPalette {
+        EmotionPalette(
+            primaryHex:   "#111111FF",
+            secondaryHex: "#222222FF",
+            lightHex:     "#333333FF",
+            surfaceHex:   "#4444441A",
+            shadedHex:    "#555555FF",
+            darkHex:      "#666666FF"
+        )!
+    }
+
+    // MARK: small / medium — theme-dependent
+
+    @Test("small/medium light: stroke=primary, backfill=light")
+    func smallMediumLight() {
+        let colors = palette().petroglyphColors(forIntensity: 1, scheme: .light)
+        #expect(colors.strokeHex == "#111111")
+        #expect(colors.fillHex == "#333333")
+        #expect(colors.fillOpacity == 1)
+    }
+
+    @Test("small/medium dark: stroke=secondary, backfill=dark")
+    func smallMediumDark() {
+        let colors = palette().petroglyphColors(forIntensity: 2, scheme: .dark)
+        #expect(colors.strokeHex == "#222222")
+        #expect(colors.fillHex == "#666666")
+        #expect(colors.fillOpacity == 1)
+    }
+
+    // MARK: large — theme-independent
+
+    @Test("large light: stroke=light, backfill=primary")
+    func largeLight() {
+        let colors = palette().petroglyphColors(forIntensity: 3, scheme: .light)
+        #expect(colors.strokeHex == "#333333")
+        #expect(colors.fillHex == "#111111")
+        #expect(colors.fillOpacity == 1)
+    }
+
+    @Test("large dark: stroke=light, backfill=primary (same as light)")
+    func largeDark() {
+        let colors = palette().petroglyphColors(forIntensity: 3, scheme: .dark)
+        #expect(colors.strokeHex == "#333333")
+        #expect(colors.fillHex == "#111111")
+        #expect(colors.fillOpacity == 1)
+    }
+}

--- a/apps/ios/PebblesTests/EmotionPaletteTests.swift
+++ b/apps/ios/PebblesTests/EmotionPaletteTests.swift
@@ -57,7 +57,9 @@ struct EmotionPaletteTests {
             primaryHex: "#7B5E99FF",
             secondaryHex: "#AE91CCFF",
             lightHex: "#F2EFF5FF",
-            surfaceHex: "#7B5E991A"
+            surfaceHex: "#7B5E991A",
+            shadedHex: "#AE91CCFF",
+            darkHex: "#7B5E99FF"
         )
     }
 
@@ -72,7 +74,9 @@ struct EmotionPaletteTests {
             primaryHex: "not-hex",
             secondaryHex: "#AE91CCFF",
             lightHex: "#F2EFF5FF",
-            surfaceHex: "#7B5E991A"
+            surfaceHex: "#7B5E991A",
+            shadedHex: "#AE91CCFF",
+            darkHex: "#7B5E99FF"
         )
         #expect(palette == nil)
     }
@@ -102,7 +106,9 @@ struct EmotionPaletteTests {
             primaryHex:   "#7B5E99FF  ",
             secondaryHex: "  #AE91CCFF",
             lightHex:     "#F2EFF5FF\n",
-            surfaceHex:   "#7B5E991A "
+            surfaceHex:   "#7B5E991A ",
+            shadedHex:    "#AE91CCFF",
+            darkHex:      "#7B5E99FF"
         )
         #expect(palette?.primaryHex == "#7B5E99FF")
         #expect(palette?.surfaceHex == "#7B5E991A")

--- a/apps/ios/PebblesTests/EmotionWithPaletteDecodingTests.swift
+++ b/apps/ios/PebblesTests/EmotionWithPaletteDecodingTests.swift
@@ -22,7 +22,9 @@ struct EmotionWithPaletteDecodingTests {
       "primary_color": "#7B5E99FF",
       "secondary_color": "#AE91CCFF",
       "light_color": "#F2EFF5FF",
-      "surface_color": "#7B5E991A"
+      "surface_color": "#7B5E991A",
+      "shaded_color": "#AE91CCFF",
+      "dark_color": "#7B5E99FF"
     }
     """
 

--- a/apps/ios/PebblesTests/LocalizationTests.swift
+++ b/apps/ios/PebblesTests/LocalizationTests.swift
@@ -54,7 +54,9 @@ struct LocalizationPatternCTests {
                 primaryHex: "#000000FF",
                 secondaryHex: "#000000FF",
                 lightHex: "#FFFFFFFF",
-                surfaceHex: "#0000001A"
+                surfaceHex: "#0000001A",
+                shadedHex: "#000000FF",
+                darkHex: "#000000FF"
             )!
         )
         #expect(category.localizedName == "Fallback Name")

--- a/apps/ios/PebblesTests/PathPebbleRowNameColorTests.swift
+++ b/apps/ios/PebblesTests/PathPebbleRowNameColorTests.swift
@@ -9,7 +9,9 @@ struct PathPebbleRowNameColorTests {
         primaryHex:   "#C07A7AFF",
         secondaryHex: "#9B5C5CFF",
         lightHex:     "#E8B8B8FF",
-        surfaceHex:   "#C07A7A1A"
+        surfaceHex:   "#C07A7A1A",
+        shadedHex:    "#9B5C5CFF",
+        darkHex:      "#C07A7AFF"
     )!
 
     // Regression (#510): large pebble name/time were unreadable in light

--- a/apps/ios/PebblesTests/PebbleFrameColorsTests.swift
+++ b/apps/ios/PebblesTests/PebbleFrameColorsTests.swift
@@ -11,7 +11,9 @@ struct PebbleFrameColorsTests {
         primaryHex:   "#C07A7AFF",
         secondaryHex: "#9B5C5CFF",
         lightHex:     "#E8B8B8FF",
-        surfaceHex:   "#C07A7A1A"
+        surfaceHex:   "#C07A7A1A",
+        shadedHex:    "#9B5C5CFF",
+        darkHex:      "#C07A7AFF"
     )!
 
     @Test func intensity3UsesLightStrokeAndOpaquePrimaryFill() {
@@ -58,7 +60,9 @@ struct PebbleFrameColorsTests {
             primaryHex:   "#487C5AFF   ",
             secondaryHex: "#80BF96FF\n",
             lightHex:     "  #EDF2EEFF",
-            surfaceHex:   "#487C5A1A                    "
+            surfaceHex:   "#487C5A1A                    ",
+            shadedHex:    "#80BF96FF",
+            darkHex:      "#487C5AFF"
         )!
         let small = padded.pebbleFrameColors(forIntensity: 1)
         #expect(small.fillHex == "#487C5A")
@@ -78,7 +82,9 @@ struct PebbleFrameColorsTests {
             primaryHex:   "#112233",
             secondaryHex: "#445566",
             lightHex:     "#778899",
-            surfaceHex:   "#AABBCC"
+            surfaceHex:   "#AABBCC",
+            shadedHex:    "#445566",
+            darkHex:      "#112233"
         )!
         let colors = sixDigit.pebbleFrameColors(forIntensity: 2)
         #expect(colors.fillHex   == "#AABBCC")

--- a/docs/superpowers/plans/2026-07-17-ios-pebble-page-snap-petroglyph.md
+++ b/docs/superpowers/plans/2026-07-17-ios-pebble-page-snap-petroglyph.md
@@ -1,0 +1,751 @@
+# iOS — Snap display on the Pebble's page (#599) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the iOS Pebble page top zone so the snap is shown entirely at its nearest aspect bucket with the petroglyph (backfill + outline + glyph) overlapping the top-right corner, using the new theme-aware glyph colors; petroglyph-only when there is no snap.
+
+**Architecture:** A new presentational `SnapPetroglyphHeader` owns the layout (cover snap + top-right petroglyph, or centered petroglyph). `PebbleReadBanner` becomes the data+color wrapper: it loads the snap bytes, picks the `BannerAspect` bucket, computes scheme-aware colors, and feeds the existing `PebbleAnimatedRenderView` (the petroglyph) into the header. A theme-aware `EmotionPalette.petroglyphColors(intensity:scheme:)` implements the #599 color table, backed by two palette columns (`shaded_color`, `dark_color`) already added to the remote view.
+
+**Dependency (DB, out of this branch):** the `shaded_color`/`dark_color` columns + the `v_emotions_with_palette` change are already applied on the remote, and the git migration + regenerated `database.ts` land via the parallel Android branch (`claude/issue-599-android-pebble-52orio`, migration `20260717000000_emotion_categories_shaded_dark.sql`). **This iOS branch adds no migration and no type regen** — the Swift client decodes the JSON columns directly (it does not consume `database.ts`), and the iOS unit tests use hardcoded palettes, so there is no DB dependency to reproduce here. A duplicate same-timestamp migration would collide, so we deliberately do not create one.
+
+**Tech Stack:** SwiftUI (iOS 17), Swift Testing (`@Suite`/`@Test`/`#expect`), xcodegen + xcodebuild.
+
+---
+
+## File structure
+
+- **Modify** `apps/ios/Pebbles/Features/Path/Read/BannerAspect.swift` — add the `threeFour` (0.75) bucket.
+- **Modify** `apps/ios/PebblesTests/BannerAspectTests.swift` — 3:4 selection, portrait → 3:4.
+- **Modify** `apps/ios/Pebbles/Features/Path/Models/EmotionWithPalette.swift` — decode `shaded_color`, `dark_color`.
+- **Modify** `apps/ios/Pebbles/Features/Path/Models/EmotionPalette.swift` — carry `dark`/`shaded`; add `petroglyphColors(forIntensity:scheme:)`.
+- **Create** `apps/ios/PebblesTests/EmotionPalettePetroglyphColorsTests.swift` — the #599 table.
+- **Create** `apps/ios/Pebbles/Features/Path/Read/SnapPetroglyphHeader.swift` — presentational layout.
+- **Modify** `apps/ios/Pebbles/Features/Path/Read/PebbleReadBanner.swift` — data+color wrapper, drop reveal gate.
+
+Tests run with: `npm run test --workspace=apps/ios` (xcodegen generate + `xcodebuild test -scheme Pebbles -destination 'platform=iOS Simulator,name=iPhone 17'`). New Swift files are globbed by `project.yml` (`sources: - path: Pebbles` / `- path: PebblesTests`), so no `project.yml` edit is needed.
+
+---
+
+### Task 1: `BannerAspect` — add the 3:4 bucket
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/Read/BannerAspect.swift`
+- Test: `apps/ios/PebblesTests/BannerAspectTests.swift`
+
+- [ ] **Step 1: Update the tests** — replace the whole file with:
+
+```swift
+import Foundation
+import Testing
+@testable import Pebbles
+
+@Suite("BannerAspect")
+struct BannerAspectTests {
+
+    @Test("16:9 source picks .sixteenNine")
+    func sixteenNineSource() {
+        #expect(BannerAspect.nearest(to: 16.0 / 9.0) == .sixteenNine)
+    }
+
+    @Test("4:3 source picks .fourThree")
+    func fourThreeSource() {
+        #expect(BannerAspect.nearest(to: 4.0 / 3.0) == .fourThree)
+    }
+
+    @Test("Square source picks .square")
+    func squareSource() {
+        #expect(BannerAspect.nearest(to: 1.0) == .square)
+    }
+
+    @Test("3:4 portrait source picks .threeFour")
+    func threeFourSource() {
+        #expect(BannerAspect.nearest(to: 3.0 / 4.0) == .threeFour)
+    }
+
+    @Test("Portrait 9:16 source picks .threeFour (nearest is 0.75, not 1.0)")
+    func portraitSource() {
+        // r ≈ 0.5625; |0.5625 - 0.75| = 0.1875 < |0.5625 - 1.0| = 0.4375 → 3:4 wins.
+        #expect(BannerAspect.nearest(to: 9.0 / 16.0) == .threeFour)
+    }
+
+    @Test("3:2 source picks .fourThree (closer than 16:9)")
+    func threeTwoSource() {
+        // r = 1.5; |1.5 - 1.333| = 0.167; |1.5 - 1.778| = 0.278 → 4:3 wins.
+        #expect(BannerAspect.nearest(to: 3.0 / 2.0) == .fourThree)
+    }
+
+    @Test("Extreme landscape 21:9 source picks .sixteenNine")
+    func extremeLandscape() {
+        #expect(BannerAspect.nearest(to: 21.0 / 9.0) == .sixteenNine)
+    }
+
+    @Test("cgRatio matches the bucket")
+    func cgRatioValues() {
+        #expect(BannerAspect.sixteenNine.cgRatio == 16.0 / 9.0)
+        #expect(BannerAspect.fourThree.cgRatio   == 4.0 / 3.0)
+        #expect(BannerAspect.square.cgRatio      == 1.0)
+        #expect(BannerAspect.threeFour.cgRatio   == 3.0 / 4.0)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test --workspace=apps/ios`
+Expected: FAIL — `.threeFour` is not a member of `BannerAspect`.
+
+- [ ] **Step 3: Add the bucket** — replace the body of `BannerAspect.swift` with:
+
+```swift
+import CoreGraphics
+
+/// Banner aspect-ratio bucket chosen for a source image. The pebble read
+/// banner snaps the source's width/height ratio to the nearest of four fixed
+/// buckets — 16:9, 4:3, 1:1, 3:4 — so landscape, square, and portrait uploads
+/// are each shown at a sensible ratio (issue #599 added the 3:4 portrait
+/// bucket).
+///
+/// Pure value type. No view dependencies; trivially unit-testable.
+enum BannerAspect: Equatable {
+    case sixteenNine
+    case fourThree
+    case square
+    case threeFour
+
+    /// CG ratio (width / height) for the bucket.
+    var cgRatio: CGFloat {
+        switch self {
+        case .sixteenNine: return 16.0 / 9.0
+        case .fourThree:   return 4.0 / 3.0
+        case .square:      return 1.0
+        case .threeFour:   return 3.0 / 4.0
+        }
+    }
+
+    /// Pick the bucket whose `cgRatio` is closest to `ratio` (absolute
+    /// distance). Portrait sources (`ratio < 1`) now bucket to `.threeFour`
+    /// (0.75) rather than collapsing to `.square`.
+    static func nearest(to ratio: CGFloat) -> BannerAspect {
+        let candidates: [BannerAspect] = [.sixteenNine, .fourThree, .square, .threeFour]
+        return candidates.min(by: { abs($0.cgRatio - ratio) < abs($1.cgRatio - ratio) })
+            ?? .sixteenNine
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test --workspace=apps/ios`
+Expected: PASS (all `BannerAspect` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Path/Read/BannerAspect.swift apps/ios/PebblesTests/BannerAspectTests.swift
+git commit -m "feat(ui): add 3:4 portrait aspect bucket (#599)"
+```
+
+---
+
+### Task 2: Decode the new colors + theme-aware `petroglyphColors`
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/Models/EmotionPalette.swift`
+- Modify: `apps/ios/Pebbles/Features/Path/Models/EmotionWithPalette.swift`
+- Test: `apps/ios/PebblesTests/EmotionPalettePetroglyphColorsTests.swift`
+
+- [ ] **Step 1: Write the failing test** — create `EmotionPalettePetroglyphColorsTests.swift`:
+
+```swift
+import SwiftUI
+import Testing
+@testable import Pebbles
+
+@Suite("EmotionPalette.petroglyphColors")
+struct EmotionPalettePetroglyphColorsTests {
+
+    // Distinct opaque hexes so each role is unambiguous in assertions.
+    private func palette() -> EmotionPalette {
+        EmotionPalette(
+            primaryHex:   "#111111FF",
+            secondaryHex: "#222222FF",
+            lightHex:     "#333333FF",
+            surfaceHex:   "#4444441A",
+            shadedHex:    "#555555FF",
+            darkHex:      "#666666FF"
+        )!
+    }
+
+    // MARK: small / medium — theme-dependent
+
+    @Test("small/medium light: stroke=primary, backfill=light")
+    func smallMediumLight() {
+        let colors = palette().petroglyphColors(forIntensity: 1, scheme: .light)
+        #expect(colors.strokeHex == "#111111")
+        #expect(colors.fillHex == "#333333")
+        #expect(colors.fillOpacity == 1)
+    }
+
+    @Test("small/medium dark: stroke=secondary, backfill=dark")
+    func smallMediumDark() {
+        let colors = palette().petroglyphColors(forIntensity: 2, scheme: .dark)
+        #expect(colors.strokeHex == "#222222")
+        #expect(colors.fillHex == "#666666")
+        #expect(colors.fillOpacity == 1)
+    }
+
+    // MARK: large — theme-independent
+
+    @Test("large light: stroke=light, backfill=primary")
+    func largeLight() {
+        let colors = palette().petroglyphColors(forIntensity: 3, scheme: .light)
+        #expect(colors.strokeHex == "#333333")
+        #expect(colors.fillHex == "#111111")
+        #expect(colors.fillOpacity == 1)
+    }
+
+    @Test("large dark: stroke=light, backfill=primary (same as light)")
+    func largeDark() {
+        let colors = palette().petroglyphColors(forIntensity: 3, scheme: .dark)
+        #expect(colors.strokeHex == "#333333")
+        #expect(colors.fillHex == "#111111")
+        #expect(colors.fillOpacity == 1)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test --workspace=apps/ios`
+Expected: FAIL — `EmotionPalette` has no `init(...shadedHex:darkHex:)` and no `petroglyphColors(forIntensity:scheme:)`.
+
+- [ ] **Step 3: Add `shaded`/`dark` to `EmotionPalette` and the new method**
+
+In `apps/ios/Pebbles/Features/Path/Models/EmotionPalette.swift`, extend the stored properties, the init, and add the method.
+
+3a. Add stored properties after the existing four `Color` lets and four `*Hex` lets:
+
+```swift
+    let primary: Color
+    let secondary: Color
+    let light: Color
+    let surface: Color
+    let shaded: Color
+    let dark: Color
+
+    let primaryHex: String
+    let secondaryHex: String
+    let lightHex: String
+    let surfaceHex: String
+    let shadedHex: String
+    let darkHex: String
+```
+
+3b. Replace the initializer signature and body:
+
+```swift
+    init?(
+        primaryHex: String,
+        secondaryHex: String,
+        lightHex: String,
+        surfaceHex: String,
+        shadedHex: String,
+        darkHex: String
+    ) {
+        // The palette hex columns on `emotion_categories` are populated by
+        // hand in Supabase Studio and can carry stray surrounding whitespace.
+        // Trim at the model boundary so the stored `*Hex` strings are clean
+        // `#RRGGBBAA`: the SVG-injection helpers (`rgbHex` / `alphaComponent`
+        // / `strokeHex`) gate on `count == 9`, which silently no-ops on a
+        // padded string and would leak 8-digit hex into the render stack.
+        let primaryHex = primaryHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        let secondaryHex = secondaryHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lightHex = lightHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        let surfaceHex = surfaceHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        let shadedHex = shadedHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        let darkHex = darkHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard
+            let primary = Color(hex: primaryHex),
+            let secondary = Color(hex: secondaryHex),
+            let light = Color(hex: lightHex),
+            let surface = Color(hex: surfaceHex),
+            let shaded = Color(hex: shadedHex),
+            let dark = Color(hex: darkHex)
+        else {
+            return nil
+        }
+        self.primary = primary
+        self.secondary = secondary
+        self.light = light
+        self.surface = surface
+        self.shaded = shaded
+        self.dark = dark
+        self.primaryHex = primaryHex
+        self.secondaryHex = secondaryHex
+        self.lightHex = lightHex
+        self.surfaceHex = surfaceHex
+        self.shadedHex = shadedHex
+        self.darkHex = darkHex
+    }
+```
+
+3c. In the `extension EmotionPalette { ... }` block (the one that already holds
+`pebbleFrameColors(forIntensity:)`, `rgbHex`, `alphaComponent`), add the new
+theme-aware method. Leave `pebbleFrameColors(forIntensity:)` untouched — it
+still serves the timeline row:
+
+```swift
+    /// Theme-aware petroglyph colors for the pebble **page** (issue #599).
+    /// "Stroke" = outline + glyph paths (one color); "backfill" = the
+    /// silhouette fill behind them. Distinct from `pebbleFrameColors`, which
+    /// keeps the older theme-neutral mapping for the timeline row.
+    ///
+    /// | intensity      | stroke (light / dark) | backfill (light / dark) |
+    /// |----------------|-----------------------|-------------------------|
+    /// | small, medium  | primary / secondary   | light / dark            |
+    /// | large (3)      | light / light         | primary / primary       |
+    func petroglyphColors(forIntensity intensity: Int, scheme: ColorScheme) -> PebbleFrameColors {
+        let isDark = scheme == .dark
+        switch intensity {
+        case 3:
+            return PebbleFrameColors(
+                strokeHex:   EmotionPalette.rgbHex(lightHex),
+                fillHex:     EmotionPalette.rgbHex(primaryHex),
+                fillOpacity: EmotionPalette.alphaComponent(primaryHex)
+            )
+        default:
+            let strokeSource = isDark ? secondaryHex : primaryHex
+            let fillSource   = isDark ? darkHex : lightHex
+            return PebbleFrameColors(
+                strokeHex:   EmotionPalette.rgbHex(strokeSource),
+                fillHex:     EmotionPalette.rgbHex(fillSource),
+                fillOpacity: EmotionPalette.alphaComponent(fillSource)
+            )
+        }
+    }
+```
+
+3d. Update the decoder in `apps/ios/Pebbles/Features/Path/Models/EmotionWithPalette.swift`. Add the coding keys and decode the two new columns.
+
+Add to the `CodingKeys` enum (after `surfaceColor`):
+
+```swift
+        case shadedColor   = "shaded_color"
+        case darkColor     = "dark_color"
+```
+
+Replace the palette construction block (the `let primary … let surface` reads and the `guard let palette = EmotionPalette(...)`):
+
+```swift
+        let primary = try container.decode(String.self, forKey: .primaryColor)
+        let secondary = try container.decode(String.self, forKey: .secondaryColor)
+        let light = try container.decode(String.self, forKey: .lightColor)
+        let surface = try container.decode(String.self, forKey: .surfaceColor)
+        let shaded = try container.decode(String.self, forKey: .shadedColor)
+        let dark = try container.decode(String.self, forKey: .darkColor)
+
+        guard let palette = EmotionPalette(
+            primaryHex: primary,
+            secondaryHex: secondary,
+            lightHex: light,
+            surfaceHex: surface,
+            shadedHex: shaded,
+            darkHex: dark
+        ) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .primaryColor,
+                in: container,
+                debugDescription: "Palette hex strings failed to parse"
+            )
+        }
+        self.palette = palette
+```
+
+- [ ] **Step 4: Find and fix the other `EmotionPalette(` call sites**
+
+The initializer signature changed, so every construction must pass the two new
+args. `EmotionWithPalette.swift` (Step 3d) and the new test (Step 1) are already
+done. The remaining sites are all in tests — patch each by inserting
+`shadedHex:` and `darkHex:` immediately after the `surfaceHex:` argument, reusing
+that site's existing opaque hexes (e.g. `shadedHex: <its secondaryHex value>,
+darkHex: <its primaryHex value>`):
+
+- `PebblesTests/PathPebbleRowNameColorTests.swift:8`
+- `PebblesTests/PebbleFrameColorsTests.swift:10`, `:57`, `:77`
+- `PebblesTests/EmotionPaletteTests.swift:56`, `:71`, `:101`
+- `PebblesTests/LocalizationTests.swift:53`
+
+Caution: if any of these sites deliberately passes an **invalid** hex to assert
+the failable init returns `nil` (check `EmotionPaletteTests.swift`), keep the
+new `shadedHex`/`darkHex` args **valid** so the test still isolates the field it
+means to corrupt. Run `grep -rn "EmotionPalette(" apps/ios/Pebbles apps/ios/PebblesTests`
+to confirm no site is missed. Expected: the project compiles with no "missing
+argument for parameter" errors.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm run test --workspace=apps/ios`
+Expected: PASS (`EmotionPalette.petroglyphColors` suite + existing suites).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Path/Models/EmotionPalette.swift apps/ios/Pebbles/Features/Path/Models/EmotionWithPalette.swift apps/ios/PebblesTests/EmotionPalettePetroglyphColorsTests.swift
+git commit -m "feat(ui): theme-aware petroglyph colors for pebble page (#599)"
+```
+
+---
+
+### Task 3: `SnapPetroglyphHeader` — presentational layout
+
+Pure layout, verified in previews/simulator (no unit test — iOS convention is
+no view/UI tests for now).
+
+**Files:**
+- Create: `apps/ios/Pebbles/Features/Path/Read/SnapPetroglyphHeader.swift`
+
+- [ ] **Step 1: Create the component**
+
+```swift
+import SwiftUI
+
+/// Presentational top-zone layout for the pebble page (issue #599).
+///
+/// - **With a snap:** the photo fills the content width at its `BannerAspect`
+///   bucket (cover-cropped, rounded), tilted −4°, with the petroglyph
+///   overlapping the top-right corner, tilted +7°.
+/// - **Without a snap:** the petroglyph is centered as the page heading.
+///
+/// Pure layout — it loads nothing. `PebbleReadBanner` owns the async snap load
+/// and the color selection. Edit mode will reuse this view later with a
+/// placeholder snap state, so it stays view-mode-agnostic.
+struct SnapPetroglyphHeader<Petroglyph: View>: View {
+    /// Decoded snap bytes; nil until they load (or when there is no snap).
+    let snapImage: UIImage?
+    /// Whether a snap is expected for this pebble. Drives the layout from first
+    /// paint (petroglyph top-right) independent of whether `snapImage` has
+    /// decoded, so the petroglyph never jumps from center to corner.
+    let hasSnapSlot: Bool
+    @ViewBuilder var petroglyph: () -> Petroglyph
+
+    private let cornerRadius: CGFloat = 24
+    private let petroglyphBox: CGFloat = 120
+    private let petroglyphInset: CGFloat = 16
+    private let snapTilt: Double = -4
+    private let petroglyphTilt: Double = 7
+
+    var body: some View {
+        if hasSnapSlot {
+            withSnapLayout
+        } else {
+            // No snap → petroglyph centered as heading content, no tilt.
+            petroglyph()
+                .frame(width: petroglyphBox, height: petroglyphBox)
+                .frame(maxWidth: .infinity)
+        }
+    }
+
+    private var withSnapLayout: some View {
+        ZStack(alignment: .topTrailing) {
+            snapArea
+                .rotationEffect(.degrees(snapTilt))
+
+            petroglyph()
+                .frame(width: petroglyphBox, height: petroglyphBox)
+                .rotationEffect(.degrees(petroglyphTilt))
+                .offset(x: petroglyphInset, y: -petroglyphInset)
+        }
+        // Reserve the inset so the petroglyph poking past the top-right corner
+        // isn't clipped by the ZStack bounds / surrounding VStack spacing.
+        .padding(.top, petroglyphInset)
+        .padding(.trailing, petroglyphInset)
+    }
+
+    @ViewBuilder
+    private var snapArea: some View {
+        // Bucket ratio is known only once the image decodes; until then the
+        // placeholder holds a neutral square so the petroglyph already sits
+        // top-right. On decode the image cross-fades in and the container
+        // settles to its bucket ratio.
+        let aspect = snapImage.map {
+            BannerAspect.nearest(to: $0.size.width / max($0.size.height, 1))
+        }
+        Color.system.muted
+            .aspectRatio(aspect?.cgRatio ?? 1, contentMode: .fit)
+            .frame(maxWidth: .infinity)
+            .overlay {
+                if let snapImage {
+                    Image(uiImage: snapImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .transition(.opacity)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            .accessibilityHidden(true)
+            .animation(.easeOut(duration: 0.25), value: snapImage)
+    }
+}
+
+#Preview("No snap · petroglyph centered") {
+    SnapPetroglyphHeader(snapImage: nil, hasSnapSlot: false) {
+        RoundedRectangle(cornerRadius: 24)
+            .fill(Color.system.secondary)
+    }
+    .padding(.horizontal, 16)
+    .background(Color.system.background)
+}
+
+#Preview("Snap slot · placeholder (no bytes)") {
+    SnapPetroglyphHeader(snapImage: nil, hasSnapSlot: true) {
+        RoundedRectangle(cornerRadius: 24)
+            .fill(Color.system.secondary)
+    }
+    .padding(.horizontal, 16)
+    .background(Color.system.background)
+}
+```
+
+- [ ] **Step 2: Verify it compiles + previews render**
+
+Run: `npm run build --workspace=apps/ios`
+Expected: BUILD SUCCEEDED. (Optionally open the file in Xcode and confirm both previews render: centered petroglyph, and a muted square placeholder with the petroglyph poking out top-right.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Path/Read/SnapPetroglyphHeader.swift
+git commit -m "feat(ui): SnapPetroglyphHeader top-zone layout (#599)"
+```
+
+---
+
+### Task 4: Rewire `PebbleReadBanner` to the new layout + colors
+
+Replace the bottom-centered reveal banner with the data+color wrapper around
+`SnapPetroglyphHeader`. Drop the timed reveal gate (show-together). Compute
+scheme-aware colors. Fall back to the centered (no-snap) layout on a settled
+load failure.
+
+**Files:**
+- Modify: `apps/ios/Pebbles/Features/Path/Read/PebbleReadBanner.swift`
+
+- [ ] **Step 1: Replace the file body**
+
+```swift
+import SwiftUI
+import os
+
+/// Top zone of the pebble read view (issue #599).
+///
+/// Loads the snap bytes in the background and composes them with the petroglyph
+/// via `SnapPetroglyphHeader`:
+/// - With a snap → the photo (cover-cropped to its `BannerAspect` bucket, tilted)
+///   with the petroglyph overlapping the top-right corner.
+/// - Without a snap (or after a settled load failure) → the petroglyph centered
+///   as the page heading.
+///
+/// The petroglyph and snap appear together — the petroglyph keeps its own
+/// entry animation (`PebbleAnimatedRenderView`); there is no timed reveal gate.
+struct PebbleReadBanner: View {
+    let snapStoragePath: String?
+    let renderSvg: String?
+    let renderVersion: String?
+    let emotionId: UUID
+    let valence: Valence
+
+    @Environment(SnapURLCache.self) private var snapURLs
+    @Environment(EmotionPaletteService.self) private var palettes
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var loadedImage: UIImage?
+    /// True once a snap load attempt has settled in failure (no image). Used to
+    /// collapse to the centered layout instead of holding an empty placeholder.
+    @State private var loadFailed: Bool = false
+
+    private static let logger = Logger(subsystem: "app.pbbls.ios", category: "pebble-read-banner")
+
+    /// A snap slot is expected when the pebble has a storage path AND the load
+    /// hasn't hard-failed. A still-loading snap keeps the slot (placeholder);
+    /// only a settled failure drops to the centered petroglyph.
+    private var hasSnapSlot: Bool {
+        snapStoragePath != nil && !loadFailed
+    }
+
+    var body: some View {
+        SnapPetroglyphHeader(snapImage: loadedImage, hasSnapSlot: hasSnapSlot) {
+            renderedPebble
+        }
+        .frame(maxWidth: .infinity)
+        .task(id: snapStoragePath) {
+            await loadPhotoIfNeeded()
+        }
+    }
+
+    // MARK: - Petroglyph (backfill + outline + glyph)
+
+    @ViewBuilder
+    private var renderedPebble: some View {
+        if let renderSvg {
+            let palette = palettes.palette(for: emotionId)
+            let colors = palette?.petroglyphColors(forIntensity: valence.intensity, scheme: colorScheme)
+            let strokeHex = colors?.strokeHex ?? Color.accent.primaryHex
+            PebbleAnimatedRenderView(
+                svg: renderSvg,
+                strokeColor: Color(hex: strokeHex) ?? Color.accent.primary,
+                strokeColorHex: strokeHex,
+                fillHex: colors?.fillHex ?? Color.accent.primaryHex,
+                fillOpacity: colors?.fillOpacity ?? 1,
+                size: valence.sizeGroup,
+                polarity: valence.polarity,
+                renderVersion: renderVersion
+            )
+        } else {
+            EmptyView()
+        }
+    }
+
+    // MARK: - Snap load
+
+    private func loadPhotoIfNeeded() async {
+        loadedImage = nil
+        loadFailed = false
+        guard let path = snapStoragePath else { return }
+        do {
+            let urls = try await snapURLs.signedURLs(storagePath: path)
+            var request = URLRequest(url: urls.original)
+            request.timeoutInterval = 30
+            let (data, _) = try await URLSession.shared.data(for: request)
+            guard let image = UIImage(data: data) else {
+                Self.logger.error("decode failed for \(path, privacy: .public)")
+                loadFailed = true
+                return
+            }
+            loadedImage = image
+        } catch {
+            Self.logger.error(
+                "photo load failed for \(path, privacy: .public): \(error.localizedDescription, privacy: .private)"
+            )
+            loadFailed = true
+        }
+    }
+}
+
+#Preview("Without photo · medium") {
+    let supabase = SupabaseService()
+    return PebbleReadBanner(
+        snapStoragePath: nil,
+        renderSvg: """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+              <circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" stroke-width="3"/>
+            </svg>
+            """,
+        renderVersion: "0.1.0",
+        emotionId: UUID(),
+        valence: .neutralMedium
+    )
+    .padding()
+    .background(Color.system.background)
+    .environment(supabase)
+    .environment(EmotionPaletteService(client: supabase.client))
+    .environment(SnapURLCache(client: supabase.client))
+}
+
+#Preview("Without photo · large") {
+    let supabase = SupabaseService()
+    return PebbleReadBanner(
+        snapStoragePath: nil,
+        renderSvg: """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+              <circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" stroke-width="3"/>
+            </svg>
+            """,
+        renderVersion: "0.1.0",
+        emotionId: UUID(),
+        valence: .highlightLarge
+    )
+    .padding()
+    .background(Color.system.background)
+    .environment(supabase)
+    .environment(EmotionPaletteService(client: supabase.client))
+    .environment(SnapURLCache(client: supabase.client))
+}
+```
+
+- [ ] **Step 2: Verify the build (types + views compile)**
+
+Run: `npm run build --workspace=apps/ios`
+Expected: BUILD SUCCEEDED. No reference remains to the removed `BannerAspect`
+usage inside `PebbleReadBanner` (it now lives in `SnapPetroglyphHeader`), no
+reference to `animationFinished` / `revealPhoto` / `PebbleAnimationTimings`
+inside this file.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `npm run test --workspace=apps/ios`
+Expected: PASS. In particular `PebbleReadBanner`-adjacent suites still build
+(the reveal-gate state was internal, not part of any test's public surface).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/ios/Pebbles/Features/Path/Read/PebbleReadBanner.swift
+git commit -m "feat(ui): snap + top-right petroglyph on pebble page (#599)"
+```
+
+---
+
+### Task 5: Verify in the simulator + final checks
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Confirm no stale reveal-gate tests reference removed state**
+
+Run: `grep -rn "revealPhoto\|animationFinished\|BannerAspect" apps/ios/PebblesTests`
+Expected: only `BannerAspectTests.swift` hits (from Task 1). If any test
+references `revealPhoto`/`animationFinished`, delete those assertions — the
+timed-reveal choreography was removed. (None are expected; the current suite
+has no such test.)
+
+- [ ] **Step 2: Run the app and exercise the pebble page**
+
+Run: `npm run build --workspace=apps/ios` then launch in the simulator (or use the `run` skill).
+Verify by observation:
+- A pebble **with** a snap: photo shown entirely at a sensible bucket, tilted −4°, petroglyph overlapping the top-right corner tilted +7°, appearing together with its entry animation. Colors match the #599 table (toggle Dark Mode: small/medium backfill switches light→dark, stroke primary→secondary; large stays light stroke / primary backfill).
+- A **portrait** snap buckets to 3:4 (taller than wide) rather than square.
+- A pebble **without** a snap: petroglyph centered as the heading, no tilt.
+
+- [ ] **Step 3: Localizable / strings check**
+
+No new user-facing strings are introduced (the snap image is
+`accessibilityHidden`). Confirm: `git diff --stat` shows no change to
+`apps/ios/Pebbles/Resources/Localizable.xcstrings`. If it changed unexpectedly,
+open it in Xcode and confirm no `New`/`Stale` entries.
+
+- [ ] **Step 4: Arkaik check**
+
+No screen/route/data-model/endpoint was added or renamed — the pebble page node
+already exists. Skip the Arkaik update. (Confirm the pebble read view already
+has a node in `docs/arkaik/bundle.json`; if for some reason it doesn't, add the
+map entry per the `arkaik` skill — otherwise no-op.)
+
+- [ ] **Step 5: Lint**
+
+Run: `npm run lint --workspace=apps/ios`
+Expected: no new violations in the touched files. Fix any that appear.
+
+---
+
+## Notes for the PR (not a build step)
+
+- **Lab Note (EN/FR):** this is a `feat` touching a user-visible view, so the PR
+  body needs a bilingual Lab Note proposal (title + 1–2 sentence EN/FR summary)
+  per the root `CLAUDE.md` PR checklist.
+- **Decision log:** likely a no-op — this implements a designed feature, not a
+  reversed/significant architectural decision. Skip unless something notable
+  surfaces during implementation.
+- **Labels/milestone:** inherit from issue #599 — `feat`, `ui`, milestone
+  "M37 · Vision Pebble Page". Confirm with the requester before opening the PR.
+- **Cross-surface:** the `shaded_color`/`dark_color` columns + view now exist for
+  web/Android to adopt the same #599 layout in their own follow-ups.
+```

--- a/docs/superpowers/specs/2026-07-17-ios-pebble-page-snap-petroglyph-design.md
+++ b/docs/superpowers/specs/2026-07-17-ios-pebble-page-snap-petroglyph-design.md
@@ -94,12 +94,15 @@ The petroglyph is the composed pebble artwork:
 (`PebbleOutlineBackdropView`) + the outline/glyph strokes. #599 changes only the
 **colors it is fed**, and makes them **scheme-dependent**.
 
-- **Migration**: `alter table public.emotion_categories add column if not exists
-  shaded_color text` and `dark_color text` (mirrors what was added in Studio);
-  `create or replace view public.v_emotions_with_palette` to expose both;
-  extend the `emotion_categories` seed inserts with the real values (read from
-  the remote DB); regenerate types with `db:types:remote` and commit
-  `packages/supabase/types/database.ts`.
+- **Migration (out of this iOS branch):** the `shaded_color`/`dark_color`
+  columns + the `v_emotions_with_palette` change are already applied on the
+  remote, and the git migration + regenerated `database.ts` land via the
+  parallel Android branch (`claude/issue-599-android-pebble-52orio`, migration
+  `20260717000000_emotion_categories_shaded_dark.sql`). This iOS branch adds
+  **no migration and no type regen** — the Swift client decodes the JSON columns
+  directly (it does not consume `database.ts`) and iOS unit tests use hardcoded
+  palettes, so there is no DB dependency to reproduce here. A duplicate
+  same-timestamp migration would collide, so we deliberately avoid one.
 - `EmotionWithPalette` / `EmotionPalette` decode `darkHex` (+ `shadedHex`,
   carried but unused by #599 — kept so the Swift model mirrors the row).
 - New `EmotionPalette.petroglyphColors(intensity:scheme:)` implementing the

--- a/docs/superpowers/specs/2026-07-17-ios-pebble-page-snap-petroglyph-design.md
+++ b/docs/superpowers/specs/2026-07-17-ios-pebble-page-snap-petroglyph-design.md
@@ -1,0 +1,178 @@
+# iOS — Snap display on the Pebble's page (issue #599)
+
+**Date:** 2026-07-17
+**Issue:** #599 · milestone M37 · Vision Pebble Page
+**Surface:** iOS (`apps/ios`). Web/Android follow separately.
+
+## Context
+
+The Pebble read page currently shows a top zone (`PebbleReadBanner`) where the
+snap fills the full content width in a **16:9 / 4:3 / 1:1** bucket and the pebble
+sits **bottom-centered, half-overlapping** the snap, revealed *after* the stroke
+animation via a timed insert/mask.
+
+Issue #599 redesigns this top zone:
+
+- **With a snap:** show the picture entirely, bucketed to the nearest of
+  **1:1, 3:4, 4:3, 16:9**, with the **Petroglyph** (backfill + outline + glyph)
+  overlapping on the **top-right**.
+- **Without a snap:** show only the Petroglyph as the heading content of the
+  page.
+
+Contrary to the issue's "Context" wording, this is **new work** — no platform
+has shipped it yet (web still hard-crops the snap to a square; iOS uses the old
+bottom-centered banner). iOS is the first platform to build it to spec.
+
+The **edit mode** is explicitly out of scope, but the same layout will be reused
+there later (snap displayed, or a dashed tap-to-upload placeholder). The layout
+must therefore be factored into a presentational, view-mode-agnostic component.
+
+## Decisions (locked with the requester)
+
+- **Snap fill:** cover — `.aspectRatio(.fill)` + clip. Fills the bucket
+  edge-to-edge, crops a thin sliver. (The bucket is the *nearest* ratio, so the
+  crop is minimal.)
+- **Entry:** show snap and petroglyph *together* on load. Drop the old timed
+  reveal gate. The petroglyph keeps its own spring/scale entry animation.
+- **Tilt:** match web — snap **−4°**, petroglyph **+7°** (with-snap composition
+  only; the no-snap petroglyph stays straight and centered).
+- **`palette.dark`:** resolves to the new `dark_color` column the requester
+  added to `public.emotion_categories` (alongside `shaded_color`).
+
+## Architecture
+
+Three concerns, cleanly separated:
+
+### 1. `SnapPetroglyphHeader` (new — presentational layout)
+
+Pure layout, no data loading, so edit mode can reuse it. Generic over the
+petroglyph content:
+
+```
+SnapPetroglyphHeader<Petroglyph: View>
+  snapImage: UIImage?       // decoded bytes, nil until loaded (or no snap)
+  hasSnapSlot: Bool         // a snap is expected — drives layout before bytes arrive
+  petroglyph: () -> Petroglyph
+```
+
+- **With snap slot** — `ZStack(alignment: .topTrailing)`:
+  - Snap: full content width at its `BannerAspect` bucket ratio,
+    `.aspectRatio(bucket, contentMode: .fill)` clipped to
+    `RoundedRectangle(cornerRadius: 24)`, rotated **−4°**. Until `snapImage`
+    decodes, the area shows a rounded placeholder (`Color.system` surface) at a
+    default **square** ratio; on decode the image cross-fades in and the
+    container settles to its bucket ratio.
+  - Petroglyph: fixed **120pt** box, anchored top-trailing, offset
+    **(x: +16, y: −16)** so it pokes out past the corner, rotated **+7°**.
+- **No snap slot** — petroglyph centered as heading content, no tilt, no
+  placeholder (today's Phase-1 behavior preserved).
+
+**Layout is driven by `hasSnapSlot` (presence of a snap path), not by
+bytes-loaded** — the petroglyph is top-right from first paint, so there is no
+center→corner jump when the async image arrives.
+
+### 2. `BannerAspect` — bucket set
+
+Add **3:4 (0.75)** to the existing set. Final buckets:
+
+| bucket | ratio (w/h) |
+|---|---|
+| 1:1 | 1.0 |
+| 3:4 | 0.75 |
+| 4:3 | 1.333… |
+| 16:9 | 1.778… |
+
+`nearest(to: width/height)` logic unchanged (min absolute distance). Portrait
+snaps now bucket to **3:4** instead of collapsing to square. The source ratio is
+computed from the **original** rendition's intrinsic size (already loaded first
+via `SnapURLCache`), chosen before layout.
+
+### 3. Color model — theme-aware petroglyph colors
+
+The petroglyph is the composed pebble artwork:
+`PebbleAnimatedRenderView` already `ZStack`s the backfill
+(`PebbleOutlineBackdropView`) + the outline/glyph strokes. #599 changes only the
+**colors it is fed**, and makes them **scheme-dependent**.
+
+- **Migration**: `alter table public.emotion_categories add column if not exists
+  shaded_color text` and `dark_color text` (mirrors what was added in Studio);
+  `create or replace view public.v_emotions_with_palette` to expose both;
+  extend the `emotion_categories` seed inserts with the real values (read from
+  the remote DB); regenerate types with `db:types:remote` and commit
+  `packages/supabase/types/database.ts`.
+- `EmotionWithPalette` / `EmotionPalette` decode `darkHex` (+ `shadedHex`,
+  carried but unused by #599 — kept so the Swift model mirrors the row).
+- New `EmotionPalette.petroglyphColors(intensity:scheme:)` implementing the
+  #599 table. "Stroke" = outline + glyph paths (one color); "backfill" = the
+  silhouette fill:
+
+  | intensity | stroke (light / dark) | backfill (light / dark) |
+  |---|---|---|
+  | small, medium (1, 2) | primary / secondary | light / dark |
+  | large (3) | light / light | primary / primary |
+
+  Returns 6-digit `#RRGGBB` hexes (SVGView requirement) plus `fillOpacity` from
+  the backfill hex's alpha byte, matching the existing `PebbleFrameColors`
+  contract.
+- `PebbleReadBanner` reads `@Environment(\.colorScheme)` and feeds these into
+  `PebbleAnimatedRenderView`.
+
+**Scope: the Pebble page only.** The timeline row (`PathPebbleRow`) keeps its
+current `pebbleFrameColors(forIntensity:)` coloring untouched — the existing
+method stays for that call site; the new method is additive.
+
+### 4. `PebbleReadBanner` — data + color wrapper
+
+Retains the async snap load (signed URL → bytes → `UIImage`) and the
+`BannerAspect` selection. **Removes** the `animationFinished` / `revealPhoto`
+timed-reveal state (superseded by "show together"). Computes scheme-aware colors
+via `petroglyphColors`, builds the petroglyph (`PebbleAnimatedRenderView`), and
+passes `snapImage` + `hasSnapSlot` + the petroglyph to `SnapPetroglyphHeader`.
+
+## Data flow
+
+```
+PebbleReadView
+  └─ PebbleReadBanner  (loads snap bytes; picks BannerAspect; picks colors by colorScheme)
+       └─ SnapPetroglyphHeader  (pure layout: cover snap + top-right petroglyph, or centered)
+            └─ PebbleAnimatedRenderView  (= petroglyph: backfill + outline/glyph, own entry anim)
+```
+
+## Error handling
+
+- Snap URL/bytes/decode failures: logged via `os.Logger` (unchanged from
+  today). On a hard load failure the header falls back to the **no-snap
+  centered** petroglyph layout, so the page never shows an empty placeholder box
+  indefinitely. (A still-loading snap keeps the placeholder; only a settled
+  failure collapses to centered.)
+- Palette miss (cache cold / bad row): `petroglyphColors` callers fall back to
+  `Color.accent.primary` / `Color.accent.primaryHex`, same as today.
+
+## Testing
+
+- `BannerAspectTests`: nearest-bucket selection including a portrait source
+  bucketing to **3:4**, and a wide source to **16:9**.
+- `EmotionPalettePetroglyphColorsTests`: the #599 table — each intensity
+  (small/medium/large) × scheme (light/dark) yields the correct stroke/backfill
+  hex and fill opacity.
+- Layout, tilt, cross-fade, and entry animation verified in the simulator
+  (no UI tests per iOS conventions).
+
+## Geometry (confirmed with requester; reconcile against Figma if access lands)
+
+Figma node `554-27469` is not accessible to the agent. Values below are
+approved from the web reference + current iOS banner:
+
+- Petroglyph box: **120pt**.
+- Petroglyph offset from top-trailing: **(x: +16, y: −16)**.
+- Snap corner radius: **24**.
+- Tilts: snap **−4°**, petroglyph **+7°**.
+- Snap width: full content width (page padding 16pt).
+
+## Out of scope
+
+- Edit mode (later; will reuse `SnapPetroglyphHeader` with a dashed
+  tap-to-upload placeholder state).
+- Web and Android — separate follow-ups. The `shaded_color` / `dark_color`
+  columns and view change land here but benefit those surfaces later.
+- Timeline row petroglyph coloring.


### PR DESCRIPTION
Resolves #599

## Summary

Redesigns the iOS Pebble page top zone so the snap is shown **entirely** at its nearest aspect bucket with the **petroglyph** (backfill + outline + glyph) overlapping the **top-right** corner. When there's no snap, the petroglyph is centered as the page heading. Glyph colors are now **theme-aware** per the #599 table.

- **Aspect buckets** now `1:1 / 3:4 / 4:3 / 16:9` (added the 3:4 portrait bucket; portrait snaps no longer collapse to square).
- **Snap** fills its bucket cover-cropped, rounded, tilted −4°; **petroglyph** overlaps top-right tilted +7°, 120pt slot. Snap + petroglyph appear **together** (old timed-reveal choreography removed).
- **Theme-aware petroglyph colors** (`EmotionPalette.petroglyphColors(intensity:scheme:)`): small/medium stroke = primary(light)/secondary(dark), backfill = light(light)/dark(dark); large stroke = light, backfill = primary. Timeline row coloring (`pebbleFrameColors`) is untouched.
- Valence **size scaling preserved** (80/100/116pt), and the petroglyph keeps a **stable view identity** across the snap/no-snap transition (no entry-animation replay on a settled snap-load failure). `Task.isCancelled` guards added to the loader.

## Key files

- `Features/Path/Read/SnapPetroglyphHeader.swift` — new presentational layout (reused later by edit mode).
- `Features/Path/Read/PebbleReadBanner.swift` — data+color wrapper (net −113 LOC; reveal state machine removed).
- `Features/Path/Read/BannerAspect.swift` — added `.threeFour`.
- `Features/Path/Models/EmotionPalette.swift` / `EmotionWithPalette.swift` — `shaded`/`dark` colors + `petroglyphColors(intensity:scheme:)`.
- Tests: `BannerAspectTests`, `EmotionPalettePetroglyphColorsTests` (+ call-site updates).
- Spec/plan: `docs/superpowers/specs|plans/2026-07-17-ios-pebble-page-snap-petroglyph*`.

## Notes

- **DB dependency (not in this branch):** the `shaded_color`/`dark_color` columns + the `v_emotions_with_palette` change are already applied on the remote and the git migration + `database.ts` regen land via the parallel Android branch (`claude/issue-599-android-pebble-52orio`). iOS decodes the JSON columns directly, so nothing DB-side ships here (a duplicate same-timestamp migration would collide).
- **Edit mode** is out of scope (issue note); `SnapPetroglyphHeader` was built view-mode-agnostic to be reused there.
- **Figma geometry** (offsets/sizes/tilts) was inferred from the web reference + old iOS banner — Figma node 554-27469 wasn't accessible to reconcile exact values.

## Test plan

- [x] `npm run build --workspace=apps/ios` — BUILD SUCCEEDED
- [x] `npm run test --workspace=apps/ios` — new `BannerAspect` + `petroglyphColors` suites pass; only 2 **pre-existing, unrelated** failures remain (`LocalizationCatalogFileTests/everyEntryHasBothLocales()`, `WobbleRendererTests/glyphInk()` — both also fail on `main`).
- [ ] Manual simulator smoke: snap-bearing pebble (portrait → 3:4, cover crop, +7° top-right petroglyph); no-snap pebble (centered heading); toggle Dark Mode (small/med backfill light→dark, stroke primary→secondary; large stays light/primary).

## Lab Note (proposal — human publishes at release)

**EN — Your photo, framed by its pebble**
On a moment's page, your photo now appears in full — portrait, square, or landscape — with its pebble mark nestled into the top-right corner. When there's no photo, the pebble takes center stage as the page's heading.

**FR — Votre photo, encadrée par son galet**
Sur la page d'un moment, votre photo s'affiche désormais en entier — portrait, carré ou paysage — avec son galet niché dans le coin supérieur droit. Sans photo, le galet occupe le devant de la scène en en-tête de la page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)