### PR TITLE
feat(ios): add delete account entry in settings

### DIFF
--- a/apps/ios/Pebbles/Features/Profile/Sheets/SettingsSheet.swift
+++ b/apps/ios/Pebbles/Features/Profile/Sheets/SettingsSheet.swift
@@ -24,6 +24,9 @@ struct SettingsSheet: View {
     @State private var saveError: String?
     @State private var presentedLegalDoc: LegalDoc?
     @State private var isPresentingGlyphPicker = false
+    @State private var isPresentingDeleteConfirm = false
+    @State private var isDeleting = false
+    @State private var deleteError: String?
     @FocusState private var focusedField: Field?
 
     private enum Field: Hashable { case displayName, newPassword }
@@ -79,6 +82,7 @@ struct SettingsSheet: View {
                     }
                 }
                 legalSection
+                deleteAccountSection
             }
             .pebblesList()
             .scrollDismissesKeyboard(.interactively)
@@ -114,6 +118,30 @@ struct SettingsSheet: View {
             .sheet(item: $presentedLegalDoc) { doc in
                 LegalDocumentSheet(url: doc.url)
                     .ignoresSafeArea()
+            }
+            .confirmationDialog(
+                "Delete your account?",
+                isPresented: $isPresentingDeleteConfirm,
+                titleVisibility: .visible
+            ) {
+                Button("Delete forever", role: .destructive) {
+                    Task { await deleteAccount() }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This permanently deletes your account and everything in it: pebbles, snaps, souls, collections, glyphs and karma. Glyphs other pebblers bought stay available to them, without your name attached. This cannot be undone.")
+            }
+            .alert(
+                "Couldn't delete",
+                isPresented: Binding(
+                    get: { deleteError != nil },
+                    set: { if !$0 { deleteError = nil } }
+                ),
+                presenting: deleteError
+            ) { _ in
+                Button("OK", role: .cancel) { deleteError = nil }
+            } message: { message in
+                Text(message)
             }
         }
     }
@@ -244,6 +272,46 @@ struct SettingsSheet: View {
             .pebblesListRow(position: .bottom)
         } header: {
             Text("Legal").pebblesSectionHeader()
+        }
+    }
+
+    /// Store-mandated account deletion entry (Apple 5.1.1(v): easy to find).
+    private var deleteAccountSection: some View {
+        Section {
+            Button(role: .destructive) {
+                isPresentingDeleteConfirm = true
+            } label: {
+                HStack {
+                    Label("Delete account", systemImage: "trash")
+                        .foregroundStyle(.red)
+                    Spacer()
+                    if isDeleting {
+                        ProgressView()
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+            .disabled(isDeleting)
+            .pebblesListRow(position: .only)
+        } header: {
+            Text("Account").pebblesSectionHeader()
+        }
+    }
+
+    /// Full erasure via the delete-account edge function (purge + storage +
+    /// auth user), then a local sign-out: the server session is already gone,
+    /// and the session stream flipping to signed-out swaps RootView to Welcome.
+    private func deleteAccount() async {
+        guard !isDeleting else { return }
+        isDeleting = true
+        do {
+            try await supabase.client.functions.invoke("delete-account")
+            await supabase.signOut()
+            dismiss()
+        } catch {
+            logger.error("account deletion failed: \(error.localizedDescription, privacy: .private)")
+            deleteError = String(localized: "We couldn't delete your account. Nothing was removed. Please try again.")
+            isDeleting = false
         }
     }
 

--- a/apps/ios/Pebbles/Resources/Localizable.xcstrings
+++ b/apps/ios/Pebbles/Resources/Localizable.xcstrings
@@ -230,6 +230,23 @@
         }
       }
     },
+    "Account" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compte"
+          }
+        }
+      }
+    },
     "Acquired · %@" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1124,6 +1141,57 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Supprimer %@ ?"
+          }
+        }
+      }
+    },
+    "Delete account" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete account"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer le compte"
+          }
+        }
+      }
+    },
+    "Delete forever" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete forever"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer définitivement"
+          }
+        }
+      }
+    },
+    "Delete your account?" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete your account?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer votre compte ?"
           }
         }
       }
@@ -4820,6 +4888,23 @@
         }
       }
     },
+    "This permanently deletes your account and everything in it: pebbles, snaps, souls, collections, glyphs and karma. Glyphs other pebblers bought stay available to them, without your name attached. This cannot be undone." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This permanently deletes your account and everything in it: pebbles, snaps, souls, collections, glyphs and karma. Glyphs other pebblers bought stay available to them, without your name attached. This cannot be undone."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre compte et tout ce qu'il contient seront supprimés définitivement : galets, photos, âmes, collections, glyphes et karma. Les glyphes achetés par d'autres personnes restent disponibles pour elles, sans votre nom. Cette action est irréversible."
+          }
+        }
+      }
+    },
     "Track" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -4953,6 +5038,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Valence"
+          }
+        }
+      }
+    },
+    "We couldn't delete your account. Nothing was removed. Please try again." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We couldn't delete your account. Nothing was removed. Please try again."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de supprimer votre compte. Rien n'a été supprimé. Veuillez réessayer."
           }
         }
       }


### PR DESCRIPTION
Resolves #635

iOS settings entry for M46 account deletion (backend shipped in #632; client contract in `docs/superpowers/specs/2026-07-29-account-deletion-design.md` §D6). Apple 5.1.1(v) requires the entry to be easy to find: Profile → gear → Settings → Account, two taps from the profile.

## Key files

- `apps/ios/Pebbles/Features/Profile/Sheets/SettingsSheet.swift` — new `Account` section after Legal: destructive `Delete account` row (trash icon, red, inline `ProgressView` + disabled while deleting). `.confirmationDialog` with visible title and a `Delete forever` destructive action (the SoulsListView idiom), separate `Couldn't delete` error alert. `deleteAccount()` invokes the `delete-account` edge function, then the existing non-throwing `SupabaseService.signOut()` (the server session is already dead; the local token is wiped regardless and the session stream flips `RootView` to Welcome), plus a defensive `dismiss()`.
- `apps/ios/Pebbles/Resources/Localizable.xcstrings` — six new entries (Account, Delete account, Delete your account?, Delete forever, the dialog message, the error message), all with en + fr values in `translated` state, inserted at Xcode's alphabetical positions. `Cancel` and `Couldn't delete` are reused. FR is vous-form per app register, same copy as the web entry (galets, âmes, glyphes).

No Arkaik change: the `V-settings → API-delete-account` calls edge ships with #634.

## Verification

- `rm -rf DerivedData/Pebbles-*` then `xcodebuild -scheme Pebbles -destination 'generic/platform=iOS Simulator' build`: **BUILD SUCCEEDED** (stale-object quirk accounted for).
- Catalog check: no `New`/`Stale` entries; every new row has en + fr.
- Manual flow to check in the simulator: Settings → Account → Delete account → confirm sheet → row spins → Welcome screen. Error path shows the alert and re-enables the row. (Backend behavior covered by the 33/33 remote acceptance run in #632.)

## Lab Note (EN/FR)

```yaml
species: feature
platform: ios
status: in_progress
published: false
en:
  title: Delete your account, right from Settings
  summary: Your account is yours to keep or to close. One confirmation in Settings and everything you made is gone for good (glyphs other pebblers bought stay with them, without your name).
fr:
  title: Supprime ton compte depuis les Réglages
  summary: Ton compte t'appartient, jusqu'au bout. Une confirmation dans les Réglages et tout ce que tu as créé disparaît pour de bon (les glyphes achetés par d'autres restent chez eux, sans ton nom).
suggested:
  molecule: pbbls
  type: feature
  tags: [account, settings, privacy]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)