### PR TITLE
feat(read): redesign pebble banner with snap frame overlay (#599)

### DIFF
--- a/apps/ios/Pebbles/Features/Path/Models/EmotionPalette.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/EmotionPalette.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// The four colors of an emotion category palette, plus role-named accessors
+/// The colors of an emotion category palette, plus role-named accessors
 /// that map to the design-token contract:
 ///
 /// - **Accent context** (used by the emotion meta pill on the read view):
@@ -11,26 +11,34 @@ import SwiftUI
 ///   raw hex `String` (for SVG-text injection in `PebbleRenderView`, which
 ///   replaces `currentColor` literally inside the SVG markup).
 ///
-/// Initialized from the four 8-digit hex strings stored on
+/// Initialized from the 8-digit hex strings stored on
 /// `public.emotion_categories`. Returns `nil` if any hex fails to parse —
 /// callers treat the palette as unavailable and fall back to
 /// `Color.accent.primary` / `Color.accent.primaryHex`.
+///
+/// `dark` is the #599 addition: the small/medium read-view Petroglyph backfill
+/// in dark mode (the "palette.dark" role, from the `dark_color` column). The
+/// sibling `shaded_color` column also exists on the view but has no iOS
+/// consumer yet, so it is intentionally not modelled here.
 struct EmotionPalette: Equatable {
     let primary: Color
     let secondary: Color
     let light: Color
     let surface: Color
+    let dark: Color
 
     let primaryHex: String
     let secondaryHex: String
     let lightHex: String
     let surfaceHex: String
+    let darkHex: String
 
     init?(
         primaryHex: String,
         secondaryHex: String,
         lightHex: String,
-        surfaceHex: String
+        surfaceHex: String,
+        darkHex: String
     ) {
         // The palette hex columns on `emotion_categories` are populated by
         // hand in Supabase Studio and can carry stray surrounding whitespace.
@@ -42,11 +50,13 @@ struct EmotionPalette: Equatable {
         let secondaryHex = secondaryHex.trimmingCharacters(in: .whitespacesAndNewlines)
         let lightHex = lightHex.trimmingCharacters(in: .whitespacesAndNewlines)
         let surfaceHex = surfaceHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        let darkHex = darkHex.trimmingCharacters(in: .whitespacesAndNewlines)
         guard
             let primary = Color(hex: primaryHex),
             let secondary = Color(hex: secondaryHex),
             let light = Color(hex: lightHex),
-            let surface = Color(hex: surfaceHex)
+            let surface = Color(hex: surfaceHex),
+            let dark = Color(hex: darkHex)
         else {
             return nil
         }
@@ -54,10 +64,12 @@ struct EmotionPalette: Equatable {
         self.secondary = secondary
         self.light = light
         self.surface = surface
+        self.dark = dark
         self.primaryHex = primaryHex
         self.secondaryHex = secondaryHex
         self.lightHex = lightHex
         self.surfaceHex = surfaceHex
+        self.darkHex = darkHex
     }
 
     var accentBackground: Color { primary }
@@ -99,6 +111,35 @@ struct PebbleFrameColors: Equatable {
     let fillOpacity: Double
 }
 
+/// Render-ready colors for the read-view Petroglyph (issue #599) — the framed
+/// pebble (backfill + outline + glyph) shown as the page heading, or
+/// overlapping the snap's top-right. Same shape as `PebbleFrameColors` (all
+/// sanitized for SVG injection), but resolved per size group AND color scheme,
+/// per the issue table:
+///
+/// | layer                 | light             | dark                |
+/// | --------------------- | ----------------- | ------------------- |
+/// | small/medium strokes  | palette.primary   | palette.secondary   |
+/// | small/medium backfill | palette.light     | palette.dark        |
+/// | large strokes         | palette.light     | palette.light       |
+/// | large backfill        | palette.primary   | palette.primary     |
+///
+/// "palette.dark" is the dedicated `dark_color` column (added for #599), not
+/// the faint `surface_color` wash — so the dark-mode backfill is a solid dark
+/// tint, mirroring the solid `light` backfill in light mode.
+///
+/// Deliberately distinct from the theme-neutral `pebbleFrameColors` used by the
+/// Path rows (which still washes small/medium with `surface`): #599 scopes the
+/// new theme-dependent coloring to the read view.
+struct PetroglyphColors: Equatable {
+    /// 6-digit `#RRGGBB` for the outline + glyph strokes.
+    let strokeHex: String
+    /// 6-digit `#RRGGBB` for the backfill silhouette.
+    let fillHex: String
+    /// The backfill fill color's alpha (0...1), applied as backdrop view opacity.
+    let fillOpacity: Double
+}
+
 extension EmotionPalette {
 
     /// Single source of truth for the intensity → role mapping.
@@ -120,6 +161,38 @@ extension EmotionPalette {
                 fillHex:     EmotionPalette.rgbHex(surfaceHex),
                 fillOpacity: EmotionPalette.alphaComponent(surfaceHex)
             )
+        }
+    }
+
+    /// Read-view Petroglyph colors (issue #599) for the given size group and
+    /// color scheme — see `PetroglyphColors` for the full role table.
+    ///
+    /// - large: `light` stroke over an opaque `primary` backfill, both schemes
+    ///   (the same hero treatment `pebbleFrameColors(forIntensity: 3)` gives).
+    /// - small/medium: theme-dependent — light mode uses a `primary` stroke over
+    ///   a solid `light` backfill; dark a `secondary` stroke over a solid `dark`.
+    func petroglyphColors(forSize size: ValenceSizeGroup, scheme: ColorScheme) -> PetroglyphColors {
+        switch size {
+        case .large:
+            return PetroglyphColors(
+                strokeHex:   EmotionPalette.rgbHex(lightHex),
+                fillHex:     EmotionPalette.rgbHex(primaryHex),
+                fillOpacity: EmotionPalette.alphaComponent(primaryHex)
+            )
+        case .small, .medium:
+            if scheme == .dark {
+                return PetroglyphColors(
+                    strokeHex:   EmotionPalette.rgbHex(secondaryHex),
+                    fillHex:     EmotionPalette.rgbHex(darkHex),
+                    fillOpacity: EmotionPalette.alphaComponent(darkHex)
+                )
+            } else {
+                return PetroglyphColors(
+                    strokeHex:   EmotionPalette.rgbHex(primaryHex),
+                    fillHex:     EmotionPalette.rgbHex(lightHex),
+                    fillOpacity: EmotionPalette.alphaComponent(lightHex)
+                )
+            }
         }
     }
 

--- a/apps/ios/Pebbles/Features/Path/Models/EmotionWithPalette.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/EmotionWithPalette.swift
@@ -4,8 +4,9 @@ import Foundation
 ///
 /// PostgREST types every view column as nullable in `database.ts`, but the
 /// underlying invariants — `emotions.category_id NOT NULL` (shipped in #367),
-/// `emotions.emoji NOT NULL` (shipped in #370), and the four palette `text NOT NULL`
-/// columns on `emotion_categories` — guarantee non-null values in practice. This
+/// `emotions.emoji NOT NULL` (shipped in #370), and the palette `text NOT NULL`
+/// columns on `emotion_categories` (including `dark_color`, added for #599) —
+/// guarantee non-null values in practice. This
 /// decoder enforces that invariant at the boundary: rows with any null required
 /// field throw `DecodingError`, which `EmotionPaletteService` logs and skips so
 /// the bad row simply isn't cached. Access sites read non-optional values from the
@@ -29,6 +30,7 @@ struct EmotionWithPalette: Identifiable, Decodable {
         case secondaryColor = "secondary_color"
         case lightColor    = "light_color"
         case surfaceColor  = "surface_color"
+        case darkColor     = "dark_color"
     }
 
     init(from decoder: Decoder) throws {
@@ -45,12 +47,14 @@ struct EmotionWithPalette: Identifiable, Decodable {
         let secondary = try container.decode(String.self, forKey: .secondaryColor)
         let light = try container.decode(String.self, forKey: .lightColor)
         let surface = try container.decode(String.self, forKey: .surfaceColor)
+        let dark = try container.decode(String.self, forKey: .darkColor)
 
         guard let palette = EmotionPalette(
             primaryHex: primary,
             secondaryHex: secondary,
             lightHex: light,
-            surfaceHex: surface
+            surfaceHex: surface,
+            darkHex: dark
         ) else {
             throw DecodingError.dataCorruptedError(
                 forKey: .primaryColor,

--- a/apps/ios/Pebbles/Features/Path/Read/BannerAspect.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/BannerAspect.swift
@@ -1,31 +1,37 @@
 import CoreGraphics
 
-/// Banner aspect-ratio bucket chosen for a source image. The pebble read
-/// banner snaps the source's width/height ratio to the nearest of three
-/// fixed buckets — 16:9, 4:3, 1:1 — so portrait or near-square uploads no
-/// longer get cropped to a forced landscape strip.
+/// Aspect-ratio bucket chosen for a pebble's snap on the read view. The snap's
+/// width/height ratio snaps to the nearest of three fixed buckets — 4:3
+/// (landscape), 1:1, 3:4 (portrait) — so the imported photo reads at a natural
+/// shape instead of a forced strip (issue #599).
+///
+/// These buckets replace the earlier 16:9/4:3/1:1 set: the redesigned page
+/// frames the whole picture (portrait included) with the Petroglyph overlapping
+/// its top-right, so a tall 3:4 crop is now first-class and the wide 16:9 strip
+/// is gone.
 ///
 /// Pure value type. No view dependencies; trivially unit-testable.
 enum BannerAspect: Equatable {
-    case sixteenNine
     case fourThree
     case square
+    case threeFour
 
     /// CG ratio (width / height) for the bucket.
     var cgRatio: CGFloat {
         switch self {
-        case .sixteenNine: return 16.0 / 9.0
-        case .fourThree:   return 4.0 / 3.0
-        case .square:      return 1.0
+        case .fourThree: return 4.0 / 3.0
+        case .square:    return 1.0
+        case .threeFour: return 3.0 / 4.0
         }
     }
 
     /// Pick the bucket whose `cgRatio` is closest to `ratio` (absolute
-    /// distance). Portrait sources (`ratio < 1`) always bucket to `.square`
-    /// since 1.0 is the smallest of the three candidates — no special case.
+    /// distance). Very wide sources collapse to `.fourThree` and very tall
+    /// ones to `.threeFour` since those are the extreme candidates — no
+    /// special case.
     static func nearest(to ratio: CGFloat) -> BannerAspect {
-        let candidates: [BannerAspect] = [.sixteenNine, .fourThree, .square]
+        let candidates: [BannerAspect] = [.fourThree, .square, .threeFour]
         return candidates.min(by: { abs($0.cgRatio - ratio) < abs($1.cgRatio - ratio) })
-            ?? .sixteenNine
+            ?? .square
     }
 }

--- a/apps/ios/Pebbles/Features/Path/Read/PebbleReadBanner.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/PebbleReadBanner.swift
@@ -1,19 +1,20 @@
 import SwiftUI
 import os
 
-/// Top zone of the pebble read view.
+/// Top zone of the pebble read view — the #599 redesign.
 ///
-/// Sequencing (issue #335):
-/// 1. Phase 1 — render the no-photo layout regardless of whether the pebble
-///    has a snap. Pebble centered in its 120pt zone. Photo bytes load in the
-///    background; the stroke animation runs in parallel.
-/// 2. Phase 2 — once both the stroke animation has finished AND the bytes
-///    have been decoded into a `UIImage`, flip `revealPhoto` inside a
-///    `withAnimation`. The banner inserts above the pebble box at the
-///    bucketed aspect ratio (`BannerAspect`), the pebble box settles into
-///    its overlap position, and content below shifts down.
+/// - **No snap** (or one that hasn't loaded / failed to load): the framed
+///   `PebbleReadPetroglyph` centered as the page heading.
+/// - **Snap present**: once the ORIGINAL rendition is signed + decoded, the
+///   whole picture shows at its nearest `BannerAspect` bucket with the
+///   Petroglyph overlapping its top-right (`PebbleSnapFrame`).
 ///
-/// Without a snap, Phase 2 never fires.
+/// This replaces the previous two-phase reveal (the snap sliding in over the
+/// pebble after the stroke animation, #335 / #582): the page now frames the
+/// picture outright, so there is no mask/slide. A failed load simply stays on
+/// the Petroglyph heading — no error UI. The Petroglyph keeps its own native
+/// draw-on (via `PebbleAnimatedRenderView`); nothing gates the snap swap but
+/// the decode itself.
 struct PebbleReadBanner: View {
     let snapStoragePath: String?
     let renderSvg: String?
@@ -23,96 +24,48 @@ struct PebbleReadBanner: View {
 
     @Environment(SnapURLCache.self) private var snapURLs
     @Environment(EmotionPaletteService.self) private var palettes
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var loadedImage: UIImage?
-    @State private var animationFinished: Bool = false
-    @State private var revealPhoto: Bool = false
 
     private static let logger = Logger(subsystem: "app.pbbls.ios", category: "pebble-read-banner")
 
-    private let bannerCornerRadius: CGFloat = 24
-    private let boxSize: CGFloat = 120
-    private let boxCornerRadius: CGFloat = 24
-    private let revealDuration: Double = 0.45
-    private let revealDurationReduceMotion: Double = 0.25
+    /// Square slot for the Petroglyph when it is the page heading (no snap).
+    private let headingPetroglyph: CGFloat = 150
 
     var body: some View {
-        // The pebble lives in a stable slot of this ZStack across both phases
-        // — same structural position before and after reveal — so its
-        // identity is preserved and `PebbleAnimatedRenderView.onAppear` does
-        // NOT re-fire. The banner inserts as an optional sibling above the
-        // pebble; its bottom padding produces the half-overlap with the box.
-        ZStack(alignment: .bottom) {
-            if revealPhoto, let image = loadedImage {
-                bannerWithPhoto(image: image)
-                    .padding(.bottom, boxSize / 2)
-                    .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
+        Group {
+            if let image = loadedImage {
+                PebbleSnapFrame(
+                    image: image,
+                    aspect: BannerAspect.nearest(to: image.size.width / max(image.size.height, 1)),
+                    renderSvg: renderSvg,
+                    renderVersion: renderVersion,
+                    valence: valence,
+                    palette: palette
+                )
+            } else {
+                PebbleReadPetroglyph(
+                    renderSvg: renderSvg,
+                    renderVersion: renderVersion,
+                    valence: valence,
+                    palette: palette
+                )
+                .frame(width: headingPetroglyph, height: headingPetroglyph)
+                .frame(maxWidth: .infinity)
             }
-
-            pebbleStableSlot
         }
-        .frame(maxWidth: .infinity, minHeight: boxSize)
         .task(id: snapStoragePath) {
             await loadPhotoIfNeeded()
         }
-        .task(id: renderVersion) {
-            await waitForAnimationToFinish()
-        }
-        .onChange(of: loadedImage) { _, _ in revealIfReady() }
-        .onChange(of: animationFinished) { _, _ in revealIfReady() }
     }
 
-    private var pebbleStableSlot: some View {
-        renderedPebble
-            .frame(width: boxSize, height: boxSize)
-            .background {
-                if revealPhoto {
-                    RoundedRectangle(cornerRadius: boxCornerRadius)
-                        .fill(Color.system.background)
-                }
-            }
+    private var palette: EmotionPalette? {
+        palettes.palette(for: emotionId)
     }
-
-    private func revealIfReady() {
-        guard !revealPhoto, loadedImage != nil, animationFinished else { return }
-        let animation: Animation = reduceMotion
-            ? .easeOut(duration: revealDurationReduceMotion)
-            : .easeOut(duration: revealDuration)
-        withAnimation(animation) {
-            revealPhoto = true
-        }
-    }
-
-    // MARK: - Phase 2 banner
-
-    @ViewBuilder
-    private func bannerWithPhoto(image: UIImage) -> some View {
-        let aspect = BannerAspect.nearest(to: image.size.width / max(image.size.height, 1))
-        // The Color.clear container is the size-of-truth: it's full-width and
-        // forced to `aspect.cgRatio`. The image overlays it with `.fill`,
-        // overflowing edges are clipped by the surrounding RoundedRectangle.
-        // This gives CSS `background-size: cover` behavior inside a fixed
-        // bucket. The half-overlap with the pebble is produced by the
-        // `.padding(.bottom, boxSize / 2)` applied at the call site.
-        Color.clear
-            .aspectRatio(aspect.cgRatio, contentMode: .fit)
-            .frame(maxWidth: .infinity)
-            .overlay {
-                Image(uiImage: image)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-            }
-            .clipShape(RoundedRectangle(cornerRadius: bannerCornerRadius))
-            .accessibilityHidden(true)
-    }
-
-    // MARK: - Phase 1 background work
 
     private func loadPhotoIfNeeded() async {
         guard let path = snapStoragePath else { return }
         loadedImage = nil
-        revealPhoto = false
         do {
             let urls = try await snapURLs.signedURLs(storagePath: path)
             var request = URLRequest(url: urls.original)
@@ -129,59 +82,6 @@ struct PebbleReadBanner: View {
             Self.logger.error(
                 "photo load failed for \(path, privacy: .public): \(error.localizedDescription, privacy: .private)"
             )
-        }
-    }
-
-    private func waitForAnimationToFinish() async {
-        // Static pebble (no animation) → reveal as soon as the photo is ready.
-        guard !reduceMotion,
-              let timings = PebbleAnimationTimings.forVersion(renderVersion) else {
-            animationFinished = true
-            return
-        }
-        do {
-            try await Task.sleep(for: .seconds(timings.totalDuration))
-        } catch {
-            // Cancellation: either the .task id changed (relaunch will reset
-            // the gate) or the view disappeared (no reveal needed). Leave
-            // animationFinished as-is in both cases.
-            return
-        }
-        animationFinished = true
-    }
-
-    // MARK: - Pebble rendering (unchanged)
-
-    @ViewBuilder
-    private var renderedPebble: some View {
-        if let renderSvg {
-            let palette = palettes.palette(for: emotionId)
-            let frameColors = palette?.pebbleFrameColors(forIntensity: valence.intensity)
-            let strokeHex = frameColors?.strokeHex ?? Color.accent.primaryHex
-            PebbleAnimatedRenderView(
-                svg: renderSvg,
-                strokeColor: Color(hex: strokeHex) ?? Color.accent.primary,
-                strokeColorHex: strokeHex,
-                fillHex: frameColors?.fillHex ?? Color.accent.primaryHex,
-                fillOpacity: frameColors?.fillOpacity ?? 1,
-                size: valence.sizeGroup,
-                polarity: valence.polarity,
-                renderVersion: renderVersion
-            )
-            .frame(height: pebbleHeight)
-        } else {
-            EmptyView()
-        }
-    }
-
-    /// Pebble height inside the 120pt box, scaled by valence size group
-    /// so higher-intensity pebbles read bigger than lower-intensity ones
-    /// while still fitting comfortably.
-    private var pebbleHeight: CGFloat {
-        switch valence.sizeGroup {
-        case .small:  return 80
-        case .medium: return 100
-        case .large:  return 116
         }
     }
 }
@@ -227,9 +127,9 @@ struct PebbleReadBanner: View {
 }
 
 #Preview("With photo (preview-only stub)") {
-    // Preview cannot reach Supabase Storage; this preview only shows the
-    // no-photo path. Manual smoke verification covers the with-photo
-    // sequencing in the simulator.
+    // Preview cannot reach Supabase Storage, so the decoded-snap path can't
+    // load here; this preview shows the no-photo heading. The `PebbleSnapFrame`
+    // overlay is previewed directly in its own file with a stand-in image.
     let supabase = SupabaseService()
     return PebbleReadBanner(
         snapStoragePath: nil,

--- a/apps/ios/Pebbles/Features/Path/Read/PebbleReadPetroglyph.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/PebbleReadPetroglyph.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+/// The read-view "Petroglyph" (issue #599): the framed pebble — outline
+/// silhouette backfill with the composed render (outline + glyph) traced on
+/// top — shown either as the page heading (no snap) or overlapping the snap's
+/// top-right corner (`PebbleSnapFrame`).
+///
+/// Reuses `PebbleAnimatedRenderView`, which already composites the backdrop and
+/// the pebble with the read view's native draw-on animation; only the coloring
+/// changes here — from the theme-neutral `pebbleFrameColors` used by the Path
+/// rows to #599's per-size, per-scheme `petroglyphColors` table.
+///
+/// Sized by the caller: the heading treatment gives it a large square slot, the
+/// snap overlay a smaller one (the render fits its own outline aspect inside
+/// whatever frame it gets). A missing `palette` (cache cold, unknown or absent
+/// emotion) falls back to the brand accent, mirroring `PathPebbleRow`. `palette`
+/// and the valence data arrive as parameters so previews drive it without a
+/// live client.
+struct PebbleReadPetroglyph: View {
+    let renderSvg: String?
+    let renderVersion: String?
+    let valence: Valence
+    let palette: EmotionPalette?
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        if let renderSvg {
+            let colors = resolvedColors
+            PebbleAnimatedRenderView(
+                svg: renderSvg,
+                strokeColor: Color(hex: colors.strokeHex) ?? Color.accent.primary,
+                strokeColorHex: colors.strokeHex,
+                fillHex: colors.fillHex,
+                fillOpacity: colors.fillOpacity,
+                size: valence.sizeGroup,
+                polarity: valence.polarity,
+                renderVersion: renderVersion
+            )
+        }
+    }
+
+    /// #599 colors for the current size + scheme, or the brand accent when the
+    /// palette is unavailable (opaque accent for both stroke and fill).
+    private var resolvedColors: PetroglyphColors {
+        guard let palette else {
+            let accentHex = Color.accent.primaryHex
+            return PetroglyphColors(strokeHex: accentHex, fillHex: accentHex, fillOpacity: 1)
+        }
+        return palette.petroglyphColors(forSize: valence.sizeGroup, scheme: colorScheme)
+    }
+}

--- a/apps/ios/Pebbles/Features/Path/Read/PebbleSnapFrame.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/PebbleSnapFrame.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+import UIKit
+
+/// The snap-present heading of the read view (issue #599): the whole picture at
+/// its nearest `BannerAspect` bucket, tilted slightly, with the
+/// `PebbleReadPetroglyph` overlapping its top-right corner and tilted the other
+/// way. Ports the web `PebbleDetail` snap+pebble bundle.
+///
+/// Stateless — the caller resolves the decoded `image` and its `aspect`, so the
+/// same frame can back the edit view's dashed placeholder in the #599 follow-up.
+/// The photo is inset from the cluster's top and trailing edges (the poke
+/// insets) so the top-trailing Petroglyph pokes out past the corner while
+/// overlapping the picture; the tilts are draw-only (`rotationEffect` does not
+/// affect layout), so each rounded rectangle turns in place. The snap is hidden
+/// from accessibility (web/Android parity).
+struct PebbleSnapFrame: View {
+    let image: UIImage
+    let aspect: BannerAspect
+    let renderSvg: String?
+    let renderVersion: String?
+    let valence: Valence
+    let palette: EmotionPalette?
+
+    private static let photoMinor: CGFloat = 150
+    /// Longer photo edge for 4:3 / 3:4 snaps (150 × 4/3).
+    private static let photoMajor: CGFloat = 200
+    /// Top inset of the photo — how far the Petroglyph pokes above it.
+    private static let pokeTop: CGFloat = 40
+    /// Trailing inset of the photo — how far the Petroglyph pokes past its edge.
+    private static let pokeEnd: CGFloat = 28
+    /// Layout slot for the overlapping Petroglyph (its tilt bounding runs a touch larger).
+    private static let overlayPetroglyph: CGFloat = 96
+    private static let photoCorner: CGFloat = 18
+    /// Counter-clockwise photo tilt, clockwise Petroglyph tilt — the web `-rotate-4` / `rotate-7`.
+    private static let photoTilt: Double = -5
+    private static let petroglyphTilt: Double = 7.5
+
+    var body: some View {
+        // The cluster (ZStack) wraps the photo plus its poke insets; the
+        // Petroglyph aligns to the cluster's top-trailing so it lands on the
+        // photo's corner. The insets are asymmetric — it pokes above the photo
+        // more than past its trailing edge, matching the design.
+        ZStack(alignment: .topTrailing) {
+            Image(uiImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: photoSize.width, height: photoSize.height)
+                .clipShape(RoundedRectangle(cornerRadius: Self.photoCorner))
+                .rotationEffect(.degrees(Self.photoTilt))
+                .padding(.top, Self.pokeTop)
+                .padding(.trailing, Self.pokeEnd)
+                .accessibilityHidden(true)
+
+            PebbleReadPetroglyph(
+                renderSvg: renderSvg,
+                renderVersion: renderVersion,
+                valence: valence,
+                palette: palette
+            )
+            .frame(width: Self.overlayPetroglyph, height: Self.overlayPetroglyph)
+            .rotationEffect(.degrees(Self.petroglyphTilt))
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    /// Photo box for the bucket: square keeps both edges short; landscape and
+    /// portrait stretch one edge to `photoMajor`.
+    private var photoSize: CGSize {
+        switch aspect {
+        case .square:    return CGSize(width: Self.photoMinor, height: Self.photoMinor)
+        case .fourThree: return CGSize(width: Self.photoMajor, height: Self.photoMinor)
+        case .threeFour: return CGSize(width: Self.photoMinor, height: Self.photoMajor)
+        }
+    }
+}
+
+#if DEBUG
+/// A neutral fill stands in for the decoded snap — a preview cannot reach
+/// Supabase Storage, so a real rendition can't load here.
+private func previewSnapImage() -> UIImage {
+    UIGraphicsImageRenderer(size: CGSize(width: 4, height: 4)).image { ctx in
+        UIColor(red: 0.42, green: 0.48, blue: 0.56, alpha: 1).setFill()
+        ctx.fill(CGRect(x: 0, y: 0, width: 4, height: 4))
+    }
+}
+
+private let previewSnapPalette = EmotionPalette(
+    primaryHex: "#7B5E99FF",
+    secondaryHex: "#AE91CCFF",
+    lightHex: "#F2EFF5FF",
+    surfaceHex: "#7B5E991A",
+    darkHex: "#2A2138FF"
+)
+
+private let previewSnapSvg = """
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" stroke-width="3"/>
+</svg>
+"""
+
+#Preview("Snap frame · square") {
+    PebbleSnapFrame(
+        image: previewSnapImage(),
+        aspect: .square,
+        renderSvg: previewSnapSvg,
+        renderVersion: "0.1.0",
+        valence: .neutralMedium,
+        palette: previewSnapPalette
+    )
+    .padding(.vertical, 24)
+    .frame(maxWidth: .infinity)
+    .background(Color.system.background)
+}
+
+#Preview("Snap frame · landscape") {
+    PebbleSnapFrame(
+        image: previewSnapImage(),
+        aspect: .fourThree,
+        renderSvg: previewSnapSvg,
+        renderVersion: "0.1.0",
+        valence: .neutralMedium,
+        palette: previewSnapPalette
+    )
+    .padding(.vertical, 24)
+    .frame(maxWidth: .infinity)
+    .background(Color.system.background)
+}
+
+#Preview("Snap frame · portrait large") {
+    PebbleSnapFrame(
+        image: previewSnapImage(),
+        aspect: .threeFour,
+        renderSvg: previewSnapSvg,
+        renderVersion: "0.1.0",
+        valence: .highlightLarge,
+        palette: previewSnapPalette
+    )
+    .padding(.vertical, 24)
+    .frame(maxWidth: .infinity)
+    .background(Color.system.background)
+}
+#endif

--- a/apps/ios/PebblesTests/BannerAspectTests.swift
+++ b/apps/ios/PebblesTests/BannerAspectTests.swift
@@ -2,29 +2,21 @@ import Foundation
 import Testing
 @testable import Pebbles
 
+/// `BannerAspect.nearest` — the #599 three-bucket snap (4:3 / 1:1 / 3:4),
+/// mirroring Android `BannerAspectTest`.
 @Suite("BannerAspect")
 struct BannerAspectTests {
-
-    @Test("16:9 source picks .sixteenNine")
-    func sixteenNineSource() {
-        #expect(BannerAspect.nearest(to: 16.0 / 9.0) == .sixteenNine)
-    }
-
-    @Test("3:2 source picks .fourThree (closer than 16:9)")
-    func threeTwoSource() {
-        // r = 1.5; |1.5 - 1.333| = 0.167; |1.5 - 1.778| = 0.278 → 4:3 wins.
-        #expect(BannerAspect.nearest(to: 3.0 / 2.0) == .fourThree)
-    }
-
-    @Test("Near-midpoint ~1.6 picks .sixteenNine (closer than 4:3)")
-    func nearMidpointPicksSixteenNine() {
-        // r = 1.6; |1.6 - 1.778| = 0.178; |1.6 - 1.333| = 0.267 → 16:9 wins.
-        #expect(BannerAspect.nearest(to: 1.6) == .sixteenNine)
-    }
 
     @Test("4:3 source picks .fourThree")
     func fourThreeSource() {
         #expect(BannerAspect.nearest(to: 4.0 / 3.0) == .fourThree)
+        #expect(BannerAspect.nearest(to: 1.4) == .fourThree)
+    }
+
+    @Test("Very wide sources still bucket to .fourThree")
+    func extremeLandscape() {
+        #expect(BannerAspect.nearest(to: 16.0 / 9.0) == .fourThree)
+        #expect(BannerAspect.nearest(to: 2.4) == .fourThree)
     }
 
     @Test("Square source picks .square")
@@ -32,21 +24,30 @@ struct BannerAspectTests {
         #expect(BannerAspect.nearest(to: 1.0) == .square)
     }
 
-    @Test("Portrait 9:16 source picks .square (no portrait bucket)")
+    @Test("Portrait 3:4 source picks .threeFour")
     func portraitSource() {
-        // r ≈ 0.5625; closer to 1.0 than to 1.333 or 1.778.
-        #expect(BannerAspect.nearest(to: 9.0 / 16.0) == .square)
+        #expect(BannerAspect.nearest(to: 3.0 / 4.0) == .threeFour)
+        #expect(BannerAspect.nearest(to: 0.8) == .threeFour)
     }
 
-    @Test("Extreme landscape 21:9 source picks .sixteenNine")
-    func extremeLandscape() {
-        #expect(BannerAspect.nearest(to: 21.0 / 9.0) == .sixteenNine)
+    @Test("Very tall sources still bucket to .threeFour")
+    func extremePortrait() {
+        #expect(BannerAspect.nearest(to: 0.1) == .threeFour)
+    }
+
+    @Test("Boundaries split at the midpoints")
+    func boundaries() {
+        // Midpoint between 3/4 and 1.0 is 0.875; between 1.0 and 4/3 is ~1.1667.
+        #expect(BannerAspect.nearest(to: 0.87) == .threeFour)
+        #expect(BannerAspect.nearest(to: 0.88) == .square)
+        #expect(BannerAspect.nearest(to: 1.16) == .square)
+        #expect(BannerAspect.nearest(to: 1.17) == .fourThree)
     }
 
     @Test("cgRatio matches the bucket")
     func cgRatioValues() {
-        #expect(BannerAspect.sixteenNine.cgRatio == 16.0 / 9.0)
-        #expect(BannerAspect.fourThree.cgRatio   == 4.0 / 3.0)
-        #expect(BannerAspect.square.cgRatio      == 1.0)
+        #expect(BannerAspect.fourThree.cgRatio == 4.0 / 3.0)
+        #expect(BannerAspect.square.cgRatio    == 1.0)
+        #expect(BannerAspect.threeFour.cgRatio == 3.0 / 4.0)
     }
 }

--- a/apps/ios/PebblesTests/EmotionPaletteTests.swift
+++ b/apps/ios/PebblesTests/EmotionPaletteTests.swift
@@ -57,7 +57,8 @@ struct EmotionPaletteTests {
             primaryHex: "#7B5E99FF",
             secondaryHex: "#AE91CCFF",
             lightHex: "#F2EFF5FF",
-            surfaceHex: "#7B5E991A"
+            surfaceHex: "#7B5E991A",
+            darkHex: "#2A2138FF"
         )
     }
 
@@ -72,7 +73,20 @@ struct EmotionPaletteTests {
             primaryHex: "not-hex",
             secondaryHex: "#AE91CCFF",
             lightHex: "#F2EFF5FF",
-            surfaceHex: "#7B5E991A"
+            surfaceHex: "#7B5E991A",
+            darkHex: "#2A2138FF"
+        )
+        #expect(palette == nil)
+    }
+
+    @Test("init returns nil when the dark_color hex is malformed (#599)")
+    func initFailsOnBadDarkHex() {
+        let palette = EmotionPalette(
+            primaryHex: "#7B5E99FF",
+            secondaryHex: "#AE91CCFF",
+            lightHex: "#F2EFF5FF",
+            surfaceHex: "#7B5E991A",
+            darkHex: "not-hex"
         )
         #expect(palette == nil)
     }
@@ -102,10 +116,12 @@ struct EmotionPaletteTests {
             primaryHex:   "#7B5E99FF  ",
             secondaryHex: "  #AE91CCFF",
             lightHex:     "#F2EFF5FF\n",
-            surfaceHex:   "#7B5E991A "
+            surfaceHex:   "#7B5E991A ",
+            darkHex:      "  #2A2138FF "
         )
         #expect(palette?.primaryHex == "#7B5E99FF")
         #expect(palette?.surfaceHex == "#7B5E991A")
+        #expect(palette?.darkHex == "#2A2138FF")
         #expect(palette?.strokeHex(for: .light) == "#7B5E99")
     }
 }

--- a/apps/ios/PebblesTests/EmotionWithPaletteDecodingTests.swift
+++ b/apps/ios/PebblesTests/EmotionWithPaletteDecodingTests.swift
@@ -22,7 +22,8 @@ struct EmotionWithPaletteDecodingTests {
       "primary_color": "#7B5E99FF",
       "secondary_color": "#AE91CCFF",
       "light_color": "#F2EFF5FF",
-      "surface_color": "#7B5E991A"
+      "surface_color": "#7B5E991A",
+      "dark_color": "#2A2138FF"
     }
     """
 
@@ -32,7 +33,17 @@ struct EmotionWithPaletteDecodingTests {
         #expect(row.slug == "anxiety")
         #expect(row.categorySlug == "fear")
         #expect(row.palette.primaryHex == "#7B5E99FF")
+        #expect(row.palette.darkHex == "#2A2138FF")
         #expect(row.palette.strokeHex(for: .dark) == "#AE91CC")
+    }
+
+    @Test("rejects null dark_color (#599 — required like the rest of the palette)")
+    func rejectsNullDarkColor() {
+        let json = validJson.replacingOccurrences(
+            of: "\"dark_color\": \"#2A2138FF\"",
+            with: "\"dark_color\": null"
+        )
+        #expect(throws: DecodingError.self) { try decode(json) }
     }
 
     @Test("rejects null id")

--- a/apps/ios/PebblesTests/LocalizationTests.swift
+++ b/apps/ios/PebblesTests/LocalizationTests.swift
@@ -54,7 +54,8 @@ struct LocalizationPatternCTests {
                 primaryHex: "#000000FF",
                 secondaryHex: "#000000FF",
                 lightHex: "#FFFFFFFF",
-                surfaceHex: "#0000001A"
+                surfaceHex: "#0000001A",
+                darkHex: "#000000FF"
             )!
         )
         #expect(category.localizedName == "Fallback Name")

--- a/apps/ios/PebblesTests/PathPebbleRowNameColorTests.swift
+++ b/apps/ios/PebblesTests/PathPebbleRowNameColorTests.swift
@@ -9,7 +9,8 @@ struct PathPebbleRowNameColorTests {
         primaryHex:   "#C07A7AFF",
         secondaryHex: "#9B5C5CFF",
         lightHex:     "#E8B8B8FF",
-        surfaceHex:   "#C07A7A1A"
+        surfaceHex:   "#C07A7A1A",
+        darkHex:      "#3A2222FF"
     )!
 
     // Regression (#510): large pebble name/time were unreadable in light

--- a/apps/ios/PebblesTests/PebbleFrameColorsTests.swift
+++ b/apps/ios/PebblesTests/PebbleFrameColorsTests.swift
@@ -11,7 +11,8 @@ struct PebbleFrameColorsTests {
         primaryHex:   "#C07A7AFF",
         secondaryHex: "#9B5C5CFF",
         lightHex:     "#E8B8B8FF",
-        surfaceHex:   "#C07A7A1A"
+        surfaceHex:   "#C07A7A1A",
+        darkHex:      "#3A2222FF"
     )!
 
     @Test func intensity3UsesLightStrokeAndOpaquePrimaryFill() {
@@ -58,7 +59,8 @@ struct PebbleFrameColorsTests {
             primaryHex:   "#487C5AFF   ",
             secondaryHex: "#80BF96FF\n",
             lightHex:     "  #EDF2EEFF",
-            surfaceHex:   "#487C5A1A                    "
+            surfaceHex:   "#487C5A1A                    ",
+            darkHex:      "  #1E3326FF "
         )!
         let small = padded.pebbleFrameColors(forIntensity: 1)
         #expect(small.fillHex == "#487C5A")
@@ -78,7 +80,8 @@ struct PebbleFrameColorsTests {
             primaryHex:   "#112233",
             secondaryHex: "#445566",
             lightHex:     "#778899",
-            surfaceHex:   "#AABBCC"
+            surfaceHex:   "#AABBCC",
+            darkHex:      "#223344"
         )!
         let colors = sixDigit.pebbleFrameColors(forIntensity: 2)
         #expect(colors.fillHex   == "#AABBCC")

--- a/apps/ios/PebblesTests/PetroglyphColorsTests.swift
+++ b/apps/ios/PebblesTests/PetroglyphColorsTests.swift
@@ -1,0 +1,60 @@
+import Testing
+import SwiftUI
+@testable import Pebbles
+
+/// `EmotionPalette.petroglyphColors(forSize:scheme:)` — the #599 per-size,
+/// per-scheme colour table, mirroring Android `PetroglyphColorsTest`. Fixture
+/// hex matches the shared `EmotionPaletteTests` palette (opaque primary /
+/// secondary / light / dark, 10%-alpha surface).
+@Suite("PetroglyphColors (#599)")
+struct PetroglyphColorsTests {
+    private let palette = EmotionPalette(
+        primaryHex:   "#7B5E99FF",
+        secondaryHex: "#AE91CCFF",
+        lightHex:     "#F2EFF5FF",
+        surfaceHex:   "#7B5E991A",
+        darkHex:      "#2A2138FF"
+    )!
+
+    @Test("large is light stroke over opaque primary backfill in both schemes")
+    func largeBothSchemes() {
+        for scheme in [ColorScheme.light, .dark] {
+            let colors = palette.petroglyphColors(forSize: .large, scheme: scheme)
+            #expect(colors.strokeHex == "#F2EFF5", "scheme \(scheme)")
+            #expect(colors.fillHex == "#7B5E99", "scheme \(scheme)")
+            #expect(abs(colors.fillOpacity - 1.0) < 0.001, "scheme \(scheme)")
+        }
+    }
+
+    @Test("small/medium in light mode use primary stroke over solid light backfill")
+    func smallMediumLight() {
+        for size in [ValenceSizeGroup.small, .medium] {
+            let colors = palette.petroglyphColors(forSize: size, scheme: .light)
+            #expect(colors.strokeHex == "#7B5E99", "size \(size)")
+            #expect(colors.fillHex == "#F2EFF5", "size \(size)")
+            #expect(abs(colors.fillOpacity - 1.0) < 0.001, "size \(size)")
+        }
+    }
+
+    @Test("small/medium in dark mode use secondary stroke over the solid dark backfill")
+    func smallMediumDark() {
+        for size in [ValenceSizeGroup.small, .medium] {
+            let colors = palette.petroglyphColors(forSize: size, scheme: .dark)
+            #expect(colors.strokeHex == "#AE91CC", "size \(size)")
+            // "palette.dark" == the dedicated opaque dark_color slot.
+            #expect(colors.fillHex == "#2A2138", "size \(size)")
+            #expect(abs(colors.fillOpacity - 1.0) < 0.001, "size \(size)")
+        }
+    }
+
+    @Test("every hex is sanitized to 6-digit for SVG injection")
+    func everyHexIsSixDigit() {
+        for size in [ValenceSizeGroup.small, .medium, .large] {
+            for scheme in [ColorScheme.light, .dark] {
+                let colors = palette.petroglyphColors(forSize: size, scheme: scheme)
+                #expect(colors.strokeHex.count == 7, "size \(size) scheme \(scheme) strokeHex")
+                #expect(colors.fillHex.count == 7, "size \(size) scheme \(scheme) fillHex")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #599

## Changes

**New components:**
- `PebbleReadPetroglyph.swift` — the framed pebble (outline + glyph on solid backfill), shown as page heading or overlapping the snap. Reuses `PebbleAnimatedRenderView` with #599's per-size, per-scheme `petroglyphColors` table.
- `PebbleSnapFrame.swift` — the snap-present heading: full picture at its nearest `BannerAspect` bucket, tilted slightly, with Petroglyph overlapping top-right corner and tilted the opposite way. Stateless; caller resolves decoded image and aspect.
- `PetroglyphColorsTests.swift` — unit tests for the new color table (mirrors Android `PetroglyphColorsTest`).

**Modified components:**
- `PebbleReadBanner.swift` — replaced two-phase reveal (stroke animation gate + photo slide-in) with immediate conditional render: Petroglyph heading if no snap, `PebbleSnapFrame` if snap decoded. Removed `animationFinished`, `revealPhoto`, `reduceMotion` state and animation logic; simplified to a single `.task` for photo load.
- `BannerAspect.swift` — replaced 16:9/4:3/1:1 buckets with 4:3/1:1/3:4 (landscape/square/portrait). Updated `nearest(to:)` logic and test suite.
- `EmotionPalette.swift` — added `dark` color (the `dark_color` column, #599 addition) and new `petroglyphColors(forSize:scheme:)` method implementing the per-size, per-scheme table. Added `PetroglyphColors` struct.
- `EmotionWithPalette.swift` — updated decoder to require `dark_color` (non-null, like the rest of the palette).

**Test updates:**
- `BannerAspectTests.swift` — rewrote for new 4:3/1:1/3:4 buckets; added boundary tests.
- `EmotionPaletteTests.swift` — added `darkHex` parameter to all palette fixtures; added test for malformed `dark_color`.
- `EmotionWithPaletteDecodingTests.swift` — updated fixture JSON; added test rejecting null `dark_color`.
- `PebbleFrameColorsTests.swift`, `PathPebbleRowNameColorTests.swift`, `LocalizationTests.swift` — updated palette fixtures to include `darkHex`.

## Notes

**Design rationale:**
- The old two-phase reveal (pebble → stroke animation → photo slides in) is replaced by a simpler conditional: no snap = Petroglyph heading; snap decoded = full `PebbleSnapFrame`. This removes the animation gate and the mask/slide complexity.
- `PebbleReadPetroglyph` extracts the pebble rendering logic and applies #599's theme-dependent coloring (per size group and color scheme), distinct from the theme-neutral `pebbleFrameColors` used by Path rows.
- `PebbleSnapFrame` is stateless and sized by the caller, so it can back both the read view heading and the edit view's dashed placeholder (follow-up).
- The snap is inset from the cluster's top and trailing edges (the "poke" insets) so the Petroglyph overlaps the picture's corner while poking out past it. Both are tilted draw-only (no layout impact).
- Portrait snaps (3:4) are now first-class; the wide 16:9 strip is gone.

**Color table (#599):**
- **Large:** light stroke over opaque primary backfill (both schemes) — the hero treatment.
- **Small/medium:** theme-dependent — light mode uses primary stroke over solid light backfill; dark uses secondary stroke over the new solid `dark` backfill (not the faint `surface` wash).

**Test coverage:**
- `PetroglyphColorsTests` mirrors Android's test suite and covers all size/scheme combinations, boundary conditions,

https://claude.ai/code/session_01LW1Frrsvhh94tvr8DfSnNW