### PR TITLE
test(karma): add unit tests pinning TS to SQL formula

### DIFF
--- a/apps/web/lib/data/karma.test.ts
+++ b/apps/web/lib/data/karma.test.ts
@@ -1,0 +1,87 @@
+// Pins the TS mirror to the SQL `compute_karma_delta` formula (packages/supabase/
+// supabase/migrations/20260411000005_security_hardening.sql) so the two can't
+// silently drift again — issue #621.
+
+import { describe, expect, it } from "vitest"
+
+import { computeKarmaDelta } from "./karma"
+import type { Pebble } from "@/lib/types"
+
+function makePebble(overrides: Partial<Pebble> = {}): Pebble {
+  return {
+    id: "pebble-1",
+    name: "Test pebble",
+    description: undefined,
+    happened_at: "2026-07-29T00:00:00Z",
+    intensity: 2,
+    positiveness: 0,
+    visibility: "private",
+    emotion_id: "emotion-1",
+    soul_ids: [],
+    domain_ids: [],
+    collection_ids: [],
+    mark_id: undefined,
+    instants: [],
+    snaps: [],
+    cards: [],
+    render_svg: null,
+    render_version: null,
+    created_at: "2026-07-29T00:00:00Z",
+    updated_at: "2026-07-29T00:00:00Z",
+    ...overrides,
+  }
+}
+
+function cards(count: number): Pebble["cards"] {
+  return Array.from({ length: count }, (_, i) => ({ species_id: `card-${i}`, value: `value-${i}` }))
+}
+
+describe("computeKarmaDelta", () => {
+  it("returns the base karma for a bare pebble", () => {
+    expect(computeKarmaDelta(makePebble())).toBe(1)
+  })
+
+  it("adds 1 for a non-empty description", () => {
+    expect(computeKarmaDelta(makePebble({ description: "a memory" }))).toBe(2)
+  })
+
+  it("ignores a whitespace-only description", () => {
+    expect(computeKarmaDelta(makePebble({ description: "   " }))).toBe(1)
+  })
+
+  it("adds 1 per non-empty card up to 4", () => {
+    expect(computeKarmaDelta(makePebble({ cards: cards(1) }))).toBe(2)
+    expect(computeKarmaDelta(makePebble({ cards: cards(4) }))).toBe(5)
+  })
+
+  it("caps the card bonus at 4 even with 5+ cards", () => {
+    expect(computeKarmaDelta(makePebble({ cards: cards(5) }))).toBe(5)
+    expect(computeKarmaDelta(makePebble({ cards: cards(8) }))).toBe(5)
+  })
+
+  it("ignores whitespace-only card values when counting", () => {
+    expect(computeKarmaDelta(makePebble({ cards: [{ species_id: "c", value: "   " }] }))).toBe(1)
+  })
+
+  it("adds 1 for at least one soul, domain, glyph, or snap", () => {
+    expect(computeKarmaDelta(makePebble({ soul_ids: ["s1"] }))).toBe(2)
+    expect(computeKarmaDelta(makePebble({ domain_ids: ["d1"] }))).toBe(2)
+    expect(computeKarmaDelta(makePebble({ mark_id: "glyph-1" }))).toBe(2)
+    expect(computeKarmaDelta(makePebble({ snaps: [{ id: "snap-1", storage_path: "u/snap-1", sort_order: 0 }] }))).toBe(
+      2,
+    )
+  })
+
+  it("caps the total delta at 10 for maximal enrichment (6 cards + everything)", () => {
+    const pebble = makePebble({
+      description: "a memory",
+      cards: cards(6),
+      soul_ids: ["s1"],
+      domain_ids: ["d1"],
+      mark_id: "glyph-1",
+      snaps: [{ id: "snap-1", storage_path: "u/snap-1", sort_order: 0 }],
+    })
+    // Uncapped: 1 base + 1 description + 6 cards + 1 soul + 1 domain + 1 glyph + 1 snap = 12
+    expect(computeKarmaDelta(pebble)).toBe(10)
+  })
+})

--- a/apps/web/lib/data/karma.ts
+++ b/apps/web/lib/data/karma.ts
@@ -10,23 +10,27 @@ import type { Pebble } from "@/lib/types"
 /**
  * Compute the karma delta for a pebble based on enrichment depth.
  *
+ * Mirrors the SQL `compute_karma_delta` RPC (packages/supabase/supabase/migrations/
+ * 20260411000005_security_hardening.sql) — keep the two in sync:
+ *
  * +1 base (pebble created)
  * +1 if description is non-empty (pearl)
- * +1 per card with non-empty value
+ * +1 per card with non-empty value, capped at 4
  * +1 if at least one soul attached
  * +1 if at least one domain attached
  * +1 if a glyph is attached
  * +1 if at least one snap is attached
+ * total capped at 10
  */
 export function computeKarmaDelta(pebble: CreatePebbleInput | Pebble): number {
   let delta = 1
 
   if (pebble.description?.trim()) delta += 1
-  if (pebble.cards?.length) delta += pebble.cards.filter((c) => c.value.trim()).length
+  if (pebble.cards?.length) delta += Math.min(pebble.cards.filter((c) => c.value.trim()).length, 4)
   if (pebble.soul_ids.length > 0) delta += 1
   if (pebble.domain_ids.length > 0) delta += 1
   if (pebble.mark_id) delta += 1
   if (pebble.snaps.length > 0) delta += 1
 
-  return delta
+  return Math.min(delta, 10)
 }


### PR DESCRIPTION
Resolves #621

## Changes

- **apps/web/lib/data/karma.test.ts** (added): Comprehensive unit tests for `computeKarmaDelta` covering all enrichment paths and edge cases
- **apps/web/lib/data/karma.ts** (modified): 
  - Capped card bonus at 4 (was unlimited)
  - Capped total delta at 10 (was unlimited)
  - Updated JSDoc to document caps and reference the SQL mirror formula

## Notes

The TypeScript `computeKarmaDelta` function now mirrors the SQL `compute_karma_delta` RPC in `packages/supabase/supabase/migrations/20260411000005_security_hardening.sql`. The test suite pins both implementations together so they can't silently drift again.

Key behavioral changes:
- Cards now contribute +1 each up to a maximum of 4 (previously unbounded)
- Total karma delta is now capped at 10 (previously unbounded)
- Whitespace-only card values are correctly ignored when counting

The test suite covers:
- Base karma (1 point)
- Description enrichment
- Card enrichment with caps
- Soul/domain/glyph/snap enrichment
- Total delta cap at 10

## Checklist
- [x] Branch name follows `type/issueNumber-description`
- [x] PR title uses conventional commits: `type(scope): description`
- [x] Labels applied (species + scope)
- [x] Milestone assigned
- [x] `npm run lint --workspace=apps/web` passes
- [x] Tests added and passing

https://claude.ai/code/session_01XUGnRUxaFYh9b1gu5mFiTB