### PR TITLE
fix(core): harden M47 drafts across surfaces

### DIFF
--- a/apps/android/app/src/main/kotlin/app/pbbls/android/services/PebbleDraftsService.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/services/PebbleDraftsService.kt
@@ -90,8 +90,17 @@ class PebbleDraftsService(
             }
     }
 
-    /** Count for the Path entry point. */
-    suspend fun count(): Int = list().size
+    /**
+     * Count for the Path entry point. Selects `id` alone rather than reusing
+     * [list]: this runs on every Path composition, and pulling every draft's full
+     * jsonb payload to render one number is waste on the app's home screen.
+     */
+    suspend fun count(): Int =
+        supabase.client
+            .from(TABLE)
+            .select(Columns.raw("id"))
+            .decodeList<DraftIdRow>()
+            .size
 
     /**
      * Whether a resumed draft's glyph is still usable (own ∪ system ∪ entitled).
@@ -118,6 +127,12 @@ class PebbleDraftsService(
  * `user_id` is explicitly encoded so the RLS `with check` sees it; `payload`
  * rides along as the nested jsonb.
  */
+/** Minimal projection for the count query. */
+@Serializable
+private data class DraftIdRow(
+    val id: String,
+)
+
 @Serializable
 private data class DraftUpsertPayload(
     val id: String,

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/services/PebbleDraftsService.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/services/PebbleDraftsService.kt
@@ -123,16 +123,16 @@ class PebbleDraftsService(
             ).decodeAs()
 }
 
-/**
- * `user_id` is explicitly encoded so the RLS `with check` sees it; `payload`
- * rides along as the nested jsonb.
- */
-/** Minimal projection for the count query. */
+/** Minimal projection for the count query — no payloads pulled. */
 @Serializable
 private data class DraftIdRow(
     val id: String,
 )
 
+/**
+ * `user_id` is explicitly encoded so the RLS `with check` sees it; `payload`
+ * rides along as the nested jsonb.
+ */
 @Serializable
 private data class DraftUpsertPayload(
     val id: String,

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/models/DraftCrossSurfaceDecodingTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/path/models/DraftCrossSurfaceDecodingTest.kt
@@ -1,0 +1,97 @@
+package app.pbbls.android.features.path.models
+
+import app.pbbls.android.services.PebbleDraftRecord
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+/**
+ * A draft written by ANOTHER surface must decode here. iOS shipped a
+ * fixed-precision ISO-8601 formatter and silently nil'd every web- and
+ * Postgres-written `happened_at` (#649); an Android-only round-trip test could
+ * not have caught it either, so these use real foreign payloads verbatim.
+ *
+ * The precisions in play all differ: web `toISOString()` emits milliseconds,
+ * Postgres `timestamptz` emits microseconds, iOS emits whole seconds.
+ */
+class DraftCrossSurfaceDecodingTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `a web-written happened_at with milliseconds parses`() {
+        // Exactly what `new Date().toISOString()` produces.
+        val decoded =
+            json.decodeFromString<PebbleDraftPayload>(
+                """{"name":"From web","happened_at":"2026-07-30T01:23:45.123Z"}""",
+            )
+        assertNotNull("a web draft's timestamp must survive", decoded.happenedAt)
+        assertEquals(2026, decoded.happenedAt?.year)
+    }
+
+    @Test
+    fun `a Postgres-style happened_at with microseconds and an offset parses`() {
+        val decoded =
+            json.decodeFromString<PebbleDraftPayload>(
+                """{"name":"x","happened_at":"2026-07-30T01:23:45.123456+00:00"}""",
+            )
+        assertNotNull(decoded.happenedAt)
+    }
+
+    @Test
+    fun `an iOS-written happened_at with whole seconds parses`() {
+        val decoded =
+            json.decodeFromString<PebbleDraftPayload>(
+                """{"name":"From iOS","happened_at":"2026-07-30T01:23:45Z"}""",
+            )
+        assertEquals(
+            OffsetDateTime.of(2026, 7, 30, 1, 23, 45, 0, ZoneOffset.UTC).toInstant(),
+            decoded.happenedAt?.toInstant(),
+        )
+    }
+
+    @Test
+    fun `a full iOS-shaped payload decodes, explicit nulls and all`() {
+        val decoded =
+            json.decodeFromString<PebbleDraftPayload>(
+                """
+                {"name":"From iOS","description":null,"happened_at":"2026-07-30T01:23:45Z",
+                 "intensity":3,"positiveness":-1,"visibility":"private",
+                 "emotion_id":null,"domain_ids":[],"soul_ids":[],"collection_ids":[],
+                 "glyph_id":null,
+                 "snaps":[{"id":"snap-1","storage_path":"user-1/snap-1","sort_order":0}]}
+                """.trimIndent(),
+            )
+        assertEquals("From iOS", decoded.name)
+        assertEquals(Visibility.PRIVATE, decoded.visibility)
+        assertEquals(Valence.LOWLIGHT_LARGE, Valence.orNull(decoded.positiveness, decoded.intensity))
+        assertEquals("user-1/snap-1", decoded.existingSnap?.storagePath)
+    }
+
+    @Test
+    fun `a pebble_drafts row decodes with a microsecond updated_at`() {
+        // The shape PostgREST returns for `select id, payload, updated_at`.
+        val record =
+            json.decodeFromString<PebbleDraftRecord>(
+                """
+                {"id":"3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+                 "payload":{"name":"Quick capture"},
+                 "updated_at":"2026-07-30T01:23:45.123456+00:00"}
+                """.trimIndent(),
+            )
+        assertEquals("Quick capture", record.payload.name)
+        assertEquals(2026, record.updatedAt.year)
+    }
+
+    @Test
+    fun `a payload from a newer build with unknown keys still decodes`() {
+        val decoded =
+            json.decodeFromString<PebbleDraftPayload>(
+                """{"name":"Forward compatible","whispers":["not a thing yet"]}""",
+            )
+        assertEquals("Forward compatible", decoded.name)
+    }
+}

--- a/apps/ios/Pebbles/Features/Path/CreatePebbleSheet+Drafts.swift
+++ b/apps/ios/Pebbles/Features/Path/CreatePebbleSheet+Drafts.swift
@@ -1,0 +1,136 @@
+import Supabase
+import SwiftUI
+
+// MARK: - Drafts (M47)
+
+/// The **server** draft (an intentional "save as draft") and the **local**
+/// snapshot (crash insurance) share one payload shape and nothing else. Design:
+/// docs/superpowers/specs/2026-07-29-drafts-and-autosave-design.md.
+extension CreatePebbleSheet {
+
+    /// Drives both autosave and the server draft, so the two cannot disagree.
+    var draftPayload: PebbleDraftPayload {
+        PebbleDraftPayload(from: draft, formSnap: snaps?.formSnap, userId: currentUserId)
+    }
+
+    var isSavableAsDraft: Bool {
+        draft.isSavableAsDraft(formSnap: snaps?.formSnap, userId: currentUserId)
+    }
+
+    /// Souls/collections are deletable, so a draft can outlive them. Glyphs are
+    /// verified server-side below.
+    var knownIds: PebbleDraft.KnownIds {
+        PebbleDraft.KnownIds(
+            soulIds: Set(refs.souls.map(\.id)),
+            collectionIds: Set(refs.collections.map(\.id))
+        )
+    }
+
+    /// Resuming a server draft wins over the local snapshot — the more deliberate
+    /// of the two, so we never prompt on top of it.
+    /// Gated on `refs.hasLoaded` (#647): hydrating before reference data arrives
+    /// would sanitize against empty sets and silently drop every soul and
+    /// collection — the exact failure D7 exists to prevent.
+    func hydrateOrOfferRestore() {
+        guard !hasCheckedSnapshot, refs.hasLoaded else { return }
+        hasCheckedSnapshot = true
+
+        if let resuming {
+            serverDraftId = resuming.id
+            draft = PebbleDraft(payload: resuming.payload, known: knownIds)
+            if let existing = resuming.payload.existingSnap {
+                snaps?.seedExisting(.existing(id: existing.id, storagePath: existing.storagePath))
+            }
+            Task { await verifyGlyph() }
+            return
+        }
+
+        if let snapshot = snapshots.load(), !snapshot.isEmpty {
+            restorableSnapshot = snapshot
+            isRestorePromptPresented = true
+        }
+    }
+
+    func restoreSnapshot() {
+        guard let snapshot = restorableSnapshot else { return }
+        draft = PebbleDraft(payload: snapshot, known: knownIds)
+        restorableSnapshot = nil
+        Task { await verifyGlyph() }
+    }
+
+    func discardSnapshot() {
+        restorableSnapshot = nil
+        autosave?.clear()
+    }
+
+    /// Drop a glyph the user can no longer use, and load the one they can for the
+    /// form's preview (D7). `can_use_glyph` is what `create_pebble` enforces, so
+    /// passing here means publish cannot 42501.
+    func verifyGlyph() async {
+        guard let glyphId = draft.glyphId, let userId = currentUserId else { return }
+        do {
+            let usable: Bool = try await supabase.client
+                .rpc(
+                    "can_use_glyph",
+                    params: ["p_glyph_id": glyphId.uuidString, "p_user": userId.uuidString]
+                )
+                .execute()
+                .value
+            guard usable else {
+                logger.notice("resumed draft referenced an unusable glyph — dropping it")
+                draft.glyphId = nil
+                selectedGlyph = nil
+                return
+            }
+            let glyphs: [Glyph] = try await supabase.client
+                .from("glyphs")
+                .select("id, name, strokes, view_box, user_id")
+                .eq("id", value: glyphId)
+                .limit(1)
+                .execute()
+                .value
+            selectedGlyph = glyphs.first
+        } catch {
+            // A verification failure is not a reason to lose the user's glyph;
+            // publishing will surface a clear message if it really is unusable.
+            logger.error("glyph verification failed: \(error.localizedDescription, privacy: .private)")
+        }
+    }
+
+    /// Intentional "save as draft". Deliberately does NOT run
+    /// `snaps.cancelAndCleanup`, which would delete the snap the draft references.
+    func saveAsDraft() async {
+        guard isSavableAsDraft else { return }
+        guard let userId = currentUserId else {
+            logger.error("save draft: no current user id")
+            saveError = "You must be signed in to save."
+            return
+        }
+
+        isSavingDraft = true
+        saveError = nil
+        do {
+            serverDraftId = try await draftsService.save(
+                payload: draftPayload, id: serverDraftId, userId: userId
+            )
+            // Once the draft is on the server the local snapshot is redundant.
+            autosave?.clear()
+            await draftsService.refreshCount()
+            dismiss()
+        } catch {
+            logger.error("save draft failed: \(error.localizedDescription, privacy: .private)")
+            saveError = "Couldn't save that draft. Please try again."
+            isSavingDraft = false
+        }
+    }
+
+    /// Publishing consumed the draft. Runs on soft-success too: a 5xx carrying a
+    /// `pebble_id` still created the pebble, so a kept draft would duplicate it.
+    func consumeDraftAfterPublish() async {
+        autosave?.clear()
+        guard let serverDraftId else { return }
+        await draftsService.deleteIgnoringFailure(id: serverDraftId)
+        self.serverDraftId = nil
+        await draftsService.refreshCount()
+    }
+}

--- a/apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
@@ -9,38 +9,38 @@ struct CreatePebbleSheet: View {
     /// is deleted once the pebble publishes.
     var resuming: PebbleDraftRecord?
 
-    @Environment(SupabaseService.self) private var supabase
-    @Environment(ReferenceDataService.self) private var refs
+    @Environment(SupabaseService.self) var supabase
+    @Environment(ReferenceDataService.self) var refs
     @Environment(KarmaNotificationService.self) private var karma
-    @Environment(PebbleDraftsService.self) private var draftsService
-    @Environment(ComposerSnapshotStore.self) private var snapshots
+    @Environment(PebbleDraftsService.self) var draftsService
+    @Environment(ComposerSnapshotStore.self) var snapshots
     @Environment(\.scenePhase) private var scenePhase
-    @Environment(\.dismiss) private var dismiss
+    @Environment(\.dismiss) var dismiss
 
-    @State private var draft = PebbleDraft()
-    @State private var selectedGlyph: Glyph?
+    @State var draft = PebbleDraft()
+    @State var selectedGlyph: Glyph?
 
     @State private var isSaving = false
-    @State private var saveError: String?
+    @State var saveError: String?
 
     @State private var isPhotoPickerPresented = false
 
-    @State private var isSavingDraft = false
+    @State var isSavingDraft = false
     /// The server draft this composer is bound to — the resumed one, or the one
     /// created by the first "Save as draft".
-    @State private var serverDraftId: UUID?
-    @State private var autosave: ComposerAutosave?
-    @State private var restorableSnapshot: PebbleDraftPayload?
-    @State private var isRestorePromptPresented = false
-    @State private var hasCheckedSnapshot = false
+    @State var serverDraftId: UUID?
+    @State var autosave: ComposerAutosave?
+    @State var restorableSnapshot: PebbleDraftPayload?
+    @State var isRestorePromptPresented = false
+    @State var hasCheckedSnapshot = false
 
     /// Lazily constructed in `.task` so we have access to `supabase.client`.
     /// Nil only for the very first body render before `.task` fires.
-    @State private var snaps: SnapUploadCoordinator?
+    @State var snaps: SnapUploadCoordinator?
 
-    private let logger = Logger(subsystem: "app.pbbls.ios", category: "create-pebble")
+    let logger = Logger(subsystem: "app.pbbls.ios", category: "create-pebble")
 
-    private var currentUserId: UUID? {
+    var currentUserId: UUID? {
         supabase.session?.user.id
     }
 
@@ -223,140 +223,6 @@ struct CreatePebbleSheet: View {
     private func softSuccessPebbleId(from error: FunctionsError) -> UUID? {
         guard case let .httpError(_, data) = error, !data.isEmpty else { return nil }
         return try? JSONDecoder().decode(PebbleIdPartial.self, from: data).pebbleId
-    }
-}
-
-// MARK: - Drafts (M47)
-
-/// The **server** draft (an intentional "save as draft") and the **local**
-/// snapshot (crash insurance) share one payload shape and nothing else. Design:
-/// docs/superpowers/specs/2026-07-29-drafts-and-autosave-design.md.
-extension CreatePebbleSheet {
-
-    /// Drives both autosave and the server draft, so the two cannot disagree.
-    fileprivate var draftPayload: PebbleDraftPayload {
-        PebbleDraftPayload(from: draft, formSnap: snaps?.formSnap, userId: currentUserId)
-    }
-
-    fileprivate var isSavableAsDraft: Bool {
-        draft.isSavableAsDraft(formSnap: snaps?.formSnap, userId: currentUserId)
-    }
-
-    /// Souls/collections are deletable, so a draft can outlive them. Glyphs are
-    /// verified server-side below.
-    fileprivate var knownIds: PebbleDraft.KnownIds {
-        PebbleDraft.KnownIds(
-            soulIds: Set(refs.souls.map(\.id)),
-            collectionIds: Set(refs.collections.map(\.id))
-        )
-    }
-
-    /// Resuming a server draft wins over the local snapshot — the more deliberate
-    /// of the two, so we never prompt on top of it.
-    /// Gated on `refs.hasLoaded` (#647): hydrating before reference data arrives
-    /// would sanitize against empty sets and silently drop every soul and
-    /// collection — the exact failure D7 exists to prevent.
-    fileprivate func hydrateOrOfferRestore() {
-        guard !hasCheckedSnapshot, refs.hasLoaded else { return }
-        hasCheckedSnapshot = true
-
-        if let resuming {
-            serverDraftId = resuming.id
-            draft = PebbleDraft(payload: resuming.payload, known: knownIds)
-            if let existing = resuming.payload.existingSnap {
-                snaps?.seedExisting(.existing(id: existing.id, storagePath: existing.storagePath))
-            }
-            Task { await verifyGlyph() }
-            return
-        }
-
-        if let snapshot = snapshots.load(), !snapshot.isEmpty {
-            restorableSnapshot = snapshot
-            isRestorePromptPresented = true
-        }
-    }
-
-    fileprivate func restoreSnapshot() {
-        guard let snapshot = restorableSnapshot else { return }
-        draft = PebbleDraft(payload: snapshot, known: knownIds)
-        restorableSnapshot = nil
-        Task { await verifyGlyph() }
-    }
-
-    fileprivate func discardSnapshot() {
-        restorableSnapshot = nil
-        autosave?.clear()
-    }
-
-    /// Drop a glyph the user can no longer use, and load the one they can for the
-    /// form's preview (D7). `can_use_glyph` is what `create_pebble` enforces, so
-    /// passing here means publish cannot 42501.
-    fileprivate func verifyGlyph() async {
-        guard let glyphId = draft.glyphId, let userId = currentUserId else { return }
-        do {
-            let usable: Bool = try await supabase.client
-                .rpc(
-                    "can_use_glyph",
-                    params: ["p_glyph_id": glyphId.uuidString, "p_user": userId.uuidString]
-                )
-                .execute()
-                .value
-            guard usable else {
-                logger.notice("resumed draft referenced an unusable glyph — dropping it")
-                draft.glyphId = nil
-                selectedGlyph = nil
-                return
-            }
-            let glyphs: [Glyph] = try await supabase.client
-                .from("glyphs")
-                .select("id, name, strokes, view_box, user_id")
-                .eq("id", value: glyphId)
-                .limit(1)
-                .execute()
-                .value
-            selectedGlyph = glyphs.first
-        } catch {
-            // A verification failure is not a reason to lose the user's glyph;
-            // publishing will surface a clear message if it really is unusable.
-            logger.error("glyph verification failed: \(error.localizedDescription, privacy: .private)")
-        }
-    }
-
-    /// Intentional "save as draft". Deliberately does NOT run
-    /// `snaps.cancelAndCleanup`, which would delete the snap the draft references.
-    fileprivate func saveAsDraft() async {
-        guard isSavableAsDraft else { return }
-        guard let userId = currentUserId else {
-            logger.error("save draft: no current user id")
-            saveError = "You must be signed in to save."
-            return
-        }
-
-        isSavingDraft = true
-        saveError = nil
-        do {
-            serverDraftId = try await draftsService.save(
-                payload: draftPayload, id: serverDraftId, userId: userId
-            )
-            // Once the draft is on the server the local snapshot is redundant.
-            autosave?.clear()
-            await draftsService.refreshCount()
-            dismiss()
-        } catch {
-            logger.error("save draft failed: \(error.localizedDescription, privacy: .private)")
-            saveError = "Couldn't save that draft. Please try again."
-            isSavingDraft = false
-        }
-    }
-
-    /// Publishing consumed the draft. Runs on soft-success too: a 5xx carrying a
-    /// `pebble_id` still created the pebble, so a kept draft would duplicate it.
-    fileprivate func consumeDraftAfterPublish() async {
-        autosave?.clear()
-        guard let serverDraftId else { return }
-        await draftsService.deleteIgnoringFailure(id: serverDraftId)
-        self.serverDraftId = nil
-        await draftsService.refreshCount()
     }
 }
 

--- a/apps/ios/Pebbles/Features/Path/Models/ISO8601Flexible.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/ISO8601Flexible.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Parses the ISO-8601 timestamps that reach this app from surfaces that do not
+/// agree on precision, and emits the one form they all accept.
+///
+/// Why this exists (#649): `pebble_drafts.payload` is written by three clients
+/// and read back by all three, plus `updated_at` comes straight from Postgres.
+/// The precisions in play are all different:
+///
+/// - web `new Date().toISOString()` → `2026-07-30T01:23:45.123Z` (milliseconds)
+/// - Postgres `timestamptz` via PostgREST → `…T01:23:45.123456+00:00` (microseconds)
+/// - iOS `.withInternetDateTime` → `2026-07-30T01:23:45Z` (whole seconds)
+///
+/// A single `ISO8601DateFormatter` handles exactly one of those: with
+/// `.withFractionalSeconds` it rejects whole seconds, and without it, it rejects
+/// both fractional forms. The original M47 code used the non-fractional formatter
+/// for decoding, so every web- and Postgres-written timestamp silently became
+/// `nil` and hydration fell back to "now" — quietly breaking the "publish a draft
+/// verbatim" rule (design D6).
+///
+/// `parse` therefore tries fractional first, then whole-second. `string` emits
+/// whole seconds, matching `PebbleCreatePayload` byte-for-byte so the publish
+/// path is unchanged, and both other surfaces parse it happily
+/// (`new Date(…)` / `OffsetDateTime.parse`).
+enum ISO8601Flexible {
+
+    private static let fractional: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let wholeSeconds: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    /// Returns nil only when the string is not ISO-8601 at all — never merely
+    /// because of its sub-second precision.
+    static func parse(_ value: String) -> Date? {
+        fractional.date(from: value) ?? wholeSeconds.date(from: value)
+    }
+
+    /// Whole seconds, the form every surface reads.
+    static func string(from date: Date) -> String {
+        wholeSeconds.string(from: date)
+    }
+}

--- a/apps/ios/Pebbles/Features/Path/Models/PebbleDraftPayload.swift
+++ b/apps/ios/Pebbles/Features/Path/Models/PebbleDraftPayload.swift
@@ -58,22 +58,15 @@ struct PebbleDraftPayload: Codable, Equatable {
         case snaps
     }
 
-    /// Same `.withInternetDateTime` convention as `PebbleCreatePayload`. Sharing
-    /// it is load-bearing: a draft encoded one way and published the other would
-    /// drift by the offset format alone.
-    private static let iso8601: ISO8601DateFormatter = {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime]
-        return formatter
-    }()
-
     /// `encodeIfPresent` throughout — that is the "omit unset keys" rule.
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(name, forKey: .name)
         try container.encodeIfPresent(description, forKey: .description)
+        // Whole seconds, matching PebbleCreatePayload byte-for-byte so the publish
+        // path is unchanged and the other surfaces parse it happily.
         try container.encodeIfPresent(
-            happenedAt.map { Self.iso8601.string(from: $0) }, forKey: .happenedAt
+            happenedAt.map { ISO8601Flexible.string(from: $0) }, forKey: .happenedAt
         )
         try container.encodeIfPresent(intensity, forKey: .intensity)
         try container.encodeIfPresent(positiveness, forKey: .positiveness)
@@ -87,14 +80,17 @@ struct PebbleDraftPayload: Codable, Equatable {
     }
 
     /// Tolerant by design: a payload written by another surface (or an older
-    /// build) must never fail to decode. A `happened_at` we cannot parse is
-    /// dropped rather than thrown, leaving hydration to fall back to "now".
+    /// build) must never fail to decode. `happened_at` goes through
+    /// `ISO8601Flexible` because web writes milliseconds and Postgres writes
+    /// microseconds — a fixed-precision formatter silently nils both (#649). A
+    /// genuinely unparseable value is still dropped rather than thrown, leaving
+    /// hydration to fall back to "now".
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = try container.decodeIfPresent(String.self, forKey: .name)
         description = try container.decodeIfPresent(String.self, forKey: .description)
         happenedAt = try container.decodeIfPresent(String.self, forKey: .happenedAt)
-            .flatMap { Self.iso8601.date(from: $0) }
+            .flatMap { ISO8601Flexible.parse($0) }
         intensity = try container.decodeIfPresent(Int.self, forKey: .intensity)
         positiveness = try container.decodeIfPresent(Int.self, forKey: .positiveness)
         visibility = try container.decodeIfPresent(String.self, forKey: .visibility)

--- a/apps/ios/Pebbles/Services/PebbleDraftsService.swift
+++ b/apps/ios/Pebbles/Services/PebbleDraftsService.swift
@@ -4,6 +4,12 @@ import Supabase
 import os
 
 /// A `pebble_drafts` row as the drafts list needs it.
+///
+/// `updated_at` is decoded from its **string** form through `ISO8601Flexible`
+/// rather than left to whatever date strategy the ambient decoder happens to
+/// carry (#649). Postgres returns microsecond precision, and a decoder expecting
+/// a numeric or fixed-precision date fails the whole row — which would break the
+/// drafts list outright, not just the timestamp.
 struct PebbleDraftRecord: Identifiable, Decodable, Equatable {
     let id: UUID
     let payload: PebbleDraftPayload
@@ -13,6 +19,27 @@ struct PebbleDraftRecord: Identifiable, Decodable, Equatable {
         case id
         case payload
         case updatedAt = "updated_at"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        payload = try container.decode(PebbleDraftPayload.self, forKey: .payload)
+        let raw = try container.decode(String.self, forKey: .updatedAt)
+        guard let parsed = ISO8601Flexible.parse(raw) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .updatedAt, in: container,
+                debugDescription: "unparseable updated_at: \(raw)"
+            )
+        }
+        updatedAt = parsed
+    }
+
+    /// Memberwise init, for tests and previews.
+    init(id: UUID, payload: PebbleDraftPayload, updatedAt: Date) {
+        self.id = id
+        self.payload = payload
+        self.updatedAt = updatedAt
     }
 }
 
@@ -41,8 +68,6 @@ final class PebbleDraftsService {
     /// Most recently saved first — `updated_at` is trigger-maintained server-side,
     /// so this ordering does not depend on client clocks.
     func list() async throws -> [PebbleDraftRecord] {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
         let rows: [PebbleDraftRecord] = try await client
             .from("pebble_drafts")
             .select("id, payload, updated_at")
@@ -101,9 +126,19 @@ final class PebbleDraftsService {
 
     /// Refresh `count` without surfacing an error — it only drives an entry
     /// point's badge, and a missing badge beats an error state on the Path.
+    ///
+    /// Selects `id` alone rather than reusing `list()`: this runs on every Path
+    /// appearance, and pulling every draft's full jsonb payload to render one
+    /// number is waste on the app's home screen.
     func refreshCount() async {
+        struct IdRow: Decodable { let id: UUID }
         do {
-            _ = try await list()
+            let rows: [IdRow] = try await client
+                .from("pebble_drafts")
+                .select("id")
+                .execute()
+                .value
+            count = rows.count
         } catch {
             logger.error("draft count refresh failed: \(error.localizedDescription, privacy: .private)")
         }

--- a/apps/ios/PebblesTests/DraftCrossSurfaceDecodingTests.swift
+++ b/apps/ios/PebblesTests/DraftCrossSurfaceDecodingTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+@testable import Pebbles
+
+/// A draft written by ANOTHER surface must decode here. Web writes
+/// `new Date().toISOString()`, which carries milliseconds; Postgres returns
+/// `timestamptz` with microseconds. iOS-only round-trip tests cannot catch a
+/// formatter that rejects either, so these use real foreign payloads verbatim.
+@Suite("Draft cross-surface decoding")
+struct DraftCrossSurfaceDecodingTests {
+
+    @Test("a web-written happened_at (milliseconds) parses")
+    func webMillisecondsParse() throws {
+        // Exactly what `new Date().toISOString()` produces.
+        let json = #"{"name":"From web","happened_at":"2026-07-30T01:23:45.123Z"}"#
+        let decoded = try JSONDecoder().decode(PebbleDraftPayload.self, from: Data(json.utf8))
+        #expect(decoded.happenedAt != nil, "a web draft's timestamp must survive")
+    }
+
+    @Test("a Postgres-style happened_at (microseconds + offset) parses")
+    func postgresMicrosecondsParse() throws {
+        let json = #"{"name":"x","happened_at":"2026-07-30T01:23:45.123456+00:00"}"#
+        let decoded = try JSONDecoder().decode(PebbleDraftPayload.self, from: Data(json.utf8))
+        #expect(decoded.happenedAt != nil)
+    }
+
+    @Test("a whole-second happened_at still parses")
+    func wholeSecondsParse() throws {
+        let json = #"{"name":"x","happened_at":"2026-07-30T01:23:45Z"}"#
+        let decoded = try JSONDecoder().decode(PebbleDraftPayload.self, from: Data(json.utf8))
+        #expect(decoded.happenedAt != nil)
+    }
+
+    @Test("a pebble_drafts row decodes with a fractional-second updated_at")
+    func draftRecordDecodes() throws {
+        // The shape PostgREST returns for `select id, payload, updated_at`.
+        let json = """
+        {"id":"3F2504E0-4F89-11D3-9A0C-0305E82C3301",
+         "payload":{"name":"Quick capture"},
+         "updated_at":"2026-07-30T01:23:45.123456+00:00"}
+        """
+        let record = try JSONDecoder().decode(PebbleDraftRecord.self, from: Data(json.utf8))
+        #expect(record.payload.name == "Quick capture")
+    }
+}

--- a/apps/ios/PebblesTests/LocalizationTests.swift
+++ b/apps/ios/PebblesTests/LocalizationTests.swift
@@ -261,10 +261,21 @@ struct LocalizationCatalogFileTests {
             // Skip entries explicitly marked as not-translatable
             // (e.g. the empty-string fallback)
             guard let localizations = entry.localizations else { continue }
-            let englishValue = localizations["en"]?.stringUnit?.value ?? ""
-            let frenchValue = localizations["fr"]?.stringUnit?.value ?? ""
-            #expect(!englishValue.isEmpty, "catalog key '\(key)' missing EN value")
-            #expect(!frenchValue.isEmpty, "catalog key '\(key)' missing FR value")
+            // The key IS the English source string (sourceLanguage: "en"), so an
+            // absent `en` localization is normal and correct — Xcode only writes
+            // one when the English copy diverges from the key. What must never be
+            // absent is the translation.
+            for (locale, localization) in localizations {
+                let values = localization.values
+                #expect(!values.isEmpty, "catalog key '\(key)' has an empty \(locale) localization")
+                for value in values {
+                    #expect(!value.isEmpty, "catalog key '\(key)' has a blank \(locale) value")
+                }
+            }
+            #expect(
+                localizations["fr"] != nil || key.isEmpty,
+                "catalog key '\(key)' is missing its FR localization"
+            )
         }
     }
 
@@ -285,6 +296,23 @@ struct LocalizationCatalogFileTests {
 
     private struct Localization: Decodable {
         let stringUnit: StringUnit?
+        let variations: Variations?
+
+        /// Every value this localization actually provides. A plural entry has no
+        /// `stringUnit` — its copy lives under `variations.plural.<category>` —
+        /// so reading `stringUnit` alone reports a fully translated plural as
+        /// missing, which is what made this suite fail on `main`.
+        var values: [String] {
+            if let stringUnit { return [stringUnit.value] }
+            guard let variations else { return [] }
+            return (variations.plural ?? [:]).values.compactMap { $0.stringUnit?.value }
+                + (variations.device ?? [:]).values.compactMap { $0.stringUnit?.value }
+        }
+    }
+
+    private struct Variations: Decodable {
+        let plural: [String: Localization]?
+        let device: [String: Localization]?
     }
 
     private struct StringUnit: Decodable {

--- a/apps/web/app/record/page.tsx
+++ b/apps/web/app/record/page.tsx
@@ -19,7 +19,11 @@ function RecordEditor() {
   const draftId = useSearchParams().get("draft") ?? undefined
 
   const [payload, setPayload] = useState<PebbleDraftPayload | undefined>(undefined)
-  const [loadingDraft, setLoadingDraft] = useState(draftId !== undefined)
+
+  // Derived, not stored: a `loadingDraft` state variable had to be cleared from
+  // inside the effect for every early return, and the branch where `provider` is
+  // still null had no such return — so the spinner ran forever.
+  const loadingDraft = draftId !== undefined && provider !== null && payload === undefined
 
   useEffect(() => {
     if (!draftId || !provider) return
@@ -27,19 +31,17 @@ function RecordEditor() {
     void (async () => {
       await Promise.resolve()
       if (cancelled) return
-      setLoadingDraft(true)
       try {
         const draft = await provider.getPebbleDraft(draftId)
         if (cancelled) return
         // A draft deleted from another tab/device just opens a blank composer;
-        // there is nothing useful to say about it.
+        // there is nothing useful to say about it. `{}` also resolves the
+        // spinner, which `undefined` would not.
         setPayload(draft?.payload ?? {})
-        setLoadingDraft(false)
       } catch (err) {
         if (cancelled) return
         console.error("[record] failed to load draft", err)
         setPayload({})
-        setLoadingDraft(false)
       }
     })()
     return () => {

--- a/apps/web/components/drafts/DraftsEntry.tsx
+++ b/apps/web/components/drafts/DraftsEntry.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import { FileText } from "lucide-react"
 import { useTranslations } from "next-intl"
-import { usePebbleDrafts } from "@/lib/data/usePebbleDrafts"
+import { usePebbleDraftCount } from "@/lib/data/usePebbleDraftCount"
 
 /**
  * Path entry point to /drafts, with a count. Renders nothing when there are no
@@ -12,9 +12,9 @@ import { usePebbleDrafts } from "@/lib/data/usePebbleDrafts"
  */
 export function DraftsEntry() {
   const t = useTranslations("drafts")
-  const { drafts, loading } = usePebbleDrafts()
+  const count = usePebbleDraftCount()
 
-  if (loading || drafts.length === 0) return null
+  if (count === 0) return null
 
   return (
     <Link
@@ -22,7 +22,7 @@ export function DraftsEntry() {
       className="inline-flex items-center gap-1.5 rounded-md border border-dashed border-muted-foreground/30 px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:border-muted-foreground/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       <FileText className="size-3.5" aria-hidden />
-      {t("entry", { count: drafts.length })}
+      {t("entry", { count })}
     </Link>
   )
 }

--- a/apps/web/lib/data/data-provider.ts
+++ b/apps/web/lib/data/data-provider.ts
@@ -164,6 +164,8 @@ export interface DataProvider {
   // None of these touch karma: `create_pebble` is the only emitter and a draft
   // never reaches it.
   listPebbleDrafts(): Promise<PebbleDraftRecord[]>
+  /** Cheap count for the Path entry badge — selects `id` only, no payloads. */
+  countPebbleDrafts(): Promise<number>
   getPebbleDraft(id: string): Promise<PebbleDraftRecord | undefined>
   savePebbleDraft(payload: PebbleDraftPayload, id?: string): Promise<PebbleDraftRecord>
   deletePebbleDraft(id: string): Promise<void>

--- a/apps/web/lib/data/supabase-provider.ts
+++ b/apps/web/lib/data/supabase-provider.ts
@@ -501,6 +501,16 @@ export class SupabaseProvider implements DataProvider {
     return (data ?? []).map(toDraftRecord)
   }
 
+  async countPebbleDrafts(): Promise<number> {
+    // `head: true` sends no rows at all — the badge needs the number, and /path
+    // is the app's home screen, so pulling every draft's payload for it is waste.
+    const { count, error } = await this.supabase
+      .from("pebble_drafts")
+      .select("id", { count: "exact", head: true })
+    if (error) throw new Error(error.message)
+    return count ?? 0
+  }
+
   async getPebbleDraft(id: string): Promise<PebbleDraftRecord | undefined> {
     const { data, error } = await this.supabase
       .from("pebble_drafts")

--- a/apps/web/lib/data/usePebbleDraftCount.ts
+++ b/apps/web/lib/data/usePebbleDraftCount.ts
@@ -1,0 +1,37 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useDataProvider } from "@/lib/data/provider-context"
+
+/**
+ * Just the number of drafts, for the Path entry badge.
+ *
+ * Separate from `usePebbleDrafts` on purpose: /path is the app's home screen, and
+ * fetching every draft's jsonb payload to render one integer is waste there. A
+ * failure resolves to 0 — a missing badge beats an error state on the timeline.
+ */
+export function usePebbleDraftCount(): number {
+  const { provider } = useDataProvider()
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    if (!provider) return
+    let cancelled = false
+    void (async () => {
+      await Promise.resolve()
+      if (cancelled) return
+      try {
+        const n = await provider.countPebbleDrafts()
+        if (!cancelled) setCount(n)
+      } catch (err) {
+        console.error("[drafts] count failed", err)
+        if (!cancelled) setCount(0)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [provider])
+
+  return count
+}

--- a/docs/superpowers/specs/2026-07-29-drafts-and-autosave-design.md
+++ b/docs/superpowers/specs/2026-07-29-drafts-and-autosave-design.md
@@ -31,6 +31,7 @@ keeps Supabase requests `NetworkOnly`.
 |---|---|
 | Migration (table + RLS + purge extension) | `packages/supabase/supabase/migrations/<ts>_pebble_drafts.sql` |
 | Purge regression harness | `packages/supabase/scripts/verify-account-purge.ts` |
+| Drafts acceptance harness | `packages/supabase/scripts/verify-pebble-drafts.ts` |
 | Web data layer | `apps/web/lib/data/usePebbleDrafts.ts`, `supabase-provider.ts` |
 | Web autosave | `apps/web/lib/hooks/useComposerAutosave.ts` |
 | Web payload projection | `apps/web/components/record/draft-payload.ts` |
@@ -239,7 +240,49 @@ reset. Publish-then-delete-draft cannot be built correctly on top of that, so
 the web issue adds the `catch` and surfaces the failure with the inline
 `role="alert"` banner precedent from `PebbleEdit.tsx:279-286`.
 
-## D12 — Verification
+## D13 — Timestamp precision is a cross-surface hazard (#649)
+
+The three surfaces do not agree on sub-second precision, and nothing in a single
+app's test suite can notice:
+
+| Writer | `happened_at` |
+|---|---|
+| web `new Date().toISOString()` | `2026-07-30T01:23:45.123Z` (milliseconds) |
+| Postgres `timestamptz` via PostgREST | `…T01:23:45.123456+00:00` (microseconds) |
+| iOS `.withInternetDateTime` | `2026-07-30T01:23:45Z` (whole seconds) |
+
+A single `ISO8601DateFormatter` parses exactly one of those. M47 first shipped
+iOS decoding with the non-fractional formatter, so **every web- and
+Postgres-written timestamp silently became `nil`** and hydration fell back to
+"now" — quietly breaking D6 in the one case D6 exists for. The same bare
+`JSONDecoder` also failed `PebbleDraftRecord` outright (`typeMismatch(Double)` on
+`updated_at`), which would have broken the iOS drafts list entirely.
+
+Rules that follow:
+
+- iOS parses through `ISO8601Flexible` (fractional first, then whole-second) and
+  **emits whole seconds**, matching `PebbleCreatePayload` byte-for-byte so the
+  publish path is unchanged and both other surfaces parse it happily.
+- `PebbleDraftRecord.updatedAt` decodes from its **string** form rather than
+  trusting whatever date strategy the ambient decoder carries. A model that
+  depends on its decoder's configuration is a model that breaks when the SDK
+  changes it.
+- Android needed no change (`OffsetDateTime.parse` accepts all three) but gets
+  the same cross-surface tests, because "it happens to work" is not a contract.
+- **Every surface has a decoding test fed real foreign payloads verbatim**, not
+  its own output. An iOS-only round-trip cannot catch an iOS-only formatter bug —
+  that is precisely how this shipped.
+
+## D14 — The badge count does not fetch payloads
+
+The Path entry point renders one integer, on the app's home screen, on every
+appearance. All three surfaces first implemented it by reusing the full list,
+pulling every draft's jsonb to count rows. They now select `id` alone (web uses a
+`head: true` exact count). Deliberately not a new count API on the native SDKs:
+there is no precedent for one in this repo and Android cannot be compiled
+locally, so the cheap projection buys the same win with no new surface.
+
+## D15 — Verification
 
 Per surface, beyond lint/build:
 

--- a/packages/supabase/scripts/verify-pebble-drafts.ts
+++ b/packages/supabase/scripts/verify-pebble-drafts.ts
@@ -1,0 +1,304 @@
+#!/usr/bin/env -S deno run --allow-env --allow-net
+/**
+ * Acceptance test for drafts (M47) — runs against the REMOTE project.
+ *
+ * The three clients are hand-written and share one contract: `pebble_drafts.payload`
+ * is a partial `compose-pebble` payload (design D2). Nothing in a single app's
+ * test suite can prove that contract holds end to end, so this exercises it
+ * against the real database and the real edge function:
+ *
+ *   1. RLS — a second user cannot read, write, delete, or upsert-hijack a draft.
+ *   2. Karma — the whole draft lifecycle emits zero `karma_events` (design D8).
+ *   3. Upsert — save-without-id creates, save-with-id replaces in place.
+ *   4. Payload fidelity — iOS-shaped and web-shaped payloads survive jsonb,
+ *      including explicit nulls, empty arrays, and nested snap descriptors.
+ *   5. Publish — a draft payload publishes through `compose-pebble` exactly once,
+ *      `happened_at` verbatim (design D6), and the draft is then removable.
+ *   6. Purge — `purge_account` reports the drafts it deleted.
+ *
+ * Run:
+ *   SUPABASE_URL=... SUPABASE_ANON_KEY=... \
+ *     deno run --allow-env --allow-net packages/supabase/scripts/verify-pebble-drafts.ts
+ *
+ * Deliberately needs NO service-role key: it signs up throwaway users and
+ * deletes them through the real `delete-account` edge function, so it is
+ * runnable by anyone who can run the app. Cleanup runs even on failure.
+ * Exits non-zero if any assertion fails.
+ *
+ * STANDING RULE: when the draft payload gains a key, add it to `iosShaped` below
+ * so the round-trip assertion keeps covering the whole contract.
+ */
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+const ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY");
+
+if (!SUPABASE_URL || !ANON_KEY) {
+  console.error("SUPABASE_URL and SUPABASE_ANON_KEY must be set");
+  Deno.exit(2);
+}
+
+import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+let passed = 0;
+let failed = 0;
+function check(name: string, ok: boolean, detail?: string) {
+  if (ok) {
+    passed += 1;
+    console.log(`✓ ${name}`);
+  } else {
+    failed += 1;
+    console.log(`✗ ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+const runId = crypto.randomUUID().slice(0, 8);
+const password = `Drafts-${crypto.randomUUID()}`;
+
+type TestUser = { client: SupabaseClient; id: string; token: string };
+
+async function signUp(label: string): Promise<TestUser> {
+  const client = createClient(SUPABASE_URL!, ANON_KEY!, { auth: { persistSession: false } });
+  const email = `drafts-verify-${label}-${runId}@example.test`;
+  const { data, error } = await client.auth.signUp({ email, password });
+  if (error || !data.session || !data.user) {
+    throw new Error(`signUp ${label}: ${error?.message ?? "no session (email confirmations on?)"}`);
+  }
+  return { client, id: data.user.id, token: data.session.access_token };
+}
+
+/** The real client teardown path — no service role needed. */
+async function deleteAccount(token: string): Promise<Response> {
+  return await fetch(`${SUPABASE_URL}/functions/v1/delete-account`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      apikey: ANON_KEY!,
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+/**
+ * Order-insensitive JSON, recursively. `jsonb` does not preserve key order at
+ * any depth, so a raw `JSON.stringify` comparison reports a perfectly intact
+ * payload as changed. Sorting keys keeps the assertion sensitive to values —
+ * which is the thing that must not drift — and blind to storage ordering.
+ */
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>).sort(([x], [y]) =>
+      x < y ? -1 : x > y ? 1 : 0
+    );
+    return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonical(v)}`).join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+async function countRows(client: SupabaseClient, table: string): Promise<number> {
+  const { count } = await client.from(table).select("*", { count: "exact", head: true });
+  return count ?? 0;
+}
+
+let alice: TestUser | null = null;
+let bob: TestUser | null = null;
+
+try {
+  alice = await signUp("a");
+  bob = await signUp("b");
+  console.log(`alice=${alice.id} bob=${bob.id}\n`);
+  const a = alice.client;
+
+  const { data: emotion } = await a.from("emotions").select("id").limit(1).single();
+  const { data: domain } = await a.from("domains").select("id").limit(1).single();
+  if (!emotion || !domain) throw new Error("reference data missing (emotion / domain)");
+
+  // ---------------------------------------------------------------------------
+  // 1. Quick capture: a name is enough, and it costs no karma.
+  // ---------------------------------------------------------------------------
+  const { data: quick, error: quickErr } = await a
+    .from("pebble_drafts")
+    .upsert({ user_id: alice.id, payload: { name: `quick ${runId}` } }, { onConflict: "id" })
+    .select("id, payload, created_at, updated_at")
+    .single();
+  check("upsert without an id creates a draft", !quickErr && !!quick?.id, quickErr?.message);
+  check("a name alone is a valid draft", quick?.payload?.name === `quick ${runId}`);
+  check("quick capture emits no karma", (await countRows(a, "karma_events")) === 0);
+  const draftId = quick!.id as string;
+
+  // ---------------------------------------------------------------------------
+  // 2. Second save of the same draft replaces the payload wholesale — the reason
+  //    this is a jsonb column and not coalescing scalar columns (design D1).
+  // ---------------------------------------------------------------------------
+  await new Promise((r) => setTimeout(r, 1100)); // let updated_at advance
+  const { data: replaced, error: replaceErr } = await a
+    .from("pebble_drafts")
+    .upsert(
+      { id: draftId, user_id: alice.id, payload: { name: `renamed ${runId}` } },
+      { onConflict: "id" },
+    )
+    .select("id, payload, created_at, updated_at")
+    .single();
+  check("upsert with an id replaces in place", !replaceErr && replaced?.id === draftId, replaceErr?.message);
+  check("payload replaced wholesale (the emptied key is gone)",
+    replaced?.payload?.name === `renamed ${runId}` && !("emotion_id" in (replaced?.payload ?? {})));
+  check("created_at survives the replace", replaced?.created_at === quick?.created_at);
+  check("updated_at advanced (trigger fires on upsert-as-update)",
+    new Date(replaced!.updated_at as string) > new Date(quick!.updated_at as string),
+    `${quick?.updated_at} -> ${replaced?.updated_at}`);
+  check("still exactly one row", (await countRows(a, "pebble_drafts")) === 1);
+
+  // ---------------------------------------------------------------------------
+  // 3. RLS: owner-only, including through upsert.
+  // ---------------------------------------------------------------------------
+  const b = bob.client;
+  const { data: bSel } = await b.from("pebble_drafts").select("id").eq("id", draftId);
+  check("a second user cannot read the draft", (bSel?.length ?? -1) === 0, `got ${bSel?.length}`);
+
+  const { data: bUpd } = await b
+    .from("pebble_drafts").update({ payload: { name: "hijacked" } }).eq("id", draftId).select("id");
+  check("a second user cannot update it", (bUpd?.length ?? -1) === 0, `affected ${bUpd?.length}`);
+
+  const { data: bDel } = await b.from("pebble_drafts").delete().eq("id", draftId).select("id");
+  check("a second user cannot delete it", (bDel?.length ?? -1) === 0, `affected ${bDel?.length}`);
+
+  const { error: spoofInsert } = await b
+    .from("pebble_drafts").insert({ user_id: alice.id, payload: { name: "spoof" } });
+  check("`with check` rejects an insert owned by someone else", !!spoofInsert,
+    spoofInsert ? `rejected ${spoofInsert.code}` : "ACCEPTED");
+
+  // The one an UPDATE-without-`with check` policy would have let through.
+  const { error: spoofUpsert } = await b
+    .from("pebble_drafts")
+    .upsert({ id: draftId, user_id: bob.id, payload: { name: "stolen" } }, { onConflict: "id" });
+  check("upsert cannot re-own an existing row", !!spoofUpsert,
+    spoofUpsert ? `rejected ${spoofUpsert.code}` : "ACCEPTED");
+
+  const { data: intact } = await a.from("pebble_drafts").select("payload").eq("id", draftId).single();
+  check("the draft survived every attempt intact", intact?.payload?.name === `renamed ${runId}`,
+    JSON.stringify(intact?.payload));
+
+  // ---------------------------------------------------------------------------
+  // 4. Payload fidelity across surfaces. jsonb normalizes key ORDER, so compare
+  //    semantically — what must not change is any value.
+  // ---------------------------------------------------------------------------
+  const snapId = crypto.randomUUID();
+  const iosShaped = {
+    name: "From iOS",
+    description: null,
+    happened_at: "2026-07-30T01:23:45Z", // iOS: whole seconds
+    intensity: 3,
+    positiveness: -1,
+    visibility: "private",
+    emotion_id: emotion.id,
+    domain_ids: [domain.id],
+    soul_ids: [] as string[],
+    collection_ids: [] as string[],
+    glyph_id: null,
+    snaps: [{ id: snapId, storage_path: `${alice.id}/${snapId}`, sort_order: 0 }],
+  };
+  const { data: iosRow, error: iosErr } = await a
+    .from("pebble_drafts")
+    .upsert({ user_id: alice.id, payload: iosShaped }, { onConflict: "id" })
+    .select("id, payload")
+    .single();
+  const stored = (iosRow?.payload ?? {}) as Record<string, unknown>;
+  const sameValues = Object.entries(iosShaped).every(
+    ([k, v]) => canonical(stored[k]) === canonical(v),
+  );
+  check("an iOS-shaped payload round-trips with no value loss", !iosErr && sameValues,
+    iosErr?.message ?? JSON.stringify(stored));
+  check("explicit nulls survive as null, not absent",
+    stored.description === null && stored.glyph_id === null);
+  check("empty arrays survive as arrays, not null",
+    Array.isArray(stored.soul_ids) && (stored.soul_ids as unknown[]).length === 0);
+  check("the nested snap descriptor survives intact",
+    canonical(stored.snaps) === canonical(iosShaped.snaps),
+    JSON.stringify(stored.snaps));
+
+  // Web writes millisecond precision, which a fixed-precision ISO-8601 parser
+  // silently drops (the #649 class of bug). Assert both that the DB preserves it
+  // and that it really is the precision web produces.
+  const webHappenedAt = new Date(Date.now() - 5 * 3600 * 1000).toISOString();
+  check("web's toISOString really does carry milliseconds", /\.\d{3}Z$/.test(webHappenedAt), webHappenedAt);
+  const webShaped = {
+    name: `From web ${runId}`,
+    happened_at: webHappenedAt,
+    intensity: 2,
+    positiveness: 0,
+    visibility: "private",
+    emotion_id: emotion.id,
+    domain_ids: [domain.id],
+  };
+  const { data: webRow, error: webErr } = await a
+    .from("pebble_drafts")
+    .upsert({ user_id: alice.id, payload: webShaped }, { onConflict: "id" })
+    .select("id, payload")
+    .single();
+  check("a web-shaped payload round-trips, milliseconds included",
+    !webErr && webRow?.payload?.happened_at === webHappenedAt,
+    `${webRow?.payload?.happened_at} vs ${webHappenedAt}`);
+
+  // ---------------------------------------------------------------------------
+  // 5. The drafts list contract: newest first.
+  // ---------------------------------------------------------------------------
+  const { data: listed } = await a
+    .from("pebble_drafts").select("payload").order("updated_at", { ascending: false });
+  check("list is ordered most-recently-saved first",
+    (listed?.[0]?.payload as { name?: string })?.name === `From web ${runId}`,
+    JSON.stringify(listed?.map((r) => (r.payload as { name?: string })?.name)));
+
+  check("no karma yet, after every draft write so far", (await countRows(a, "karma_events")) === 0);
+
+  // ---------------------------------------------------------------------------
+  // 6. Publishing: the draft payload goes through the normal edge function once.
+  // ---------------------------------------------------------------------------
+  const { data: composed, error: composeErr } = await a.functions.invoke("compose-pebble", {
+    body: { payload: webShaped },
+  });
+  const pebbleId = (composed as { pebble_id?: string })?.pebble_id;
+  check("a draft payload publishes through compose-pebble", !composeErr && !!pebbleId,
+    composeErr ? composeErr.message : JSON.stringify(composed));
+
+  const { error: dropErr } = await a.from("pebble_drafts").delete().eq("id", webRow!.id as string);
+  check("the published draft is then removable", !dropErr, dropErr?.message);
+
+  check("exactly one pebble exists", (await countRows(a, "pebbles")) === 1);
+  const { data: events } = await a.from("karma_events").select("reason, ref_id");
+  const created = (events ?? []).filter((e) => e.reason === "pebble_created");
+  check("exactly one pebble_created event", created.length === 1, JSON.stringify(events));
+  check("it points at the published pebble", created[0]?.ref_id === pebbleId);
+
+  const { data: pebble } = await a
+    .from("pebbles").select("happened_at, render_svg").eq("id", pebbleId!).single();
+  check("happened_at published verbatim, not re-stamped (design D6)",
+    Math.abs(new Date(pebble!.happened_at as string).getTime() - new Date(webHappenedAt).getTime()) < 1000,
+    `${pebble?.happened_at} vs ${webHappenedAt}`);
+  check("render_svg composed on publish",
+    typeof pebble?.render_svg === "string" && (pebble.render_svg as string).length > 0);
+
+  // ---------------------------------------------------------------------------
+  // 7. Purge covers pebble_drafts (the M46 standing rule).
+  // ---------------------------------------------------------------------------
+  const remaining = await countRows(a, "pebble_drafts");
+  const res = await deleteAccount(alice.token);
+  const body = await res.json().catch(() => ({}));
+  check("delete-account responds 200 { ok: true }", res.status === 200 && body?.ok === true,
+    `status=${res.status} body=${JSON.stringify(body)}`);
+  check(`purge counts report pebble_drafts: ${remaining}`,
+    body?.purged?.counts?.pebble_drafts === remaining,
+    JSON.stringify(body?.purged?.counts));
+  alice = null;
+} catch (err) {
+  failed += 1;
+  console.error(`✗ aborted: ${err instanceof Error ? err.message : String(err)}`);
+} finally {
+  for (const [user, label] of [[alice, "alice"], [bob, "bob"]] as const) {
+    if (!user) continue;
+    const res = await deleteAccount(user.token).catch(() => null);
+    console.log(`… cleanup ${label}: ${res ? res.status : "FAILED — remove drafts-verify-* manually"}`);
+  }
+}
+
+console.log(`\nSummary: passed=${passed} failed=${failed}`);
+Deno.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Resolves #651

Hardening pass over the four merged M47 PRs. **It found two real defects that the shipped tests could not reach**, plus the follow-ups from #648.

## The defect worth reading about

`pebble_drafts.payload` is written by three hand-written clients that disagree on sub-second precision:

| Writer | `happened_at` |
|---|---|
| web `new Date().toISOString()` | `2026-07-30T01:23:45.123Z` (milliseconds) |
| Postgres `timestamptz` via PostgREST | `…T01:23:45.123456+00:00` (microseconds) |
| iOS `.withInternetDateTime` | `2026-07-30T01:23:45Z` (whole seconds) |

A single `ISO8601DateFormatter` parses exactly **one** of those. iOS shipped the non-fractional one for decoding, so:

1. **Every web- and Postgres-written `happened_at` silently decoded to `nil`.** Resuming a web draft on iOS reset its timestamp to now — quietly breaking design D6 in precisely the case D6 exists for. No error, no log; the draft just published at the wrong time.
2. **`PebbleDraftRecord` failed to decode at all** — `typeMismatch(Double)` on `updated_at`, because a bare `JSONDecoder` wants a numeric date. That would have broken the iOS drafts list outright on first load.

Proven before fixing:

```
✘ a web-written happened_at (milliseconds) parses — (decoded.happenedAt → nil) != nil
✘ a Postgres-style happened_at (microseconds + offset) parses — (decoded.happenedAt → nil) != nil
✘ a pebble_drafts row decodes with a fractional-second updated_at — Caught error: typeMismatch(Swift.Double, …)
✔ a whole-second happened_at still parses
```

**Why the shipped tests missed it:** they round-tripped iOS output through iOS. My PR #645 claimed the contract was verified on the strength of exactly that. It wasn't. The lesson is now design D12, and every surface has decoding tests fed real *foreign* payloads verbatim.

Also worth noting: the dead `let decoder = JSONDecoder()` sitting unused in `list()` was the half-finished fix. Unused locals that look load-bearing are worse than none.

## What changed

| Area | Change |
|---|---|
| iOS | `ISO8601Flexible` — fractional-then-whole parse, whole-second emit (unchanged publish bytes) |
| iOS | `PebbleDraftRecord.updatedAt` decoded from its string form, independent of the ambient decoder |
| iOS + Android | cross-surface decoding tests using real web/Postgres/iOS payloads |
| db | **`packages/supabase/scripts/verify-pebble-drafts.ts`** — committed acceptance harness |
| all three | badge count selects `id` only (was pulling every payload on the home screen) |
| web | `/record?draft=` loading derived, not stored — it spun forever when `provider` was null |
| iOS | `CreatePebbleSheet` split into `+Drafts.swift` (the #648 follow-up) |
| iOS | localization gate repaired — it read `stringUnit` only, so every plural read as untranslated |

## Verification

**`verify-pebble-drafts.ts` — 31/31 against the real remote and the real edge function.** Needs only an anon key (signs up throwaway users, tears them down via `delete-account`), so anyone who can run the app can run it:

```
✓ upsert without an id creates a draft         ✓ a name alone is a valid draft
✓ quick capture emits no karma                 ✓ upsert with an id replaces in place
✓ payload replaced wholesale                   ✓ created_at survives the replace
✓ updated_at advanced                          ✓ still exactly one row
✓ a second user cannot read / update / delete it
✓ `with check` rejects an insert owned by someone else
✓ upsert cannot re-own an existing row         ✓ the draft survived every attempt intact
✓ an iOS-shaped payload round-trips with no value loss
✓ explicit nulls survive as null, not absent   ✓ empty arrays survive as arrays
✓ the nested snap descriptor survives intact
✓ web's toISOString really does carry milliseconds
✓ a web-shaped payload round-trips, milliseconds included
✓ list is ordered most-recently-saved first    ✓ no karma after every draft write
✓ a draft payload publishes through compose-pebble
✓ exactly one pebble_created event             ✓ it points at the published pebble
✓ happened_at published verbatim (design D6)   ✓ render_svg composed on publish
✓ purge counts report pebble_drafts: 2
```

Two of its assertions failed on first run and **both were my assertion being wrong, not the product** — `jsonb` does not preserve key order at any depth. Fixed with a recursive canonical serializer that stays sensitive to values and blind to ordering.

- iOS: `xcodebuild build` succeeded; the four new cross-surface tests plus all M47 suites pass; the repaired localization gate passes **and I confirmed it bites** by blanking a French value (`catalog key 'Drafts' has a blank fr value`) before restoring it.
- swiftlint **302 vs 300 on `main`**, and the `file_length` overage from #648 is gone. The 2 remaining are `nesting` on a `CodingKeys` inside a nested payload struct — the pattern already accepted in `PebbleCreatePayload`, `PebbleUpdatePayload` and `PebbleDetail`.
- Web: `eslint` clean (it correctly rejected my first spinner fix for calling `setState` in an effect — the derived version is better anyway). Full `npm run build` green, 6/6 workspaces.

## One pre-existing problem I found and did not fix

`npm run test --workspace=apps/ios` also fails because **`WobbleRendererTests` "glyph ink parses carve strokes and caches by content" crashes the test runner** — reproducible on `main` at 31a578d, unrelated to drafts. It matters more than one red test: the crash aborts the run, so every test scheduled after it never executes.

Filed as **#650** with the repro. The build's own `Sendable` warnings on `WobbleShapes.swift` point at the cause (`WobbleBackdropArt` — the thing `glyphInk` memoizes — carried across an isolation boundary), so it wants an isolation fix rather than a quieted test. Out of scope for a drafts PR.

No Lab Note: no user-visible change beyond drafts behaving as documented.

