### PR TITLE
fix(db): persist consent timestamps in handle_new_user

### DIFF
--- a/packages/supabase/supabase/migrations/20260729120000_handle_new_user_consent.sql
+++ b/packages/supabase/supabase/migrations/20260729120000_handle_new_user_consent.sql
@@ -1,0 +1,52 @@
+-- Migration: persist consent timestamps at signup
+--
+-- All three clients send `terms_accepted_at` / `privacy_accepted_at` in the
+-- signup metadata and `profiles` has the columns, but handle_new_user() only
+-- ever inserted user_id + display_name — the consent proof was collected and
+-- thrown away (GDPR accountability gap, issue #617).
+
+-- ============================================================
+-- 1. handle_new_user — copy consent timestamps into the profile
+-- ============================================================
+-- `->>` yields NULL when the key is absent (OAuth signups carry no consent
+-- metadata) or when the client sent JSON null, so the casts are NULL-safe.
+
+create or replace function public.handle_new_user()
+returns trigger as $$
+begin
+  insert into public.profiles (
+    user_id,
+    display_name,
+    terms_accepted_at,
+    privacy_accepted_at
+  )
+  values (
+    new.id,
+    coalesce(new.raw_user_meta_data->>'full_name', 'Pebbler'),
+    (new.raw_user_meta_data->>'terms_accepted_at')::timestamptz,
+    (new.raw_user_meta_data->>'privacy_accepted_at')::timestamptz
+  );
+  return new;
+end;
+$$ language plpgsql security definer set search_path = public;
+
+-- ============================================================
+-- 2. One-shot backfill from auth.users.raw_user_meta_data
+-- ============================================================
+-- Signup metadata survives in auth.users, so profiles created before the fix
+-- can recover their consent proof. Only fills NULLs — never overwrites a
+-- timestamp already on the profile, and no-ops for rows without metadata.
+
+update public.profiles p
+set
+  terms_accepted_at =
+    coalesce(p.terms_accepted_at, (u.raw_user_meta_data->>'terms_accepted_at')::timestamptz),
+  privacy_accepted_at =
+    coalesce(p.privacy_accepted_at, (u.raw_user_meta_data->>'privacy_accepted_at')::timestamptz)
+from auth.users u
+where u.id = p.user_id
+  and (p.terms_accepted_at is null or p.privacy_accepted_at is null)
+  and (
+    u.raw_user_meta_data ? 'terms_accepted_at'
+    or u.raw_user_meta_data ? 'privacy_accepted_at'
+  );


### PR DESCRIPTION
Resolves #617

## Problem

All three clients send `terms_accepted_at` / `privacy_accepted_at` in the signup metadata and `profiles` has the columns, but `handle_new_user()` only inserted `user_id` + `display_name` — the consent proof was collected and thrown away (GDPR accountability gap, parity audit §6, F2 of the store-launch roadmap).

## Change

`packages/supabase/supabase/migrations/20260729120000_handle_new_user_consent.sql`

1. **Trigger** — `handle_new_user()` now copies `raw_user_meta_data->>'terms_accepted_at'` / `->>'privacy_accepted_at'` into the profile row, cast to `timestamptz`. `->>` returns SQL NULL both when the key is absent (OAuth signups) and when the client sent JSON `null` (web sends `null` for an unchecked box), so the casts are NULL-safe. `search_path` stays pinned, per the security-hardening migration.
2. **One-shot backfill** — the signup metadata survives in `auth.users`, so pre-fix profiles can recover their consent proof. The `UPDATE` only fills NULLs (`coalesce` on the profile side), so it never overwrites an existing timestamp and no-ops for rows without metadata.

No type regeneration needed: the change is a function body plus a data backfill, and `handle_new_user` is a trigger function that never appears in `types/database.ts`.

## Verification (applied to the linked remote project)

- `supabase db push --linked` → migration applied; `pg_get_functiondef` on remote confirms the new body.
- **Backfill:** 29 profiles → 23 now carry both timestamps. `meta_but_profile_null = 0` (every user whose `auth.users` metadata holds consent now has it on the profile). The remaining 6 are OAuth users with no consent metadata. 3 profiles that already had timestamps set were left untouched.
- **Email/password signup** (simulated via an `auth.users` insert inside a transaction rolled back by a `raise`): profile created with `display_name = Pebbler`, `terms = 2026-07-29 10:00:00+00`, `privacy = 2026-07-29 10:00:01+00`.
- **OAuth signup** (metadata with `iss` + `full_name`, no consent keys): profile still created (`rows = 1`, `display_name = Ada L`), both timestamps NULL.
- Confirmed 0 leftover rows from the simulations.

## Notes

- The backfill bumps `profiles.updated_at` on the 23 touched rows via the existing `profiles_updated_at` trigger. Nothing in web/admin/iOS/Android reads that column, so this is cosmetic.
- **Unrelated drift spotted, not fixed here:** regenerating types from remote surfaces `emotion_categories.dark_color` / `shaded_color` as nullable on remote, while `20260717000000_emotion_categories_shaded_dark.sql` declares them `not null`. `add column if not exists ... not null` is a no-op when the column already exists, so the constraint never landed remotely and the committed `database.ts` (generated from a fresh local schema) disagrees with production. I reverted that unrelated diff out of this PR — worth its own issue.
