### PR TITLE
docs: add insights curation design and discovery report

### DIFF
--- a/docs/superpowers/specs/2026-07-30-insights-curation-design.md
+++ b/docs/superpowers/specs/2026-07-30-insights-curation-design.md
@@ -1,0 +1,295 @@
+# Insights — Curation Design Propositions
+
+- **Date:** 2026-07-30
+- **Status:** design proposition (no code, no schema change in this doc)
+- **Companion doc:** `2026-07-30-insights-discovery-report.md` (audit + scientific grounding; citations referenced as *DR §6.x*)
+- **Problem:** Pebbles collects valence, intensity, emotions, domains, souls, cards, photos and two time axes on every recorded moment — and reflects almost none of it back. Surfacing *everything* would produce a quantophrenic, unusable wall of boring data; surfacing *nothing* breaks the mirror the product promises. We need digestible, curated layers that feel thoughtful to a newbie and substantial to an advanced user, reinforce the practice, and are AI-empowerable later without being AI-dependent now.
+
+---
+
+## 1. Design philosophy — a mirror, not a dashboard
+
+A dashboard answers "how much?". A mirror answers "who am I becoming, and who is with me?". Every design choice below follows from treating insights as **the second half of the record loop**: you drop a pebble; later, the water gives something back.
+
+### The charter (ten rules every insight must pass)
+
+1. **Descriptive, never diagnostic.** We reflect the record; we do not assess the person. No scores of the self ("you are 73% happy" is banned), no clinical language (Terms §13.4).
+2. **About the record, honestly.** Pebbles are self-chosen records, not life (*DR §6.E selection bias*). Copy says "your pebbles / tes galets", never "your life".
+3. **No causal claims from co-occurrence.** Especially for souls: co-presence with lowlights is framed as support, never cause (*DR §6.D social baseline*).
+4. **No prescriptive ratios or targets.** No critical positivity ratio (debunked — *DR §6.B*), no Gottman number, no "aim for X% highlights".
+5. **Asymmetric gentleness.** Bad is stronger than good (*DR §6.E negativity bias*): lowlight-derived insights are rarer, sensitivity-gated, framed with agency and distance (*DR §6.E self-distancing*), and **nothing is ever ranked by negativity**.
+6. **Scarce and rotating.** Few insights, refreshed, varied (*DR §6.C hedonic adaptation*; *DR §6.E measurement cost*). One brilliant card beats six mediocre tiles.
+7. **Earned by data, or silent.** Every insight has a minimum-support gate; below it, we mirror and celebrate milestones instead of computing statistics.
+8. **Explainable on demand.** Every card can answer "how is this made?" (the `V-mechanic-sheet` pattern). Trust now, AI-grounding later.
+9. **Autonomy-supportive.** Celebrate, invite, never pressure (*DR §6.B SDT*; the shipped "no streak to protect" promise). Missing days are never a debt.
+10. **Private by construction.** Computed from the user's own rows under RLS; no cross-user comparison ("people like you") in any layer of this design.
+
+### Three altitudes (progressive disclosure)
+
+| Altitude | What | Who it serves | Volume |
+|---|---|---|---|
+| **Featured** | 1–3 curated insight cards per surface, chosen by the engine | everyone, from day one | scarce |
+| **Ritual** | weekly/monthly Cairn wraps — a paced, narrative sequence | the engaged | periodic |
+| **Deep layer** | browsable granular data: filters, full distributions, time ranges | the advanced, opt-in | on demand |
+
+The deep layer exists so granularity has a home that is *not* the default face of the feature — that inversion is the anti-quantophrenia move.
+
+---
+
+## 2. Approaches considered
+
+### Approach A — Cairn-first (ritual only)
+
+Build the weekly/monthly wrap flows (the nine reserved Arkaik nodes) and nothing else.
+
+- **For:** flagship experience; matches the product definition ("get weekly and monthly wraps") and the shipped valence-picker promise; naturally scarce and narrative.
+- **Against:** ROADMAP #345 already sizes cairns "Large — full product feature" (table + lifecycle + client surface ×3 platforms); all value is gated on period boundaries; soul pages and the deferred stats page stay empty; a wrap needs insight computations *anyway* — building them inside the wrap couples them to one surface.
+
+### Approach B — Deep-layer-first (stats page)
+
+Build the deferred Profile stats page with charts (emotion share, domain share, valence over time), reusing admin patterns per-user.
+
+- **For:** cheapest path (admin metric semantics + chart library exist); satisfies advanced users immediately; fills the reserved chevron.
+- **Against:** it is exactly the quantophrenic failure mode — a wall of well-engineered, boring, possibly harmful charts (raw negative trends, small-N noise) with no curation, no framing, no cold-start story. Etkin's measurement cost lands on the core ritual (*DR §6.E*). Rejected as the *first* move; demoted to the opt-in deep layer, last.
+
+### Approach C — Curated Insight Engine (recommended spine)
+
+Build a small deterministic engine: a **catalog** of typed insights, each with eligibility gates, a server-computed **fact**, salience scoring, curation policy, and template copy. Surfaces (soul page, profile, wraps, deep layer) are thin consumers of the same engine.
+
+- **For:** one computation layer serves every surface (soul strip today, cairn ritual tomorrow, LLM narration someday); curation and safety are first-class citizens, not afterthoughts; value ships incrementally from the first slice; deterministic and testable (fixtures like the admin playground).
+- **Against:** more upfront design than B; the engine must resist becoming a framework (kept to a catalog + a scorer, both plain SQL/TS).
+
+**Recommendation:** **C as the spine, A as its flagship consumer, B as its final opt-in layer.** The phasing in §8 delivers them in that order.
+
+---
+
+## 3. Architecture — the Insight Engine
+
+No code here; shapes and responsibilities only.
+
+```
+ catalog (declarative)          facts (server)              curation (server)         rendering (client ×3)
+┌──────────────────────┐   ┌─────────────────────────┐   ┌─────────────────────┐   ┌──────────────────────┐
+│ insight definitions  │ → │ per-user fact queries   │ → │ eligibility gates   │ → │ template copy EN/FR  │
+│ id, family, surfaces │   │ (security-invoker RPCs, │   │ salience scoring    │   │ card components      │
+│ gates, salience      │   │  p_tz, RLS-scoped)      │   │ rotation memory     │   │ "how is this made?"  │
+│ framing, templates   │   │ typed JSON + provenance │   │ valence-mix policy  │   │ sheet                │
+└──────────────────────┘   └─────────────────────────┘   └─────────────────────┘   └──────────────────────┘
+```
+
+### 3.1 An insight instance is a typed fact
+
+Every computed insight is a small structured payload, e.g.:
+
+```json
+{
+  "key": "soul.gleam-share",
+  "subject": { "soul_id": "…" },
+  "period": { "kind": "trailing", "days": 90 },
+  "metrics": { "co_pebbles": 11, "highlight_share": 0.72, "n_min": 8 },
+  "provenance": { "axis": "happened_at", "computed_at": "…", "tz": "Europe/Paris" },
+  "template": "soul.gleam-share.v1"
+}
+```
+
+Facts are computed server-side (one implementation, three consumers — *DR §7.6*), carry their own provenance (the explainability sheet and the future AI layer read the same field), and are rendered client-side from i18n templates. **Numbers never originate on the client.**
+
+### 3.2 Server shape
+
+- One orchestrator RPC per surface family — `get_featured_insights(p_surface text, p_context uuid, p_tz text)` — plus focused fact RPCs where a surface needs a fixed module (e.g. `get_soul_insights(p_soul_id, p_tz)`). All `security invoker`, `set search_path = public`, following the `get_profile_engagement` precedent; new views (if any) `security_invoker = true` + revoke/grant (*DR §7.2*).
+- **Time-axis principle (resolves drift #6):** insights about *your life* aggregate on `happened_at`; insights about *your practice* aggregate on `created_at`. Each catalog entry declares its axis; provenance carries it.
+- **Rotation memory:** one new user-owned table, `insight_impressions` (`user_id, insight_key, subject_id, surface, shown_at, dismissed`), so curation can enforce novelty across devices. Must be appended to `purge_account` §4 and `verify-account-purge.ts` (*DR §7.5*). No other new tables in phases S1–S3.
+- **Index work (prerequisite):** `pebbles(user_id, happened_at)`, `pebbles(user_id, created_at)`, reverse indexes `pebble_souls(soul_id)`, `pebble_domains(domain_id)` (*DR §7.10*).
+- **Drafts stay invisible** by construction (separate table). Deleted pebbles disappear from facts (no soft delete) — wraps therefore snapshot *nothing*; they recompute on view, and a confirmed cairn stores only its confirmation (see §6).
+
+### 3.3 AI-empowerable, not AI-first
+
+The engine is deliberately the "perfectly modelized anything" that a future LLM can amplify:
+
+- **Facts are the grounding substrate.** An LLM layer may later *narrate* (stitch several facts of a wrap into prose, adapt tone, translate register) but **never computes, estimates or invents a number** — facts pass through verbatim from provenance-carrying payloads.
+- **Templates are the fallback and the benchmark.** Deterministic template copy ships first and remains the render path when no AI is configured; any AI narration is evaluated against the same fixtures.
+- **The catalog is the contract.** Adding AI later means adding one renderer, not redesigning the pipeline.
+
+---
+
+## 4. The insight catalog v1
+
+Seven families + the wraps that compose them. Each entry: **gate** (minimum support), **fact** (computation on the real schema), **framing** (charter rules applied), example copy (EN / FR in "Tu", benefit-first, no em dashes in user copy). Valence words in copy use the settled register: highlight / lowlight (EN); FR wording to be settled in the i18n pass (working: "moment lumineux" / "moment sombre" — never "positif/négatif").
+
+### Family M — Mirror & milestones (the cold-start family)
+
+| Key | Gate | Fact | Example copy |
+|---|---|---|---|
+| `mirror.first-pebble` | 1 pebble | the first pebble, mirrored back | EN: "Your path has begun. One pebble, placed." / FR: "Ton chemin commence. Un premier galet, posé." |
+| `mirror.counting` | at 10/25/50/100/250… (created_at) | Nth pebble milestone; goal-gradient near next (*DR §6.F*) | EN: "That was your 50th pebble." / FR: "C'était ton 50e galet." |
+| `mirror.first-with-soul` | 1st pebble linked to a given soul | firsts per soul/domain/emotion | EN: "A first moment with Léa is on your path." / FR: "Un premier moment avec Léa rejoint ton chemin." |
+| `mirror.new-shade` | user records an emotion slug never used before | vocabulary growth (*DR §6.A granularity*) | EN: "A new shade in your palette: relieved." / FR: "Une nouvelle nuance dans ta palette : soulagé·e." |
+
+### Family P — Peaks & moments (peak–end, savoring — *DR §6.C*)
+
+| Key | Gate | Fact | Notes |
+|---|---|---|---|
+| `peak.of-week` | ≥3 pebbles in the week | the week's peak: max(`intensity`) among `positiveness = 1`, tie-break recency (`happened_at` axis) | anchor module of the weekly cairn |
+| `peak.how-it-closed` | ≥3 pebbles in the week | the period's last pebble (the "end" of peak–end) | never selected when the end is a lowlight *and* sensitivity is off — falls back to `peak.of-week` |
+| `peak.on-this-day` | ≥1 pebble ≥1 month old on this date (±1 day) | flashback; prefers highlight/neutral; lowlight flashbacks only in "full" sensitivity (*DR §6.C fading affect bias*) | EN: "A year ago today, you kept this moment." / FR: "Il y a un an jour pour jour, tu gardais ce moment." |
+| `peak.snap-gleam` | ≥1 highlight with a snap in period | resurface one photo | savoring with an image beats savoring with a number |
+
+### Family S — Souls (the crown jewels — *DR §6.D*)
+
+| Key | Gate | Fact | Framing guard |
+|---|---|---|---|
+| `soul.constellation` | ≥3 souls each with ≥2 co-pebbles in 90 d | most-present souls of the period (count over `pebble_souls`) | presence, not ranking by quality |
+| `soul.gleam-share` | ≥8 co-pebbles spanning ≥3 weeks | share of highlights among pebbles with this soul | EN: "Moments with Léa tend to gleam: 8 of the 11 pebbles she appears in are highlights." / FR: "Les moments avec Léa ont tendance à briller : 8 des 11 galets où elle apparaît sont des moments lumineux." **Never surfaced as a comparison between souls.** |
+| `soul.anchor` | ≥5 lowlight co-pebbles spanning ≥4 weeks, sensitivity ≥ gentle | soul most present in lowlight moments — support framing only | EN: "Léa is often there in the hard moments you chose to keep." / FR: "Léa est souvent là dans les moments difficiles que tu as choisis de garder." (support, never cause) |
+| `soul.reunion` | soul with ≥6 co-pebbles historically, none in >3× their median gap | gentle reconnection invitation, opt-in-able | EN: "It's been a while since a moment with Sam joined your path." / FR: "Ça fait un moment qu'aucun souvenir avec Sam n'a rejoint ton chemin." No guilt, no counter. |
+| `soul.anniversary` | 1 year since first co-pebble | history with X: first moment + count since (*DR §6.C nostalgia*) | |
+| `soul.shared-ground` | ≥6 co-pebbles, ≥50% in one domain | where your moments with X live | EN: "Your moments with Sam mostly live in Travel." / FR: "Tes moments avec Sam vivent surtout dans Voyage." |
+
+### Family E — Emotional palette (*DR §6.A*)
+
+| Key | Gate | Fact | Framing guard |
+|---|---|---|---|
+| `palette.signature` | ≥8 pebbles in period | modal emotion of the period | descriptive: "the shade you reached for most" |
+| `palette.breadth` | ≥15 pebbles in 30 d | distinct emotions used vs the 38 (emodiversity, shown as breadth, never as an entropy score) | EN: "Your palette used 14 of 38 shades this month." / FR: "Ta palette a utilisé 14 nuances sur 38 ce mois-ci." |
+| `palette.finer-shades` | ≥6 pebbles of one category with ≤2 distinct emotions, sensitivity ≥ gentle | granularity invitation (*Barrett*): the category has unexplored shades | invitation, never correction: EN "Joy has more shades if you ever want them." / FR "La joie a d'autres nuances si tu en veux un jour." |
+| `palette.weather` | ≥8 pebbles this period and ≥8 prior | dominant category shift vs prior period | "more Peace than usual" — descriptive, no target |
+| `palette.texture` | ≥10 pebbles in period | highlight/neutral/lowlight distribution (SPANE-flavored balance — *DR §6.B*) | both poles framed as normal; **no ratio target** (charter 4) |
+| `palette.quiet-loud` | ≥10 pebbles | intensity profile: share of small vs large moments | ties to the shipped day/week/month framing of the valence picker |
+
+### Family D — Domains (portfolio, not pyramid — *DR §6.F Maslow revised*)
+
+| Key | Gate | Fact | Framing guard |
+|---|---|---|---|
+| `domain.portfolio` | ≥10 pebbles with ≥1 domain in period | top domains by share (multi-label; shares needn't sum to 100 — copy says "appears in") | portfolio framing |
+| `domain.rising` | ≥8 domain-tagged pebbles this and prior period | biggest share gain vs prior period (the admin "movers" pattern, per-user) | |
+| `domain.quiet` | domain with ≥6 pebbles historically, none in >6 weeks, sensitivity ≥ gentle | a once-alive domain gone quiet — invitation, not alarm | EN: "Fitness has been quiet on your path lately." / FR: "Le sport se fait discret sur ton chemin ces temps-ci." |
+| `domain.gleams-most` | ≥8 domain-tagged pebbles | which domain carries the highest highlight share | positive direction only; the inverse ("your worst domain") is **never generated** (charter 5) |
+
+### Family R — Rhythm & practice (`created_at` axis — *DR §6.F*)
+
+| Key | Gate | Fact | Framing guard |
+|---|---|---|---|
+| `rhythm.gentle-cadence` | ≥4 weeks of history | days practiced this month vs personal norm | celebratory above norm; **silent** below it (never "you're behind") |
+| `rhythm.personal-best` | new max of pebbles-per-week | soft record | "your fullest week yet" — practice, not obligation |
+| `rhythm.fresh-start` | new month/year boundary | landmark invitation (*fresh start effect*) | composed into wraps, not pushed |
+| `rhythm.life-texture` | ≥20 pebbles | when your moments happen (weekday/weekend, `happened_at`) | descriptive curiosity |
+
+### Family C — Craft & depth
+
+| Key | Gate | Fact | Notes |
+|---|---|---|---|
+| `craft.depth` | ≥10 pebbles across 2 periods | enrichment trend from `compute_karma_delta` components (souls/domains/snaps/description attach rates) | "your pebbles carry more detail lately" — affect labeling & expressive writing rationale (*DR §6.A*) |
+| `craft.reflections` | cards shipped on web (drift #7) + ≥5 cards | card-writing depth across the feelings/thoughts/behaviour triad | **blocked on the web cards gap; do not gate the family on it** |
+| `craft.carved` | ≥3 custom glyphs used | creativity mirror (`glyphs.is_custom`) | |
+
+### Wraps — the Cairn ritual (Approach A, powered by the engine)
+
+A wrap is a **composition of facts** presented as a paced sequence (intro → 3–5 insight screens → review/confirm), matching the six reserved Arkaik views.
+
+- **Weekly Cairn** composes: `peak.of-week` → `palette.texture` (week) → `soul.constellation` (week) → `rhythm.gentle-cadence` → review. Review = the reflect-and-confirm screen already described by `V-weekly-cairn-review`; confirming stores only `{period, confirmed_at}` (facts recompute; no snapshot table until a real need emerges — YAGNI per the marketplace precedent "capture data, defer analytics").
+- **Monthly Cairn** composes: month peak → `palette.breadth` → `domain.portfolio` + `domain.rising` → `soul.gleam-share` (best-supported soul) → review.
+- **Yearly recap** (the Lab-backlog pitch + the valence picker's promised "yearly Cairn"): a later, richer composition — out of scope for v1 phases but the engine makes it a composition problem, not a new system.
+- Wraps respect intensity semantics already shipped in the valence picker: small moments star in weekly, medium in monthly, large in yearly compositions (selection weight, not hard filter).
+
+---
+
+## 5. Surface mapping
+
+| Surface | Module | Content (engine slots) |
+|---|---|---|
+| **Soul detail** (all 3 platforms) | header strip + 1 featured card | fixed strip: co-pebble count, signature emotion with this soul, valence texture; featured slot: best of `soul.*` for this soul |
+| **Profile → Insights page** (the deferred chevron destination) | featured stack (3 slots) + practice module | featured: engine's top 3 transversal picks; practice: existing ripple + assiduity + `rhythm.*`; entry point to the deep layer |
+| **Path week roll** | 1 slot under the focused week | that week's `peak.of-week` or valence texture; foreshadows the weekly cairn |
+| **Cairn wraps** (F-weekly-wrap / F-monthly-wrap) | ritual sequence | compositions in §4; entered from the Path week roll cairn + a gentle Profile card when a period completes |
+| **Pebble detail** | 1 contextual echo (later phase) | e.g. "this was your first highlight in Travel" — computed at read, no new plumbing |
+| **Deep layer ("Strata")** | opt-in browsable views | full emotion/domain/valence distributions with time-range tabs (admin patterns, per-user RPCs); explicitly labeled as the advanced room |
+
+Naming proposal (decision owed to the maintainer, not assumed): featured cards = **Gleams**; ritual = **Cairns** (already canon); deep layer = **Strata**. All three stay inside the mineral register (pebble, path, cairn, ripple, glyph). Fallbacks: "Echoes" for cards, plain "Insights" for the page. EN/FR naming resolved in the i18n pass with the "Tu" register question (*DR §9.6*).
+
+---
+
+## 6. Curation policy (deterministic)
+
+**Per-surface slot counts:** profile 3, soul 1 (+fixed strip), week roll 1, wrap 3–5. Scarcity is enforced, not aspirational.
+
+**Selection = filter → score → constrain:**
+
+1. **Eligibility filter:** catalog gates (§4) + data freshness (subject has ≥1 new pebble since last shown, or a period boundary crossed).
+2. **Salience score** (tunable weights, all inputs deterministic):
+   - *novelty*: time since this `(key, subject)` last shown (from `insight_impressions`), never repeat within 14 days;
+   - *magnitude*: normalized deviation from the user's own baseline (e.g. share vs trailing-90-day share) — self-referenced, never peer-referenced;
+   - *support*: sample size above the gate (more data → more confidence);
+   - *timeliness*: period boundaries and anniversaries score higher near their date.
+3. **Constraints (the charter, mechanized):**
+   - ≤1 insight per family per surface refresh;
+   - care-framed insights (`soul.anchor`, `domain.quiet`, `palette.finer-shades`, lowlight flashbacks): **≤1 per refresh, never in the first slot, never two refreshes in a row, only at sensitivity ≥ gentle**;
+   - every refresh contains ≥1 purely celebratory or mirroring insight;
+   - ties break toward the family least recently shown (rotation across families, *hedonic adaptation*).
+
+**Sensitivity setting** (new user preference; home decided in S0 — *DR §9.4*): `off` (celebratory + neutral only) / `gentle` (default; care-framed insights, softest wording) / `full` (adds lowlight flashbacks and lowlight-texture detail). The setting is explained in plain words at first insight contact.
+
+**Explainability:** every card exposes "How is this made?" → a mechanic sheet stating the fact's inputs, period, axis and gate, in user words. (Pattern and copy precedent: the unwired `GamificationBlocks` dialogs + `V-mechanic-sheet`.)
+
+---
+
+## 7. Cold-start ladder
+
+The feature must feel thoughtful at pebble #1 and substantial at pebble #1000.
+
+| Tier | Data | What unlocks |
+|---|---|---|
+| 0 | 0 pebbles | nothing; onboarding already promises the mirror |
+| 1 | 1–4 pebbles | Family M only (mirroring, firsts) — no statistics of any kind |
+| 2 | ≥5 pebbles | + `peak.of-week`, `palette.signature` (descriptive, no comparisons) |
+| 3 | ≥15 pebbles and ≥3 active weeks | + soul strip, `domain.portfolio`, `palette.breadth`; **weekly Cairn unlocks** |
+| 4 | ≥40 pebbles and ≥6 active weeks | + deltas and trends (`palette.weather`, `domain.rising`, `rhythm.*` norms); **monthly Cairn unlocks** |
+| 5 | opt-in, any time after tier 3 | Strata deep layer |
+
+Per-insight gates (§4) still apply within tiers — the ladder bounds the *vocabulary*, gates bound each *utterance*. Newbies get reinforcement from the first pebble (positive reinforcement loop: record → be mirrored → record more); advanced users get compounding depth instead of a wall that was all visible on day two.
+
+---
+
+## 8. Phasing
+
+- **S0 — Foundations (prerequisite, small):** resolve drift ledger items that insights would bake in (domain slug canon; time-axis principle; Bounce-vs-Ripple confirmation; sensitivity preference home; FR register decision). Add the four indexes. Decision-log entries for: time-axis principle, insights charter, Bounce legacy status, FR "Tu" register.
+- **S1 — Soul strip (first visible value):** fixed 3-fact strip + `soul.anniversary` on soul detail, via one `get_soul_insights(p_soul_id, p_tz)` RPC. No engine yet, but facts already shaped as §3.1 payloads. Cheapest genuinely new insight in the repo (audit-ranked), on the surface with the strongest science (*DR §6.D*).
+- **S2 — Insights page + engine core:** the deferred Profile chevron destination; catalog + eligibility + salience + `insight_impressions` + featured stack; families M, P, E(partial), R. Cold-start tiers live.
+- **S3 — Weekly Cairn:** the ritual composition over existing facts; the six weekly Arkaik views become 3 (intro, sequence, review) or stay 3 as reserved; week-roll entry point.
+- **S4 — Monthly Cairn + families D, S(full), E(full).**
+- **S5 — Strata (opt-in deep layer):** per-user share/distribution RPCs + time-range tabs, admin visual patterns reused.
+- **Later:** pebble-detail echoes, `craft.reflections` (after web cards ship), yearly recap, optional soul relationship-kind capture, LLM narration layer (§3.3).
+
+Fits the roadmap reality: insights sit outside the M45–M57 v1.0 gate; S0 is the only piece worth landing pre-launch (it is cheap and prevents post-launch schema regret). Public profiles (M50) must **not** expose any engine output; everything here is private by construction (charter 10).
+
+**Arkaik reconciliation (at each ship, per the arkaik skill):** add `V-insights` (profile destination), `V-soul-insights` (strip), engine endpoint nodes; flip the cairn/wrap nodes from `idea` as they materialize; resolve the `V-home` vs `V-timeline` overlap by re-homing `F-weekly-wrap`/`F-monthly-wrap` onto the shipped Path/Profile; mark `V-bounce-tempo` superseded by the Ripple-based practice module (decision-log entry).
+
+---
+
+## 9. Evaluation & acceptance heuristics (design-level)
+
+- **The boredom test:** would a user screenshot this card? If a card is true but inert ("you have 47 pebbles" past tier 1), it doesn't ship in Featured — it belongs in Strata.
+- **The reread test:** every copy template read aloud in both languages sounds like a warm friend, not a report ("Tu" register, benefit-first, no jargon, no em dashes).
+- **The harm test:** for each care-framed insight, write the worst plausible misreading; if the copy can't survive it, the framing (or the insight) is cut. Standing examples: `soul.anchor` must not read as blame; `domain.quiet` must not read as failure.
+- **The determinism test:** same rows + same tz + same date ⇒ same facts, same selection. Golden fixtures per catalog entry (admin playground precedent), including empty/small-N/timezone-boundary cases.
+- **The silence test:** a brand-new user, a sparse user, and a user mid-hiatus each get something kind or nothing at all — never a broken chart, never an accusation.
+
+---
+
+## 10. Out of scope (explicit)
+
+- Cross-user or normative comparisons of any kind; public exposure of any insight.
+- Multi-emotion pebbles (V1 stays 1:1; the catalog reads `emotion_id` and survives a future join table).
+- Text/NLP analysis of names, descriptions or cards (V1 counts presence/species only).
+- Push notifications for insights (wraps are entered, not pushed, in v1).
+- New telemetry of any kind (privacy §13.3).
+- LLM-generated content (the engine is its prerequisite, not its first consumer).
+- A composite well-being score (banned by charter 1, permanently).
+
+## 11. Decisions owed to the decision log when this ships
+
+1. Time-axis principle (`happened_at` = life, `created_at` = practice).
+2. The insights charter (ten rules) as a standing product constraint.
+3. Bounce = admin-only legacy; Ripple + assiduity are the practice signals.
+4. FR register for intimate surfaces ("Tu") and the Galet/Caillou/pebble canon.
+5. Naming: Gleams / Cairns / Strata (or the chosen alternatives).
+6. Sensitivity preference location (+ purge_account addendum for `insight_impressions`).

--- a/docs/superpowers/specs/2026-07-30-insights-discovery-report.md
+++ b/docs/superpowers/specs/2026-07-30-insights-discovery-report.md
@@ -1,0 +1,233 @@
+# Insights — Discovery Report
+
+- **Date:** 2026-07-30
+- **Status:** discovery (no code, no schema change)
+- **Companion doc:** `2026-07-30-insights-curation-design.md` (design propositions)
+- **Scope:** full audit of what Pebbles collects, where it is (and is not) reflected back to users, what the repo has already decided or reserved on the topic, and the scientific grounding a user-facing insights system should stand on.
+
+---
+
+## 1. Executive summary
+
+Pebbles already collects a remarkably well-shaped corpus for personal insights: every pebble is a point in a valence × arousal space (`positiveness` −1/0/+1, `intensity` 1–3) with exactly one emotion drawn from a 38-emotion / 7-category vocabulary, zero or more of 18 life domains, zero or more souls, optional CBT-shaped reflective cards, a photo, and two time axes. Almost none of this is reflected back to the user: the only shipped insight surface is the Profile stats card (ripple badge, 28-day assiduity grid, three counters). Valence, emotions, domains and souls are captured on every pebble and **never aggregated for the user anywhere**.
+
+The product has been promising this mirror since day one. "Get weekly and monthly wraps" is in the Arkaik top-level product description; nine `idea`-status Arkaik nodes (two wrap flows, six cairn views, `DM-cairn`) reserve the territory; the valence picker ships copy promising weekly/monthly/yearly Cairns; the privacy policy already names "Cairns" as a data category; the deferred "stats page" behind the Profile chevron is a named open gap; the Lab backlog fixture pitches a "Yearly recap". The legal basis (Terms §6.1, §13.4) already exists, including the non-advice disclaimer.
+
+The main risks are equally well-documented in the literature: quantification can kill the joy of the practice (Etkin 2016 — the scientific core of the "quantophrenia" worry), raw negative aggregates fuel rumination, co-occurrence invites false causal readings ("X makes you sad"), and small-N statistics lie. The companion design doc proposes a curated, deterministic, explainable insight engine that is AI-empowerable later but fully valuable without it.
+
+---
+
+## 2. Product vision anchor
+
+Everything below should be read against the product's own words:
+
+- Arkaik `project.description`: *"Pebbles is an atomic diary app allowing to record memories and enrich them with emotions, instants, thoughts, related to people and **get weekly and monthly wraps**."*
+- Admin analytics POC (`docs/poc/admin-analytics/admin-analytics.md`): success depends on whether *"the product gives them back **the mirror it promises** (emotional shape, who matters, what domains of their life are full or starved)"*.
+- Onboarding copy: *"No streak to protect, no feed to scroll. Just a calm ritual that grows with you."* / *"no blank page, no pressure, no audience."*
+- Settled naming decision (2026-05-27, #487): avoid value-stigmatizing language. User-facing valence labels are **Lowlight / Neutral / Highlight**, never "negative/positive". Internal jargon (souls, glyph slugs) must not leak into end-user copy.
+- Privacy policy §13.3: *"No analytics tools… no tracking pixels."* User insights must be computed from the user's own records, not from telemetry — and indeed there is no telemetry to compute from (see §3.7).
+
+**Implication:** an insights feature is not a "stats" feature. It is the second half of the core loop — record, then be mirrored — and it must inherit the calm, no-pressure, no-audience register.
+
+---
+
+## 3. What we collect — data audit
+
+Ground truth: 55 migrations in `packages/supabase/supabase/migrations/`, `packages/supabase/types/database.ts`.
+
+### 3.1 The pebble record
+
+| Field | Type / constraint | Insight relevance |
+|---|---|---|
+| `name` | text NOT NULL | title; text mining out of scope for V1 |
+| `description` | text NULL | free "pearl"; presence = `pct_with_thought` quality signal |
+| `happened_at` | timestamptz NOT NULL | **life time** — when the moment occurred (user-set) |
+| `created_at` | timestamptz NOT NULL | **practice time** — when it was recorded |
+| `intensity` | smallint, `1..3` | arousal / magnitude axis: small / medium / large |
+| `positiveness` | smallint, `-1..+1` | valence axis: lowlight / neutral / highlight (code name: polarity) |
+| `emotion_id` | uuid NOT NULL FK | exactly **one** emotion per pebble → emotion shares sum to 100% |
+| `glyph_id` | uuid NULL FK | personal mark; `glyphs.is_custom` = creativity proxy |
+| `visibility` | text, default `'private'` | only `'private'` ever written today |
+| joins | `pebble_souls`, `pebble_domains`, `collection_pebbles`, `pebble_cards`, `snaps` | the relational richness |
+
+⚠️ The README still says positiveness is "-2 to +2" and describes 5 Maslow domains — both stale (see drift ledger §3.8).
+
+**The two time axes are used inconsistently today**: `v_bounce` counts distinct `happened_at` days, while `v_ripple`, `get_profile_engagement` and every `v_analytics_*` view use `created_at`. Any insight design must adopt an explicit principle (proposed in the design doc: *insights about your life use `happened_at`; insights about your practice use `created_at`*).
+
+**A pebble is a circumplex point.** Russell's circumplex model (valence × arousal, §6.A) is literally the shape of the record: `(positiveness, intensity)` is a 3×3 grid, and the emotion picker already curates which of the 7 emotion categories to surface first *per grid cell* (`emotion-category-ordering`). The data model is insight-ready without any schema change.
+
+### 3.2 Reference axes
+
+- **Emotions:** 38 rows in 7 categories (`joy, pride, peace, fear, anger, shame, sadness`), each category carrying a full color palette (`v_emotions_with_palette`). Category + palette data was hand-entered in Supabase Studio, not migrated — production is the source of truth, `db:reset` does not reproduce it.
+- **Domains:** 18 canonical slugs (DB + i18n + seed): `community, currentevents, dating, education, family, fitness, friends, health, hobbies, identity, money, partner, selfcare, spirituality, tasks, travel, weather, work`. There is **no level/order column**; the "revisited Maslow pyramid" framing survives only in stale copy and in `v_analytics_domain_share_weekly.domain_level`, which resolves to NULL for every live domain (its `array_position` list still contains the five legacy Greek slugs). A pebble may carry many domains → domain shares do **not** sum to 100%.
+- **Cards:** 4 species — `free` ("Write anything…"), `feelings` ("What did I feel?"), `thoughts` ("What did I think?"), `behaviour` ("What did I do?"). This is the CBT triangle (§6.A) sitting latent in the schema. **The web composer currently always sends `cards: []`** — the card path is unreachable on web; the `V-cards-thoughts` Arkaik node is archived.
+- **Collections:** optional mode `stack` (goal) / `pack` (time-bound) / `track` (recurring) — three declared intents with **zero computed progress anywhere**.
+- **Souls:** name + glyph only. **No relationship-kind column** (partner/friend/pet/…). Any soul-typed insight either works without it or motivates a (later, optional) enrichment.
+
+### 3.3 Engagement plumbing (user-scoped, exists today)
+
+| Primitive | Grain | Notes |
+|---|---|---|
+| `v_ripple` | `ripple_level` 0–6, `pebbles_28d`, `active_today` | by `created_at`; thresholds `[1,5,9,13,17,21]` duplicated in 3 clients; `active_today` is UTC and locally patched on iOS/Android, not on web |
+| `v_bounce` / `bounces.score` | level 0–7 from distinct active days | by `happened_at`; web client thresholds (`bounce-levels.ts`) **disagree with the SQL view**; retired from iOS/Android display |
+| `get_profile_engagement(p_tz)` | `days_practiced`, `assiduity bool[28]` | the **only timezone-aware aggregate** in the product; the sanctioned pattern for user-scoped RPCs (`security invoker`, `set search_path`, client passes IANA tz) |
+| `v_karma_summary` | `total_karma`, `pebbles_count` | total = **all** ledger types = spendable, not earned |
+| `v_wallet_summary` | balance / earned / spent | |
+| `path_pebbles()` | every pebble, unpaginated | the bulk read used by the timeline |
+
+### 3.4 The karma ledger as a richness signal
+
+`compute_karma_delta` is a pure enrichment score per pebble ∈ [1,10]: +1 base, +1 description, +1 per card (cap 4), +1 souls, +1 domains, +1 glyph, +1 snap. It is a ready-made "depth of capture" metric — reconstructible per pebble, no new data needed. Two caveats: deleted pebbles leave net-zero ledger rows behind, and "karma" now means two different numbers (earned vs spendable) since the marketplace.
+
+### 3.5 Admin analytics — patterns, not surfaces
+
+Ten `v_analytics_*` views + `security definer` RPCs gated on `is_admin()`: KPI daily, active users, weekly retention cohorts, pebble volume, enrichment percentages, per-active-user averages, **emotion share weekly**, **domain share weekly**, bounce distribution, quality signals. All are **cross-user with no per-user grain** — nothing is reusable as-is, but the metric semantics (point-in-time counts, gap-filled series, share definitions, "movers" deltas) and the admin UI pattern library (sparklines, donuts, stacked areas, heatmaps, fixtures playground, `TimeRangeTabs`) are directly transferable.
+
+### 3.6 What the user already sees (complete list)
+
+Profile stats card (ripple badge + "X more pebbles to level Y" + 28-cell assiduity grid + Days/Pebbles/Karma tiles) on all three platforms; per-soul and per-collection pebble counts; wallet aggregates; week-roll cairn presence; Lab reaction counts. **That is the entire user-facing derived-data surface.** No charts ship to users on any platform.
+
+### 3.7 What is NOT collected
+
+- **No telemetry at all**: no sessions table, no `pebble_views`, no `analytics_events` (4 of 8 admin quality signals are stubbed `available = false`). "You revisited this pebble N times" has no data source — and adding one would contradict privacy policy §13.3.
+- **No analytics/insights consent column** — only `terms_accepted_at` / `privacy_accepted_at`. If insights ship with a sensitivity setting or opt-out, that preference has no home yet.
+- **No soul relationship type, no domain ordering, no cairn table** (ROADMAP issue #345: "Large — full product feature").
+
+### 3.8 Drift ledger (do not build on these without resolving)
+
+| # | Drift | Where |
+|---|---|---|
+| 1 | README: positiveness "-2..+2", 5 Maslow domains | `README.md` vs `pebbles` check constraint, live domains |
+| 2 | Two 18-domain slug sets on web: `lib/config/domains.ts` (`finance, sport, passions, event, self-care`) vs DB/i18n canon (`money, fitness, hobbies, currentevents, selfcare`) — composer reads the DB view, config feeds only seed data | `apps/web/lib/config/domains.ts` |
+| 3 | `v_analytics_domain_share_weekly.domain_level` NULL for all live domains (legacy Greek `array_position`) | migration `20260501000003` |
+| 4 | Bounce thresholds: web `bounce-levels.ts` ≠ SQL `v_bounce` | two threshold tables |
+| 5 | Ripple thresholds `[1,5,9,13,17,21]` hand-copied in 3 clients + SQL | drift risk, `packages/shared` is empty |
+| 6 | `happened_at` vs `created_at` inconsistently chosen across views | §3.1 |
+| 7 | Cards karma-rewarded and admin-measured (`pct_with_thought`) but uncreatable on web | `QuickPebbleEditor.tsx` |
+| 8 | FR renders "pebble" three ways (Galets / Caillou / pebble); web app copy is "Vous" while the Lab voice mandates "Tu" | `fr.json` vs lab-note skill |
+| 9 | `v_ripple.active_today` UTC bug patched on iOS/Android, not web | `PathView` / `PathScreen` vs web |
+| 10 | Privacy policy documents Cairns/therapist stats that don't exist (M56 rewrite planned) | `apps/web/docs/privacy/*` |
+
+---
+
+## 4. Where insights could live — surface audit
+
+Ranked by fit (full inventory in the audit annex of this report's PR):
+
+1. **Behind the Profile stats card.** The chevron to a stats page was explicitly deferred ("Issue 4", spec 2026-05-16) and all three platforms share the same card, props and `PathStatsService`. This is the reserved front door.
+2. **Soul detail** — today: name, glyph, `pebbles.length`, flat list. The joined rows already carry emotion + valence + domains. Highest-leverage *new* insight for the least plumbing.
+3. **Collection detail** — `stack`/`pack`/`track` declare goal/period/frequency intent; nothing is computed. Mode-aware progress is a self-chosen goal, the ethically safe kind (§6.F).
+4. **Path week roll** — each cairn cell already receives its week's full pebble array; a valence/volume texture belongs here and foreshadows the weekly wrap.
+5. **The wraps ritual** — the six reserved cairn views (see §5).
+6. **`V-mechanic-sheet` + dead `GamificationBlocks` code** — a fully built "explain this metric" dialog pattern with copy, unreferenced on web. The explainability affordance every insight card needs already has a precedent.
+
+Cross-cutting: `packages/shared` is an empty placeholder; every derived-data formula today is hand-ported three times with measurable drift already (bounce, ripple). **Any insight math must live server-side (RPC/view), not in three clients.** This aligns with the RPC-first decision (2026-05-26) and the `security_invoker` decision (2026-07-29, #616): new views are `with (security_invoker = true)` + explicit revoke/grant; the bolt-on `where auth.uid()` view pattern is explicitly not-to-copy.
+
+---
+
+## 5. Prior art & reserved territory
+
+- **Arkaik latent design (all `idea`):** `F-weekly-wrap`, `F-monthly-wrap`, `F-gamification` flows; `V-weekly-cairn-intro/-cairn/-cairn-review` and the monthly triplet; `V-home`, `V-bounce-tempo`, `V-collection-rise`, `V-achievements`; `DM-cairn` ("Weekly or monthly wrap stacking pebbles into a summary"), `DM-achievement`, `DM-thought`; endpoints `GET /cairns/weekly`, `GET /cairns/monthly`, `GET /bounce`, `GET /achievements`. Note the map inconsistency: wrap flows hang off `V-home` (`idea`) while the shipped root is `V-timeline`.
+- **Shipped promises:** the valence picker copy ties intensity to wrap cadence — small → "wrapped in my weekly Cairn", medium → monthly, large → **yearly** (a yearly Cairn exists nowhere else). The Path renders one decorative Rive cairn per week already.
+- **Legal:** Terms §6.1 already licenses "generate anonymized statistics and insights"; §13.4 mandates the non-advice disclaimer; §13.1–13.2 "not a medical device… does not provide psychotherapy". Privacy policy already names Cairns as a data category (flagged as fiction to fix in M56 — an insights ship would *un-fiction* it).
+- **Adjacent milestones:** M48 Achievements (`check_achievements()` idempotent RPC, badges cosmetic in v1) and M50 Public profiles (`get_public_profile` projects rings + assiduity; hard rule: never un-scope the private views). Insights sit **outside** the ten v1.0-gating milestones (M45–M57) — this is post-launch surface, which buys design time but demands the design be launch-compatible (no schema landmines).
+- **User appetite signal:** the Lab backlog fixture "Yearly recap — A look back over your path, one year at a time" is the repo's closest authored insights pitch.
+
+---
+
+## 6. Scientific foundations
+
+The design should be groundable claim-by-claim. Summary of the load-bearing literature, with the design implication each carries.
+
+### A. Structure of affect — what a pebble already encodes
+
+- **Circumplex model of affect** (Russell 1980; Posner, Russell & Peterson 2005): affective states organize along valence × arousal. `positiveness` is a 3-step valence scale, `intensity` a 3-step arousal proxy: every pebble is a circumplex point plus a discrete label. → Insight families can be built on the existing schema, no new capture needed.
+- **Emotional granularity** (Barrett 2006, 2017; Kashdan, Barrett & McKnight 2015): people who differentiate emotions finely regulate them better. → An insight reflecting the breadth/precision of a user's emotion vocabulary nudges a scientifically supported skill; the 38-emotion picker is the instrument.
+- **Emodiversity** (Quoidbach et al. 2014, *JEP: General*, N≈37k): variety and evenness of experienced emotions predicts health beyond mean affect — for positive *and* negative emotions. → "Richness of your palette" is a legitimate, computable insight (`emotion_id` frequencies).
+- **Affect labeling** (Lieberman et al. 2007; Torre & Lieberman 2018): naming feelings dampens amygdala response — implicit emotion regulation. → Recording a pebble *is* the intervention; insights can honestly reinforce the practice itself.
+- **Expressive writing** (Pennebaker 1986; Pennebaker & Chung 2011) and the CBT triangle (Beck 1979): structured writing about feelings/thoughts/behaviour has reliable benefits. → The `feelings/thoughts/behaviour` card species are a latent micro-intervention; depth-of-reflection insights are supported (once cards ship on web — drift #7).
+
+### B. Well-being frameworks — what "good" looks like
+
+- **Affect balance / SPANE** (Diener et al. 2010): well-being tracks the balance of positive to negative experience, not the absence of the negative. → Valence-texture insights present both poles as normal and informative; a lowlight is data, not failure.
+- **Broaden-and-build** (Fredrickson 1998, 2001) — with the mandatory caveat: the "critical positivity ratio" (Fredrickson & Losada 2005) was mathematically debunked (Brown, Sokal & Friedman 2013). → **No insight may present a numeric positivity ratio as a threshold or target. Ever.**
+- **PERMA** (Seligman 2011) / **psychological well-being** (Ryff 1989): well-being is a multi-dimensional portfolio. → Prefer a portfolio view (domains, souls, emotions, practice) over any single score. **No composite "happiness score".**
+- **Three Good Things / gratitude** (Seligman, Steen, Park & Peterson 2005 RCT; Emmons & McCullough 2003): noticing positive events produces lasting, modest well-being gains. → Recording highlights is structurally this exercise; celebrate the practice, keep claims modest.
+- **Self-determination theory** (Ryan & Deci 2000; Deci, Koestner & Ryan 1999): intrinsic motivation thrives on autonomy/competence/relatedness and is undermined by controlling rewards. → Insights inform and celebrate; never pressure. Matches the shipped "No streak to protect" promise.
+
+### C. Memory, retrospection, savoring — why wraps and resurfacing work
+
+- **Peak–end rule** (Kahneman et al. 1993; Redelmeier & Kahneman 1996; Kahneman 2011): retrospective evaluation is dominated by the peak and the end, not the mean. → Wraps lead with the peak moment and how the period closed; averages are demoted to the advanced layer.
+- **Day Reconstruction Method** (Kahneman, Krueger, Schkade, Schwarz & Stone 2004, *Science*): structured episodic reconstruction is a validated retrospection instrument; Pebbles sits between ESM and DRM.
+- **Fading affect bias** (Walker, Skowronski & Thompson 2003): negative affect fades from memory faster than positive. → Resurfacing old pebbles disproportionately re-delivers positive affect; "on this day" is emotionally safer than it looks (still valence-gated, §E).
+- **Savoring / positive reminiscence** (Bryant 2003; Bryant & Veroff 2007): deliberately attending to past positives amplifies their benefit. → Flashbacks are an intervention, not just retrieval.
+- **Nostalgia** (Sedikides & Wildschut research program): increases social connectedness, meaning, self-continuity. → Soul anniversaries and "your history with X" have this backing.
+- **Hedonic adaptation** (Brickman & Campbell 1971; Lyubomirsky 2011): identical stimuli fade; variety and appreciation slow adaptation. → Rotate insight types; scarcity is a feature. A permanently identical dashboard adapts into invisibility.
+
+### D. Relationships — why soul insights are the crown jewels
+
+- **Harvard Study of Adult Development** (Vaillant 2012; Waldinger & Schulz 2023): relationship quality is the strongest predictor of long-term health and happiness. **Holt-Lunstad, Smith & Layton 2010**: social integration's mortality effect rivals quitting smoking. → A per-soul insight surface aligns the product with the most robust finding in the field.
+- **Social baseline theory** (Coan, Schaefer & Davidson 2006; Coan & Sbarra 2015): the brain treats social proximity as its default risk-regulation resource. → A soul who co-occurs with hard moments is plausibly **support, not cause**. Framing must honor this: "who's there in your hardest moments", never "who brings you down".
+- **Capitalization** (Gable, Reis, Impett & Asher 2004): sharing good news with responsive others amplifies it beyond the event itself. → Recording a highlight *with* a soul is a capitalization act worth reflecting back.
+- **Gottman's interaction ratios** (Gottman & Levenson 1992): descriptive lab science about observed couple conflict — **never a prescriptive app metric**; must not appear as a target number in copy.
+
+### E. Risks the design must engineer against
+
+- **Rumination** (Nolen-Hoeksema 1991, 2008): repetitive passive focus on negative affect worsens outcomes. Raw feeds of one's own negative data are rumination fuel.
+- **Self-distancing** (Kross & Ayduk 2011, 2017): adaptive reflection needs a distanced perspective; immersed replay of negatives harms, distanced appraisal helps. → Lowlight-tinted insights are framed at pattern/trajectory/care altitude, never as immersive replay.
+- **The hidden cost of measurement** (Etkin 2016, *Journal of Consumer Research*): quantifying an enjoyable activity can reduce intrinsic motivation and enjoyment. This is the scientific core of the quantophrenia worry (the term: Sorokin 1956). → Insights are scarce, curated, narrative-first; the granular layer is opt-in, never the default face.
+- **Negativity bias** (Baumeister et al. 2001; Rozin & Royzman 2001): bad is stronger than good; one harsh insight outweighs five kind ones. → Asymmetric caution on anything lowlight-derived: sensitivity gates, agency framing, and **no ranking of souls or domains by negativity, ever**.
+- **Selection bias** (vs. ESM: Csikszentmihalyi & Larson 1987; EMA: Shiffman, Stone & Hufford 2008): pebbles are self-initiated, event-contingent records — the corpus is what the user *chose to record*, not their life. → Every insight is an insight about the record. Copy says "your pebbles", never "your life is X". This honesty is also the legal shield (Terms §13.4).
+- **Small-N instability**: percentages and trends on tiny samples mislead. → Per-insight minimum-support gates; below them, degrade to milestones and mirroring, not statistics.
+- **Reward-loop caution** (Schultz 1997 reward-prediction error; SDT undermining): variable-reward mechanics tip reflection into compulsion. → No push-notification slot machines; insights reinforce meaning, not checking.
+
+### F. Habits & momentum — reinforcement that respects the user
+
+- **Habit formation** (Lally et al. 2010): ~66 days median to automaticity; missing one day costs nothing measurable. → Rhythm framing, forgiving by construction — which the assiduity grid already embodies (it shows presence, not chains).
+- **Fresh start effect** (Dai, Milkman & Riis 2014): temporal landmarks boost aspirational behavior. → Wraps timed to week/month/year boundaries double as fresh-start springboards.
+- **Goal-gradient** (Kivetz, Urminsky & Zheng 2006): progress accelerates near a self-chosen goal. → Milestones and collection `stack` progress tap this ethically because the goal is the user's own.
+- **Maslow, revised** (Kenrick et al. 2010; Tay & Diener 2011, N≈61k across 123 countries): need fulfillment contributes to well-being in parallel, not as a strict ladder. → The 18 domains form a **portfolio, not a pyramid**; imbalance insights suggest attention, never a required order. (Convenient, since the Maslow ordering is already dead in the data — drift #3.)
+
+---
+
+## 7. Constraints any design must honor (non-negotiable inventory)
+
+1. **RPC-first** for anything multi-table (decision 2026-05-26); aggregate math lives server-side, once.
+2. **New views are `security_invoker = true`** + explicit `revoke`/`grant` (decision 2026-07-29, #616). Do not copy the `where auth.uid()` view pattern.
+3. **Timezone**: follow `get_profile_engagement(p_tz)` — client passes IANA tz, server buckets.
+4. **Drafts are invisible** to all aggregates by construction (separate table, decision 2026-07-29 #639) — keep it that way.
+5. **Any new user-owned table** must be appended to `purge_account` section 4 **and** to `scripts/verify-account-purge.ts` (decision 2026-07-29 #631).
+6. **Three hand-written clients**, database as the only contract (decision 2026-07-10); `packages/shared` is empty. Client-side insight math would be written three times — don't.
+7. **EN/FR mandatory** everywhere; user copy warm, benefit-first; FR is an adaptation, "Tu" register per the Lab voice (the app's "Vous" catalog is drift #8 to resolve, not to imitate blindly).
+8. **No telemetry** may be introduced (privacy §13.3); insights compute from records only.
+9. **No offline** framing (decision 2026-07-29 #620).
+10. **Missing indexes**: no `pebbles(user_id, created_at)` composite, no reverse indexes on `pebble_souls(soul_id)` / `pebble_domains(domain_id)` — per-user aggregate queries need index work.
+11. **Terms §13.4 disclaimer** applies to any generated insight; nothing diagnostic, nothing prescriptive-medical.
+12. **Arkaik**: an insights ship adds view/flow/model/endpoint nodes and reconciles the nine reserved `idea` nodes (and the `V-home` vs `V-timeline` overlap) — via the hosted project per decision 2026-07-28.
+
+---
+
+## 8. Risk register
+
+| Risk | Severity | Mitigation lever (design doc §) |
+|---|---|---|
+| Quantophrenia: dashboard sprawl kills the calm ritual | High | Curation-first architecture; scarcity; advanced layer opt-in |
+| Rumination fuel from negative aggregates | High | Valence-mix policy, sensitivity setting, distanced framing |
+| False causality on souls ("X makes me sad") | High | Framing charter: support-not-cause; no negativity rankings |
+| Small-N nonsense insights | Medium | Eligibility gates + cold-start ladder |
+| Streak anxiety / SDT undermining | Medium | Forgiving rhythm framing; no loss mechanics |
+| Hedonic adaptation of the surface itself | Medium | Rotation memory; seasonal wraps |
+| Metric drift across 3 clients | Medium | Server-computed facts only |
+| Legal/clinical overreach | Medium | Descriptive copy, "your pebbles" honesty, §13.4 disclaimer surfaced |
+| Building on stale semantics (domains, bounce, time axes) | Medium | Drift ledger resolved in phase S0 |
+
+---
+
+## 9. Open product questions
+
+1. **One emotion per pebble is V1** — a multi-emotion model is an explicit admin-analytics non-goal today; insights should assume 1:1 but not paint the schema into a corner.
+2. **Souls have no relationship kind** — several strong insight types survive without it; is a light, optional "kind" worth capturing later?
+3. **Bounce vs Ripple** — two parallel 28-day mechanics, one retired from display. Insights should build on Ripple + assiduity and treat Bounce as admin-only legacy; confirm and log the decision.
+4. **Where does the sensitivity/insight preference live** — `profiles` column vs a new preferences table (purge_account implications either way)?
+5. **The yearly Cairn** — shipped copy promises it; is it in scope for the insights roadmap or should the valence picker copy be softened?
+6. **FR register** — app copy is "Vous", Lab voice is "Tu". Insights copy is intimate by nature; recommend "Tu" and a harmonization pass (needs its own decision-log entry).


### PR DESCRIPTION
## Changes

Added two comprehensive design and discovery documents for the Insights feature:

- **`docs/superpowers/specs/2026-07-30-insights-discovery-report.md`** — The audit and scientific grounding. Inventories what Pebbles collects (valence, intensity, emotions, domains, souls, cards, photos, two time axes), where it is and is not reflected back to users, prior art and reserved territory (nine Arkaik `idea` nodes, shipped promises, deferred stats page, legal basis), the drift ledger (ten unresolved inconsistencies), the constraints inventory, and the load-bearing literature (circumplex affect, emodiversity, peak–end rule, social baseline theory, measurement cost / quantophrenia, negativity bias, self-determination theory).

- **`docs/superpowers/specs/2026-07-30-insights-curation-design.md`** — The design proposition for a curated, deterministic insight engine. Covers the design philosophy (mirror, not dashboard), the ten-rule insights charter, three approaches compared (Cairn-first ritual, stats-page-first, curated engine — the engine recommended as the spine), typed-fact architecture (AI-empowerable, not AI-first), a catalog of seven insight families (Mirror, Peaks, Souls, Palette, Domains, Rhythm, Craft) with eligibility gates and EN/FR copy examples, Cairn wrap compositions, curation policy, cold-start ladder, phasing S0–S5, and evaluation heuristics.

## Notes

- **No code changes.** These are specification documents establishing the design contract before implementation begins.
- **Companion documents.** The design doc references the discovery report as `DR §6.x` for scientific grounding.
- **Decision log entries owed.** Design doc §11 lists six decisions to log when the feature ships: time-axis principle (`happened_at` = life, `created_at` = practice), insights charter, Bounce legacy status, FR register ("Tu"), naming (Gleams / Cairns / Strata), and sensitivity preference location.
- **Drift ledger resolution.** Discovery report §3.8 identifies ten inconsistencies (README staleness, dual domain slug sets, bounce threshold mismatch, time-axis inconsistency, cards unreachable on web, FR register split, ripple UTC patch missing on web, privacy-policy fiction) proposed for resolution in phase S0, before any insights implementation.
- **Arkaik reconciliation.** Design doc §8 maps how each ship phase updates the product graph (add `V-insights`, `V-soul-insights`, engine endpoints; flip cairn/wrap nodes from `idea`; resolve the `V-home` / `V-timeline` overlap).
- **No Lab Note:** docs-only PR, per the Lab Note gate (`no-lab-note` label applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmHPLZGhvddko6eUU24f9n