### PR TITLE
feat(android): add quick-capture drafts and composer autosave

### DIFF
--- a/apps/android/app/src/main/kotlin/app/pbbls/android/MainActivity.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/MainActivity.kt
@@ -11,10 +11,12 @@ import app.pbbls.android.features.glyph.services.LocalGlyphService
 import app.pbbls.android.features.karma.LocalKarmaNotificationService
 import app.pbbls.android.features.lab.services.LocalLogsService
 import app.pbbls.android.services.LocalCollectionsService
+import app.pbbls.android.services.LocalComposerSnapshotStore
 import app.pbbls.android.services.LocalEmotionPaletteService
 import app.pbbls.android.services.LocalPathService
 import app.pbbls.android.services.LocalPathStatsService
 import app.pbbls.android.services.LocalPebbleDetailService
+import app.pbbls.android.services.LocalPebbleDraftsService
 import app.pbbls.android.services.LocalPebbleWriteService
 import app.pbbls.android.services.LocalProfileService
 import app.pbbls.android.services.LocalReferenceDataService
@@ -54,6 +56,8 @@ class MainActivity : ComponentActivity() {
                     LocalPebbleDetailService provides app.pebbleDetailService,
                     LocalSoulsService provides app.soulsService,
                     LocalCollectionsService provides app.collectionsService,
+                    LocalPebbleDraftsService provides app.draftsService,
+                    LocalComposerSnapshotStore provides app.composerSnapshots,
                     LocalGlyphService provides app.glyphService,
                     LocalGlyphMarketService provides app.glyphMarket,
                     LocalLogsService provides app.logsService,

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/PebblesApp.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/PebblesApp.kt
@@ -6,10 +6,12 @@ import app.pbbls.android.features.glyph.services.GlyphService
 import app.pbbls.android.features.karma.KarmaNotificationService
 import app.pbbls.android.features.lab.services.LogsService
 import app.pbbls.android.services.CollectionsService
+import app.pbbls.android.services.ComposerSnapshotStore
 import app.pbbls.android.services.EmotionPaletteService
 import app.pbbls.android.services.PathService
 import app.pbbls.android.services.PathStatsService
 import app.pbbls.android.services.PebbleDetailService
+import app.pbbls.android.services.PebbleDraftsService
 import app.pbbls.android.services.PebbleWriteService
 import app.pbbls.android.services.ProfileService
 import app.pbbls.android.services.ReferenceDataService
@@ -68,6 +70,10 @@ class PebblesApp :
         private set
 
     lateinit var collectionsService: CollectionsService
+
+    lateinit var draftsService: PebbleDraftsService
+
+    lateinit var composerSnapshots: ComposerSnapshotStore
         private set
 
     lateinit var glyphService: GlyphService
@@ -96,6 +102,8 @@ class PebblesApp :
         pebbleWrite = PebbleWriteService(supabase)
         soulsService = SoulsService(supabase)
         collectionsService = CollectionsService(supabase)
+        draftsService = PebbleDraftsService(supabase)
+        composerSnapshots = ComposerSnapshotStore(this)
         glyphService = GlyphService(supabase)
         glyphMarket = GlyphMarketService(supabase)
         logsService = LogsService(supabase)

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/DraftsScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/DraftsScreen.kt
@@ -1,0 +1,281 @@
+package app.pbbls.android.features.path
+
+import android.util.Log
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import app.pbbls.android.R
+import app.pbbls.android.services.LocalPebbleDraftsService
+import app.pbbls.android.services.PebbleDraftRecord
+import app.pbbls.android.theme.PebblesText
+import app.pbbls.android.theme.PebblesTheme
+import app.pbbls.android.theme.PebblesTopBar
+import app.pbbls.android.theme.PebblesTopBarTextButton
+import app.pbbls.android.theme.PebblesTypography
+import kotlinx.coroutines.launch
+import java.time.Duration
+import java.time.OffsetDateTime
+
+private const val TAG = "drafts"
+
+/**
+ * Unpublished quick captures, most recently saved first (M47) — ports iOS
+ * `DraftsListSheet`.
+ *
+ * Its own surface rather than a section inside the Path timeline, whose week
+ * grouping, ripple, bounce and stats all assume real pebbles (design D4).
+ * Tapping a row resumes it in `CreatePebbleScreen`.
+ *
+ * Self-applies `safeDrawingPadding()`, so the caller composes it in the OUTER
+ * (unpadded) Box alongside the other full-screen covers (D5).
+ */
+@Composable
+fun DraftsScreen(
+    onResume: (PebbleDraftRecord) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    reloadKey: Int = 0,
+) {
+    val draftsService = LocalPebbleDraftsService.current
+    val scope = rememberCoroutineScope()
+
+    var drafts by remember { mutableStateOf<List<PebbleDraftRecord>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(true) }
+    var loadFailed by remember { mutableStateOf(false) }
+    // Retry token, the EditPebbleScreen idiom.
+    var retryKey by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(reloadKey, retryKey) {
+        isLoading = true
+        loadFailed = false
+        try {
+            drafts = draftsService.list()
+            isLoading = false
+        } catch (e: Exception) {
+            Log.e(TAG, "drafts load failed", e)
+            loadFailed = true
+            isLoading = false
+        }
+    }
+
+    BackHandler { onDismiss() }
+
+    DraftsContent(
+        drafts = drafts,
+        isLoading = isLoading,
+        loadFailed = loadFailed,
+        onRetry = { retryKey++ },
+        onResume = onResume,
+        onDelete = { record ->
+            // Optimistic: the row leaves immediately and a failure reloads the
+            // truth back in.
+            drafts = drafts.filterNot { it.id == record.id }
+            scope.launch {
+                try {
+                    draftsService.delete(record.id)
+                } catch (e: Exception) {
+                    Log.e(TAG, "draft delete failed", e)
+                    retryKey++
+                }
+            }
+        },
+        onDismiss = onDismiss,
+        modifier = modifier,
+    )
+}
+
+/**
+ * Stateless drafts list — what screenshot previews drive. Takes its data as
+ * parameters rather than reading services, the same previewability rule the
+ * funnel and Path screens follow.
+ */
+@Composable
+fun DraftsContent(
+    drafts: List<PebbleDraftRecord>,
+    isLoading: Boolean,
+    loadFailed: Boolean,
+    onRetry: () -> Unit,
+    onResume: (PebbleDraftRecord) -> Unit,
+    onDelete: (PebbleDraftRecord) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val system = PebblesTheme.colors.system
+    val accent = PebblesTheme.colors.accent
+
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(system.background)
+                .safeDrawingPadding(),
+    ) {
+        PebblesTopBar(
+            title = stringResource(R.string.drafts_title),
+            titleStyle = PebblesTypography.headlineEmphasized,
+            titleColor = system.foreground,
+            leading = {
+                PebblesTopBarTextButton(
+                    text = stringResource(R.string.action_done),
+                    onClick = onDismiss,
+                    color = accent.primary,
+                )
+            },
+        )
+
+        when {
+            isLoading ->
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator(color = accent.primary)
+                }
+
+            loadFailed ->
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        PebblesText(
+                            text = stringResource(R.string.drafts_load_error),
+                            style = PebblesTypography.body,
+                            color = system.secondary,
+                            textAlign = TextAlign.Center,
+                        )
+                        TextButton(onClick = onRetry) {
+                            PebblesText(
+                                text = stringResource(R.string.action_retry),
+                                style = PebblesTypography.body,
+                                color = accent.primary,
+                            )
+                        }
+                    }
+                }
+
+            drafts.isEmpty() ->
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    PebblesText(
+                        text = stringResource(R.string.drafts_empty),
+                        style = PebblesTypography.body,
+                        color = system.secondary,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(horizontal = 32.dp),
+                    )
+                }
+
+            else ->
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items(drafts, key = { it.id }) { record ->
+                        DraftRow(
+                            record = record,
+                            onClick = { onResume(record) },
+                            onDelete = { onDelete(record) },
+                        )
+                    }
+                }
+        }
+    }
+}
+
+/**
+ * A draft has no `render_svg` — nothing is carved until it publishes — so the row
+ * leads with a dashed placeholder rather than a pebble visual.
+ */
+@Composable
+private fun DraftRow(
+    record: PebbleDraftRecord,
+    onClick: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val system = PebblesTheme.colors.system
+    val name = record.payload.name
+
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .size(36.dp)
+                    .background(system.muted, RoundedCornerShape(8.dp)),
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f)) {
+            PebblesText(
+                text = name ?: stringResource(R.string.drafts_untitled),
+                style = PebblesTypography.body,
+                color = if (name != null) system.foreground else system.secondary,
+                maxLines = 1,
+            )
+            PebblesText(
+                text = stringResource(R.string.drafts_saved_ago, relativeAgo(record.updatedAt)),
+                style = PebblesTypography.meta,
+                color = system.secondary,
+                maxLines = 1,
+            )
+        }
+        TextButton(onClick = onDelete) {
+            PebblesText(
+                text = stringResource(R.string.action_delete),
+                style = PebblesTypography.body,
+                color = system.secondary,
+            )
+        }
+    }
+}
+
+/**
+ * Coarse "saved N ago" label. Pure and JVM-testable — for a draft's last-saved
+ * stamp the exact minute matters far less than "recent" vs "a while back".
+ *
+ * Returns a bare quantity ("3h", "2d"); the surrounding sentence is localized by
+ * `drafts_saved_ago`, so no per-unit plural catalog entries are needed.
+ */
+fun relativeAgo(
+    then: OffsetDateTime,
+    now: OffsetDateTime = OffsetDateTime.now(),
+): String {
+    val seconds = Duration.between(then, now).seconds.coerceAtLeast(0)
+    return when {
+        seconds < 60 -> "${seconds}s"
+        seconds < 3_600 -> "${seconds / 60}m"
+        seconds < 86_400 -> "${seconds / 3_600}h"
+        seconds < 604_800 -> "${seconds / 86_400}d"
+        else -> "${seconds / 604_800}w"
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/PathScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/PathScreen.kt
@@ -2,8 +2,10 @@ package app.pbbls.android.features.path
 
 import android.util.Log
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -40,7 +42,9 @@ import app.pbbls.android.features.shared.ripples.RippleSummary
 import app.pbbls.android.services.LocalEmotionPaletteService
 import app.pbbls.android.services.LocalPathService
 import app.pbbls.android.services.LocalPathStatsService
+import app.pbbls.android.services.LocalPebbleDraftsService
 import app.pbbls.android.services.LocalPebbleWriteService
+import app.pbbls.android.services.PebbleDraftRecord
 import app.pbbls.android.theme.PebblesDestructive
 import app.pbbls.android.theme.PebblesText
 import app.pbbls.android.theme.PebblesTheme
@@ -77,6 +81,7 @@ fun PathScreen(
     var didLoadFail by remember { mutableStateOf(false) }
 
     val writeService = LocalPebbleWriteService.current
+    val draftsService = LocalPebbleDraftsService.current
     val scope = rememberCoroutineScope()
     var selectedPebbleId by remember { mutableStateOf<String?>(null) }
     var editingPebbleId by remember { mutableStateOf<String?>(null) }
@@ -84,6 +89,10 @@ fun PathScreen(
     var pendingDeletion by remember { mutableStateOf<Pebble?>(null) }
     var deleteError by remember { mutableStateOf(false) }
     var isPresentingCreate by remember { mutableStateOf(false) }
+    var isPresentingDrafts by remember { mutableStateOf(false) }
+    var resumingDraft by remember { mutableStateOf<PebbleDraftRecord?>(null) }
+    var draftsReloadKey by remember { mutableIntStateOf(0) }
+    var draftCount by remember { mutableIntStateOf(0) }
 
     LaunchedEffect(Unit) {
         try {
@@ -102,6 +111,19 @@ fun PathScreen(
     // Stats load rides its own effect so a slow/failed stats fetch never
     // delays the timeline (the iOS `.task { await stats.load() }` analog).
     LaunchedEffect(Unit) { stats.load() }
+
+    // Drafts count for the entry point (M47) — its own effect for the same reason
+    // stats has one: a slow or failed fetch must not delay the timeline. Re-keyed
+    // on draftsReloadKey so every draft write refreshes the badge.
+    LaunchedEffect(draftsReloadKey) {
+        draftCount =
+            try {
+                draftsService.count()
+            } catch (e: Exception) {
+                Log.e(TAG, "draft count failed", e)
+                0
+            }
+    }
 
     // Hoisted so the delete flow and create/edit can refresh the timeline
     // without re-triggering the first-load spinner: isLoading is left
@@ -178,6 +200,8 @@ fun PathScreen(
                         onPebbleTap = { pebble -> selectedPebbleId = pebble.id },
                         onPebbleDelete = { pebble -> pendingDeletion = pebble },
                         onCreatePebble = { isPresentingCreate = true },
+                        onOpenDrafts = { isPresentingDrafts = true },
+                        draftCount = draftCount,
                         karma = stats.karma,
                         ripple = rippleWithLocalActiveToday,
                         onProfile = onProfile,
@@ -225,11 +249,39 @@ fun PathScreen(
             CreatePebbleScreen(
                 onCreated = { newId ->
                     isPresentingCreate = false
+                    resumingDraft = null
+                    isPresentingDrafts = false
                     selectedPebbleId = newId
+                    draftsReloadKey++
                     reload()
                 },
-                onCancel = { isPresentingCreate = false },
+                onCancel = {
+                    isPresentingCreate = false
+                    resumingDraft = null
+                    draftsReloadKey++
+                },
                 modifier = Modifier.fillMaxSize(),
+                resuming = resumingDraft,
+                onDraftSaved = {
+                    isPresentingCreate = false
+                    resumingDraft = null
+                    draftsReloadKey++
+                },
+            )
+        }
+
+        // Full-screen drafts cover (M47) — self-applies safeDrawingPadding, so it
+        // belongs in the OUTER Box like its siblings. Composed BEFORE the create
+        // cover in z-order so resuming a draft stacks the composer on top of it.
+        if (isPresentingDrafts && !isPresentingCreate) {
+            DraftsScreen(
+                onResume = { record ->
+                    resumingDraft = record
+                    isPresentingCreate = true
+                },
+                onDismiss = { isPresentingDrafts = false },
+                modifier = Modifier.fillMaxSize(),
+                reloadKey = draftsReloadKey,
             )
         }
 
@@ -278,6 +330,8 @@ fun PathContent(
     onPebbleTap: (Pebble) -> Unit = {},
     onPebbleDelete: (Pebble) -> Unit = {},
     onCreatePebble: () -> Unit = {},
+    onOpenDrafts: () -> Unit = {},
+    draftCount: Int = 0,
     karma: Int? = null,
     ripple: RippleSummary? = null,
     onProfile: () -> Unit = {},
@@ -336,6 +390,22 @@ fun PathContent(
                 onCreatePebble = onCreatePebble,
                 modifier = Modifier.fillMaxSize(),
             )
+        }
+        // Drafts entry (M47), above the create button so it reads as "unfinished
+        // business first". Hidden at zero so it is never dead chrome.
+        if (draftCount > 0) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                TextButton(onClick = onOpenDrafts) {
+                    PebblesText(
+                        text = stringResource(R.string.drafts_entry, draftCount),
+                        style = PebblesTypography.meta,
+                        color = PebblesTheme.colors.system.secondary,
+                    )
+                }
+            }
         }
         // Pinned "New pebble" entry — the PathView.safeAreaInset(.bottom) analog.
         NewPebbleButton(

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/create/CreatePebbleScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/create/CreatePebbleScreen.kt
@@ -6,13 +6,20 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -26,25 +33,39 @@ import app.pbbls.android.R
 import app.pbbls.android.features.glyph.models.Glyph
 import app.pbbls.android.features.karma.KarmaReason
 import app.pbbls.android.features.karma.LocalKarmaNotificationService
+import app.pbbls.android.features.path.models.KnownDraftIds
 import app.pbbls.android.features.path.models.PebbleDraft
+import app.pbbls.android.features.path.models.PebbleDraftPayload
 import app.pbbls.android.features.path.models.PebbleSnapPayload
+import app.pbbls.android.features.path.models.isSavableAsDraft
+import app.pbbls.android.features.path.models.toDraft
 import app.pbbls.android.features.pebblemedia.ImagePipeline
 import app.pbbls.android.features.pebblemedia.SnapUploadCoordinator
 import app.pbbls.android.services.ComposeResult
+import app.pbbls.android.services.ComposerAutosave
+import app.pbbls.android.services.LocalComposerSnapshotStore
 import app.pbbls.android.services.LocalEmotionPaletteService
+import app.pbbls.android.services.LocalPebbleDraftsService
 import app.pbbls.android.services.LocalPebbleWriteService
 import app.pbbls.android.services.LocalReferenceDataService
 import app.pbbls.android.services.LocalSupabaseService
+import app.pbbls.android.services.PebbleDraftRecord
 import app.pbbls.android.services.PebbleSnapRepository
+import app.pbbls.android.services.asSink
+import app.pbbls.android.theme.PebblesText
 import app.pbbls.android.theme.PebblesTheme
 import app.pbbls.android.theme.PebblesTopBar
 import app.pbbls.android.theme.PebblesTopBarTextButton
 import app.pbbls.android.theme.PebblesTypography
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 private const val TAG = "create-pebble"
+
+/** Long enough that typing does not thrash SharedPreferences (iOS parity). */
+private const val AUTOSAVE_DEBOUNCE_MS = 800L
 
 /**
  * The create-pebble surface (D5) — ports iOS `CreatePebbleSheet`. Owns the
@@ -68,14 +89,25 @@ fun CreatePebbleScreen(
     val karma = LocalKarmaNotificationService.current
     val palettes = LocalEmotionPaletteService.current
     val supabase = LocalSupabaseService.current
+    val draftsService = LocalPebbleDraftsService.current
+    val snapshots = LocalComposerSnapshotStore.current
     val context = LocalContext.current
     val system = PebblesTheme.colors.system
+    val accent = PebblesTheme.colors.accent
     val scope = rememberCoroutineScope()
 
     var draft by remember { mutableStateOf(PebbleDraft()) }
     var selectedGlyph by remember { mutableStateOf<Glyph?>(null) }
     var isSaving by remember { mutableStateOf(false) }
     var saveErrorRes by remember { mutableStateOf<Int?>(null) }
+
+    // Drafts (M47). `serverDraftId` is the row this composer is bound to — the
+    // resumed one, or the one created by the first "Save as draft".
+    var isSavingDraft by remember { mutableStateOf(false) }
+    var serverDraftId by remember { mutableStateOf(resuming?.id) }
+    var restorableSnapshot by remember { mutableStateOf<PebbleDraftPayload?>(null) }
+    var hasCheckedSnapshot by remember { mutableStateOf(false) }
+    val autosave = remember { ComposerAutosave(snapshots.asSink()) }
 
     // Form-scoped (M42 D6): an in-flight upload dies with this cover.
     val snaps = remember { SnapUploadCoordinator(repo = PebbleSnapRepository(supabase)) }
@@ -95,6 +127,63 @@ fun CreatePebbleScreen(
             }
         }
 
+    // Souls and collections are user-owned and deletable, so a resumed draft may
+    // reference ones that are gone. Glyphs are verified server-side below.
+    val knownIds =
+        KnownDraftIds(
+            soulIds = refs.souls.map { it.id }.toSet(),
+            collectionIds = refs.collections.map { it.id }.toSet(),
+        )
+
+    /**
+     * Drop a glyph the user can no longer use (design D7). `can_use_glyph` is the
+     * predicate `create_pebble` enforces, so passing here means publish cannot
+     * fail on 42501 later. A verification failure keeps the glyph — publishing
+     * will surface a clear message if it really is unusable.
+     */
+    suspend fun verifyGlyph(glyphId: String) {
+        val userId = supabase.session?.user?.id ?: return
+        try {
+            if (!draftsService.canUseGlyph(glyphId, userId)) {
+                Log.i(TAG, "resumed draft referenced an unusable glyph — dropping it")
+                draft = draft.copy(glyphId = null)
+                selectedGlyph = null
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "glyph verification failed", e)
+        }
+    }
+
+    // Resuming a server draft wins over the local snapshot — it is the more
+    // deliberate of the two, so we never prompt on top of it.
+    //
+    // Gated on refs.hasLoaded: hydrating before reference data arrives would
+    // sanitize against empty sets and silently drop every soul and collection.
+    LaunchedEffect(resuming?.id, refs.hasLoaded) {
+        if (hasCheckedSnapshot || !refs.hasLoaded) return@LaunchedEffect
+        hasCheckedSnapshot = true
+        if (resuming != null) {
+            draft = resuming.payload.toDraft(knownIds)
+            resuming.payload.existingSnap?.let { snaps.seedExisting(it) }
+            draft.glyphId?.let { verifyGlyph(it) }
+        } else {
+            restorableSnapshot = snapshots.load()
+        }
+    }
+
+    // Autosave the open composer. The debounce lives here (ComposerAutosave stays
+    // a pure, JVM-testable policy object) and restarts on every keystroke because
+    // LaunchedEffect is keyed on the payload.
+    val currentPayload = PebbleDraftPayload.from(draft, snaps.formSnap, supabase.session?.user?.id)
+    LaunchedEffect(currentPayload, restorableSnapshot) {
+        // Held off while the restore prompt is up so the pending answer is not
+        // overwritten before it is given.
+        if (restorableSnapshot != null || currentPayload.isEmpty) return@LaunchedEffect
+        autosave.stage(currentPayload)
+        delay(AUTOSAVE_DEBOUNCE_MS)
+        autosave.flush()
+    }
+
     fun cancel() {
         if (isSaving) return
         scope.launch {
@@ -110,6 +199,55 @@ fun CreatePebbleScreen(
 
     val selectedEmotion = draft.emotionId?.let { palettes.byEmotionId[it] }
     val saveError = saveErrorRes?.let { stringResource(it) }
+
+    /**
+     * Intentional "save as draft". Deliberately does NOT run
+     * `snaps.cancelAndCleanup` — that would delete from Storage the very object
+     * the draft references (design D3).
+     */
+    fun saveAsDraft() {
+        if (isSaving || isSavingDraft) return
+        val userId = supabase.session?.user?.id
+        if (userId == null) {
+            saveErrorRes = R.string.pebble_save_error_generic
+            return
+        }
+        scope.launch {
+            isSavingDraft = true
+            saveErrorRes = null
+            try {
+                serverDraftId =
+                    draftsService.save(
+                        payload = PebbleDraftPayload.from(draft, snaps.formSnap, userId),
+                        id = serverDraftId,
+                        userId = userId,
+                    )
+                // Once the draft is on the server the local snapshot is redundant.
+                autosave.clear()
+                onDraftSaved()
+            } catch (e: Exception) {
+                Log.e(TAG, "save draft failed", e)
+                saveErrorRes = R.string.draft_save_error
+                isSavingDraft = false
+            }
+        }
+    }
+
+    /**
+     * Publishing consumed the draft. Runs on the soft-success path too: a 5xx
+     * carrying a `pebble_id` still created the pebble, so leaving the draft would
+     * duplicate it in the list. A failed delete must not fail the publish.
+     */
+    suspend fun consumeDraftAfterPublish() {
+        autosave.clear()
+        val id = serverDraftId ?: return
+        try {
+            draftsService.delete(id)
+        } catch (e: Exception) {
+            Log.w(TAG, "draft cleanup after publish failed", e)
+        }
+        serverDraftId = null
+    }
 
     fun save() {
         if (!draft.isValid || isSaving) return
@@ -133,9 +271,13 @@ fun CreatePebbleScreen(
             when (val result = writeService.create(draft, snapPayload)) {
                 is ComposeResult.Success -> {
                     karma.notifyEarned(result.response.karmaDelta ?: 0, KarmaReason.PEBBLE_CREATED)
+                    consumeDraftAfterPublish()
                     onCreated(result.response.pebbleId)
                 }
-                is ComposeResult.SoftSuccess -> onCreated(result.pebbleId)
+                is ComposeResult.SoftSuccess -> {
+                    consumeDraftAfterPublish()
+                    onCreated(result.pebbleId)
+                }
                 is ComposeResult.Failure -> {
                     saveErrorRes = result.messageRes
                     isSaving = false
@@ -155,7 +297,7 @@ fun CreatePebbleScreen(
     ) {
         CreateTopBar(
             saveEnabled = draft.isValid,
-            isSaving = isSaving,
+            isSaving = isSaving || isSavingDraft,
             onCancel = { cancel() },
             onSave = { save() },
         )
@@ -185,6 +327,74 @@ fun CreatePebbleScreen(
                     ?.user
                     ?.id
                     ?.let { id -> scope.launch { snaps.removePending(id) } }
+            },
+        )
+        // Quick capture: ungated, unlike Save (design D5). "Just a name" is a
+        // valid draft. Mirrors the iOS .bottomBar toolbar item.
+        val draftEnabled =
+            draft.isSavableAsDraft(snaps.formSnap, supabase.session?.user?.id) &&
+                !isSaving &&
+                !isSavingDraft
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            TextButton(onClick = { saveAsDraft() }, enabled = draftEnabled) {
+                PebblesText(
+                    text = stringResource(R.string.draft_save),
+                    style = PebblesTypography.body,
+                    color = if (draftEnabled) accent.primary else system.muted,
+                )
+            }
+        }
+    }
+
+    // Crash-insurance restore. Only offered when not already resuming a server
+    // draft, and only once per composition.
+    restorableSnapshot?.let { snapshot ->
+        AlertDialog(
+            onDismissRequest = { restorableSnapshot = null },
+            title = {
+                PebblesText(
+                    text = stringResource(R.string.draft_restore_title),
+                    style = PebblesTypography.headlineEmphasized,
+                    color = system.foreground,
+                )
+            },
+            text = {
+                PebblesText(
+                    text = stringResource(R.string.draft_restore_body),
+                    style = PebblesTypography.body,
+                    color = system.secondary,
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    draft = snapshot.toDraft(knownIds)
+                    restorableSnapshot = null
+                    snapshot.glyphId?.let { id -> scope.launch { verifyGlyph(id) } }
+                }) {
+                    PebblesText(
+                        text = stringResource(R.string.draft_restore_confirm),
+                        style = PebblesTypography.body,
+                        color = accent.primary,
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    autosave.clear()
+                    restorableSnapshot = null
+                }) {
+                    PebblesText(
+                        text = stringResource(R.string.draft_restore_discard),
+                        style = PebblesTypography.body,
+                        color = system.secondary,
+                    )
+                }
             },
         )
     }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/create/CreatePebbleScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/create/CreatePebbleScreen.kt
@@ -77,12 +77,18 @@ private const val AUTOSAVE_DEBOUNCE_MS = 800L
  * surfaces an inline error (D16). Self-applies `safeDrawingPadding()` +
  * `imePadding()`, so the caller composes it in an edge-to-edge (unpadded) slot,
  * sibling to the detail cover in `PathScreen`'s OUTER Box.
+ *
+ * M47 adds draft mode: a "Save as draft" action ungated by the publish
+ * requirements (design D5), a debounced local snapshot of the open form as crash
+ * insurance, and [resuming] to hydrate from a server draft.
  */
 @Composable
 fun CreatePebbleScreen(
     onCreated: (String) -> Unit,
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
+    resuming: PebbleDraftRecord? = null,
+    onDraftSaved: () -> Unit = onCancel,
 ) {
     val writeService = LocalPebbleWriteService.current
     val refs = LocalReferenceDataService.current

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/models/PebbleDraftPayload.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/models/PebbleDraftPayload.kt
@@ -1,0 +1,183 @@
+package app.pbbls.android.features.path.models
+
+import app.pbbls.android.features.pebblemedia.models.FormSnap
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.time.OffsetDateTime
+
+/**
+ * The `payload` jsonb of a `pebble_drafts` row (M47) — a **partial**
+ * [PebbleCreatePayload].
+ *
+ * Keyed like the wire, not like [PebbleDraft]: web and iOS write this same
+ * shape, so a draft saved on one surface resumes on the others and publishing is
+ * a straight pass-through. See
+ * `docs/superpowers/specs/2026-07-29-drafts-and-autosave-design.md` (D2).
+ *
+ * Every field is nullable with a `null` default and **`encodeDefaults` stays
+ * off** on the encoding `Json`, which is what implements "omit unset keys".
+ * Note this is the opposite configuration from [PebbleCreatePayload], which
+ * needs `explicitNulls = true` so edit can clear `description` / `glyph_id`; a
+ * draft has no prior value to clear, so absence is the right encoding.
+ *
+ * Deliberately absent: `valence`. It is stored decomposed as [intensity] +
+ * [positiveness] exactly as the wire wants it, which is why neither [Valence]
+ * nor [Visibility] needed a serialization change for M47 — this holds
+ * primitives only.
+ */
+@Serializable
+data class PebbleDraftPayload(
+    val name: String? = null,
+    val description: String? = null,
+    @SerialName("happened_at")
+    @Serializable(with = OffsetDateTimeSerializer::class)
+    val happenedAt: OffsetDateTime? = null,
+    val intensity: Int? = null,
+    val positiveness: Int? = null,
+    val visibility: Visibility? = null,
+    @SerialName("emotion_id")
+    val emotionId: String? = null,
+    @SerialName("domain_ids")
+    val domainIds: List<String>? = null,
+    @SerialName("soul_ids")
+    val soulIds: List<String>? = null,
+    @SerialName("collection_ids")
+    val collectionIds: List<String>? = null,
+    @SerialName("glyph_id")
+    val glyphId: String? = null,
+    val snaps: List<PebbleSnapPayload>? = null,
+) {
+    /**
+     * True when nothing a user would recognise as their own input is present.
+     * `happenedAt` / `intensity` / `positiveness` / `visibility` never count:
+     * they are always defaulted, and counting them would make every freshly
+     * opened composer look like an unsaved draft.
+     */
+    val isEmpty: Boolean
+        get() =
+            name == null &&
+                description == null &&
+                emotionId == null &&
+                glyphId == null &&
+                domainIds.isNullOrEmpty() &&
+                soulIds.isNullOrEmpty() &&
+                collectionIds.isNullOrEmpty() &&
+                snaps.isNullOrEmpty()
+
+    /** The snap to seed onto a `SnapUploadCoordinator` on resume, if any. */
+    val existingSnap: FormSnap.Existing?
+        get() = snaps?.firstOrNull()?.let { FormSnap.Existing(id = it.id, storagePath = it.storagePath) }
+
+    companion object {
+        /**
+         * Composer state → draft payload. Empty strings and empty lists become
+         * `null` so [isEmpty] can tell "untouched" from "deliberately blank".
+         *
+         * `formSnap` is passed separately because snap state lives on the
+         * `SnapUploadCoordinator`, not on the draft — the same split
+         * [PebbleCreatePayload] makes. Pass `null` for the local autosave
+         * snapshot, which carries no media (design D3).
+         */
+        fun from(
+            draft: PebbleDraft,
+            formSnap: FormSnap? = null,
+            userId: String? = null,
+        ): PebbleDraftPayload {
+            // trim() drops newlines as well as spaces: the description field is
+            // multiline, so a draft holding only newlines is still empty.
+            val trimmedName = draft.name.trim()
+            val trimmedDescription = draft.description.trim()
+            return PebbleDraftPayload(
+                name = trimmedName.ifEmpty { null },
+                description = trimmedDescription.ifEmpty { null },
+                happenedAt = draft.happenedAt,
+                // Both or neither: a null valence means the user has not picked
+                // one, and hydration must not invent an intensity for them.
+                intensity = draft.valence?.intensity,
+                positiveness = draft.valence?.positiveness,
+                visibility = draft.visibility,
+                emotionId = draft.emotionId,
+                domainIds = draft.domainId?.let { listOf(it) },
+                soulIds = draft.soulIds.ifEmpty { null },
+                collectionIds = draft.collectionId?.let { listOf(it) },
+                glyphId = draft.glyphId,
+                snaps = snapPayloads(formSnap, userId),
+            )
+        }
+
+        private fun snapPayloads(
+            formSnap: FormSnap?,
+            userId: String?,
+        ): List<PebbleSnapPayload>? =
+            when (formSnap) {
+                null -> null
+                is FormSnap.Existing ->
+                    listOf(PebbleSnapPayload(id = formSnap.id, storagePath = formSnap.storagePath, sortOrder = 0))
+                is FormSnap.Pending -> {
+                    // The bytes are already in Storage (upload happens at pick
+                    // time), so the descriptor alone carries the photo.
+                    userId?.let {
+                        listOf(
+                            PebbleSnapPayload(
+                                id = formSnap.snap.id,
+                                storagePath = formSnap.snap.storagePrefix(it),
+                                sortOrder = 0,
+                            ),
+                        )
+                    }
+                }
+            }
+    }
+}
+
+/**
+ * Ids the composer can verify synchronously from `ReferenceDataService`. Souls
+ * and collections are user-owned and deletable, so a draft can outlive them;
+ * emotions and domains are seeded reference rows and pass through untouched.
+ *
+ * Glyphs are deliberately absent: usability is `can_use_glyph(id, user)` (own ∪
+ * system ∪ entitled), the same predicate `create_pebble` enforces, and only the
+ * server can answer it. `CreatePebbleScreen` verifies it after hydrating.
+ */
+data class KnownDraftIds(
+    val soulIds: Set<String>,
+    val collectionIds: Set<String>,
+)
+
+/**
+ * Draft payload → composer state, dropping references that no longer resolve
+ * (design D7). Sanitizing here rather than at publish means a deleted soul costs
+ * the user a chip, not an opaque foreign-key error at the worst possible moment.
+ */
+fun PebbleDraftPayload.toDraft(known: KnownDraftIds): PebbleDraft {
+    val defaults = PebbleDraft()
+    return PebbleDraft(
+        // Restored verbatim (design D6): for a quick capture the moment captured
+        // IS the moment it happened, so publishing later must not move it.
+        happenedAt = happenedAt ?: defaults.happenedAt,
+        name = name ?: defaults.name,
+        description = description ?: defaults.description,
+        emotionId = emotionId,
+        domainId = domainIds?.firstOrNull(),
+        valence = Valence.orNull(positiveness, intensity),
+        soulIds = soulIds.orEmpty().filter { it in known.soulIds },
+        collectionId = collectionIds?.firstOrNull()?.takeIf { it in known.collectionIds },
+        // Kept as-is; `can_use_glyph` is checked asynchronously by the composer,
+        // which clears it if the glyph is no longer usable.
+        glyphId = glyphId,
+        visibility = visibility ?: defaults.visibility,
+    )
+}
+
+/**
+ * Relaxed counterpart to [PebbleDraft.isValid] (design D5): what "Save as draft"
+ * allows. `isValid` must stay strict because [PebbleCreatePayload.from]
+ * `require`s it and force-unwraps the mandatory fields.
+ *
+ * Takes `formSnap` so a photo-only draft counts as savable — the photo is real
+ * input, and it lives outside [PebbleDraft].
+ */
+fun PebbleDraft.isSavableAsDraft(
+    formSnap: FormSnap? = null,
+    userId: String? = null,
+): Boolean = !PebbleDraftPayload.from(this, formSnap, userId).isEmpty

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/models/Valence.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/models/Valence.kt
@@ -72,5 +72,19 @@ enum class Valence(
         ): Valence =
             entries.firstOrNull { it.positiveness == positiveness && it.intensity == intensity }
                 ?: NEUTRAL_MEDIUM
+
+        /**
+         * Null-returning variant for drafts (M47), where the pair may be absent
+         * entirely. Deliberately does NOT fall back to [NEUTRAL_MEDIUM]: a draft
+         * with no valence picked yet must hydrate the picker as unset rather than
+         * claim a value the user never chose.
+         */
+        fun orNull(
+            positiveness: Int?,
+            intensity: Int?,
+        ): Valence? {
+            if (positiveness == null || intensity == null) return null
+            return entries.firstOrNull { it.positiveness == positiveness && it.intensity == intensity }
+        }
     }
 }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/services/ComposerSnapshotStore.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/services/ComposerSnapshotStore.kt
@@ -1,0 +1,136 @@
+package app.pbbls.android.services
+
+import android.content.Context
+import android.util.Log
+import androidx.compose.runtime.staticCompositionLocalOf
+import app.pbbls.android.features.path.models.PebbleDraftPayload
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Crash insurance for the open composer (M47) — ports iOS
+ * `ComposerSnapshotStore.swift`.
+ *
+ * Deliberately **not** offline support: see the 2026-07-29 "Offline is a
+ * non-goal on every surface" decision-log entry. No merge logic, no cross-device
+ * sync, one composer at a time, cleared on publish or server-draft save. Media
+ * is excluded (design D3): an intentional "save as draft" earns durable media, an
+ * accidental crash recovery does not.
+ *
+ * Backed by the existing `pebbles_prefs` SharedPreferences file rather than
+ * DataStore — that would need a `libs.versions.toml` entry, and version bumps
+ * are deliberate isolated commits (`apps/android/CLAUDE.md`). One JSON string is
+ * well within what SharedPreferences is for.
+ *
+ * The composer state this guards is otherwise lost on any process death:
+ * `CreatePebbleScreen` is an `if`-composed cover with no back-stack entry.
+ */
+class ComposerSnapshotStore(
+    private val context: Context,
+) {
+    private companion object {
+        const val PREFS_NAME = "pebbles_prefs"
+        const val KEY_SNAPSHOT = "composerSnapshot"
+        const val TAG = "ComposerSnapshotStore"
+    }
+
+    // encodeDefaults stays off so unset keys are omitted, matching the wire.
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /**
+     * The stored snapshot, or null when there is nothing worth restoring. A
+     * payload written by an older build must never crash the composer, so a
+     * decode failure discards the entry rather than propagating.
+     */
+    fun load(): PebbleDraftPayload? {
+        val raw = prefs().getString(KEY_SNAPSHOT, null) ?: return null
+        return try {
+            json.decodeFromString<PebbleDraftPayload>(raw).takeUnless { it.isEmpty }
+        } catch (e: Exception) {
+            Log.w(TAG, "discarding unreadable snapshot", e)
+            clear()
+            null
+        }
+    }
+
+    /** Overwrite the snapshot. Callers debounce; see [ComposerAutosave]. */
+    fun save(payload: PebbleDraftPayload) {
+        if (payload.isEmpty) {
+            clear()
+            return
+        }
+        try {
+            val encoded = json.encodeToString(payload)
+            prefs().edit().putString(KEY_SNAPSHOT, encoded).apply()
+        } catch (e: Exception) {
+            Log.e(TAG, "snapshot write failed", e)
+        }
+    }
+
+    fun clear() {
+        prefs().edit().remove(KEY_SNAPSHOT).apply()
+    }
+
+    private fun prefs() = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+}
+
+/**
+ * Pure debounce policy over a snapshot sink, kept free of `Context` and
+ * `SharedPreferences` so it is JVM-testable without a device — the same
+ * discipline as `PebbleWriteService`'s companion helpers.
+ *
+ * Not a coroutine timer: the composer drives it from a `LaunchedEffect` keyed on
+ * the payload, so the delay lives at the call site and this only has to decide
+ * *what* to write. That keeps the whole thing synchronous and deterministic.
+ */
+class ComposerAutosave(
+    private val sink: SnapshotSink,
+) {
+    /** Indirection so tests can assert writes without touching Android APIs. */
+    interface SnapshotSink {
+        fun write(payload: PebbleDraftPayload)
+
+        fun erase()
+    }
+
+    private var pending: PebbleDraftPayload? = null
+
+    /** Remember what the composer currently holds, without writing yet. */
+    fun stage(payload: PebbleDraftPayload) {
+        pending = payload.takeUnless { it.isEmpty }
+    }
+
+    /**
+     * Write the staged snapshot. Called once the debounce delay has elapsed, and
+     * again when the composer leaves the foreground.
+     */
+    fun flush() {
+        val payload = pending ?: return
+        pending = null
+        sink.write(payload)
+    }
+
+    /**
+     * The composer published or saved a server draft — the snapshot is redundant,
+     * and leaving it would re-offer work the user already committed. Drops the
+     * staged value too, so a later [flush] cannot resurrect it.
+     */
+    fun clear() {
+        pending = null
+        sink.erase()
+    }
+}
+
+/** Adapts the real store to [ComposerAutosave.SnapshotSink]. */
+fun ComposerSnapshotStore.asSink(): ComposerAutosave.SnapshotSink =
+    object : ComposerAutosave.SnapshotSink {
+        override fun write(payload: PebbleDraftPayload) = save(payload)
+
+        override fun erase() = clear()
+    }
+
+val LocalComposerSnapshotStore =
+    staticCompositionLocalOf<ComposerSnapshotStore> {
+        error("LocalComposerSnapshotStore not provided — wrap the tree in MainActivity's CompositionLocalProvider")
+    }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/services/PebbleDraftsService.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/services/PebbleDraftsService.kt
@@ -1,0 +1,132 @@
+package app.pbbls.android.services
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import app.pbbls.android.features.path.models.OffsetDateTimeSerializer
+import app.pbbls.android.features.path.models.PebbleDraftPayload
+import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.postgrest
+import io.github.jan.supabase.postgrest.query.Columns
+import io.github.jan.supabase.postgrest.query.Order
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/** A `pebble_drafts` row as the drafts list needs it. */
+@Serializable
+data class PebbleDraftRecord(
+    val id: String,
+    val payload: PebbleDraftPayload,
+    @SerialName("updated_at")
+    @Serializable(with = OffsetDateTimeSerializer::class)
+    val updatedAt: OffsetDateTime,
+)
+
+/**
+ * Server-side drafts (M47) — ports iOS `PebbleDraftsService.swift`.
+ *
+ * Direct RLS-scoped single-table calls (design D6, the sanctioned cross-surface
+ * pattern): nothing here is multi-table and nothing emits karma. Errors
+ * propagate to the caller, which owns loading/error view state.
+ *
+ * Zero karma is structural rather than enforced: `create_pebble` is the schema's
+ * only `pebble_created` emitter and a draft never reaches it.
+ */
+class PebbleDraftsService(
+    private val supabase: SupabaseService,
+) {
+    private companion object {
+        const val TABLE = "pebble_drafts"
+        const val COLUMNS = "id, payload, updated_at"
+    }
+
+    /**
+     * Most recently saved first. `updated_at` is trigger-maintained server-side,
+     * so the ordering does not depend on device clocks.
+     */
+    suspend fun list(): List<PebbleDraftRecord> =
+        supabase.client
+            .from(TABLE)
+            .select(Columns.raw(COLUMNS)) {
+                order("updated_at", Order.DESCENDING)
+            }.decodeList()
+
+    suspend fun load(id: String): PebbleDraftRecord? =
+        supabase.client
+            .from(TABLE)
+            .select(Columns.raw(COLUMNS)) {
+                filter { eq("id", id) }
+                limit(1)
+            }.decodeList<PebbleDraftRecord>()
+            .firstOrNull()
+
+    /**
+     * Upsert. Passing an existing [id] replaces that draft's payload wholesale —
+     * the point of the jsonb column, since a coalescing update could never clear
+     * a field the user emptied.
+     *
+     * `user_id` is explicit because the RLS `with check` compares it to
+     * `auth.uid()`.
+     */
+    suspend fun save(
+        payload: PebbleDraftPayload,
+        id: String?,
+        userId: String,
+    ): String {
+        val rowId = id ?: UUID.randomUUID().toString()
+        supabase.client
+            .from(TABLE)
+            .upsert(DraftUpsertPayload(id = rowId, userId = userId, payload = payload))
+        return rowId
+    }
+
+    suspend fun delete(id: String) {
+        supabase.client
+            .from(TABLE)
+            .delete {
+                filter { eq("id", id) }
+            }
+    }
+
+    /** Count for the Path entry point. */
+    suspend fun count(): Int = list().size
+
+    /**
+     * Whether a resumed draft's glyph is still usable (own ∪ system ∪ entitled).
+     * Lives here rather than on `GlyphService` because draft hydration is its only
+     * caller: `can_use_glyph` is the predicate `create_pebble` enforces, so
+     * checking it while hydrating means publishing cannot fail on 42501 later
+     * (design D7).
+     */
+    suspend fun canUseGlyph(
+        glyphId: String,
+        userId: String,
+    ): Boolean =
+        supabase.client.postgrest
+            .rpc(
+                "can_use_glyph",
+                buildJsonObject {
+                    put("p_glyph_id", glyphId)
+                    put("p_user", userId)
+                },
+            ).decodeAs()
+}
+
+/**
+ * `user_id` is explicitly encoded so the RLS `with check` sees it; `payload`
+ * rides along as the nested jsonb.
+ */
+@Serializable
+private data class DraftUpsertPayload(
+    val id: String,
+    @SerialName("user_id")
+    val userId: String,
+    val payload: PebbleDraftPayload,
+)
+
+val LocalPebbleDraftsService =
+    staticCompositionLocalOf<PebbleDraftsService> {
+        error("LocalPebbleDraftsService not provided — wrap the tree in MainActivity's CompositionLocalProvider")
+    }

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -351,4 +351,19 @@
     <string name="lab_reaction_upvote_a11y">Voter</string>
     <string name="lab_reaction_remove_a11y">Ôter mon vote</string>
     <string name="lab_reaction_count_a11y">%1$d rocks</string>
+    <!-- ==== Brouillons et sauvegarde auto (M47) ==== -->
+    <string name="action_retry">Réessayer</string>
+    <string name="action_delete">Supprimer</string>
+    <string name="draft_save">Garder pour plus tard</string>
+    <string name="draft_save_error">Impossible de garder ce brouillon. Réessaie.</string>
+    <string name="draft_restore_title">On reprend où tu t\'étais arrêté ?</string>
+    <string name="draft_restore_body">On a gardé ce que tu écrivais ici. Remets ta photo quand tu veux.</string>
+    <string name="draft_restore_confirm">Reprendre</string>
+    <string name="draft_restore_discard">Repartir de zéro</string>
+    <string name="drafts_title">Brouillons</string>
+    <string name="drafts_entry">%1$d gardés pour plus tard</string>
+    <string name="drafts_untitled">Encore sans nom</string>
+    <string name="drafts_saved_ago">Gardé il y a %1$s</string>
+    <string name="drafts_empty">Aucun brouillon. Tout ce que tu commences à garder apparaît ici.</string>
+    <string name="drafts_load_error">Impossible de charger tes brouillons. Réessaie.</string>
 </resources>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -364,4 +364,19 @@
     <string name="lab_reaction_upvote_a11y">Upvote</string>
     <string name="lab_reaction_remove_a11y">Remove rock</string>
     <string name="lab_reaction_count_a11y">%1$d upvotes</string>
+    <!-- ==== Drafts & composer autosave (M47) ==== -->
+    <string name="action_retry">Try again</string>
+    <string name="action_delete">Delete</string>
+    <string name="draft_save">Save as draft</string>
+    <string name="draft_save_error">Couldn\'t save that draft. Please try again.</string>
+    <string name="draft_restore_title">Pick up where you left off?</string>
+    <string name="draft_restore_body">We kept what you were writing here. Add your photo again when you\'re ready.</string>
+    <string name="draft_restore_confirm">Restore it</string>
+    <string name="draft_restore_discard">Start fresh</string>
+    <string name="drafts_title">Drafts</string>
+    <string name="drafts_entry">%1$d saved for later</string>
+    <string name="drafts_untitled">No name yet</string>
+    <string name="drafts_saved_ago">Saved %1$s ago</string>
+    <string name="drafts_empty">No drafts yet. Anything you start keeping shows up here.</string>
+    <string name="drafts_load_error">Couldn\'t load your drafts. Please try again.</string>
 </resources>

--- a/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/DraftsScreenshots.kt
+++ b/apps/android/app/src/screenshotTest/kotlin/app/pbbls/android/DraftsScreenshots.kt
@@ -1,0 +1,109 @@
+package app.pbbls.android
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import app.pbbls.android.features.path.DraftsContent
+import app.pbbls.android.features.path.models.PebbleDraftPayload
+import app.pbbls.android.services.PebbleDraftRecord
+import app.pbbls.android.theme.PebblesTheme
+import com.android.tools.screenshot.PreviewTest
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+/**
+ * Render-to-view previews for the M47 drafts cover — the SDK-less maintainer
+ * reviews these as the `ui-screenshots` CI artifact. Drives the stateless
+ * [DraftsContent], never the service-reading `DraftsScreen`.
+ *
+ * A fixed `now` keeps the "saved N ago" labels stable across runs.
+ */
+private val NOW: OffsetDateTime = OffsetDateTime.of(2026, 7, 30, 12, 0, 0, 0, ZoneOffset.UTC)
+
+private fun record(
+    id: String,
+    name: String?,
+    minutesAgo: Long,
+): PebbleDraftRecord =
+    PebbleDraftRecord(
+        id = id,
+        payload = PebbleDraftPayload(name = name),
+        updatedAt = NOW.minusMinutes(minutesAgo),
+    )
+
+private val sampleDrafts =
+    listOf(
+        record("d1", "Argument with Lea", 12),
+        // The "just a name" case is the whole point of quick capture, and the
+        // no-name case is what the placeholder copy is for.
+        record("d2", null, 60 * 5),
+        record("d3", "That thing at the market I want to come back to", 60 * 26),
+    )
+
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+fun DraftsListLight() {
+    PebblesTheme {
+        DraftsContent(
+            drafts = sampleDrafts,
+            isLoading = false,
+            loadFailed = false,
+            onRetry = {},
+            onResume = {},
+            onDelete = {},
+            onDismiss = {},
+        )
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun DraftsListDark() {
+    PebblesTheme {
+        DraftsContent(
+            drafts = sampleDrafts,
+            isLoading = false,
+            loadFailed = false,
+            onRetry = {},
+            onResume = {},
+            onDelete = {},
+            onDismiss = {},
+        )
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+fun DraftsEmptyLight() {
+    PebblesTheme {
+        DraftsContent(
+            drafts = emptyList(),
+            isLoading = false,
+            loadFailed = false,
+            onRetry = {},
+            onResume = {},
+            onDelete = {},
+            onDismiss = {},
+        )
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun DraftsLoadErrorDark() {
+    PebblesTheme {
+        DraftsContent(
+            drafts = emptyList(),
+            isLoading = false,
+            loadFailed = true,
+            onRetry = {},
+            onResume = {},
+            onDelete = {},
+            onDismiss = {},
+        )
+    }
+}

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/RelativeAgoTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/RelativeAgoTest.kt
@@ -1,0 +1,46 @@
+package app.pbbls.android.features.path
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+/**
+ * [relativeAgo] renders a draft's last-saved stamp. Pure so it is JVM-testable
+ * without a device — and deliberately unit-bearing rather than plural-bearing, so
+ * no per-unit catalog entries are needed (the surrounding sentence is localized
+ * by `drafts_saved_ago`).
+ */
+class RelativeAgoTest {
+    private val now = OffsetDateTime.of(2026, 7, 30, 12, 0, 0, 0, ZoneOffset.UTC)
+
+    private fun ago(seconds: Long) = relativeAgo(now.minusSeconds(seconds), now)
+
+    @Test
+    fun `sub-minute reads in seconds`() {
+        assertEquals("0s", ago(0))
+        assertEquals("45s", ago(45))
+    }
+
+    @Test
+    fun `crossing each boundary switches unit`() {
+        assertEquals("1m", ago(60))
+        assertEquals("59m", ago(3_599))
+        assertEquals("1h", ago(3_600))
+        assertEquals("23h", ago(86_399))
+        assertEquals("1d", ago(86_400))
+        assertEquals("6d", ago(604_799))
+        assertEquals("1w", ago(604_800))
+    }
+
+    @Test
+    fun `long-abandoned drafts stay in weeks rather than overflowing`() {
+        assertEquals("52w", ago(604_800 * 52))
+    }
+
+    @Test
+    fun `a clock that moved backwards clamps to zero instead of going negative`() {
+        // Device clock changes are real; "-3s ago" would be worse than "0s ago".
+        assertEquals("0s", relativeAgo(now.plusSeconds(3), now))
+    }
+}

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/models/PebbleDraftPayloadTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/models/PebbleDraftPayloadTest.kt
@@ -28,8 +28,10 @@ class PebbleDraftPayloadTest {
     private val domainA = "44444444-4444-4444-4444-444444444444"
     private val glyphA = "55555555-5555-5555-5555-555555555555"
 
-    private fun keysOf(payload: PebbleDraftPayload): Set<String> =
-        json.parseToJsonElement(json.encodeToString(payload)).jsonObject.keys
+    private fun keysOf(payload: PebbleDraftPayload): Set<String> {
+        val encoded = json.encodeToString(payload)
+        return json.parseToJsonElement(encoded).jsonObject.keys
+    }
 
     // --- omitted keys ---------------------------------------------------------
 
@@ -42,12 +44,20 @@ class PebbleDraftPayloadTest {
         assertTrue(keys.contains("visibility"))
 
         // Absent, not null: nothing has been set.
-        for (key in
-            listOf(
-                "name", "description", "emotion_id", "domain_ids", "soul_ids",
-                "collection_ids", "glyph_id", "snaps", "intensity", "positiveness",
+        val optional =
+            setOf(
+                "name",
+                "description",
+                "emotion_id",
+                "domain_ids",
+                "soul_ids",
+                "collection_ids",
+                "glyph_id",
+                "snaps",
+                "intensity",
+                "positiveness",
             )
-        ) {
+        for (key in optional) {
             assertFalse("$key should be omitted, not encoded as null", keys.contains(key))
         }
     }

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/models/PebbleDraftPayloadTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/models/PebbleDraftPayloadTest.kt
@@ -1,0 +1,211 @@
+package app.pbbls.android.features.path.models
+
+import app.pbbls.android.features.pebblemedia.models.FormSnap
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+/**
+ * [PebbleDraftPayload] is the M47 cross-surface contract: web, iOS and Android
+ * all read and write this exact shape. These tests pin the parts that would
+ * break silently — omitted keys, the offset date format, and the sanitizing
+ * rules — plus the draft-vs-publish gate split.
+ */
+class PebbleDraftPayloadTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val soulA = "11111111-1111-1111-1111-111111111111"
+    private val collectionA = "22222222-2222-2222-2222-222222222222"
+    private val emotionA = "33333333-3333-3333-3333-333333333333"
+    private val domainA = "44444444-4444-4444-4444-444444444444"
+    private val glyphA = "55555555-5555-5555-5555-555555555555"
+
+    private fun keysOf(payload: PebbleDraftPayload): Set<String> =
+        json.parseToJsonElement(json.encodeToString(payload)).jsonObject.keys
+
+    // --- omitted keys ---------------------------------------------------------
+
+    @Test
+    fun `an empty draft encodes only the always-defaulted keys`() {
+        val keys = keysOf(PebbleDraftPayload.from(PebbleDraft()))
+
+        // Present because the composer always holds a real value for them.
+        assertTrue(keys.contains("happened_at"))
+        assertTrue(keys.contains("visibility"))
+
+        // Absent, not null: nothing has been set.
+        for (key in
+            listOf(
+                "name", "description", "emotion_id", "domain_ids", "soul_ids",
+                "collection_ids", "glyph_id", "snaps", "intensity", "positiveness",
+            )
+        ) {
+            assertFalse("$key should be omitted, not encoded as null", keys.contains(key))
+        }
+    }
+
+    @Test
+    fun `a quick capture with only a name encodes just that name, trimmed`() {
+        val payload = PebbleDraftPayload.from(PebbleDraft(name = "  Argument with Lea  "))
+        assertEquals("Argument with Lea", payload.name)
+        assertNull(payload.emotionId)
+        assertFalse(payload.isEmpty)
+    }
+
+    @Test
+    fun `whitespace and newline only fields are omitted entirely`() {
+        val payload = PebbleDraftPayload.from(PebbleDraft(name = "   ", description = "\n\t "))
+        assertNull(payload.name)
+        assertNull(payload.description)
+        assertTrue("a whitespace-only draft is not worth saving", payload.isEmpty)
+    }
+
+    // --- valence decomposition ------------------------------------------------
+
+    @Test
+    fun `valence is stored decomposed, and both keys are omitted when unset`() {
+        val unset = PebbleDraftPayload.from(PebbleDraft(name = "x"))
+        assertNull(unset.intensity)
+        assertNull(unset.positiveness)
+
+        val set = PebbleDraftPayload.from(PebbleDraft(name = "x", valence = Valence.HIGHLIGHT_LARGE))
+        assertEquals(3, set.intensity)
+        assertEquals(1, set.positiveness)
+    }
+
+    @Test
+    fun `every valence round-trips through the decomposed pair`() {
+        for (valence in Valence.entries) {
+            assertEquals(valence, Valence.orNull(valence.positiveness, valence.intensity))
+        }
+    }
+
+    @Test
+    fun `an absent or out-of-grid pair leaves the valence unset rather than guessing`() {
+        // Deliberately NOT fromOrDefault's NEUTRAL_MEDIUM fallback: a draft with
+        // no valence must hydrate the picker as unset.
+        assertNull(Valence.orNull(null, null))
+        assertNull(Valence.orNull(0, null))
+        assertNull(Valence.orNull(7, 2))
+        assertNull(Valence.orNull(0, 0))
+    }
+
+    // --- round trip -----------------------------------------------------------
+
+    @Test
+    fun `a fully populated payload survives an encode-decode round trip`() {
+        val happenedAt = OffsetDateTime.of(2026, 7, 25, 17, 20, 0, 0, ZoneOffset.UTC)
+        val draft =
+            PebbleDraft(
+                happenedAt = happenedAt,
+                name = "Full",
+                description = "Everything set",
+                emotionId = emotionA,
+                domainId = domainA,
+                valence = Valence.LOWLIGHT_SMALL,
+                soulIds = listOf(soulA),
+                collectionId = collectionA,
+                glyphId = glyphA,
+                visibility = Visibility.PUBLIC,
+            )
+        val original = PebbleDraftPayload.from(draft)
+        val decoded = json.decodeFromString<PebbleDraftPayload>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+        assertEquals(happenedAt, decoded.happenedAt)
+    }
+
+    @Test
+    fun `unknown keys and a missing date decode without throwing`() {
+        val decoded =
+            json.decodeFromString<PebbleDraftPayload>(
+                """{"name":"From another surface","unknown_key":42}""",
+            )
+        assertEquals("From another surface", decoded.name)
+        assertNull(decoded.happenedAt)
+    }
+
+    // --- hydration and sanitizing (design D7) --------------------------------
+
+    @Test
+    fun `hydration drops souls and collections the user no longer owns`() {
+        val goneSoul = "99999999-9999-9999-9999-999999999999"
+        val payload =
+            PebbleDraftPayload(
+                name = "Stale",
+                soulIds = listOf(soulA, goneSoul),
+                collectionIds = listOf("88888888-8888-8888-8888-888888888888"),
+                emotionId = emotionA,
+                domainIds = listOf(domainA),
+            )
+        val hydrated =
+            payload.toDraft(
+                KnownDraftIds(soulIds = setOf(soulA), collectionIds = setOf(collectionA)),
+            )
+
+        assertEquals(listOf(soulA), hydrated.soulIds)
+        assertNull("a collection the user lost is dropped", hydrated.collectionId)
+        // Reference data is never sanitized — it is seeded, not user-owned.
+        assertEquals(emotionA, hydrated.emotionId)
+        assertEquals(domainA, hydrated.domainId)
+    }
+
+    @Test
+    fun `hydration restores happened_at verbatim rather than re-stamping it`() {
+        val captured = OffsetDateTime.of(2026, 1, 2, 3, 4, 5, 0, ZoneOffset.UTC)
+        val hydrated =
+            PebbleDraftPayload(name = "Captured hours ago", happenedAt = captured)
+                .toDraft(KnownDraftIds(emptySet(), emptySet()))
+        assertEquals(captured, hydrated.happenedAt)
+    }
+
+    @Test
+    fun `an empty payload hydrates to the composer defaults`() {
+        val hydrated = PebbleDraftPayload().toDraft(KnownDraftIds(emptySet(), emptySet()))
+        assertTrue(hydrated.name.isEmpty())
+        assertNull(hydrated.valence)
+        assertEquals(Visibility.PRIVATE, hydrated.visibility)
+        assertFalse(hydrated.isValid)
+    }
+
+    // --- the draft/publish gate split (design D5) ----------------------------
+
+    @Test
+    fun `isSavableAsDraft is looser than isValid`() {
+        val blank = PebbleDraft()
+        assertFalse("nothing typed yet", blank.isSavableAsDraft())
+        assertFalse(blank.isValid)
+
+        val named = blank.copy(name = "Just a name")
+        assertTrue("a name alone is a valid draft", named.isSavableAsDraft())
+        assertFalse("but not enough to publish", named.isValid)
+
+        val publishable =
+            named.copy(emotionId = emotionA, domainId = domainA, valence = Valence.NEUTRAL_MEDIUM)
+        assertTrue(publishable.isValid)
+    }
+
+    @Test
+    fun `a photo alone makes a draft savable`() {
+        val snap = FormSnap.Existing(id = "snap-1", storagePath = "user-1/snap-1")
+        assertTrue(PebbleDraft().isSavableAsDraft(snap, "user-1"))
+    }
+
+    @Test
+    fun `an existing snap survives a round trip so a draft keeps its photo`() {
+        val snap = FormSnap.Existing(id = "snap-1", storagePath = "user-1/snap-1")
+        val payload = PebbleDraftPayload.from(PebbleDraft(name = "With a photo"), snap, "user-1")
+        val decoded = json.decodeFromString<PebbleDraftPayload>(json.encodeToString(payload))
+
+        assertEquals("snap-1", decoded.existingSnap?.id)
+        assertEquals("user-1/snap-1", decoded.existingSnap?.storagePath)
+    }
+}

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/services/ComposerAutosaveTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/services/ComposerAutosaveTest.kt
@@ -1,0 +1,115 @@
+package app.pbbls.android.services
+
+import app.pbbls.android.features.path.models.PebbleDraft
+import app.pbbls.android.features.path.models.PebbleDraftPayload
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * [ComposerAutosave] is the pure half of the crash-insurance snapshot — the
+ * `Context`-touching [ComposerSnapshotStore] is untestable off-device, so the
+ * policy lives here and gets covered here.
+ *
+ * The debounce *delay* is the composer's `LaunchedEffect`; what this class owns
+ * is deciding what to write and, crucially, what NOT to write after a clear.
+ */
+class ComposerAutosaveTest {
+    /** Records writes/erases instead of touching SharedPreferences. */
+    private class RecordingSink : ComposerAutosave.SnapshotSink {
+        var written: PebbleDraftPayload? = null
+        var writeCount = 0
+        var eraseCount = 0
+
+        override fun write(payload: PebbleDraftPayload) {
+            written = payload
+            writeCount++
+        }
+
+        override fun erase() {
+            written = null
+            eraseCount++
+        }
+    }
+
+    private fun payload(name: String) = PebbleDraftPayload.from(PebbleDraft(name = name))
+
+    @Test
+    fun `staging alone does not write`() {
+        val sink = RecordingSink()
+        ComposerAutosave(sink).stage(payload("Typing"))
+
+        assertEquals(0, sink.writeCount)
+        assertNull(sink.written)
+    }
+
+    @Test
+    fun `flush writes the staged snapshot`() {
+        val sink = RecordingSink()
+        val autosave = ComposerAutosave(sink)
+
+        autosave.stage(payload("Backgrounded mid-sentence"))
+        autosave.flush()
+
+        assertEquals(1, sink.writeCount)
+        assertEquals("Backgrounded mid-sentence", sink.written?.name)
+    }
+
+    @Test
+    fun `rapid keystrokes collapse into one write of the final value`() {
+        val sink = RecordingSink()
+        val autosave = ComposerAutosave(sink)
+
+        for (name in listOf("A", "Ar", "Arg", "Argu")) autosave.stage(payload(name))
+        autosave.flush()
+
+        assertEquals(1, sink.writeCount)
+        assertEquals("Argu", sink.written?.name)
+    }
+
+    @Test
+    fun `flush with nothing staged does not write`() {
+        val sink = RecordingSink()
+        ComposerAutosave(sink).flush()
+        assertEquals(0, sink.writeCount)
+    }
+
+    @Test
+    fun `flushing twice writes once - the staged value is consumed`() {
+        val sink = RecordingSink()
+        val autosave = ComposerAutosave(sink)
+
+        autosave.stage(payload("Once"))
+        autosave.flush()
+        autosave.flush()
+
+        assertEquals(1, sink.writeCount)
+    }
+
+    @Test
+    fun `an empty payload is never staged`() {
+        val sink = RecordingSink()
+        val autosave = ComposerAutosave(sink)
+
+        autosave.stage(PebbleDraftPayload.from(PebbleDraft()))
+        autosave.flush()
+
+        assertEquals("a blank composer is not worth a restore prompt", 0, sink.writeCount)
+    }
+
+    @Test
+    fun `clear erases and drops the staged value so a later flush cannot resurrect it`() {
+        val sink = RecordingSink()
+        val autosave = ComposerAutosave(sink)
+
+        autosave.stage(payload("About to publish"))
+        autosave.clear()
+        autosave.flush()
+
+        // Regression guard: if the staged value survived clear(), a published
+        // pebble would be re-offered as an unsaved draft on the next open.
+        assertEquals(1, sink.eraseCount)
+        assertEquals(0, sink.writeCount)
+        assertNull(sink.written)
+    }
+}

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -9,7 +9,7 @@
       "view_card_variant": "large"
     },
     "created_at": "2026-04-01T00:00:00.000Z",
-    "updated_at": "2026-07-30T00:30:00.000Z"
+    "updated_at": "2026-07-30T01:15:00.000Z"
   },
   "nodes": [
     {
@@ -194,7 +194,7 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Pebble Drafts",
-      "description": "List of unpublished quick captures, most recently saved first. Each row shows a placeholder chip (a draft has no render_svg \u2014 nothing is carved until it publishes), the draft name or a \"no name yet\" fallback, and a relative saved-at stamp; tapping resumes it in the Quick Pebble Editor, and rows are deletable behind a confirm. Deliberately its own surface rather than a section inside the Path timeline, whose week grouping, ripple, bounce and stats all assume real pebbles (M47 design D4). Reached from a Path header entry that only appears when drafts exist. Web (M47, #640): /drafts route. iOS (M47, #641): DraftsListSheet presented from the Path, swipe-to-delete, resume into CreatePebbleSheet.",
+      "description": "List of unpublished quick captures, most recently saved first. Each row shows a placeholder chip (a draft has no render_svg \u2014 nothing is carved until it publishes), the draft name or a \"no name yet\" fallback, and a relative saved-at stamp; tapping resumes it in the Quick Pebble Editor, and rows are deletable behind a confirm. Deliberately its own surface rather than a section inside the Path timeline, whose week grouping, ripple, bounce and stats all assume real pebbles (M47 design D4). Reached from a Path header entry that only appears when drafts exist. Web (M47, #640): /drafts route. iOS (M47, #641): DraftsListSheet presented from the Path, swipe-to-delete, resume into CreatePebbleSheet. Android (M47, #642): DraftsScreen full-screen cover with a stateless DraftsContent for previews, per-row delete, resume stacking the composer on top.",
       "status": "development",
       "platforms": [
         "web",
@@ -220,7 +220,7 @@
       "project_id": "pebbles",
       "species": "view",
       "title": "Quick Pebble Editor",
-      "description": "Single-page pebble creation editor (V2) combining all enrichment steps. On /path the editor is anchored to the bottom dock — collapsed as a 'What happened?' trigger that opens an overlay bottom-sheet on tap; on /record it auto-opens as the route's primary affordance. Android (M39, #541/#542): full-screen CreatePebbleScreen/EditPebbleScreen hosting the shared PebbleForm with modal bottom-sheet pickers — full-screen surfaces instead of a bottom-sheet dock (M39 design D5). M42 (#581): the shared Android form gains the Photo section — single-photo attach via the system photo picker (client-side compression to 1024px/420px JPEG renditions, upload with compensating deletes), existing-snap row with eager delete_pebble_media removal, and save gates while an upload is pending or failed. M47 (#640): the composer gains draft mode \u2014 a \"Save as draft\" action ungated by the publish requirements (name + emotion), so \"just a name\" is a valid quick capture, plus debounced local autosave of the open form as crash insurance (text and ids only, no media) with a restore prompt on return. Resuming a draft hydrates the form from its jsonb payload, dropping souls/collections/glyphs the user no longer owns. Publishing runs the normal compose-pebble path once and deletes the draft row. iOS (M47, #641): a bottom-bar \"Save as draft\" action, a file-backed snapshot flushed on scene-phase change, and server-side glyph verification via can_use_glyph on resume.",
+      "description": "Single-page pebble creation editor (V2) combining all enrichment steps. On /path the editor is anchored to the bottom dock — collapsed as a 'What happened?' trigger that opens an overlay bottom-sheet on tap; on /record it auto-opens as the route's primary affordance. Android (M39, #541/#542): full-screen CreatePebbleScreen/EditPebbleScreen hosting the shared PebbleForm with modal bottom-sheet pickers — full-screen surfaces instead of a bottom-sheet dock (M39 design D5). M42 (#581): the shared Android form gains the Photo section — single-photo attach via the system photo picker (client-side compression to 1024px/420px JPEG renditions, upload with compensating deletes), existing-snap row with eager delete_pebble_media removal, and save gates while an upload is pending or failed. M47 (#640): the composer gains draft mode \u2014 a \"Save as draft\" action ungated by the publish requirements (name + emotion), so \"just a name\" is a valid quick capture, plus debounced local autosave of the open form as crash insurance (text and ids only, no media) with a restore prompt on return. Resuming a draft hydrates the form from its jsonb payload, dropping souls/collections/glyphs the user no longer owns. Publishing runs the normal compose-pebble path once and deletes the draft row. iOS (M47, #641): a bottom-bar \"Save as draft\" action, a file-backed snapshot flushed on scene-phase change, and server-side glyph verification via can_use_glyph on resume. Android (M47, #642): symmetric \u2014 a footer \"Save as draft\" action, a SharedPreferences-backed snapshot debounced in a LaunchedEffect, and the same can_use_glyph check.",
       "status": "live",
       "platforms": [
         "web",

--- a/docs/arkaik/journal.jsonl
+++ b/docs/arkaik/journal.jsonl
@@ -211,3 +211,5 @@
 {"id": "01KYQZ09SNRKGXPB5X00M34AJG", "ts": "2026-07-29T21:55:00.000Z", "actor": "claude-code", "type": "edge.added", "edge_id": "e-API-delete-account-DM-pebble-drafts", "source_id": "API-delete-account", "target_id": "DM-pebble-drafts", "edge_type": "queries"}
 {"id": "01KYR0A1QJKMNPQRSTVWXYZ234", "ts": "2026-07-30T00:30:00.000Z", "actor": "claude-code", "type": "node.updated", "node_id": "V-pebble-drafts", "fields": ["description"]}
 {"id": "01KYR0A1QK5MNPQRSTVWXYZ235", "ts": "2026-07-30T00:30:00.000Z", "actor": "claude-code", "type": "node.updated", "node_id": "V-quick-pebble-editor", "fields": ["description"]}
+{"id": "01KYR1B2QJKMNPQRSTVWXYZ236", "ts": "2026-07-30T01:15:00.000Z", "actor": "claude-code", "type": "node.updated", "node_id": "V-pebble-drafts", "fields": ["description"]}
+{"id": "01KYR1B2QK5MNPQRSTVWXYZ237", "ts": "2026-07-30T01:15:00.000Z", "actor": "claude-code", "type": "node.updated", "node_id": "V-quick-pebble-editor", "fields": ["description"]}


### PR DESCRIPTION
Resolves #642

Android port of **M47 · Drafts and local autosave**, closing the milestone. Symmetric to iOS (#645), mirroring web (#644). Design: `docs/superpowers/specs/2026-07-29-drafts-and-autosave-design.md`.

## Key files

| File | What |
|---|---|
| `features/path/models/PebbleDraftPayload.kt` | the cross-surface payload, `KnownDraftIds`, `toDraft`, `isSavableAsDraft` |
| `features/path/models/Valence.kt` | new `orNull(positiveness, intensity)` |
| `services/PebbleDraftsService.kt` | `pebble_drafts` CRUD + `canUseGlyph` |
| `services/ComposerSnapshotStore.kt` | SharedPreferences snapshot + pure `ComposerAutosave` policy |
| `features/path/create/CreatePebbleScreen.kt` | draft action, restore dialog, hydration, publish-then-delete |
| `features/path/DraftsScreen.kt` | the drafts cover, split into stateful + stateless `DraftsContent` |
| `features/path/PathScreen.kt` | drafts cover host + entry point with a count |
| `res/values{,-fr}/strings.xml` | 15 keys each |
| tests + `DraftsScreenshots.kt` | 16 payload tests, 7 autosave tests, 4 relative-time tests, 4 previews |

## Implementation notes

- **`Valence.orNull` rather than the existing `fromOrDefault`.** That one falls back to `NEUTRAL_MEDIUM`, which is right for a decoded pebble (DB CHECKs guarantee the pair) but wrong for a draft: an unset valence must hydrate the picker as unset, not claim a value the user never picked.
- **`encodeDefaults` stays off** on the draft payload's `Json`, which is what implements "omit unset keys". This is the opposite configuration from `PebbleCreatePayload`, which needs `explicitNulls = true` so edit can clear `description`/`glyph_id` — a draft has no prior value to clear, so absence is the right encoding. Both are documented at their declaration.
- **Hydration is gated on `refs.hasLoaded`.** Without it, a resume racing the reference fetch would sanitize against empty sets and silently drop every soul and collection. (The same gate is missing on iOS as merged in #645 — follow-up fix coming.)
- **`ComposerAutosave` is a pure policy object** with a `SnapshotSink` seam, so it is JVM-testable without a device; the debounce *delay* lives in the composer's `LaunchedEffect`, keyed on the payload. Follows the `PebbleWriteService.softSuccessPebbleId` discipline of keeping logic out of `Context`-touching code.
- **`DraftsContent` is split out stateless** so screenshot previews can drive it, per the repo's previewability rule (`DraftsScreen` reads a CompositionLocal that `error()`s when absent).
- **`can_use_glyph` lives on `PebbleDraftsService`** rather than in the screen — screens don't call postgrest directly here.
- Draft deletion runs on `SoftSuccess` as well as `Success`, or a failed render write-back would leave the draft next to its published pebble.
- SharedPreferences rather than DataStore: that would need a `libs.versions.toml` entry, and version bumps are deliberate isolated commits.

## Verification

**This machine has no JDK and no Android SDK** (`gradle-if-sdk.sh` no-ops; `/usr/bin/java` is the macOS stub), so `android.yml` is the only compile gate — as `apps/android/CLAUDE.md` documents. In place of a local build I ran static checks:

- **en/fr string parity**: 306 vs 305 keys, the only delta being `app_name` (`translatable="false"`) — the same shape as before this PR. Both files parse as XML. `LocalizationParityTest` should pass.
- **ktlint import ordering** verified against the idea layout (others alphabetical, then `java`/`javax`/`kotlin`): 4 real violations found and fixed in `MainActivity`, `PebblesApp`, `PathScreen` and `PebbleDraftsService`.
- **No line exceeds 120 chars**; one 4-deep call chain was split (the repo notes ktlint's 3-dot limit).
- Arkaik validator exits 0 (160 nodes, 316 edges, 215 journal events).

New JVM tests cover: omitted-vs-null keys, whitespace/newline-only rejection, valence decomposition across all nine cases, `orNull` vs `fromOrDefault` divergence, full round trip, tolerant decoding, stale-reference sanitizing, verbatim `happened_at`, the draft-vs-publish gate split, photo round trip, autosave staging/flush/collapse semantics, the clear-cancels-pending regression guard, and relative-time boundaries including a backwards clock.

**CI is green** after one fix-up commit, which is what the compile gate caught that no static check could: my patch adding `resuming` / `onDraftSaved` to `CreatePebbleScreen`'s signature had silently no-op'd on a mismatched search string, so `PathScreen` was passing parameters the function never declared. Also four ktlint formatting nits in the new test file.

Final run: `ktlintCheck testDebugUnitTest assembleDebug` **BUILD SUCCESSFUL**, screenshot render **BUILD SUCCESSFUL** (4 new previews in the `ui-screenshots` artifact), `LocalizationParityTest` passing.

## Lab Note (EN/FR)

```yaml
species: feature
platform: android
status: in_progress
published: false
en:
  title: Keep the half-formed thoughts
  summary: Not every pebble arrives fully formed. You can now keep one with just a name and come back to it whenever, and the composer quietly remembers what you were writing if the app is closed mid-sentence.
fr:
  title: Garde tes pensées à moitié formées
  summary: Un caillou n'arrive pas toujours tout prêt. Tu peux maintenant en garder un avec juste un nom et y revenir quand tu veux, et l'éditeur retient discrètement ce que tu écrivais si l'app se ferme en pleine phrase.
suggested:
  molecule: pbbls
  type: feature
  tags: [changelog]
```
