### PR TITLE
feat(ios): tint pebble read page to emotion palette (#605)

### DIFF
--- a/apps/ios/Pebbles/Features/Path/Models/EmotionPalette.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/EmotionPalette.swift
@@ -17,28 +17,32 @@ import SwiftUI
 /// `Color.accent.primary` / `Color.accent.primaryHex`.
 ///
 /// `dark` is the #599 addition: the small/medium read-view Petroglyph backfill
-/// in dark mode (the "palette.dark" role, from the `dark_color` column). The
-/// sibling `shaded_color` column also exists on the view but has no iOS
-/// consumer yet, so it is intentionally not modelled here.
+/// in dark mode (the "palette.dark" role, from the `dark_color` column).
+/// `shaded` is the #605 addition: a deeper tint used for the pebble read-page
+/// title / tile label / description in light mode (the "shaded_color" role on
+/// the view).
 struct EmotionPalette: Equatable {
     let primary: Color
     let secondary: Color
     let light: Color
     let surface: Color
     let dark: Color
+    let shaded: Color
 
     let primaryHex: String
     let secondaryHex: String
     let lightHex: String
     let surfaceHex: String
     let darkHex: String
+    let shadedHex: String
 
     init?(
         primaryHex: String,
         secondaryHex: String,
         lightHex: String,
         surfaceHex: String,
-        darkHex: String
+        darkHex: String,
+        shadedHex: String
     ) {
         // The palette hex columns on `emotion_categories` are populated by
         // hand in Supabase Studio and can carry stray surrounding whitespace.
@@ -51,12 +55,14 @@ struct EmotionPalette: Equatable {
         let lightHex = lightHex.trimmingCharacters(in: .whitespacesAndNewlines)
         let surfaceHex = surfaceHex.trimmingCharacters(in: .whitespacesAndNewlines)
         let darkHex = darkHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        let shadedHex = shadedHex.trimmingCharacters(in: .whitespacesAndNewlines)
         guard
             let primary = Color(hex: primaryHex),
             let secondary = Color(hex: secondaryHex),
             let light = Color(hex: lightHex),
             let surface = Color(hex: surfaceHex),
-            let dark = Color(hex: darkHex)
+            let dark = Color(hex: darkHex),
+            let shaded = Color(hex: shadedHex)
         else {
             return nil
         }
@@ -65,11 +71,13 @@ struct EmotionPalette: Equatable {
         self.light = light
         self.surface = surface
         self.dark = dark
+        self.shaded = shaded
         self.primaryHex = primaryHex
         self.secondaryHex = secondaryHex
         self.lightHex = lightHex
         self.surfaceHex = surfaceHex
         self.darkHex = darkHex
+        self.shadedHex = shadedHex
     }
 
     var accentBackground: Color { primary }

--- a/apps/ios/Pebbles/Features/Path/Models/EmotionWithPalette.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/EmotionWithPalette.swift
@@ -5,9 +5,9 @@ import Foundation
 /// PostgREST types every view column as nullable in `database.ts`, but the
 /// underlying invariants — `emotions.category_id NOT NULL` (shipped in #367),
 /// `emotions.emoji NOT NULL` (shipped in #370), and the palette `text NOT NULL`
-/// columns on `emotion_categories` (including `dark_color`, added for #599) —
-/// guarantee non-null values in practice. This
-/// decoder enforces that invariant at the boundary: rows with any null required
+/// columns on `emotion_categories` (including `dark_color`, added for #599, and
+/// `shaded_color`, consumed for #605) — guarantee non-null values in practice.
+/// This decoder enforces that invariant at the boundary: rows with any null required
 /// field throw `DecodingError`, which `EmotionPaletteService` logs and skips so
 /// the bad row simply isn't cached. Access sites read non-optional values from the
 /// cached `EmotionPalette` and never need to handle null.
@@ -31,6 +31,7 @@ struct EmotionWithPalette: Identifiable, Decodable {
         case lightColor    = "light_color"
         case surfaceColor  = "surface_color"
         case darkColor     = "dark_color"
+        case shadedColor   = "shaded_color"
     }
 
     init(from decoder: Decoder) throws {
@@ -48,13 +49,15 @@ struct EmotionWithPalette: Identifiable, Decodable {
         let light = try container.decode(String.self, forKey: .lightColor)
         let surface = try container.decode(String.self, forKey: .surfaceColor)
         let dark = try container.decode(String.self, forKey: .darkColor)
+        let shaded = try container.decode(String.self, forKey: .shadedColor)
 
         guard let palette = EmotionPalette(
             primaryHex: primary,
             secondaryHex: secondary,
             lightHex: light,
             surfaceHex: surface,
-            darkHex: dark
+            darkHex: dark,
+            shadedHex: shaded
         ) else {
             throw DecodingError.dataCorruptedError(
                 forKey: .primaryColor,

--- a/apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/PebbleDetailSheet.swift
@@ -14,6 +14,7 @@ struct PebbleDetailSheet: View {
     var onPebbleUpdated: (() -> Void)?
 
     @Environment(SupabaseService.self) private var supabase
+    @Environment(EmotionPaletteService.self) private var palettes
     @Environment(\.dismiss) private var dismiss
 
     @State private var detail: PebbleDetail?
@@ -62,7 +63,9 @@ struct PebbleDetailSheet: View {
                 Button("Retry") { Task { await load() } }
             }
         } else if let detail {
-            PebbleReadView(detail: detail)
+            // Look up the pebble's emotion palette so the whole read page tints
+            // to it (#605). A cache miss (nil) leaves the page on system chrome.
+            PebbleReadView(detail: detail, palette: palettes.palette(for: detail.emotion.id))
         }
     }
 
@@ -96,6 +99,9 @@ struct PebbleDetailSheet: View {
 }
 
 #Preview {
-    PebbleDetailSheet(pebbleId: UUID())
-        .environment(SupabaseService())
+    let supabase = SupabaseService()
+    return PebbleDetailSheet(pebbleId: UUID())
+        .environment(supabase)
+        .environment(EmotionPaletteService(client: supabase.client))
+        .environment(SnapURLCache(client: supabase.client))
 }

--- a/apps/ios/Pebbles/Features/Path/Read/PebblePageColors.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/PebblePageColors.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+/// Emotion-palette colors for the whole pebble read page (issue #605), resolved
+/// per element AND color scheme. Before #605 only the Petroglyph carried the
+/// palette and the rest of the page used the system/accent chrome; now the page
+/// tints to the pebble's emotion palette per this table:
+///
+/// | element         | light     | dark    |
+/// | --------------- | --------- | ------- |
+/// | background      | light     | dark    |
+/// | name (title)    | shaded    | light   |
+/// | date            | secondary | primary |
+/// | tile.background | surface   | surface |
+/// | tile.icon       | secondary | primary |
+/// | tile.label      | shaded    | light   |
+/// | description     | shaded    | light   |
+/// | soul.glyph      | secondary | primary |
+/// | soul.name       | primary   | light   |
+///
+/// Pure value type — resolved once at the read-view root and threaded into the
+/// leaf composables as `Color` parameters, keeping them palette-agnostic.
+/// Callers fall back to the system/accent chrome when the palette is
+/// unavailable (cache miss). Mirrors the #599 `PetroglyphColors` resolver.
+struct PebblePageColors: Equatable {
+    let background: Color
+    let title: Color
+    let date: Color
+    let tileBackground: Color
+    let tileIcon: Color
+    let tileLabel: Color
+    let description: Color
+    let soulGlyph: Color
+    let soulName: Color
+}
+
+extension EmotionPalette {
+    /// Read-page colors (issue #605) for the given color scheme — see
+    /// `PebblePageColors` for the full role table.
+    func pebblePageColors(for scheme: ColorScheme) -> PebblePageColors {
+        if scheme == .dark {
+            return PebblePageColors(
+                background: dark,
+                title: light,
+                date: primary,
+                tileBackground: surface,
+                tileIcon: primary,
+                tileLabel: light,
+                description: light,
+                soulGlyph: primary,
+                soulName: light
+            )
+        } else {
+            return PebblePageColors(
+                background: light,
+                title: shaded,
+                date: secondary,
+                tileBackground: surface,
+                tileIcon: secondary,
+                tileLabel: shaded,
+                description: shaded,
+                soulGlyph: secondary,
+                soulName: primary
+            )
+        }
+    }
+}

--- a/apps/ios/Pebbles/Features/Path/Read/PebbleReadTitle.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/PebbleReadTitle.swift
@@ -3,21 +3,26 @@ import SwiftUI
 /// Title block for the pebble read view: serif name + uppercase tracked
 /// date, both centered. Sized smaller than the original header so the
 /// banner above it can carry the visual weight (issue #331).
+///
+/// `nameColor` / `dateColor` override the default chrome colors — the read page
+/// tints them to the emotion palette (#605). `nil` keeps the system chrome.
 struct PebbleReadTitle: View {
     let name: String
     let happenedAt: Date
+    var nameColor: Color? = nil
+    var dateColor: Color? = nil
 
     var body: some View {
         VStack(spacing: 6) {
             Text(name)
                 .font(.custom("Ysabeau-SemiBold", size: 24))
                 .multilineTextAlignment(.center)
-                .foregroundStyle(Color.system.foreground)
+                .foregroundStyle(nameColor ?? Color.system.foreground)
             Text(formattedDate)
                 .font(.caption)
                 .tracking(1.2)
                 .textCase(.uppercase)
-                .foregroundStyle(Color.system.secondary)
+                .foregroundStyle(dateColor ?? Color.system.secondary)
         }
         .frame(maxWidth: .infinity)
     }

--- a/apps/ios/Pebbles/Features/Path/Read/PebbleReadView.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/PebbleReadView.swift
@@ -1,13 +1,27 @@
 import SwiftUI
 
 /// Body of the pebble read view. Pure UI — receives a fully-loaded
-/// `PebbleDetail` and lays out the sections per spec
-/// `docs/superpowers/specs/2026-04-29-ios-pebble-read-view-polish-design.md`.
+/// `PebbleDetail` plus its resolved emotion `palette` and lays out the sections
+/// per spec `docs/superpowers/specs/2026-04-29-ios-pebble-read-view-polish-design.md`.
+///
+/// The whole page tints to the pebble's emotion palette (#605) — background plus
+/// every text / tile / soul color resolves through `pebblePageColors(for:)`. On
+/// a palette cache miss (`palette` nil) the page falls back to the system/accent
+/// chrome.
 ///
 /// `PebbleDetailSheet` wraps this view with the navigation bar (privacy
 /// chip + edit button) and handles loading/error states.
 struct PebbleReadView: View {
     let detail: PebbleDetail
+    let palette: EmotionPalette?
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    /// #605 page colors for the current scheme, or `nil` on a palette cache
+    /// miss — every leaf falls back to its system/accent chrome then.
+    private var pageColors: PebblePageColors? {
+        palette?.pebblePageColors(for: colorScheme)
+    }
 
     var body: some View {
         ScrollView {
@@ -20,14 +34,19 @@ struct PebbleReadView: View {
                     valence: detail.valence
                 )
 
-                PebbleReadTitle(name: detail.name, happenedAt: detail.happenedAt)
+                PebbleReadTitle(
+                    name: detail.name,
+                    happenedAt: detail.happenedAt,
+                    nameColor: pageColors?.title,
+                    dateColor: pageColors?.date
+                )
 
                 metadataRow
 
                 if let description = detail.description, !description.isEmpty {
                     Text(description)
                         .font(.system(size: 17, weight: .regular, design: .serif))
-                        .foregroundStyle(Color.system.foreground)
+                        .foregroundStyle(pageColors?.description ?? Color.system.foreground)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
@@ -39,28 +58,47 @@ struct PebbleReadView: View {
             .padding(.top, 8)
             .padding(.bottom, 32)
         }
-        .background(Color.system.background)
+        // The ScrollView frame fills the sheet (content is inset by the safe
+        // area, the frame is not), so this background carries the #605 page tint
+        // across the whole page — behind the transparent nav bar and into the
+        // bottom inset — meeting the Petroglyph's palette seamlessly. Falls back
+        // to the system background on a palette cache miss.
+        .background(pageColors?.background ?? Color.system.background)
     }
 
     /// Emotion / domain / collection as the shared `SurfaceTile`s — the same
     /// tiles used for the profile shortcuts and glyph swap stats (issue #513).
-    /// Page-wide emotion palette coloring is intentionally out of scope, so the
-    /// emotion tile keeps the default accent surface like its neighbours.
+    /// The read page tints them to the emotion palette (#605); the muted
+    /// "No domain" placeholder keeps its muted icon/label on the tinted surface.
     @ViewBuilder
     private var metadataRow: some View {
         HStack(spacing: Spacing.sm) {
             // Emotion — always present.
-            SurfaceTile(systemImage: "heart.fill") {
+            SurfaceTile(
+                systemImage: "heart.fill",
+                backgroundColor: pageColors?.tileBackground,
+                iconTint: pageColors?.tileIcon,
+                labelColor: pageColors?.tileLabel
+            ) {
                 Text(LocalizedStringResource(stringLiteral: detail.emotion.localizedName))
             }
 
             // Domain — always rendered. Muted placeholder when unset.
             if detail.domains.isEmpty {
-                SurfaceTile(systemImage: "tag.fill", muted: true) {
+                SurfaceTile(
+                    systemImage: "tag.fill",
+                    muted: true,
+                    backgroundColor: pageColors?.tileBackground
+                ) {
                     Text("No domain")
                 }
             } else {
-                SurfaceTile(systemImage: "tag.fill") {
+                SurfaceTile(
+                    systemImage: "tag.fill",
+                    backgroundColor: pageColors?.tileBackground,
+                    iconTint: pageColors?.tileIcon,
+                    labelColor: pageColors?.tileLabel
+                ) {
                     Text(LocalizedStringResource(
                         stringLiteral: detail.domains.map(\.localizedName).joined(separator: ", ")
                     ))
@@ -69,7 +107,12 @@ struct PebbleReadView: View {
 
             // Collections — only when non-empty.
             if !detail.collections.isEmpty {
-                SurfaceTile(systemImage: "square.stack.3d.up.fill") {
+                SurfaceTile(
+                    systemImage: "square.stack.3d.up.fill",
+                    backgroundColor: pageColors?.tileBackground,
+                    iconTint: pageColors?.tileIcon,
+                    labelColor: pageColors?.tileLabel
+                ) {
                     Text(LocalizedStringResource(
                         stringLiteral: detail.collections.map(\.name).joined(separator: ", ")
                     ))
@@ -82,8 +125,43 @@ struct PebbleReadView: View {
     private var soulsRow: some View {
         LazyVGrid(columns: SoulPillGrid.columns, spacing: SoulPillGrid.spacing) {
             ForEach(detail.souls) { soulWithGlyph in
-                SoulItem(case: .default, soul: soulWithGlyph, count: nil)
+                DetailSoulCell(
+                    soul: soulWithGlyph,
+                    glyphColor: pageColors?.soulGlyph,
+                    nameColor: pageColors?.soulName
+                )
             }
         }
+    }
+}
+
+/// One soul cell on the read page — ports the shared `SoulItem(case: .default)`
+/// look (glyph above its name in the hand font, no pebble count) with the glyph
+/// and name tinted to the emotion palette (#605). `glyphColor` / `nameColor`
+/// fall back to `system.secondary` on a palette cache miss, reproducing the
+/// shared cell's default chrome. Dedicated (rather than tinting the shared
+/// `SoulItem` / `GlyphView`) so the picker's spec-governed state colors stay
+/// untouched — the glyph rides `GlyphThumbnail`, which already takes a color.
+private struct DetailSoulCell: View {
+    let soul: SoulWithGlyph
+    var glyphColor: Color? = nil
+    var nameColor: Color? = nil
+
+    var body: some View {
+        VStack(spacing: Spacing.sm) {
+            GlyphThumbnail(
+                strokes: soul.glyph.strokes,
+                side: 96,
+                strokeColor: glyphColor ?? Color.system.secondary
+            )
+            Text(soul.name)
+                .pebblesFont(.bodyLeadHand)
+                .foregroundStyle(nameColor ?? Color.system.secondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(soul.name)
     }
 }

--- a/apps/ios/Pebbles/Features/Path/Read/PebbleSnapFrame.swift
+++ b/apps/ios/Pebbles/Features/Path/Read/PebbleSnapFrame.swift
@@ -89,7 +89,8 @@ private let previewSnapPalette = EmotionPalette(
     secondaryHex: "#AE91CCFF",
     lightHex: "#F2EFF5FF",
     surfaceHex: "#7B5E991A",
-    darkHex: "#2A2138FF"
+    darkHex: "#2A2138FF",
+    shadedHex: "#4A3A5CFF"
 )
 
 private let previewSnapSvg = """

--- a/apps/ios/Pebbles/Theme/SurfaceTile.swift
+++ b/apps/ios/Pebbles/Theme/SurfaceTile.swift
@@ -6,30 +6,39 @@ import SwiftUI
 ///
 /// `muted` renders the icon + label in `system.muted` for placeholder values
 /// (e.g. the "Soon" stats we don't source yet).
+///
+/// `backgroundColor` / `iconTint` / `labelColor` override the default chrome
+/// colors — the pebble read page tints its tiles to the emotion palette (#605).
+/// Each is `nil` by default, reproducing the accent-surface chrome elsewhere.
+/// `muted` still wins for the icon/label so an empty placeholder reads muted
+/// even on a tinted background.
 struct SurfaceTile<Label: View>: View {
     let systemImage: String
     var muted: Bool = false
+    var backgroundColor: Color? = nil
+    var iconTint: Color? = nil
+    var labelColor: Color? = nil
     @ViewBuilder let label: () -> Label
 
     var body: some View {
         VStack(spacing: Spacing.xs) {
             Image(systemName: systemImage)
                 .pebblesIcon(.large)
-                .foregroundStyle(muted ? Color.system.muted : Color.accent.primary)
+                .foregroundStyle(muted ? Color.system.muted : (iconTint ?? Color.accent.primary))
                 // Fixed icon slot so tiles stay equal height regardless of which
                 // SF Symbol they carry (heart/tag/stack render at different
                 // intrinsic heights). Matches the Figma tile spec (30×30).
                 .frame(width: 30, height: 30)
             label()
                 .pebblesFont(.callout)
-                .foregroundStyle(muted ? Color.system.muted : Color.system.secondary)
+                .foregroundStyle(muted ? Color.system.muted : (labelColor ?? Color.system.secondary))
                 // Clamp to one line so tiles stay equal height even when a label
                 // (e.g. multiple joined domains/collections) would otherwise wrap.
                 .lineLimit(1)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, Spacing.md)
-        .background(Color.accent.surface)
+        .background(backgroundColor ?? Color.accent.surface)
         .clipShape(RoundedRectangle(cornerRadius: Spacing.lg))
     }
 }

--- a/apps/ios/PebblesTests/EmotionPaletteTests.swift
+++ b/apps/ios/PebblesTests/EmotionPaletteTests.swift
@@ -58,7 +58,8 @@ struct EmotionPaletteTests {
             secondaryHex: "#AE91CCFF",
             lightHex: "#F2EFF5FF",
             surfaceHex: "#7B5E991A",
-            darkHex: "#2A2138FF"
+            darkHex: "#2A2138FF",
+            shadedHex: "#4A3A5CFF"
         )
     }
 
@@ -74,7 +75,8 @@ struct EmotionPaletteTests {
             secondaryHex: "#AE91CCFF",
             lightHex: "#F2EFF5FF",
             surfaceHex: "#7B5E991A",
-            darkHex: "#2A2138FF"
+            darkHex: "#2A2138FF",
+            shadedHex: "#4A3A5CFF"
         )
         #expect(palette == nil)
     }
@@ -86,9 +88,28 @@ struct EmotionPaletteTests {
             secondaryHex: "#AE91CCFF",
             lightHex: "#F2EFF5FF",
             surfaceHex: "#7B5E991A",
-            darkHex: "not-hex"
+            darkHex: "not-hex",
+            shadedHex: "#4A3A5CFF"
         )
         #expect(palette == nil)
+    }
+
+    @Test("init returns nil when the shaded_color hex is malformed (#605)")
+    func initFailsOnBadShadedHex() {
+        let palette = EmotionPalette(
+            primaryHex: "#7B5E99FF",
+            secondaryHex: "#AE91CCFF",
+            lightHex: "#F2EFF5FF",
+            surfaceHex: "#7B5E991A",
+            darkHex: "#2A2138FF",
+            shadedHex: "not-hex"
+        )
+        #expect(palette == nil)
+    }
+
+    @Test("preserves the shaded_color hex verbatim (#605)")
+    func shadedHexPreserved() {
+        #expect(Self.makePalette()?.shadedHex == "#4A3A5CFF")
     }
 
     @Test("strokeHex returns 6-digit primary in light mode")
@@ -117,11 +138,13 @@ struct EmotionPaletteTests {
             secondaryHex: "  #AE91CCFF",
             lightHex:     "#F2EFF5FF\n",
             surfaceHex:   "#7B5E991A ",
-            darkHex:      "  #2A2138FF "
+            darkHex:      "  #2A2138FF ",
+            shadedHex:    " #4A3A5CFF "
         )
         #expect(palette?.primaryHex == "#7B5E99FF")
         #expect(palette?.surfaceHex == "#7B5E991A")
         #expect(palette?.darkHex == "#2A2138FF")
+        #expect(palette?.shadedHex == "#4A3A5CFF")
         #expect(palette?.strokeHex(for: .light) == "#7B5E99")
     }
 }

--- a/apps/ios/PebblesTests/EmotionWithPaletteDecodingTests.swift
+++ b/apps/ios/PebblesTests/EmotionWithPaletteDecodingTests.swift
@@ -23,7 +23,8 @@ struct EmotionWithPaletteDecodingTests {
       "secondary_color": "#AE91CCFF",
       "light_color": "#F2EFF5FF",
       "surface_color": "#7B5E991A",
-      "dark_color": "#2A2138FF"
+      "dark_color": "#2A2138FF",
+      "shaded_color": "#4A3A5CFF"
     }
     """
 
@@ -34,6 +35,7 @@ struct EmotionWithPaletteDecodingTests {
         #expect(row.categorySlug == "fear")
         #expect(row.palette.primaryHex == "#7B5E99FF")
         #expect(row.palette.darkHex == "#2A2138FF")
+        #expect(row.palette.shadedHex == "#4A3A5CFF")
         #expect(row.palette.strokeHex(for: .dark) == "#AE91CC")
     }
 
@@ -42,6 +44,15 @@ struct EmotionWithPaletteDecodingTests {
         let json = validJson.replacingOccurrences(
             of: "\"dark_color\": \"#2A2138FF\"",
             with: "\"dark_color\": null"
+        )
+        #expect(throws: DecodingError.self) { try decode(json) }
+    }
+
+    @Test("rejects null shaded_color (#605 — required like the rest of the palette)")
+    func rejectsNullShadedColor() {
+        let json = validJson.replacingOccurrences(
+            of: "\"shaded_color\": \"#4A3A5CFF\"",
+            with: "\"shaded_color\": null"
         )
         #expect(throws: DecodingError.self) { try decode(json) }
     }

--- a/apps/ios/PebblesTests/LocalizationTests.swift
+++ b/apps/ios/PebblesTests/LocalizationTests.swift
@@ -55,7 +55,8 @@ struct LocalizationPatternCTests {
                 secondaryHex: "#000000FF",
                 lightHex: "#FFFFFFFF",
                 surfaceHex: "#0000001A",
-                darkHex: "#000000FF"
+                darkHex: "#000000FF",
+                shadedHex: "#000000FF"
             )!
         )
         #expect(category.localizedName == "Fallback Name")

--- a/apps/ios/PebblesTests/PathPebbleRowNameColorTests.swift
+++ b/apps/ios/PebblesTests/PathPebbleRowNameColorTests.swift
@@ -10,7 +10,8 @@ struct PathPebbleRowNameColorTests {
         secondaryHex: "#9B5C5CFF",
         lightHex:     "#E8B8B8FF",
         surfaceHex:   "#C07A7A1A",
-        darkHex:      "#3A2222FF"
+        darkHex:      "#3A2222FF",
+        shadedHex:    "#5A3A3AFF"
     )!
 
     // Regression (#510): large pebble name/time were unreadable in light

--- a/apps/ios/PebblesTests/PebbleFrameColorsTests.swift
+++ b/apps/ios/PebblesTests/PebbleFrameColorsTests.swift
@@ -12,7 +12,8 @@ struct PebbleFrameColorsTests {
         secondaryHex: "#9B5C5CFF",
         lightHex:     "#E8B8B8FF",
         surfaceHex:   "#C07A7A1A",
-        darkHex:      "#3A2222FF"
+        darkHex:      "#3A2222FF",
+        shadedHex:    "#5A3A3AFF"
     )!
 
     @Test func intensity3UsesLightStrokeAndOpaquePrimaryFill() {
@@ -60,7 +61,8 @@ struct PebbleFrameColorsTests {
             secondaryHex: "#80BF96FF\n",
             lightHex:     "  #EDF2EEFF",
             surfaceHex:   "#487C5A1A                    ",
-            darkHex:      "  #1E3326FF "
+            darkHex:      "  #1E3326FF ",
+            shadedHex:    "  #2E4B38FF "
         )!
         let small = padded.pebbleFrameColors(forIntensity: 1)
         #expect(small.fillHex == "#487C5A")
@@ -81,7 +83,8 @@ struct PebbleFrameColorsTests {
             secondaryHex: "#445566",
             lightHex:     "#778899",
             surfaceHex:   "#AABBCC",
-            darkHex:      "#223344"
+            darkHex:      "#223344",
+            shadedHex:    "#556677"
         )!
         let colors = sixDigit.pebbleFrameColors(forIntensity: 2)
         #expect(colors.fillHex   == "#AABBCC")

--- a/apps/ios/PebblesTests/PebblePageColorsTests.swift
+++ b/apps/ios/PebblesTests/PebblePageColorsTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import SwiftUI
+@testable import Pebbles
+
+/// `EmotionPalette.pebblePageColors(for:)` — the #605 whole-page emotion-palette
+/// colour table, mirroring Android `PebblePageColorsTest`. Fixture hex matches
+/// the shared `EmotionPaletteTests` palette (opaque primary / secondary / light /
+/// dark / shaded, 10%-alpha surface). Each element must resolve to the exact
+/// palette role per scheme; roles are compared against the palette's own stored
+/// `Color`s so the mapping is verified without reconstructing colors from hex.
+@Suite("PebblePageColors (#605)")
+struct PebblePageColorsTests {
+    private let palette = EmotionPalette(
+        primaryHex:   "#7B5E99FF",
+        secondaryHex: "#AE91CCFF",
+        lightHex:     "#F2EFF5FF",
+        surfaceHex:   "#7B5E991A",
+        darkHex:      "#2A2138FF",
+        shadedHex:    "#4A3A5CFF"
+    )!
+
+    @Test("light mode maps each element to its role")
+    func lightMode() {
+        let colors = palette.pebblePageColors(for: .light)
+        #expect(colors.background == palette.light)
+        #expect(colors.title == palette.shaded)
+        #expect(colors.date == palette.secondary)
+        #expect(colors.tileBackground == palette.surface)
+        #expect(colors.tileIcon == palette.secondary)
+        #expect(colors.tileLabel == palette.shaded)
+        #expect(colors.description == palette.shaded)
+        #expect(colors.soulGlyph == palette.secondary)
+        #expect(colors.soulName == palette.primary)
+    }
+
+    @Test("dark mode maps each element to its role")
+    func darkMode() {
+        let colors = palette.pebblePageColors(for: .dark)
+        #expect(colors.background == palette.dark)
+        #expect(colors.title == palette.light)
+        #expect(colors.date == palette.primary)
+        #expect(colors.tileBackground == palette.surface)
+        #expect(colors.tileIcon == palette.primary)
+        #expect(colors.tileLabel == palette.light)
+        #expect(colors.description == palette.light)
+        #expect(colors.soulGlyph == palette.primary)
+        #expect(colors.soulName == palette.light)
+    }
+
+    @Test("tile background is the surface wash in both schemes")
+    func tileBackgroundIsSurface() {
+        #expect(palette.pebblePageColors(for: .light).tileBackground == palette.surface)
+        #expect(palette.pebblePageColors(for: .dark).tileBackground == palette.surface)
+    }
+}

--- a/apps/ios/PebblesTests/PetroglyphColorsTests.swift
+++ b/apps/ios/PebblesTests/PetroglyphColorsTests.swift
@@ -13,7 +13,8 @@ struct PetroglyphColorsTests {
         secondaryHex: "#AE91CCFF",
         lightHex:     "#F2EFF5FF",
         surfaceHex:   "#7B5E991A",
-        darkHex:      "#2A2138FF"
+        darkHex:      "#2A2138FF",
+        shadedHex:    "#4A3A5CFF"
     )!
 
     @Test("large is light stroke over opaque primary backfill in both schemes")


### PR DESCRIPTION
Resolves #605

## Changes

**New files:**
- `apps/ios/Pebbles/Features/Path/Read/PebblePageColors.swift` — emotion-palette color resolver for the read page, mapping palette roles to UI elements per color scheme (light/dark). Mirrors the #599 `PetroglyphColors` pattern.
- `apps/ios/PebblesTests/PebblePageColorsTests.swift` — unit tests verifying the color mapping table for both schemes.

**Modified files:**
- `EmotionPalette.swift` — added `shaded` color and `shadedHex` field (the #605 palette role for light-mode text). Updated initializer to parse and validate the new field.
- `PebbleReadView.swift` — threaded `palette` parameter through the view hierarchy; resolved `pageColors` at the root and passed color overrides to `PebbleReadTitle`, `SurfaceTile`, and a new `DetailSoulCell` component. Background now tints to the palette.
- `PebbleReadTitle.swift` — added `nameColor` and `dateColor` parameters to override default chrome.
- `SurfaceTile.swift` — added `backgroundColor`, `iconTint`, `labelColor` parameters for palette tinting. `muted` state still wins for placeholders.
- `DetailSoulCell` (new private struct in `PebbleReadView.swift`) — ports the shared `SoulItem(case: .default)` look with palette-tinted glyph and name. Dedicated to keep the picker's state colors untouched.
- `PebbleDetailSheet.swift` — looks up the pebble's emotion palette via `EmotionPaletteService` and passes it to `PebbleReadView`.
- `EmotionWithPalette.swift` — added `shadedColor` decoding case; enforces non-null `shaded_color` at the boundary.
- Test files updated to include `shadedHex` in all `EmotionPalette` fixtures: `EmotionPaletteTests.swift`, `EmotionWithPaletteDecodingTests.swift`, `PebbleFrameColorsTests.swift`, `PetroglyphColorsTests.swift`, `PathPebbleRowNameColorTests.swift`, `LocalizationTests.swift`, `PebbleSnapFrame.swift`.

## Notes

- **Color mapping table** (per `PebblePageColors`):
  - Light mode: background=light, title=shaded, date=secondary, tiles/description=shaded, souls=secondary/primary
  - Dark mode: background=dark, title=light, date=primary, tiles/description=light, souls=primary/light
  - Tile backgrounds use `surface` in both schemes; muted placeholders keep their muted styling even on tinted backgrounds.

- **Palette cache miss fallback**: When `palette` is `nil` (cache miss), all color parameters default to `nil`, and leaf components fall back to their system/accent chrome. This keeps the page readable if the palette service hasn't cached the emotion yet.

- **DetailSoulCell** is a dedicated private component rather than tinting the shared `SoulItem` to preserve the picker's spec-governed state colors (which ride `GlyphThumbnail`'s color parameter).

- **ScrollView background** carries the palette tint across the whole page — behind the transparent nav bar and into the bottom safe-area inset — meeting the Petroglyph seamlessly.

- All test fixtures now include the `shadedHex` field; `EmotionWithPaletteDecodingTests` verifies that null `shaded_color` is rejected (required like the rest of the palette).

## Lab Note (EN/FR)

```yaml
species: feature
platform: ios
status: in_progress
published: false
en:
  title: "Pebble read page now tints to emotion palette"
  summary: "The whole pebble detail view — background, title, date, tiles, description, and soul glyphs — now colors to the pebble's emotion palette per light/dark scheme. Palette cache misses fall back

https://claude.ai/code/session_014EacsQSeFSdJC74pi93uPM