### PR TITLE
feat(ios): add quick-capture drafts and composer autosave

### DIFF
--- a/apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
@@ -5,9 +5,16 @@ import os
 struct CreatePebbleSheet: View {
     let onCreated: (UUID) -> Void
 
+    /// Resuming a server draft (M47): its payload hydrates the form, and the row
+    /// is deleted once the pebble publishes.
+    var resuming: PebbleDraftRecord?
+
     @Environment(SupabaseService.self) private var supabase
     @Environment(ReferenceDataService.self) private var refs
     @Environment(KarmaNotificationService.self) private var karma
+    @Environment(PebbleDraftsService.self) private var draftsService
+    @Environment(ComposerSnapshotStore.self) private var snapshots
+    @Environment(\.scenePhase) private var scenePhase
     @Environment(\.dismiss) private var dismiss
 
     @State private var draft = PebbleDraft()
@@ -17,6 +24,15 @@ struct CreatePebbleSheet: View {
     @State private var saveError: String?
 
     @State private var isPhotoPickerPresented = false
+
+    @State private var isSavingDraft = false
+    /// The server draft this composer is bound to — the resumed one, or the one
+    /// created by the first "Save as draft".
+    @State private var serverDraftId: UUID?
+    @State private var autosave: ComposerAutosave?
+    @State private var restorableSnapshot: PebbleDraftPayload?
+    @State private var isRestorePromptPresented = false
+    @State private var hasCheckedSnapshot = false
 
     /// Lazily constructed in `.task` so we have access to `supabase.client`.
     /// Nil only for the very first body render before `.task` fires.
@@ -39,7 +55,7 @@ struct CreatePebbleSheet: View {
                         }
                     }
                     ToolbarItem(placement: .confirmationAction) {
-                        if isSaving {
+                        if isSaving || isSavingDraft {
                             ProgressView()
                         } else {
                             PebbleToolbarButton("Save") {
@@ -48,6 +64,14 @@ struct CreatePebbleSheet: View {
                             .disabled(!draft.isValid)
                         }
                     }
+                    // Quick capture: ungated, unlike Save (design D5). "Just a
+                    // name" is a valid draft.
+                    ToolbarItem(placement: .bottomBar) {
+                        PebbleToolbarButton("Save as draft") {
+                            Task { await saveAsDraft() }
+                        }
+                        .disabled(!isSavableAsDraft || isSaving || isSavingDraft)
+                    }
                 }
                 .pebblesScreen()
         }
@@ -55,6 +79,26 @@ struct CreatePebbleSheet: View {
             if snaps == nil {
                 snaps = SnapUploadCoordinator(repo: PebbleSnapRepository(client: supabase.client))
             }
+            if autosave == nil {
+                autosave = ComposerAutosave(store: snapshots)
+            }
+            hydrateOrOfferRestore()
+        }
+        .onChange(of: draftPayload) { _, newValue in
+            // Debounced inside ComposerAutosave. Held off while the restore
+            // prompt is up so the pending answer is not overwritten first.
+            guard !isRestorePromptPresented else { return }
+            autosave?.schedule(newValue)
+        }
+        .onChange(of: scenePhase) { _, phase in
+            // Last reliable moment before a process kill.
+            if phase != .active { autosave?.flush() }
+        }
+        .alert("Pick up where you left off?", isPresented: $isRestorePromptPresented) {
+            Button("Restore it") { restoreSnapshot() }
+            Button("Start fresh", role: .destructive) { discardSnapshot() }
+        } message: {
+            Text("We kept what you were writing here. Add your photo again when you're ready.")
         }
         .sheet(isPresented: $isPhotoPickerPresented) {
             PhotoPickerView { picked in
@@ -140,11 +184,13 @@ struct CreatePebbleSheet: View {
                     decoder: decoder
                 )
             karma.notifyEarned(amount: response.karmaDelta ?? 0, reason: .pebbleCreated)
+            await consumeDraftAfterPublish()
             onCreated(response.pebbleId)
             dismiss()
         } catch let functionsError as FunctionsError {
             if let pebbleId = softSuccessPebbleId(from: functionsError) {
                 logger.warning("compose-pebble returned 5xx but pebble_id found — advancing to detail sheet")
+                await consumeDraftAfterPublish()
                 onCreated(pebbleId)
                 dismiss()
             } else {
@@ -176,6 +222,141 @@ struct CreatePebbleSheet: View {
     }
 }
 
+// MARK: - Drafts (M47)
+
+/// The **server** draft (`pebble_drafts`, an intentional "save as draft") and the
+/// **local** snapshot (crash insurance for the open composer) share one payload
+/// shape and nothing else. Design:
+/// docs/superpowers/specs/2026-07-29-drafts-and-autosave-design.md.
+extension CreatePebbleSheet {
+
+    /// The form projected onto the wire payload. Drives both autosave and the
+    /// server draft, so the two can never disagree about the shape.
+    fileprivate var draftPayload: PebbleDraftPayload {
+        PebbleDraftPayload(from: draft, formSnap: snaps?.formSnap, userId: currentUserId)
+    }
+
+    fileprivate var isSavableAsDraft: Bool {
+        draft.isSavableAsDraft(formSnap: snaps?.formSnap, userId: currentUserId)
+    }
+
+    /// Souls and collections are user-owned and deletable, so a resumed draft may
+    /// reference ones that are gone. Glyphs are verified server-side below.
+    fileprivate var knownIds: PebbleDraft.KnownIds {
+        PebbleDraft.KnownIds(
+            soulIds: Set(refs.souls.map(\.id)),
+            collectionIds: Set(refs.collections.map(\.id))
+        )
+    }
+
+    /// Resuming a server draft wins over the local snapshot — it is the more
+    /// deliberate of the two, so we never prompt on top of it.
+    fileprivate func hydrateOrOfferRestore() {
+        guard !hasCheckedSnapshot else { return }
+        hasCheckedSnapshot = true
+
+        if let resuming {
+            serverDraftId = resuming.id
+            draft = PebbleDraft(payload: resuming.payload, known: knownIds)
+            if let existing = resuming.payload.existingSnap {
+                snaps?.seedExisting(.existing(id: existing.id, storagePath: existing.storagePath))
+            }
+            Task { await verifyGlyph() }
+            return
+        }
+
+        if let snapshot = snapshots.load(), !snapshot.isEmpty {
+            restorableSnapshot = snapshot
+            isRestorePromptPresented = true
+        }
+    }
+
+    fileprivate func restoreSnapshot() {
+        guard let snapshot = restorableSnapshot else { return }
+        draft = PebbleDraft(payload: snapshot, known: knownIds)
+        restorableSnapshot = nil
+        Task { await verifyGlyph() }
+    }
+
+    fileprivate func discardSnapshot() {
+        restorableSnapshot = nil
+        autosave?.clear()
+    }
+
+    /// Drop a glyph the user can no longer use, and load the one they can for the
+    /// form's preview (design D7). `can_use_glyph` is the predicate
+    /// `create_pebble` enforces, so passing here means publish cannot 42501.
+    fileprivate func verifyGlyph() async {
+        guard let glyphId = draft.glyphId, let userId = currentUserId else { return }
+        do {
+            let usable: Bool = try await supabase.client
+                .rpc(
+                    "can_use_glyph",
+                    params: ["p_glyph_id": glyphId.uuidString, "p_user": userId.uuidString]
+                )
+                .execute()
+                .value
+            guard usable else {
+                logger.notice("resumed draft referenced an unusable glyph — dropping it")
+                draft.glyphId = nil
+                selectedGlyph = nil
+                return
+            }
+            let glyphs: [Glyph] = try await supabase.client
+                .from("glyphs")
+                .select("id, name, strokes, view_box, user_id")
+                .eq("id", value: glyphId)
+                .limit(1)
+                .execute()
+                .value
+            selectedGlyph = glyphs.first
+        } catch {
+            // A verification failure is not a reason to lose the user's glyph;
+            // publishing will surface a clear message if it really is unusable.
+            logger.error("glyph verification failed: \(error.localizedDescription, privacy: .private)")
+        }
+    }
+
+    /// Intentional "save as draft". Deliberately does NOT run
+    /// `snaps.cancelAndCleanup` — that would delete from Storage the very object
+    /// the draft references (design D3).
+    fileprivate func saveAsDraft() async {
+        guard isSavableAsDraft else { return }
+        guard let userId = currentUserId else {
+            logger.error("save draft: no current user id")
+            saveError = "You must be signed in to save."
+            return
+        }
+
+        isSavingDraft = true
+        saveError = nil
+        do {
+            serverDraftId = try await draftsService.save(
+                payload: draftPayload, id: serverDraftId, userId: userId
+            )
+            // Once the draft is on the server the local snapshot is redundant.
+            autosave?.clear()
+            await draftsService.refreshCount()
+            dismiss()
+        } catch {
+            logger.error("save draft failed: \(error.localizedDescription, privacy: .private)")
+            saveError = "Couldn't save that draft. Please try again."
+            isSavingDraft = false
+        }
+    }
+
+    /// Publishing consumed the draft. Runs on the soft-success path too: a 5xx
+    /// carrying a `pebble_id` still created the pebble, so leaving the draft
+    /// would duplicate it in the list.
+    fileprivate func consumeDraftAfterPublish() async {
+        autosave?.clear()
+        guard let serverDraftId else { return }
+        await draftsService.deleteIgnoringFailure(id: serverDraftId)
+        self.serverDraftId = nil
+        await draftsService.refreshCount()
+    }
+}
+
 private struct ComposePebbleRequest: Encodable {
     let payload: PebbleCreatePayload
 }
@@ -193,6 +374,8 @@ private struct PebbleIdPartial: Decodable {
         .environment(supabase)
         .environment(ReferenceDataService(client: supabase.client))
         .environment(KarmaNotificationService())
+        .environment(PebbleDraftsService(client: supabase.client))
+        .environment(ComposerSnapshotStore())
 }
 
 /// Maps a thrown error to a user-facing localized string. Module-private so

--- a/apps/ios/Pebbles/Features/Path/DraftsListSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/DraftsListSheet.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+import os
+
+/// Unpublished quick captures, most recently saved first (M47).
+///
+/// Its own surface rather than a section inside the Path timeline, whose week
+/// grouping, ripple, bounce and stats all assume real pebbles (design D4).
+/// Tapping a row resumes it in `CreatePebbleSheet`.
+struct DraftsListSheet: View {
+    /// Called after a resumed draft publishes, so the Path can reload and reveal
+    /// the new pebble — same contract as `CreatePebbleSheet.onCreated`.
+    let onPebbleCreated: (UUID) -> Void
+
+    @Environment(PebbleDraftsService.self) private var draftsService
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var drafts: [PebbleDraftRecord] = []
+    @State private var isLoading = true
+    @State private var loadError: String?
+    @State private var resuming: PebbleDraftRecord?
+
+    private let logger = Logger(subsystem: "app.pbbls.ios", category: "drafts-list")
+
+    var body: some View {
+        NavigationStack {
+            content
+                .pebblesToolbarTitle("Drafts")
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        PebbleToolbarButton("Done") { dismiss() }
+                    }
+                }
+                .pebblesScreen()
+        }
+        .task { await load() }
+        .sheet(item: $resuming) { draft in
+            CreatePebbleSheet(
+                onCreated: { pebbleId in
+                    resuming = nil
+                    onPebbleCreated(pebbleId)
+                    dismiss()
+                },
+                resuming: draft
+            )
+        }
+        .onChange(of: resuming) { _, newValue in
+            // The resume sheet may have saved the draft again or published it;
+            // either way the list is stale once it closes.
+            if newValue == nil { Task { await load() } }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isLoading {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let loadError {
+            VStack(spacing: 12) {
+                Text(loadError)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                Button("Try again") { Task { await load() } }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding()
+        } else if drafts.isEmpty {
+            Text("No drafts yet. Anything you start keeping shows up here.")
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding()
+        } else {
+            List {
+                ForEach(drafts) { draft in
+                    Button {
+                        resuming = draft
+                    } label: {
+                        DraftRow(draft: draft)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .onDelete(perform: delete)
+            }
+        }
+    }
+
+    private func load() async {
+        isLoading = true
+        loadError = nil
+        do {
+            drafts = try await draftsService.list()
+            isLoading = false
+        } catch {
+            logger.error("drafts load failed: \(error.localizedDescription, privacy: .private)")
+            loadError = "Couldn't load your drafts. Please try again."
+            isLoading = false
+        }
+    }
+
+    private func delete(at offsets: IndexSet) {
+        let doomed = offsets.map { drafts[$0] }
+        drafts.remove(atOffsets: offsets)
+        Task {
+            for draft in doomed {
+                do {
+                    try await draftsService.delete(id: draft.id)
+                } catch {
+                    logger.error("draft delete failed: \(error.localizedDescription, privacy: .private)")
+                    await load()
+                    return
+                }
+            }
+            await draftsService.refreshCount()
+        }
+    }
+}
+
+/// A draft has no `render_svg` — nothing is carved until it publishes — so the
+/// row leads with a placeholder rather than a pebble visual.
+private struct DraftRow: View {
+    let draft: PebbleDraftRecord
+
+    var body: some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
+                .foregroundStyle(.secondary)
+                .frame(width: 36, height: 36)
+                .overlay {
+                    Image(systemName: "square.dashed")
+                        .foregroundStyle(.secondary)
+                        .font(.footnote)
+                }
+
+            VStack(alignment: .leading, spacing: 2) {
+                if let name = draft.payload.name, !name.isEmpty {
+                    Text(name)
+                        .lineLimit(1)
+                } else {
+                    Text("No name yet")
+                        .italic()
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                Text(draft.updatedAt, format: .relative(presentation: .named))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+}

--- a/apps/ios/Pebbles/Features/Path/Models/PebbleDraftPayload.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/PebbleDraftPayload.swift
@@ -1,0 +1,234 @@
+import Foundation
+
+/// The `payload` jsonb of a `pebble_drafts` row (M47) — a **partial**
+/// `create_pebble` payload.
+///
+/// Keyed like the wire, not like `PebbleDraft`: the same shape is what the web
+/// and Android composers write, so a draft saved on one surface resumes on the
+/// others and publishing is a straight pass-through. See
+/// `docs/superpowers/specs/2026-07-29-drafts-and-autosave-design.md` (D2).
+///
+/// Everything is optional, because a draft is partial by definition — "just a
+/// name" is valid. Unset keys are **omitted**, never encoded as null: only
+/// `description` and `glyph_id` treat null as meaningful, and a draft has no
+/// prior value to clear.
+///
+/// Note what is deliberately absent: `PebbleDraft.valence` is stored decomposed
+/// as `intensity` + `positiveness`, exactly as the wire wants it. That is why
+/// neither `Valence` nor `Visibility` needed a `Codable` conformance for M47 —
+/// this struct holds primitives only.
+struct PebbleDraftPayload: Codable, Equatable {
+    var name: String?
+    var description: String?
+    var happenedAt: Date?
+    var intensity: Int?
+    var positiveness: Int?
+    var visibility: String?
+    var emotionId: UUID?
+    var domainIds: [UUID]?
+    var soulIds: [UUID]?
+    var collectionIds: [UUID]?
+    var glyphId: UUID?
+    var snaps: [SnapPayload]?
+
+    struct SnapPayload: Codable, Equatable {
+        let id: UUID
+        let storagePath: String
+        let sortOrder: Int
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case storagePath = "storage_path"
+            case sortOrder   = "sort_order"
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case description
+        case happenedAt = "happened_at"
+        case intensity
+        case positiveness
+        case visibility
+        case emotionId     = "emotion_id"
+        case domainIds     = "domain_ids"
+        case soulIds       = "soul_ids"
+        case collectionIds = "collection_ids"
+        case glyphId       = "glyph_id"
+        case snaps
+    }
+
+    /// Same `.withInternetDateTime` convention as `PebbleCreatePayload`. Sharing
+    /// it is load-bearing: a draft encoded one way and published the other would
+    /// drift by the offset format alone.
+    private static let iso8601: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    /// `encodeIfPresent` throughout — that is the "omit unset keys" rule.
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(description, forKey: .description)
+        try container.encodeIfPresent(
+            happenedAt.map { Self.iso8601.string(from: $0) }, forKey: .happenedAt
+        )
+        try container.encodeIfPresent(intensity, forKey: .intensity)
+        try container.encodeIfPresent(positiveness, forKey: .positiveness)
+        try container.encodeIfPresent(visibility, forKey: .visibility)
+        try container.encodeIfPresent(emotionId, forKey: .emotionId)
+        try container.encodeIfPresent(domainIds, forKey: .domainIds)
+        try container.encodeIfPresent(soulIds, forKey: .soulIds)
+        try container.encodeIfPresent(collectionIds, forKey: .collectionIds)
+        try container.encodeIfPresent(glyphId, forKey: .glyphId)
+        try container.encodeIfPresent(snaps, forKey: .snaps)
+    }
+
+    /// Tolerant by design: a payload written by another surface (or an older
+    /// build) must never fail to decode. A `happened_at` we cannot parse is
+    /// dropped rather than thrown, leaving hydration to fall back to "now".
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decodeIfPresent(String.self, forKey: .name)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        happenedAt = try container.decodeIfPresent(String.self, forKey: .happenedAt)
+            .flatMap { Self.iso8601.date(from: $0) }
+        intensity = try container.decodeIfPresent(Int.self, forKey: .intensity)
+        positiveness = try container.decodeIfPresent(Int.self, forKey: .positiveness)
+        visibility = try container.decodeIfPresent(String.self, forKey: .visibility)
+        emotionId = try container.decodeIfPresent(UUID.self, forKey: .emotionId)
+        domainIds = try container.decodeIfPresent([UUID].self, forKey: .domainIds)
+        soulIds = try container.decodeIfPresent([UUID].self, forKey: .soulIds)
+        collectionIds = try container.decodeIfPresent([UUID].self, forKey: .collectionIds)
+        glyphId = try container.decodeIfPresent(UUID.self, forKey: .glyphId)
+        snaps = try container.decodeIfPresent([SnapPayload].self, forKey: .snaps)
+    }
+
+    init() {}
+}
+
+// MARK: - Projections
+
+extension PebbleDraftPayload {
+    /// Composer state → draft payload. Empty strings and empty arrays are
+    /// omitted so `isEmpty` below can tell "untouched" from "deliberately blank".
+    ///
+    /// `formSnap` is passed separately because snap state lives on the
+    /// `SnapUploadCoordinator`, not on the draft — same split as
+    /// `PebbleCreatePayload`. Pass `nil` for the local autosave snapshot, which
+    /// carries no media (D3).
+    init(from draft: PebbleDraft, formSnap: FormSnap?, userId: UUID?) {
+        self.init()
+        // whitespacesAndNewlines, not .whitespaces: the description field is
+        // multiline, so a draft holding only newlines is still an empty draft.
+        // (PebbleCreatePayload trims with .whitespaces — worth aligning one day.)
+        let trimmedName = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedDescription = draft.description.trimmingCharacters(in: .whitespacesAndNewlines)
+        name = trimmedName.isEmpty ? nil : trimmedName
+        description = trimmedDescription.isEmpty ? nil : trimmedDescription
+        happenedAt = draft.happenedAt
+        // Both or neither: a nil valence means the user has not picked one, and
+        // hydration must not invent an intensity for them.
+        intensity = draft.valence?.intensity
+        positiveness = draft.valence?.positiveness
+        visibility = draft.visibility.rawValue
+        emotionId = draft.emotionId
+        domainIds = draft.domainId.map { [$0] }
+        soulIds = draft.soulIds.isEmpty ? nil : draft.soulIds
+        collectionIds = draft.collectionId.map { [$0] }
+        glyphId = draft.glyphId
+        snaps = Self.snapPayloads(for: formSnap, userId: userId)
+    }
+
+    private static func snapPayloads(for formSnap: FormSnap?, userId: UUID?) -> [SnapPayload]? {
+        switch formSnap {
+        case .none:
+            return nil
+        case .pending(let snap):
+            // The bytes are already in Storage (upload happens at pick time), so
+            // the descriptor alone is enough to carry the photo across a draft.
+            guard let userId else { return nil }
+            return [SnapPayload(id: snap.id, storagePath: snap.storagePrefix(userId: userId), sortOrder: 0)]
+        case .existing(let id, let storagePath):
+            return [SnapPayload(id: id, storagePath: storagePath, sortOrder: 0)]
+        }
+    }
+
+    /// True when nothing a user would recognise as their own input is present.
+    /// `happenedAt` / `intensity` / `positiveness` / `visibility` never count:
+    /// they are always defaulted, and counting them would make every freshly
+    /// opened composer look like an unsaved draft.
+    var isEmpty: Bool {
+        name == nil
+        && description == nil
+        && emotionId == nil
+        && glyphId == nil
+        && (domainIds?.isEmpty ?? true)
+        && (soulIds?.isEmpty ?? true)
+        && (collectionIds?.isEmpty ?? true)
+        && (snaps?.isEmpty ?? true)
+    }
+
+    /// The snap descriptor to seed onto a `SnapUploadCoordinator` on resume, if
+    /// this draft carries one.
+    var existingSnap: (id: UUID, storagePath: String)? {
+        guard let snap = snaps?.first else { return nil }
+        return (snap.id, snap.storagePath)
+    }
+}
+
+extension PebbleDraft {
+    /// Ids the composer can verify synchronously from `ReferenceDataService`.
+    /// Souls and collections are user-owned and deletable, so a draft can outlive
+    /// them; emotions and domains are seeded reference rows and pass through
+    /// untouched.
+    ///
+    /// Glyphs are deliberately absent: usability is `can_use_glyph(id, user)`
+    /// (own ∪ system ∪ entitled), the same predicate `create_pebble` enforces,
+    /// and it can only be answered server-side. The composer verifies it
+    /// asynchronously after hydrating — see `CreatePebbleSheet.verifyGlyph()`.
+    struct KnownIds {
+        let soulIds: Set<UUID>
+        let collectionIds: Set<UUID>
+    }
+
+    /// Draft payload → composer state, dropping references that no longer
+    /// resolve (D7). Sanitizing here rather than at publish means a deleted soul
+    /// costs the user a chip, not an opaque foreign-key error at the worst
+    /// possible moment.
+    init(payload: PebbleDraftPayload, known: KnownIds) {
+        self.init()
+        if let name = payload.name { self.name = name }
+        if let description = payload.description { self.description = description }
+        // Restored verbatim (D6): for a quick capture the moment captured IS the
+        // moment it happened, so publishing later must not move it.
+        if let happenedAt = payload.happenedAt { self.happenedAt = happenedAt }
+        if let positiveness = payload.positiveness, let intensity = payload.intensity {
+            self.valence = Valence.from(positiveness: positiveness, intensity: intensity)
+        }
+        if let visibility = payload.visibility {
+            self.visibility = Visibility(rawValue: visibility) ?? .private
+        }
+        self.emotionId = payload.emotionId
+        self.domainId = payload.domainIds?.first
+        self.soulIds = (payload.soulIds ?? []).filter { known.soulIds.contains($0) }
+        self.collectionId = payload.collectionIds?.first.flatMap {
+            known.collectionIds.contains($0) ? $0 : nil
+        }
+        // Kept as-is here; `can_use_glyph` is checked asynchronously by the
+        // composer, which clears it if the glyph is no longer usable.
+        self.glyphId = payload.glyphId
+    }
+
+    /// Relaxed counterpart to `isValid` (D5): what "Save as draft" allows.
+    /// `isValid` must stay strict because `PebbleCreatePayload.init`
+    /// preconditions on it and force-unwraps the mandatory fields.
+    ///
+    /// Takes `formSnap` so a photo-only draft counts as savable — the photo is
+    /// real input, and it lives outside `PebbleDraft`.
+    func isSavableAsDraft(formSnap: FormSnap?, userId: UUID?) -> Bool {
+        !PebbleDraftPayload(from: self, formSnap: formSnap, userId: userId).isEmpty
+    }
+}

--- a/apps/ios/Pebbles/Features/Path/Models/Valence.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/Valence.swift
@@ -43,6 +43,30 @@ enum Valence: String, CaseIterable, Identifiable, Hashable {
     }
 }
 
+extension Valence {
+    /// Rebuild a valence from the decomposed `(positiveness, intensity)` pair the
+    /// wire and `pebble_drafts.payload` store (M47). Returns nil for any pair
+    /// outside the 3×3 grid so a malformed draft leaves the picker unset rather
+    /// than silently claiming a value the user never chose.
+    ///
+    /// Note: `PebbleDetail.valence` carries the same mapping inline for the
+    /// non-optional read path; worth collapsing into this one day.
+    static func from(positiveness: Int, intensity: Int) -> Valence? {
+        switch (positiveness, intensity) {
+        case (-1, 1): return .lowlightSmall
+        case (-1, 2): return .lowlightMedium
+        case (-1, 3): return .lowlightLarge
+        case (0, 1):  return .neutralSmall
+        case (0, 2):  return .neutralMedium
+        case (0, 3):  return .neutralLarge
+        case (1, 1):  return .highlightSmall
+        case (1, 2):  return .highlightMedium
+        case (1, 3):  return .highlightLarge
+        default:      return nil
+        }
+    }
+}
+
 /// Groups the nine `Valence` cases by size for the picker sheet.
 /// Drives the three section headers ("Day event" / "Week event" / "Month event").
 enum ValenceSizeGroup: String, CaseIterable, Identifiable {

--- a/apps/ios/Pebbles/Features/Path/PathView.swift
+++ b/apps/ios/Pebbles/Features/Path/PathView.swift
@@ -14,12 +14,14 @@ struct PathView: View {
     @Environment(SupabaseService.self) private var supabase
     @Environment(EmotionPaletteService.self) private var palettes
     @Environment(PathStatsService.self) private var stats
+    @Environment(PebbleDraftsService.self) private var draftsService
 
     @State private var pebbles: [Pebble] = []
     @State private var entries: [WeekRollEntry] = []
     @State private var focusedWeekStart: Date = Date()
     @State private var navPath = NavigationPath()
     @State private var isPresentingCreate = false
+    @State private var isPresentingDrafts = false
     @State private var selectedPebbleId: UUID?
     @State private var pendingDeletion: Pebble?
     @State private var deleteError: String?
@@ -61,8 +63,19 @@ struct PathView: View {
             onFirstLoad()
         }
         .task { await stats.load() }
+        .task { await draftsService.refreshCount() }
         .sheet(isPresented: $isPresentingCreate) {
             CreatePebbleSheet(onCreated: { newPebbleId in
+                selectedPebbleId = newPebbleId
+                Task {
+                    async let timeline: Void = load()
+                    async let statsReload: Void = stats.refresh()
+                    _ = await (timeline, statsReload)
+                }
+            })
+        }
+        .sheet(isPresented: $isPresentingDrafts) {
+            DraftsListSheet(onPebbleCreated: { newPebbleId in
                 selectedPebbleId = newPebbleId
                 Task {
                     async let timeline: Void = load()
@@ -154,6 +167,21 @@ struct PathView: View {
             }
             .safeAreaInset(edge: .bottom) {
                 VStack(spacing: 12) {
+                    if draftsService.count > 0 {
+                        Button {
+                            isPresentingDrafts = true
+                        } label: {
+                            Label {
+                                // Count is verbatim so this needs no plural
+                                // entry in the catalog.
+                                Text("Drafts") + Text(verbatim: " (\(draftsService.count))")
+                            } icon: {
+                                Image(systemName: "square.dashed")
+                            }
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                        }
+                    }
                     NewPebbleButton(onTap: { isPresentingCreate = true })
                     PathBottomBar(
                         karma: stats.karma,

--- a/apps/ios/Pebbles/PebblesApp.swift
+++ b/apps/ios/Pebbles/PebblesApp.swift
@@ -9,6 +9,8 @@ struct PebblesApp: App {
     @State private var stats: PathStatsService
     @State private var snapURLs: SnapURLCache
     @State private var karma: KarmaNotificationService
+    @State private var drafts: PebbleDraftsService
+    @State private var snapshots: ComposerSnapshotStore
     @State private var karmaOverlay = KarmaOverlayWindowController()
 
     init() {
@@ -19,6 +21,8 @@ struct PebblesApp: App {
         self._stats    = State(initialValue: PathStatsService(supabase: supabase))
         self._snapURLs = State(initialValue: SnapURLCache(client: supabase.client))
         self._karma    = State(initialValue: KarmaNotificationService())
+        self._drafts   = State(initialValue: PebbleDraftsService(client: supabase.client))
+        self._snapshots = State(initialValue: ComposerSnapshotStore())
         Self.configureSegmentedControlAppearance()
         Self.configureNavigationBarAppearance()
     }
@@ -32,6 +36,8 @@ struct PebblesApp: App {
                 .environment(stats)
                 .environment(snapURLs)
                 .environment(karma)
+                .environment(drafts)
+                .environment(snapshots)
                 .onAppear { karmaOverlay.attachIfNeeded(service: karma) }
         }
     }

--- a/apps/ios/Pebbles/Resources/Localizable.xcstrings
+++ b/apps/ios/Pebbles/Resources/Localizable.xcstrings
@@ -4,6 +4,159 @@
     "" : {
 
     },
+    "Drafts" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drafts"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brouillons"
+          }
+        }
+      }
+    },
+    "No drafts yet. Anything you start keeping shows up here." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No drafts yet. Anything you start keeping shows up here."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun brouillon. Tout ce que tu commences \u00e0 garder appara\u00eet ici."
+          }
+        }
+      }
+    },
+    "No name yet" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No name yet"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Encore sans nom"
+          }
+        }
+      }
+    },
+    "Pick up where you left off?" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pick up where you left off?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "On reprend o\u00f9 tu t'\u00e9tais arr\u00eat\u00e9 ?"
+          }
+        }
+      }
+    },
+    "Restore it" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore it"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprendre"
+          }
+        }
+      }
+    },
+    "Save as draft" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save as draft"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Garder pour plus tard"
+          }
+        }
+      }
+    },
+    "Start fresh" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start fresh"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Repartir de z\u00e9ro"
+          }
+        }
+      }
+    },
+    "Try again" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try again"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "R\u00e9essayer"
+          }
+        }
+      }
+    },
+    "We kept what you were writing here. Add your photo again when you're ready." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We kept what you were writing here. Add your photo again when you're ready."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "On a gard\u00e9 ce que tu \u00e9crivais ici. Remets ta photo quand tu veux."
+          }
+        }
+      }
+    },
     "—" : {
       "localizations" : {
         "fr" : {

--- a/apps/ios/Pebbles/Services/ComposerSnapshotStore.swift
+++ b/apps/ios/Pebbles/Services/ComposerSnapshotStore.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Observation
+import os
+
+/// Crash insurance for the open composer (M47) — a single JSON snapshot of the
+/// in-progress draft on disk.
+///
+/// This is the first on-disk persistence in the app: `SnapURLCache` is
+/// per-session and the only `@AppStorage` key is a boolean. Deliberately
+/// **not** offline support — see the 2026-07-29 "Offline is a non-goal on every
+/// surface" decision-log entry. No merge logic, no cross-device sync, one
+/// composer at a time, cleared on publish or server-draft save.
+///
+/// Media is excluded (D3): an intentional "save as draft" earns durable media,
+/// an accidental crash recovery does not.
+///
+/// Encoding/decoding is pure and injectable so the debounce and round-trip are
+/// testable without touching the real caches directory.
+@Observable
+@MainActor
+final class ComposerSnapshotStore {
+
+    private let fileURL: URL
+    private let logger = Logger(subsystem: "app.pbbls.ios", category: "composer-snapshot")
+
+    /// Production initializer: a file in the caches directory. Caches is right —
+    /// losing a snapshot to a purge costs the user an unsaved composer, which is
+    /// exactly the risk they already accept by not saving a draft.
+    convenience init() {
+        let base = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        self.init(fileURL: base.appendingPathComponent("composer-snapshot.json"))
+    }
+
+    /// Test initializer.
+    init(fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    /// The stored snapshot, or nil when there is nothing to restore. A payload
+    /// written by an older build must never crash the composer, so a decode
+    /// failure discards the file rather than propagating.
+    func load() -> PebbleDraftPayload? {
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        do {
+            let payload = try JSONDecoder().decode(PebbleDraftPayload.self, from: data)
+            return payload.isEmpty ? nil : payload
+        } catch {
+            logger.warning("discarding unreadable snapshot: \(error.localizedDescription, privacy: .private)")
+            clear()
+            return nil
+        }
+    }
+
+    /// Overwrite the snapshot. Callers debounce; see `ComposerAutosave`.
+    func save(_ payload: PebbleDraftPayload) {
+        guard !payload.isEmpty else {
+            clear()
+            return
+        }
+        do {
+            try JSONEncoder().encode(payload).write(to: fileURL, options: .atomic)
+        } catch {
+            logger.error("snapshot write failed: \(error.localizedDescription, privacy: .private)")
+        }
+    }
+
+    func clear() {
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+}
+
+/// Debounces snapshot writes so every keystroke does not hit the disk, and
+/// flushes on demand when the scene backgrounds.
+///
+/// Separate from the store so the store stays a dumb, testable file wrapper and
+/// the timing policy lives in one place.
+@MainActor
+final class ComposerAutosave {
+
+    private let store: ComposerSnapshotStore
+    private let debounce: Duration
+    private var task: Task<Void, Never>?
+    private var pending: PebbleDraftPayload?
+
+    init(store: ComposerSnapshotStore, debounce: Duration = .milliseconds(800)) {
+        self.store = store
+        self.debounce = debounce
+    }
+
+    /// Queue a write. Supersedes any pending one.
+    func schedule(_ payload: PebbleDraftPayload) {
+        pending = payload
+        task?.cancel()
+        task = Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(for: debounce)
+            guard !Task.isCancelled else { return }
+            flush()
+        }
+    }
+
+    /// Write the pending snapshot now. Called when the scene leaves the
+    /// foreground, which is the last reliable moment before a process kill.
+    func flush() {
+        task?.cancel()
+        task = nil
+        guard let payload = pending else { return }
+        pending = nil
+        store.save(payload)
+    }
+
+    /// The composer published or saved a server draft — the snapshot is
+    /// redundant, and leaving it would re-offer work the user already committed.
+    func clear() {
+        task?.cancel()
+        task = nil
+        pending = nil
+        store.clear()
+    }
+}

--- a/apps/ios/Pebbles/Services/PebbleDraftsService.swift
+++ b/apps/ios/Pebbles/Services/PebbleDraftsService.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Observation
+import Supabase
+import os
+
+/// A `pebble_drafts` row as the drafts list needs it.
+struct PebbleDraftRecord: Identifiable, Decodable, Equatable {
+    let id: UUID
+    let payload: PebbleDraftPayload
+    let updatedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case payload
+        case updatedAt = "updated_at"
+    }
+}
+
+/// Server-side drafts (M47). Direct single-table CRUD on `pebble_drafts`,
+/// owner-scoped by RLS — the sanctioned direct-client pattern, since nothing
+/// here is multi-table and nothing emits karma.
+///
+/// Zero karma is structural rather than enforced: `create_pebble` is the
+/// schema's only `pebble_created` emitter and a draft never reaches it.
+///
+/// Production wiring lives in `PebblesApp`, alongside `SnapURLCache`.
+@Observable
+@MainActor
+final class PebbleDraftsService {
+
+    private let client: SupabaseClient
+    private let logger = Logger(subsystem: "app.pbbls.ios", category: "pebble-drafts")
+
+    /// Mirrors the count shown on the Path entry point. Refreshed by `list()`.
+    private(set) var count: Int = 0
+
+    init(client: SupabaseClient) {
+        self.client = client
+    }
+
+    /// Most recently saved first — `updated_at` is trigger-maintained server-side,
+    /// so this ordering does not depend on client clocks.
+    func list() async throws -> [PebbleDraftRecord] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let rows: [PebbleDraftRecord] = try await client
+            .from("pebble_drafts")
+            .select("id, payload, updated_at")
+            .order("updated_at", ascending: false)
+            .execute()
+            .value
+        count = rows.count
+        return rows
+    }
+
+    func load(id: UUID) async throws -> PebbleDraftRecord? {
+        let rows: [PebbleDraftRecord] = try await client
+            .from("pebble_drafts")
+            .select("id, payload, updated_at")
+            .eq("id", value: id)
+            .limit(1)
+            .execute()
+            .value
+        return rows.first
+    }
+
+    /// Upsert. `id` nil creates; passing one replaces that draft's payload
+    /// wholesale — which is the point of the jsonb column, since a coalescing
+    /// update could never clear a field the user emptied.
+    ///
+    /// `userId` is explicit because the RLS `with check` compares it to
+    /// `auth.uid()`.
+    @discardableResult
+    func save(payload: PebbleDraftPayload, id: UUID?, userId: UUID) async throws -> UUID {
+        let row = DraftUpsertPayload(id: id ?? UUID(), userId: userId, payload: payload)
+        try await client
+            .from("pebble_drafts")
+            .upsert(row, onConflict: "id")
+            .execute()
+        return row.id
+    }
+
+    func delete(id: UUID) async throws {
+        try await client
+            .from("pebble_drafts")
+            .delete()
+            .eq("id", value: id)
+            .execute()
+    }
+
+    /// Best-effort cleanup after a successful publish: the pebble exists, so a
+    /// failure here must not surface as a publish failure. Worst case a stale
+    /// draft is left in the list.
+    func deleteIgnoringFailure(id: UUID) async {
+        do {
+            try await delete(id: id)
+        } catch {
+            logger.warning("draft cleanup after publish failed: \(error.localizedDescription, privacy: .private)")
+        }
+    }
+
+    /// Refresh `count` without surfacing an error — it only drives an entry
+    /// point's badge, and a missing badge beats an error state on the Path.
+    func refreshCount() async {
+        do {
+            _ = try await list()
+        } catch {
+            logger.error("draft count refresh failed: \(error.localizedDescription, privacy: .private)")
+        }
+    }
+
+    /// `user_id` is explicitly encoded so the RLS `with check` sees it; `payload`
+    /// rides along as the nested jsonb.
+    private struct DraftUpsertPayload: Encodable {
+        let id: UUID
+        let userId: UUID
+        let payload: PebbleDraftPayload
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case userId = "user_id"
+            case payload
+        }
+    }
+}

--- a/apps/ios/PebblesTests/ComposerSnapshotStoreTests.swift
+++ b/apps/ios/PebblesTests/ComposerSnapshotStoreTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Testing
+@testable import Pebbles
+
+/// The snapshot store is crash insurance, so its failure modes matter more than
+/// its happy path: a corrupt or stale file must never take the composer with it.
+@Suite("ComposerSnapshotStore")
+@MainActor
+struct ComposerSnapshotStoreTests {
+
+    /// A store over a unique temp file, plus that file's URL.
+    private func makeStore() -> (ComposerSnapshotStore, URL) {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("composer-snapshot-test-\(UUID().uuidString).json")
+        return (ComposerSnapshotStore(fileURL: url), url)
+    }
+
+    private func payload(name: String) -> PebbleDraftPayload {
+        var draft = PebbleDraft()
+        draft.name = name
+        return PebbleDraftPayload(from: draft, formSnap: nil, userId: nil)
+    }
+
+    @Test("Loading with no file on disk returns nil")
+    func loadWithNoFile() {
+        let (store, _) = makeStore()
+        #expect(store.load() == nil)
+    }
+
+    @Test("A saved snapshot round-trips")
+    func saveThenLoad() {
+        let (store, url) = makeStore()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        store.save(payload(name: "Half a thought"))
+        #expect(store.load()?.name == "Half a thought")
+    }
+
+    @Test("Saving replaces the previous snapshot rather than accumulating")
+    func saveReplaces() {
+        let (store, url) = makeStore()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        store.save(payload(name: "First"))
+        store.save(payload(name: "Second"))
+        #expect(store.load()?.name == "Second")
+    }
+
+    @Test("Saving an empty payload clears the file instead of storing nothing")
+    func savingEmptyClears() {
+        let (store, url) = makeStore()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        store.save(payload(name: "Something"))
+        store.save(PebbleDraftPayload())
+
+        #expect(store.load() == nil)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @Test("clear() removes the snapshot")
+    func clearRemoves() {
+        let (store, url) = makeStore()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        store.save(payload(name: "Publish me"))
+        store.clear()
+        #expect(store.load() == nil)
+    }
+
+    @Test("clear() on an absent file is a no-op, not a crash")
+    func clearIsIdempotent() {
+        let (store, _) = makeStore()
+        store.clear()
+        store.clear()
+        #expect(store.load() == nil)
+    }
+
+    @Test("An unreadable snapshot is discarded rather than propagated")
+    func corruptSnapshotIsDiscarded() throws {
+        let (store, url) = makeStore()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try Data("{ this is not json".utf8).write(to: url)
+
+        #expect(store.load() == nil)
+        // And the bad file is gone, so it cannot fail again on every launch.
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @Test("A well-formed but empty snapshot is treated as nothing to restore")
+    func emptySnapshotIsNotOffered() throws {
+        let (store, url) = makeStore()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try JSONEncoder().encode(PebbleDraftPayload()).write(to: url)
+        #expect(store.load() == nil, "restoring a blank composer is not worth a prompt")
+    }
+}
+
+@Suite("ComposerAutosave")
+@MainActor
+struct ComposerAutosaveTests {
+
+    private func makeStore() -> (ComposerSnapshotStore, URL) {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("composer-autosave-test-\(UUID().uuidString).json")
+        return (ComposerSnapshotStore(fileURL: url), url)
+    }
+
+    private func payload(name: String) -> PebbleDraftPayload {
+        var draft = PebbleDraft()
+        draft.name = name
+        return PebbleDraftPayload(from: draft, formSnap: nil, userId: nil)
+    }
+
+    @Test("A scheduled write does not hit disk before its debounce elapses")
+    func debounceDelaysWrite() async throws {
+        let (store, url) = makeStore()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let autosave = ComposerAutosave(store: store, debounce: .milliseconds(400))
+
+        autosave.schedule(payload(name: "Typing"))
+        #expect(store.load() == nil, "the write should still be pending")
+
+        try await Task.sleep(for: .milliseconds(700))
+        #expect(store.load()?.name == "Typing")
+    }
+
+    @Test("Rapid keystrokes collapse into a single write of the final value")
+    func rapidSchedulesCollapse() async throws {
+        let (store, url) = makeStore()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let autosave = ComposerAutosave(store: store, debounce: .milliseconds(200))
+
+        for name in ["A", "Ar", "Arg", "Argu"] {
+            autosave.schedule(payload(name: name))
+        }
+        try await Task.sleep(for: .milliseconds(500))
+
+        #expect(store.load()?.name == "Argu")
+    }
+
+    @Test("flush() writes the pending snapshot immediately")
+    func flushWritesNow() {
+        let (store, url) = makeStore()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let autosave = ComposerAutosave(store: store, debounce: .seconds(30))
+
+        autosave.schedule(payload(name: "Backgrounded mid-sentence"))
+        autosave.flush()
+
+        // This is the scene-phase path: without it, a process kill inside the
+        // debounce window would lose everything typed.
+        #expect(store.load()?.name == "Backgrounded mid-sentence")
+    }
+
+    @Test("flush() with nothing pending does not write")
+    func flushWithoutPendingIsNoOp() {
+        let (store, url) = makeStore()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let autosave = ComposerAutosave(store: store, debounce: .milliseconds(100))
+
+        autosave.flush()
+        #expect(store.load() == nil)
+    }
+
+    @Test("clear() cancels a pending write so it cannot resurrect the snapshot")
+    func clearCancelsPendingWrite() async throws {
+        let (store, url) = makeStore()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let autosave = ComposerAutosave(store: store, debounce: .milliseconds(200))
+
+        autosave.schedule(payload(name: "About to publish"))
+        autosave.clear()
+        try await Task.sleep(for: .milliseconds(500))
+
+        // Regression guard: if the debounced task still fired after clear(), a
+        // published pebble would be re-offered as an unsaved draft.
+        #expect(store.load() == nil)
+    }
+}

--- a/apps/ios/PebblesTests/PebbleDraftPayloadTests.swift
+++ b/apps/ios/PebblesTests/PebbleDraftPayloadTests.swift
@@ -1,0 +1,229 @@
+import Foundation
+import Testing
+@testable import Pebbles
+
+/// The draft payload is the M47 cross-surface contract: web, iOS and Android all
+/// read and write this exact shape. These tests pin the parts that would break
+/// silently — omitted keys, the ISO-8601 convention, and the sanitizing rules.
+@Suite("PebbleDraftPayload")
+struct PebbleDraftPayloadTests {
+
+    private let soulA = UUID()
+    private let collectionA = UUID()
+    private let emotionA = UUID()
+    private let domainA = UUID()
+    private let glyphA = UUID()
+
+    private func encoded(_ payload: PebbleDraftPayload) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(payload)
+        let object = try JSONSerialization.jsonObject(with: data)
+        return object as? [String: Any] ?? [:]
+    }
+
+    // MARK: - omitted keys
+
+    @Test("An empty draft encodes only the always-defaulted keys")
+    func emptyDraftOmitsUnsetKeys() throws {
+        let payload = PebbleDraftPayload(from: PebbleDraft(), formSnap: nil, userId: nil)
+        let json = try encoded(payload)
+
+        // Present because the composer always holds a real value for them.
+        #expect(json["happened_at"] != nil)
+        #expect(json["visibility"] as? String == "private")
+
+        // Absent, not null: nothing has been set.
+        for key in ["name", "description", "emotion_id", "domain_ids",
+                    "soul_ids", "collection_ids", "glyph_id", "snaps",
+                    "intensity", "positiveness"] {
+            #expect(json[key] == nil, "\(key) should be omitted, not encoded as null")
+        }
+    }
+
+    @Test("A quick capture with only a name encodes just that name")
+    func quickCaptureEncodesName() throws {
+        var draft = PebbleDraft()
+        draft.name = "  Argument with Léa  "
+        let json = try encoded(PebbleDraftPayload(from: draft, formSnap: nil, userId: nil))
+
+        #expect(json["name"] as? String == "Argument with Léa", "name should be trimmed")
+        #expect(json["emotion_id"] == nil)
+    }
+
+    @Test("Whitespace-only name and description are omitted entirely")
+    func whitespaceOnlyFieldsAreOmitted() throws {
+        var draft = PebbleDraft()
+        draft.name = "   "
+        draft.description = "\n\t "
+        let payload = PebbleDraftPayload(from: draft, formSnap: nil, userId: nil)
+
+        #expect(payload.name == nil)
+        #expect(payload.description == nil)
+        #expect(payload.isEmpty, "a whitespace-only draft is not worth saving")
+    }
+
+    // MARK: - valence decomposition
+
+    @Test("Valence is stored decomposed, and both keys are omitted when unset")
+    func valenceDecomposes() throws {
+        var draft = PebbleDraft()
+        draft.name = "x"
+        #expect(try encoded(PebbleDraftPayload(from: draft, formSnap: nil, userId: nil))["intensity"] == nil)
+
+        draft.valence = .highlightLarge
+        let json = try encoded(PebbleDraftPayload(from: draft, formSnap: nil, userId: nil))
+        #expect(json["intensity"] as? Int == 3)
+        #expect(json["positiveness"] as? Int == 1)
+    }
+
+    @Test("Every valence round-trips through the decomposed pair")
+    func everyValenceRoundTrips() {
+        for valence in Valence.allCases {
+            let rebuilt = Valence.from(positiveness: valence.positiveness, intensity: valence.intensity)
+            #expect(rebuilt == valence)
+        }
+    }
+
+    @Test("An out-of-grid pair leaves the valence unset rather than guessing")
+    func invalidValencePairIsRejected() {
+        #expect(Valence.from(positiveness: 7, intensity: 2) == nil)
+        #expect(Valence.from(positiveness: 0, intensity: 0) == nil)
+    }
+
+    // MARK: - round trip
+
+    @Test("A fully populated payload survives an encode/decode round trip")
+    func fullRoundTrip() throws {
+        var draft = PebbleDraft()
+        draft.name = "Full"
+        draft.description = "Everything set"
+        draft.happenedAt = Date(timeIntervalSince1970: 1_785_000_000)
+        draft.valence = .lowlightSmall
+        draft.emotionId = emotionA
+        draft.domainId = domainA
+        draft.soulIds = [soulA]
+        draft.collectionId = collectionA
+        draft.glyphId = glyphA
+        draft.visibility = .public
+
+        let original = PebbleDraftPayload(from: draft, formSnap: nil, userId: nil)
+        let decoded = try JSONDecoder().decode(
+            PebbleDraftPayload.self, from: try JSONEncoder().encode(original)
+        )
+
+        #expect(decoded == original)
+        // Second-precision: the wire format carries no sub-second component, so a
+        // round trip must not drift by more than that.
+        #expect(abs(decoded.happenedAt!.timeIntervalSince(draft.happenedAt)) < 1)
+    }
+
+    @Test("happened_at uses the same internet-date-time format as the create payload")
+    func happenedAtFormatMatchesCreatePayload() throws {
+        var draft = PebbleDraft()
+        draft.name = "x"
+        draft.happenedAt = Date(timeIntervalSince1970: 1_785_000_000)
+        let value = try encoded(PebbleDraftPayload(from: draft, formSnap: nil, userId: nil))["happened_at"] as? String
+
+        // No fractional seconds, explicit offset — .withInternetDateTime.
+        #expect(value == "2026-07-25T17:20:00Z")
+    }
+
+    @Test("Unknown and malformed keys decode without throwing")
+    func decodingIsTolerant() throws {
+        let json = """
+        {"name":"From another surface","happened_at":"not-a-date","unknown_key":42}
+        """
+        let decoded = try JSONDecoder().decode(PebbleDraftPayload.self, from: Data(json.utf8))
+
+        #expect(decoded.name == "From another surface")
+        #expect(decoded.happenedAt == nil, "an unparseable date is dropped, not thrown")
+    }
+
+    // MARK: - hydration and sanitizing (D7)
+
+    @Test("Hydration drops souls and collections the user no longer owns")
+    func hydrationDropsStaleReferences() {
+        let goneSoul = UUID()
+        var payload = PebbleDraftPayload()
+        payload.name = "Stale"
+        payload.soulIds = [soulA, goneSoul]
+        payload.collectionIds = [UUID()]
+        payload.emotionId = emotionA
+        payload.domainIds = [domainA]
+
+        let hydrated = PebbleDraft(
+            payload: payload,
+            known: .init(soulIds: [soulA], collectionIds: [collectionA])
+        )
+
+        #expect(hydrated.soulIds == [soulA], "the deleted soul is dropped")
+        #expect(hydrated.collectionId == nil, "a collection the user lost is dropped")
+        // Reference data is never sanitized — it is seeded, not user-owned.
+        #expect(hydrated.emotionId == emotionA)
+        #expect(hydrated.domainId == domainA)
+    }
+
+    @Test("Hydration restores happened_at verbatim rather than re-stamping it")
+    func hydrationKeepsCapturedTimestamp() {
+        let captured = Date(timeIntervalSince1970: 1_700_000_000)
+        var payload = PebbleDraftPayload()
+        payload.name = "Captured hours ago"
+        payload.happenedAt = captured
+
+        let hydrated = PebbleDraft(payload: payload, known: .init(soulIds: [], collectionIds: []))
+        #expect(hydrated.happenedAt == captured)
+    }
+
+    @Test("An empty payload hydrates to the composer's defaults")
+    func emptyPayloadHydratesToDefaults() {
+        let hydrated = PebbleDraft(
+            payload: PebbleDraftPayload(), known: .init(soulIds: [], collectionIds: [])
+        )
+        #expect(hydrated.name.isEmpty)
+        #expect(hydrated.valence == nil)
+        #expect(hydrated.visibility == .private)
+        #expect(!hydrated.isValid)
+    }
+
+    // MARK: - the draft/publish gate split (D5)
+
+    @Test("isSavableAsDraft is looser than isValid")
+    func draftGateIsLooserThanPublishGate() {
+        var draft = PebbleDraft()
+        #expect(!draft.isSavableAsDraft(formSnap: nil, userId: nil), "nothing typed yet")
+        #expect(!draft.isValid)
+
+        draft.name = "Just a name"
+        #expect(draft.isSavableAsDraft(formSnap: nil, userId: nil), "a name alone is a valid draft")
+        #expect(!draft.isValid, "but not enough to publish")
+
+        draft.emotionId = emotionA
+        draft.domainId = domainA
+        draft.valence = .neutralMedium
+        #expect(draft.isValid)
+    }
+
+    @Test("A photo alone makes a draft savable")
+    func photoOnlyDraftIsSavable() {
+        let draft = PebbleDraft()
+        let snap = FormSnap.existing(id: UUID(), storagePath: "user/snap")
+        #expect(draft.isSavableAsDraft(formSnap: snap, userId: UUID()))
+    }
+
+    @Test("An existing snap survives a payload round trip so a draft keeps its photo")
+    func existingSnapRoundTrips() throws {
+        let snapId = UUID()
+        var draft = PebbleDraft()
+        draft.name = "With a photo"
+        let payload = PebbleDraftPayload(
+            from: draft,
+            formSnap: .existing(id: snapId, storagePath: "user-1/\(snapId)"),
+            userId: UUID()
+        )
+        let decoded = try JSONDecoder().decode(
+            PebbleDraftPayload.self, from: try JSONEncoder().encode(payload)
+        )
+
+        #expect(decoded.existingSnap?.id == snapId)
+        #expect(decoded.existingSnap?.storagePath == "user-1/\(snapId)")
+    }
+}

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -9,7 +9,7 @@
       "view_card_variant": "large"
     },
     "created_at": "2026-04-01T00:00:00.000Z",
-    "updated_at": "2026-07-29T21:55:00.000Z"
+    "updated_at": "2026-07-30T00:30:00.000Z"
   },
   "nodes": [
     {
@@ -194,7 +194,7 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Pebble Drafts",
-      "description": "List of unpublished quick captures, most recently saved first. Each row shows a placeholder chip (a draft has no render_svg \u2014 nothing is carved until it publishes), the draft name or a \"no name yet\" fallback, and a relative saved-at stamp; tapping resumes it in the Quick Pebble Editor, and rows are deletable behind a confirm. Deliberately its own surface rather than a section inside the Path timeline, whose week grouping, ripple, bounce and stats all assume real pebbles (M47 design D4). Reached from a Path header entry that only appears when drafts exist. Web (M47, #640): /drafts route.",
+      "description": "List of unpublished quick captures, most recently saved first. Each row shows a placeholder chip (a draft has no render_svg \u2014 nothing is carved until it publishes), the draft name or a \"no name yet\" fallback, and a relative saved-at stamp; tapping resumes it in the Quick Pebble Editor, and rows are deletable behind a confirm. Deliberately its own surface rather than a section inside the Path timeline, whose week grouping, ripple, bounce and stats all assume real pebbles (M47 design D4). Reached from a Path header entry that only appears when drafts exist. Web (M47, #640): /drafts route. iOS (M47, #641): DraftsListSheet presented from the Path, swipe-to-delete, resume into CreatePebbleSheet.",
       "status": "development",
       "platforms": [
         "web",
@@ -220,7 +220,7 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Quick Pebble Editor",
-      "description": "Single-page pebble creation editor (V2) combining all enrichment steps. On /path the editor is anchored to the bottom dock — collapsed as a 'What happened?' trigger that opens an overlay bottom-sheet on tap; on /record it auto-opens as the route's primary affordance. Android (M39, #541/#542): full-screen CreatePebbleScreen/EditPebbleScreen hosting the shared PebbleForm with modal bottom-sheet pickers — full-screen surfaces instead of a bottom-sheet dock (M39 design D5). M42 (#581): the shared Android form gains the Photo section — single-photo attach via the system photo picker (client-side compression to 1024px/420px JPEG renditions, upload with compensating deletes), existing-snap row with eager delete_pebble_media removal, and save gates while an upload is pending or failed. M47 (#640): the composer gains draft mode \u2014 a \"Save as draft\" action ungated by the publish requirements (name + emotion), so \"just a name\" is a valid quick capture, plus debounced local autosave of the open form as crash insurance (text and ids only, no media) with a restore prompt on return. Resuming a draft hydrates the form from its jsonb payload, dropping souls/collections/glyphs the user no longer owns. Publishing runs the normal compose-pebble path once and deletes the draft row.",
+      "description": "Single-page pebble creation editor (V2) combining all enrichment steps. On /path the editor is anchored to the bottom dock — collapsed as a 'What happened?' trigger that opens an overlay bottom-sheet on tap; on /record it auto-opens as the route's primary affordance. Android (M39, #541/#542): full-screen CreatePebbleScreen/EditPebbleScreen hosting the shared PebbleForm with modal bottom-sheet pickers — full-screen surfaces instead of a bottom-sheet dock (M39 design D5). M42 (#581): the shared Android form gains the Photo section — single-photo attach via the system photo picker (client-side compression to 1024px/420px JPEG renditions, upload with compensating deletes), existing-snap row with eager delete_pebble_media removal, and save gates while an upload is pending or failed. M47 (#640): the composer gains draft mode \u2014 a \"Save as draft\" action ungated by the publish requirements (name + emotion), so \"just a name\" is a valid quick capture, plus debounced local autosave of the open form as crash insurance (text and ids only, no media) with a restore prompt on return. Resuming a draft hydrates the form from its jsonb payload, dropping souls/collections/glyphs the user no longer owns. Publishing runs the normal compose-pebble path once and deletes the draft row. iOS (M47, #641): a bottom-bar \"Save as draft\" action, a file-backed snapshot flushed on scene-phase change, and server-side glyph verification via can_use_glyph on resume.",
       "status": "live",
       "platforms": [
         "web",

--- a/docs/arkaik/journal.jsonl
+++ b/docs/arkaik/journal.jsonl
@@ -209,3 +209,5 @@
 {"id": "01KYQZ07VRKPKP75TNFDCJ66TD", "ts": "2026-07-29T21:55:00.000Z", "actor": "claude-code", "type": "edge.added", "edge_id": "e-V-timeline-V-pebble-drafts", "source_id": "V-timeline", "target_id": "V-pebble-drafts", "edge_type": "composes"}
 {"id": "01KYQZ08S77W0FSJ2Y3C8YCSG0", "ts": "2026-07-29T21:55:00.000Z", "actor": "claude-code", "type": "edge.added", "edge_id": "e-V-quick-pebble-editor-DM-pebble-drafts", "source_id": "V-quick-pebble-editor", "target_id": "DM-pebble-drafts", "edge_type": "displays"}
 {"id": "01KYQZ09SNRKGXPB5X00M34AJG", "ts": "2026-07-29T21:55:00.000Z", "actor": "claude-code", "type": "edge.added", "edge_id": "e-API-delete-account-DM-pebble-drafts", "source_id": "API-delete-account", "target_id": "DM-pebble-drafts", "edge_type": "queries"}
+{"id": "01KYR0A1QJKMNPQRSTVWXYZ234", "ts": "2026-07-30T00:30:00.000Z", "actor": "claude-code", "type": "node.updated", "node_id": "V-pebble-drafts", "fields": ["description"]}
+{"id": "01KYR0A1QK5MNPQRSTVWXYZ235", "ts": "2026-07-30T00:30:00.000Z", "actor": "claude-code", "type": "node.updated", "node_id": "V-quick-pebble-editor", "fields": ["description"]}


### PR DESCRIPTION
Resolves #641

iOS port of **M47 · Drafts and local autosave**, mirroring the web reference (#644). Design: `docs/superpowers/specs/2026-07-29-drafts-and-autosave-design.md`. Depends on #643 (merged).

## Key files

| File | What |
|---|---|
| `Features/Path/Models/PebbleDraftPayload.swift` | the cross-surface payload + projections to/from `PebbleDraft` |
| `Features/Path/Models/Valence.swift` | new `from(positiveness:intensity:)` factory |
| `Services/PebbleDraftsService.swift` | direct `pebble_drafts` CRUD + the Path badge count |
| `Services/ComposerSnapshotStore.swift` | file-backed snapshot + `ComposerAutosave` debouncer |
| `Features/Path/CreatePebbleSheet.swift` | draft action, restore prompt, hydration, publish-then-delete (in a same-file `Drafts` extension) |
| `Features/Path/DraftsListSheet.swift` | the drafts surface |
| `Features/Path/PathView.swift` | entry point, shown only when drafts exist |
| `PebblesTests/` | 17 payload tests + 15 snapshot/autosave tests |

## Implementation notes

- **No new `Codable`/`@Serializable` conformances were needed.** Valence is stored decomposed as `intensity` + `positiveness` exactly as the wire does (both keys omitted together when unset), and `visibility` is a string — so the payload struct holds primitives only. `Valence` gains a `from(positiveness:intensity:)` factory for hydration; `PebbleDetail.valence` still carries the same mapping inline, noted in a comment rather than refactored.
- **`isSavableAsDraft` is a new predicate, not a relaxed `isValid`.** `PebbleCreatePayload.init` `precondition`s on validity and force-unwraps `valence!`/`emotionId!`/`domainId!`, so a partial draft must never reach it. It takes `formSnap` so a photo-only draft counts as savable.
- **Glyphs are verified server-side with `can_use_glyph`**, not against a client list. That is the exact predicate `create_pebble` enforces (own ∪ system ∪ entitled), and it is a strict subset of what `glyphs_select` returns, so a client-side check could not answer it. Souls and collections are sanitized synchronously from `ReferenceDataService`; emotions and domains pass through as seeded reference rows.
- **Saving as draft skips `snaps.cancelAndCleanup`** — it would otherwise delete from Storage the very object the draft references.
- **Draft deletion runs on the soft-success path too** (5xx carrying a `pebble_id`), or a failed render write-back would leave the draft behind next to its published pebble.
- `ComposerAutosave` is separate from the store so the store stays a dumb, testable file wrapper and the timing policy lives in one place. It flushes on `scenePhase != .active`, the last reliable moment before a process kill.
- Fixed while writing the tests: draft trimming used `.whitespaces`, which excludes newlines, so a description of `"\n"` made a blank draft look non-empty. Now `.whitespacesAndNewlines`.

## Verification

`xcodebuild build` **succeeded** (clean `DerivedData/Pebbles-*/Build` first).

`npm run test --workspace=apps/ios` — the three new suites pass:

```
✔ Suite "PebbleDraftPayload" passed        (17 tests)
✔ Suite "ComposerSnapshotStore" passed     (8 tests)
✔ Suite "ComposerAutosave" passed          (6 tests)
```

Covering: omitted-vs-null keys, whitespace-only rejection, valence decomposition across all nine cases, out-of-grid rejection, full encode/decode round trip, the exact `.withInternetDateTime` string, tolerant decoding of foreign/malformed payloads, stale-reference sanitizing, verbatim `happened_at`, the draft-vs-publish gate split, photo round trip, debounce timing, flush-on-background, corrupt-file discard, and a regression guard that `clear()` cancels a pending write (otherwise a published pebble would be re-offered as an unsaved draft).

**Pre-existing failures, unchanged by this PR** (both also fail on `main`):
- `Localization — catalog file coverage`: **19 issues before and after**. The test reads `stringUnit` only, so it cannot see `variations`-based plurals. I deliberately rendered the drafts count verbatim (`Text("Drafts") + Text(verbatim: " (3)")`) rather than add a plural entry, so this PR contributes **zero** new issues to it.
- `swiftlint`: 300 violations on `main`, **302** here. Both additions are `nesting` on a `CodingKeys` inside a nested payload struct — the identical pattern already accepted in `PebbleCreatePayload`, `PebbleUpdatePayload` and `PebbleDetail`. The `line_length`, `type_body_length` and `file_length` warnings my first draft introduced are all fixed.

All 10 new catalog entries have both `en` and `fr`; no entry is `New` or `Stale`.

Not exercised by hand in a simulator yet: the restore prompt, resume hydration and the photo round-trip are covered at the model layer but not through the live UI.

## Lab Note (EN/FR)

```yaml
species: feature
platform: ios
status: in_progress
published: false
en:
  title: Keep the half-formed thoughts
  summary: Not every pebble arrives fully formed. You can now keep one with just a name and come back to it whenever, and the composer quietly remembers what you were writing if the app is closed mid-sentence.
fr:
  title: Garde tes pensées à moitié formées
  summary: Un caillou n'arrive pas toujours tout prêt. Tu peux maintenant en garder un avec juste un nom et y revenir quand tu veux, et l'éditeur retient discrètement ce que tu écrivais si l'app se ferme en pleine phrase.
suggested:
  molecule: pbbls
  type: feature
  tags: [changelog]
```
