### PR TITLE
docs(core): wire the Ariko Lab Note pipeline

### DIFF
--- a/.claude/skills/lab-note/SKILL.md
+++ b/.claude/skills/lab-note/SKILL.md
@@ -7,9 +7,11 @@ description: >
   PR has the `feat` label, or it touches a user-visible Arkaik view node
   (`docs/arkaik/bundle.json`) — and you need to fill the `## Lab Note (EN/FR)`
   section of the PR body. It defines the exact schema (the fields the `logs`
-  table accepts), the allowed values, and the friendly, casual tone of voice
-  (French uses "Tu"). It does NOT publish anything — the note is a proposal a
-  human pastes into the Lab admin at release time.
+  table accepts plus the optional `suggested:` block for the Ariko vault), the
+  allowed values, and the friendly, casual tone of voice (French uses "Tu").
+  One block serves two destinations: on merge it auto-posts to the Ariko
+  changelog vault, and a human pastes the same YAML into the Pebbles Lab admin
+  at release time. The skill itself publishes nothing — it only authors the note.
 ---
 
 # Lab Note Authoring
@@ -21,6 +23,23 @@ publishes it via the Lab admin (the `logs` table that drives the iOS Lab tab).
 Your job here: produce **one YAML snippet** in the PR's `## Lab Note (EN/FR)`
 section, following the schema and tone below. It is a **proposal only** (never
 write to Supabase / the `logs` table from the dev loop).
+
+## One block, two destinations
+
+The single snippet you write serves **both** delivery legs:
+
+1. **Ariko inbox (automatic, on merge):** the repo's `.github/workflows/lab-note.yml`
+   watches for merged PRs, reads this section, and posts the note to the Ariko
+   changelog vault (idempotent upsert on `owner/repo#N`). No human action beyond
+   merging. Ariko's gate is a heading that starts with `## Lab Note` holding one
+   fenced `yaml` block — which our `## Lab Note (EN/FR)` heading already matches.
+   Ariko requires `en.title` + `en.summary`; it reads the optional `suggested:`
+   block and **ignores every other top-level key** (`species`, `platform`, etc.).
+2. **Pebbles Lab admin (manual, at release):** the maintainer copies the same
+   YAML and publishes it via the Lab admin, unchanged (see "Where it goes").
+
+So you write one block with the full Pebbles key set **plus** the `suggested:`
+block; each destination reads the keys it cares about and ignores the rest.
 
 ## Both languages are mandatory
 
@@ -67,6 +86,11 @@ en:
 fr:
   title: Échange des glyphes avec la communauté
   summary: Ta page Glyphes propose désormais les onglets Miens, Acquis et Commu. Trouve un glyphe qui te plaît pour l'échanger contre du karma.
+suggested:                  # optional; for the Ariko vault only
+  molecule: pbbls
+  atom: glyphs              # only when confidently known
+  type: feature
+  tags: [glyphs, community, karma]
 ```
 
 | Field | Required | Allowed values / format | Notes |
@@ -80,10 +104,18 @@ fr:
 | `en.summary` | yes | 1–2 sentences | Required. |
 | `fr.title` | yes | short string | The DB falls back to EN if absent, but the note is incomplete without it. Always write it. |
 | `fr.summary` | yes | 1–2 sentences | The DB tolerates its absence, but the note is incomplete without it. Always write it. |
+| `suggested.molecule` | no | `pbbls` | Always `pbbls` for this repo. Routing hint for the Ariko vault; ignored by the Lab admin. |
+| `suggested.atom` | no | short string | The feature area (`glyphs`, `path`, `read-view`, …). Include **only when confidently known** — omit rather than guess. |
+| `suggested.type` | no | short string | The kind of change, e.g. `feature`, `announcement`. |
+| `suggested.tags` | no | list of short strings | A few free-form topic tags for the vault. |
 
 **PR-time defaults:** `status: in_progress`, `published: false`, and omit
 `release-date`. Those three are the maintainer's release-time switches — draft
 them safe.
+
+**The `suggested:` block** is optional and read **only by the Ariko vault** (the
+Lab admin ignores it). Always set `molecule: pbbls`. Add `atom`, `type`, and
+`tags` when you can fill them meaningfully; leave `atom` out rather than guess.
 
 ## Tone of voice
 
@@ -136,7 +168,12 @@ fr:
 
 1. Put the finished snippet in the PR body's `## Lab Note (EN/FR)` section
    (inside a ```yaml fence). That's the whole deliverable for the dev loop.
-2. **At release time (a human):** copy the YAML, open the Lab admin, and click
+2. **On merge (automatic):** `.github/workflows/lab-note.yml` reads this section
+   and posts the note to the Ariko changelog vault. The upsert is keyed on
+   `owner/repo#N`, so merging (or re-running the job) never duplicates the
+   capture. A chore PR with no `## Lab Note` section makes the job log
+   "skipped" — nothing is posted. No human action beyond merging.
+3. **At release time (a human):** copy the YAML, open the Lab admin, and click
    **"New log"** on the Features or Announcements list. If the snippet is on the
    clipboard, the New-log form opens **prefilled** from it — review, set
    `status: shipped` / the release date / `published`, and Save.

--- a/.github/workflows/lab-note.yml
+++ b/.github/workflows/lab-note.yml
@@ -1,0 +1,13 @@
+name: lab-note
+on:
+  pull_request:
+    types: [closed]
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  lab-note:
+    if: github.event.pull_request.merged == true
+    uses: alexisbohns/ariko/.github/workflows/lab-note.yml@main
+    secrets:
+      inbox_token: ${{ secrets.ARIKO_INBOX_TOKEN }}


### PR DESCRIPTION
Resolves #612

Wires pbbls into Ariko's Lab Note pipeline so merged user-facing PRs file their
own changelog into the Ariko vault — the only human action is merging.

## Key files

- `.github/workflows/lab-note.yml` — the caller stub (verbatim from the issue).
  Fires on merged PRs and delegates to `alexisbohns/ariko/.github/workflows/lab-note.yml@main`,
  passing `ARIKO_INBOX_TOKEN` (already set on this repo). No `## Lab Note`
  section → the job logs "skipped".
- `.claude/skills/lab-note/SKILL.md` — rewritten to the superset. One block now
  serves both destinations: added the optional `suggested:` block
  (`molecule: pbbls`, plus `atom`/`type`/`tags`) read only by the Ariko vault,
  and documented the auto-post-on-merge leg alongside the unchanged manual
  paste into the Pebbles Lab admin. All Pebbles keys, PR-time defaults, the
  gate, and the tone rules are preserved; the `## Lab Note (EN/FR)` heading
  already matches Ariko's `## Lab Note` prefix gate.

## Bootstrap = the proof

This PR's body carries the repo's first Lab Note (below). Because the workflow
file lives on this PR's merge ref, merging this very PR fires the pipeline and
should log `lab-note: posted (HTTP 201)`, with the capture visible in the Ariko
admin inbox. Re-running the job should log `lab-note: updated (HTTP 200)` and
keep exactly one capture (idempotent on `owner/repo#N`).

## Lab Note (EN/FR)

```yaml
species: announcement
platform: project
status: in_progress
published: false
en:
  title: The Lab keeps itself up to date
  summary: From now on, every change we ship files its own note here, so the Lab stays fresh without us ever forgetting to update it.
fr:
  title: Le Lab se tient à jour tout seul
  summary: Désormais, chaque nouveauté qu'on livre publie sa propre note ici, pour que le Lab reste frais sans qu'on oublie jamais de le mettre à jour.
suggested:
  molecule: pbbls
  atom: lab
  type: announcement
  tags: [lab, changelog, automation]
```
