### PR TITLE
docs(lab-note): enforce bilingual notes and ban em dashes

### DIFF
--- a/.claude/skills/lab-note/SKILL.md
+++ b/.claude/skills/lab-note/SKILL.md
@@ -19,8 +19,26 @@ You draft it in the PR body; at release time the maintainer copies the YAML and
 publishes it via the Lab admin (the `logs` table that drives the iOS Lab tab).
 
 Your job here: produce **one YAML snippet** in the PR's `## Lab Note (EN/FR)`
-section, following the schema and tone below. It is a **proposal only** — never
-write to Supabase / the `logs` table from the dev loop.
+section, following the schema and tone below. It is a **proposal only** (never
+write to Supabase / the `logs` table from the dev loop).
+
+## Both languages are mandatory
+
+Every Lab Note **must** contain a complete `en:` block **and** a complete `fr:`
+block, each with its own `title` and `summary`. A note with only English is
+**incomplete** and must not be shipped. Do not treat French as optional or as a
+"nice to have" step you can skip when short on time. If you emit the snippet, it
+has all four fields (`en.title`, `en.summary`, `fr.title`, `fr.summary`).
+
+## No em dashes — use parentheses
+
+Do **not** use the em dash (`—`) anywhere in a Lab Note, in either language. For
+an aside or parenthetical, use round brackets `( )` instead. For a hard break
+between two clauses, use a period and start a new sentence. This applies to
+`title` and `summary` in both `en:` and `fr:`.
+
+- Wrong: `The whole detail view — background, title, tiles — now tints.`
+- Right: `The whole detail view (background, title, tiles) now tints.`
 
 ## When to use
 
@@ -60,8 +78,8 @@ fr:
 | `published` | yes | `true` / `false` | **`false` at PR time** — a draft. The maintainer flips it to `true` when publishing. |
 | `en.title` | yes | short string | Required. |
 | `en.summary` | yes | 1–2 sentences | Required. |
-| `fr.title` | recommended | short string | Optional in the DB (falls back to EN), but always write it. |
-| `fr.summary` | recommended | 1–2 sentences | Optional in the DB, but always write it. |
+| `fr.title` | yes | short string | The DB falls back to EN if absent, but the note is incomplete without it. Always write it. |
+| `fr.summary` | yes | 1–2 sentences | The DB tolerates its absence, but the note is incomplete without it. Always write it. |
 
 **PR-time defaults:** `status: in_progress`, `published: false`, and omit
 `release-date`. Those three are the maintainer's release-time switches — draft


### PR DESCRIPTION
Resolves #

## Changes

Updated `.claude/skills/lab-note/SKILL.md` to clarify and enforce Lab Note authoring standards:

- **New section: "Both languages are mandatory"** — explicitly states that every Lab Note must include complete `en:` and `fr:` blocks with all four fields (`en.title`, `en.summary`, `fr.title`, `fr.summary`). Emphasizes that French is not optional or a "nice to have."
- **New section: "No em dashes — use parentheses"** — bans the em dash (`—`) from Lab Notes in both languages. Provides guidance to use round brackets for asides and periods + new sentences for hard breaks, with a concrete example.
- **Updated schema table** — changed `fr.title` and `fr.summary` from "recommended" to "yes" (required), and clarified that while the DB may tolerate their absence, the note is incomplete without them. Updated the rationale to emphasize completeness over optional fallback behavior.
- **Minor punctuation fix** — adjusted parenthetical phrasing in the intro for consistency.

## Notes

This is a documentation-only change to the Lab Note skill. It codifies existing best practices and raises the bar for completeness and consistency in user-facing release notes. No code changes; no impact on build or runtime behavior.

The changes align with the project's commitment to bilingual communication and professional presentation standards for the iOS Lab tab.

## Checklist

- [x] Branch name follows `type/issueNumber-description`
- [x] PR title uses conventional commits: `type(scope): description`
- [x] Labels applied (docs)
- [x] Milestone assigned
- [x] No build/lint required (documentation only)

https://claude.ai/code/session_014WsZHCHv2cayNhD42qeDXu