### PR TITLE
feat(android): add delete account entry in settings

### DIFF
--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/SettingsScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/SettingsScreen.kt
@@ -44,7 +44,10 @@ import app.pbbls.android.features.glyph.models.GlyphStroke
 import app.pbbls.android.features.glyph.views.GlyphView
 import app.pbbls.android.features.glyph.views.GlyphViewCase
 import app.pbbls.android.features.path.create.pickers.GlyphPickerSheet
+import app.pbbls.android.features.profile.components.ConfirmDeleteDialog
+import app.pbbls.android.features.profile.components.DeleteErrorDialog
 import app.pbbls.android.services.LocalProfileService
+import app.pbbls.android.services.LocalSupabaseService
 import app.pbbls.android.theme.PebblesDestructive
 import app.pbbls.android.theme.PebblesListSection
 import app.pbbls.android.theme.PebblesScreen
@@ -53,6 +56,7 @@ import app.pbbls.android.theme.PebblesTheme
 import app.pbbls.android.theme.PebblesTopBar
 import app.pbbls.android.theme.PebblesTopBarTextButton
 import app.pbbls.android.theme.PebblesTypography
+import io.github.jan.supabase.functions.functions
 import kotlinx.coroutines.launch
 
 private const val TAG = "settings"
@@ -78,6 +82,7 @@ fun SettingsScreen(
     modifier: Modifier = Modifier,
 ) {
     val profileService = LocalProfileService.current
+    val supabase = LocalSupabaseService.current
     val system = PebblesTheme.colors.system
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -88,6 +93,9 @@ fun SettingsScreen(
     var isSaving by remember { mutableStateOf(false) }
     var showSaveError by remember { mutableStateOf(false) }
     var isPresentingGlyphPicker by remember { mutableStateOf(false) }
+    var showDeleteConfirm by remember { mutableStateOf(false) }
+    var isDeleting by remember { mutableStateOf(false) }
+    var showDeleteError by remember { mutableStateOf(false) }
 
     val isDirty =
         settingsIsDirty(
@@ -99,7 +107,7 @@ fun SettingsScreen(
         )
     val currentStrokes = pickedGlyph?.strokes ?: initialGlyphStrokes
 
-    BackHandler(enabled = !isSaving) { onDismiss() }
+    BackHandler(enabled = !isSaving && !isDeleting) { onDismiss() }
 
     fun save() {
         if (!isDirty || isSaving) return
@@ -121,6 +129,27 @@ fun SettingsScreen(
                 Log.e(TAG, "settings save failed", e)
                 showSaveError = true
                 isSaving = false
+            }
+        }
+    }
+
+    /**
+     * Full erasure via the delete-account edge function (purge + storage +
+     * auth user), then a local sign-out: the server session is already gone,
+     * and `sessionStatus` dropping unmounts the authed NavHost to Welcome —
+     * no navigation code needed here.
+     */
+    fun deleteAccount() {
+        if (isDeleting) return
+        scope.launch {
+            isDeleting = true
+            try {
+                supabase.client.functions.invoke("delete-account")
+                supabase.signOut()
+            } catch (e: Exception) {
+                Log.e(TAG, "account deletion failed", e)
+                showDeleteError = true
+                isDeleting = false
             }
         }
     }
@@ -346,7 +375,58 @@ fun SettingsScreen(
                         },
                     ),
             )
+
+            // Store-mandated account deletion entry (Play hard blocker;
+            // parity with iOS Settings → Account).
+            PebblesListSection(
+                header = stringResource(R.string.settings_account_header),
+                rows =
+                    listOf(
+                        {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .clickable(enabled = !isDeleting) { showDeleteConfirm = true },
+                            ) {
+                                PebblesText(
+                                    text = stringResource(R.string.settings_delete_account),
+                                    style = PebblesTypography.body,
+                                    color = PebblesDestructive,
+                                )
+                                Spacer(Modifier.weight(1f))
+                                if (isDeleting) {
+                                    CircularProgressIndicator(
+                                        color = PebblesDestructive,
+                                        strokeWidth = 2.dp,
+                                        modifier = Modifier.size(16.dp),
+                                    )
+                                }
+                            }
+                        },
+                    ),
+            )
         }
+    }
+
+    if (showDeleteConfirm) {
+        ConfirmDeleteDialog(
+            title = stringResource(R.string.settings_delete_account_title),
+            message = stringResource(R.string.settings_delete_account_message),
+            confirmText = stringResource(R.string.settings_delete_account_confirm),
+            onConfirm = {
+                showDeleteConfirm = false
+                deleteAccount()
+            },
+            onDismiss = { showDeleteConfirm = false },
+        )
+    }
+    if (showDeleteError) {
+        DeleteErrorDialog(
+            message = stringResource(R.string.settings_delete_account_error),
+            onDismiss = { showDeleteError = false },
+        )
     }
 
     if (isPresentingGlyphPicker) {

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/components/DeleteDialogs.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/components/DeleteDialogs.kt
@@ -14,7 +14,8 @@ import app.pbbls.android.theme.PebblesTypography
  * Destructive-action confirmation for the profile surfaces — the same chrome
  * as PathScreen's pebble-delete dialog (M39 D8 idiom) with the title/message
  * parameterized, because souls and pebbles carry different consequences
- * ("linked pebbles stay" vs "can't be undone").
+ * ("linked pebbles stay" vs "can't be undone"). `confirmText` defaults to the
+ * generic Delete label; account deletion passes its own.
  */
 @Composable
 internal fun ConfirmDeleteDialog(
@@ -22,6 +23,7 @@ internal fun ConfirmDeleteDialog(
     message: String,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
+    confirmText: String? = null,
 ) {
     val system = PebblesTheme.colors.system
     val accent = PebblesTheme.colors.accent
@@ -45,7 +47,7 @@ internal fun ConfirmDeleteDialog(
         confirmButton = {
             TextButton(onClick = onConfirm) {
                 PebblesText(
-                    text = stringResource(R.string.pebble_delete),
+                    text = confirmText ?: stringResource(R.string.pebble_delete),
                     style = PebblesTypography.buttonLabel,
                     color = PebblesDestructive,
                 )
@@ -65,7 +67,10 @@ internal fun ConfirmDeleteDialog(
 
 /** Delete-failure notice — mirrors PathScreen's single-action error dialog. */
 @Composable
-internal fun DeleteErrorDialog(onDismiss: () -> Unit) {
+internal fun DeleteErrorDialog(
+    onDismiss: () -> Unit,
+    message: String? = null,
+) {
     val system = PebblesTheme.colors.system
     val accent = PebblesTheme.colors.accent
     AlertDialog(
@@ -73,7 +78,7 @@ internal fun DeleteErrorDialog(onDismiss: () -> Unit) {
         containerColor = system.background,
         text = {
             PebblesText(
-                text = stringResource(R.string.pebble_delete_error),
+                text = message ?: stringResource(R.string.pebble_delete_error),
                 style = PebblesTypography.body,
                 color = system.secondary,
             )

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -89,6 +89,12 @@
     <string name="settings_providers_header">Fournisseurs</string>
     <string name="settings_legal_header">Mentions légales</string>
     <string name="settings_save_error">Impossible d\'enregistrer vos modifications. Veuillez réessayer.</string>
+    <string name="settings_account_header">Compte</string>
+    <string name="settings_delete_account">Supprimer le compte</string>
+    <string name="settings_delete_account_title">Supprimer votre compte ?</string>
+    <string name="settings_delete_account_message">Votre compte et tout ce qu\'il contient seront supprimés définitivement : galets, photos, âmes, collections, glyphes et karma. Les glyphes achetés par d\'autres personnes restent disponibles pour elles, sans votre nom. Cette action est irréversible.</string>
+    <string name="settings_delete_account_confirm">Supprimer définitivement</string>
+    <string name="settings_delete_account_error">Impossible de supprimer votre compte. Rien n\'a été supprimé. Veuillez réessayer.</string>
 
     <!-- ==== Gestion des âmes (M41 sous-projet D). -->
     <string name="souls_title">Âmes</string>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -96,6 +96,12 @@
     <string name="settings_providers_header">Providers</string>
     <string name="settings_legal_header">Legal</string>
     <string name="settings_save_error">Couldn\'t save your changes. Please try again.</string>
+    <string name="settings_account_header">Account</string>
+    <string name="settings_delete_account">Delete account</string>
+    <string name="settings_delete_account_title">Delete your account?</string>
+    <string name="settings_delete_account_message">This permanently deletes your account and everything in it: pebbles, snaps, souls, collections, glyphs and karma. Glyphs other pebblers bought stay available to them, without your name attached. This cannot be undone.</string>
+    <string name="settings_delete_account_confirm">Delete forever</string>
+    <string name="settings_delete_account_error">We couldn\'t delete your account. Nothing was removed. Please try again.</string>
 
     <!-- ==== Souls management (M41 sub-project D). "Souls" is product vocabulary
          but localizes ("Âmes"), unlike "Pebbles". ==== -->


### PR DESCRIPTION
Resolves #637

Android settings entry for M46 account deletion (backend shipped in #632; client contract in `docs/superpowers/specs/2026-07-29-account-deletion-design.md` §D6). Account deletion is the Play production hard blocker. Completes the milestone's three client surfaces (web #634, iOS #636).

## Key files

- `apps/android/.../features/profile/SettingsScreen.kt` — new `Account` section after Legal: `Delete account` row in `PebblesDestructive` with a small inline `CircularProgressIndicator` while deleting (row disabled meanwhile), `BackHandler` extended to block dismissal mid-delete. `deleteAccount()` reads `LocalSupabaseService.current` (this is local session teardown, not user-intent sign-out, so no lambda threading from RootScreen) and calls `supabase.client.functions.invoke("delete-account")` — the installed-but-unused Functions plugin finally earns its keep; the raw-Ktor pattern exists only for compose-pebble's soft-success body, which this endpoint doesn't have — then `supabase.signOut()`; `sessionStatus` dropping unmounts the authed NavHost to Welcome.
- `apps/android/.../features/profile/components/DeleteDialogs.kt` — source-compatible generalization: `ConfirmDeleteDialog` gains optional `confirmText` (defaults to the generic Delete label), `DeleteErrorDialog` gains optional `message`. All existing call sites use named args and are untouched.
- `values/strings.xml` + `values-fr/strings.xml` — six `settings_delete_account*` keys in both files (LocalizationParityTest enforces parity), vous-form FR, same copy as web/iOS (galets, âmes, glyphes).

No Arkaik change: the `V-settings → API-delete-account` calls edge ships with #634.

## Verification

- This machine is SDK-less by design (per `apps/android/CLAUDE.md`) — `android.yml` CI is the gate: ktlint, `testDebugUnitTest` (includes `LocalizationParityTest` on the new keys), `assembleDebug`, screenshot render. CI status on this PR is the evidence; I'll confirm it goes green.
- Manual flow on a device/emulator: Settings → Account → Delete account → confirm dialog (Delete forever) → row spins → Welcome. Error path shows the parameterized `DeleteErrorDialog` and re-enables the row. (Backend behavior covered by the 33/33 remote acceptance run in #632.)

## Lab Note (EN/FR)

```yaml
species: feature
platform: android
status: in_progress
published: false
en:
  title: Delete your account, right from Settings
  summary: Your account is yours to keep or to close. One confirmation in Settings and everything you made is gone for good (glyphs other pebblers bought stay with them, without your name).
fr:
  title: Supprime ton compte depuis les Réglages
  summary: Ton compte t'appartient, jusqu'au bout. Une confirmation dans les Réglages et tout ce que tu as créé disparaît pour de bon (les glyphes achetés par d'autres restent chez eux, sans ton nom).
suggested:
  molecule: pbbls
  type: feature
  tags: [account, settings, privacy]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)