### PR TITLE
fix(path): require emotion selection before saving pebble

### DIFF
--- a/apps/web/components/path/QuickPebbleEditor.tsx
+++ b/apps/web/components/path/QuickPebbleEditor.tsx
@@ -120,7 +120,7 @@ export function QuickPebbleEditor({
   }, [snapPreview])
 
   const handleSubmit = useCallback(async () => {
-    if (!name.trim() || saving || snapUploading) return
+    if (!name.trim() || !emotionId || saving || snapUploading) return
     setSaving(true)
 
     try {
@@ -133,7 +133,7 @@ export function QuickPebbleEditor({
         intensity,
         positiveness: valence,
         visibility,
-        emotion_id: emotionId || "serenity",
+        emotion_id: emotionId,
         soul_ids: soulIds,
         domain_ids: domainIds,
         collection_ids: collectionIds,
@@ -347,7 +347,7 @@ export function QuickPebbleEditor({
           <Button
             variant="default"
             size="icon"
-            disabled={!name.trim() || saving || snapUploading}
+            disabled={!name.trim() || !emotionId || saving || snapUploading}
             onClick={() => void handleSubmit()}
             aria-label={t("save")}
             className="size-9 rounded-full"


### PR DESCRIPTION
Resolves #619

## Changes

**apps/web/components/path/QuickPebbleEditor.tsx**
- Added `emotionId` validation to the `handleSubmit` guard clause to prevent saving without an emotion selected
- Removed fallback default value `"serenity"` from the `emotion_id` field — now requires explicit user selection
- Updated the submit button's `disabled` state to include the `!emotionId` check, preventing submission when no emotion is chosen

## Notes

This change enforces that users must explicitly select an emotion before saving a pebble, rather than silently defaulting to "serenity". The validation is applied at both the handler level (early return) and the UI level (button disabled state) for consistency, aligning web validation with iOS/Android (both require an emotion before save).

Could not verify end-to-end in a live browser — this sandboxed dev environment has no Supabase credentials configured, so the authenticated record flow can't be reached. Recommend a manual check before merging: no emotion selected → Save disabled, no DB error; emotion selected → pebble created successfully.

## Checklist
- [x] Branch name follows `type/issueNumber-description` — note: this branch (`claude/issue-619-sfsioe`) was assigned by the task harness rather than created following the convention
- [x] PR title uses conventional commits: `type(scope): description`
- [x] Labels applied (species + scope)
- [x] Milestone assigned
- [x] `npm run lint --workspace=apps/web` passes

https://claude.ai/code/session_013s4QgJMr9HG76dXFvGhVJu