### PR TITLE
feat(ui): add achievements grid, unlock moment and profile entry on web

### DIFF
--- a/apps/web/app/achievements/page.tsx
+++ b/apps/web/app/achievements/page.tsx
@@ -1,0 +1,5 @@
+import { AchievementsView } from "@/components/achievements/AchievementsView"
+
+export default function AchievementsPage() {
+  return <AchievementsView />
+}

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -15,6 +15,7 @@ import { ProfileBanner } from "@/components/profile/ProfileBanner"
 import { ShortcutsRow } from "@/components/profile/ShortcutsRow"
 import { StatsCard } from "@/components/profile/StatsCard"
 import { CollectionsCard } from "@/components/profile/CollectionsCard"
+import { AchievementsCard } from "@/components/profile/AchievementsCard"
 import { LabCard } from "@/components/profile/LabCard"
 import { LogoutButton } from "@/components/profile/LogoutButton"
 import { PageLayout } from "@/components/layout/PageLayout"
@@ -92,6 +93,7 @@ export default function ProfilePage() {
             pebbles={pebblesCount}
             karma={karma}
           />
+          <AchievementsCard />
           <CollectionsCard />
           <LabCard />
           <LogoutButton onLogout={handleLogout} />

--- a/apps/web/components/achievements/AchievementBadge.tsx
+++ b/apps/web/components/achievements/AchievementBadge.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import { Compass, Gem, Heart, Layers, Lock, PenTool, Shapes, Store, Trophy, Users } from "lucide-react"
+import type { LucideIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { useFormatDate } from "@/lib/i18n"
+import type { Achievement, AchievementFamily } from "@/lib/types"
+import type { AchievementCopy } from "@/lib/i18n"
+
+// Seeded rows carry no glyph_id today, so every badge renders its family's
+// fallback icon (D12). Glyph rendering for admin-assigned visuals ships with
+// the rewarding-moment satellite — deliberately not built here.
+const FAMILY_ICONS: Record<AchievementFamily, LucideIcon> = {
+  pebble_count: Gem,
+  emotion_first: Heart,
+  domain_first: Compass,
+  first_collection: Layers,
+  first_glyph: PenTool,
+  first_soul: Users,
+  glyph_count: Shapes,
+  glyph_sales: Store,
+}
+
+type AchievementBadgeProps = {
+  achievement: Achievement
+  copy: AchievementCopy
+  /** Present iff the badge is unlocked. */
+  unlockedAt?: string
+}
+
+export function AchievementBadge({ achievement, copy, unlockedAt }: AchievementBadgeProps) {
+  const t = useTranslations("achievements")
+  const formatDate = useFormatDate()
+  // The DB types family as string and the provider narrows it with a cast, so
+  // a server ahead of this build can ship families we don't know yet. Degrade
+  // to a generic icon instead of crashing the grid on an undefined component.
+  const Icon = FAMILY_ICONS[achievement.family] ?? Trophy
+  const locked = unlockedAt === undefined
+
+  // Locked state is never color-only: the greyed treatment is paired with a
+  // lock icon and a visible "Locked" caption that screen readers also get.
+  return (
+    <li
+      className={cn(
+        "flex flex-col items-center gap-2 rounded-2xl border border-border p-4 text-center",
+        locked && "opacity-60",
+      )}
+    >
+      <div
+        className={cn(
+          "flex size-12 shrink-0 items-center justify-center rounded-full",
+          locked ? "bg-muted text-muted-foreground" : "bg-primary/10 text-primary",
+        )}
+      >
+        <Icon aria-hidden className="size-6" />
+      </div>
+      <span className="text-sm font-semibold text-foreground">{copy.title}</span>
+      <span className="text-xs text-muted-foreground">{copy.description}</span>
+      {locked ? (
+        <span className="mt-auto flex items-center gap-1 text-xs font-medium text-muted-foreground">
+          <Lock aria-hidden className="size-3" />
+          {t("locked")}
+        </span>
+      ) : (
+        <span className="mt-auto text-xs font-medium text-primary">
+          {t("unlockedOn", { date: formatDate(unlockedAt, { dateStyle: "medium" }) })}
+        </span>
+      )}
+    </li>
+  )
+}

--- a/apps/web/components/achievements/AchievementsView.tsx
+++ b/apps/web/components/achievements/AchievementsView.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import { useAchievements } from "@/lib/data/useAchievements"
+import { useAchievementCopy } from "@/lib/i18n"
+import { PageLayout } from "@/components/layout/PageLayout"
+import { PageHeader } from "@/components/layout/PageHeader"
+import { AchievementBadge } from "@/components/achievements/AchievementBadge"
+import type { Achievement, AchievementFamily } from "@/lib/types"
+import type { AchievementCopy } from "@/lib/i18n"
+
+type BadgeEntry = { achievement: Achievement; copy: AchievementCopy }
+type FamilyGroup = { family: AchievementFamily; entries: BadgeEntry[] }
+
+export function AchievementsView() {
+  const t = useTranslations("achievements")
+  const { achievements, unlockedAt, loading, error } = useAchievements()
+  const resolveCopy = useAchievementCopy()
+
+  // Family sections follow the catalog's per-family sort_order blocks; inside
+  // a family, generated rows (emotion_first / domain_first) share one
+  // sort_order and are ordered by localized title instead (D2). Inactive
+  // badges are retired: hidden while locked, still shown once earned (D12).
+  const groups: FamilyGroup[] = []
+  const byFamily = new Map<AchievementFamily, FamilyGroup>()
+  const visible = achievements
+    .filter((a) => a.isActive || unlockedAt.has(a.id))
+    .map((a): BadgeEntry => ({ achievement: a, copy: resolveCopy(a) }))
+    .sort(
+      (a, b) =>
+        a.achievement.sortOrder - b.achievement.sortOrder ||
+        a.copy.title.localeCompare(b.copy.title),
+    )
+  for (const entry of visible) {
+    const family = entry.achievement.family
+    let group = byFamily.get(family)
+    if (!group) {
+      group = { family, entries: [] }
+      byFamily.set(family, group)
+      groups.push(group)
+    }
+    group.entries.push(entry)
+  }
+
+  return (
+    <PageLayout>
+      <div className="flex flex-col gap-6">
+        <PageHeader title={t("title")} backHref="/profile" />
+        {loading && (
+          <p aria-live="polite" className="text-sm text-muted-foreground">
+            {t("loading")}
+          </p>
+        )}
+        {!loading && error && (
+          <p role="alert" className="text-sm text-destructive">
+            {t("error")}
+          </p>
+        )}
+        {!loading &&
+          !error &&
+          groups.map((group) => (
+            <section key={group.family}>
+              <h2 className="mb-2 text-sm font-semibold text-muted-foreground">
+                {/* Unknown families (server ahead of this build) fall back to
+                    the raw slug instead of rendering a bare message-key path. */}
+                {t.has(`group.${group.family}`) ? t(`group.${group.family}`) : group.family}
+              </h2>
+              <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                {group.entries.map(({ achievement, copy }) => (
+                  <AchievementBadge
+                    key={achievement.id}
+                    achievement={achievement}
+                    copy={copy}
+                    unlockedAt={unlockedAt.get(achievement.id)}
+                  />
+                ))}
+              </ul>
+            </section>
+          ))}
+      </div>
+    </PageLayout>
+  )
+}

--- a/apps/web/components/activity/AchievementUnlockPill.tsx
+++ b/apps/web/components/activity/AchievementUnlockPill.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useTranslations } from "next-intl"
+import { Trophy } from "lucide-react"
+import { toast } from "sonner"
+import { useAchievementCopy } from "@/lib/i18n"
+import type { AchievementUnlockResult } from "@/lib/data/data-provider"
+import type { Achievement } from "@/lib/types"
+
+type AchievementUnlockPillProps = {
+  toastId: string | number
+  results: AchievementUnlockResult[]
+  catalog: Achievement[]
+}
+
+export function AchievementUnlockPill({
+  toastId,
+  results,
+  catalog,
+}: AchievementUnlockPillProps) {
+  const router = useRouter()
+  const t = useTranslations("activity")
+  const resolveCopy = useAchievementCopy()
+
+  const handleTap = () => {
+    toast.dismiss(toastId)
+    router.push("/achievements")
+  }
+
+  // One pill per response (D8): a lone unlock is announced by its localized
+  // title; several collapse into a count phrase. The catalog lookup can only
+  // miss if the check raced a catalog change — the count phrase covers it.
+  const single =
+    results.length === 1 ? catalog.find((a) => a.slug === results[0].slug) : undefined
+  const headline = single
+    ? resolveCopy(single).title
+    : t("achievementsUnlocked", { count: results.length })
+
+  // Total karma the unlocks actually paid — reported by the RPC from the
+  // ledger, so the pill can never show a number the wallet doesn't hold.
+  const totalKarma = results.reduce((sum, r) => sum + r.karmaGranted, 0)
+
+  // Full spoken sentence: "Achievement unlocked: First pebble. Earned 5 karma.
+  // View achievements."
+  const label = [
+    single
+      ? t("srAchievementUnlocked", { title: headline })
+      : t("srAchievementsUnlocked", { count: results.length }),
+    totalKarma > 0 ? t("srAchievementKarma", { amount: totalKarma }) : null,
+    `${t("viewAchievements")}.`,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(" ")
+
+  return (
+    <button
+      type="button"
+      onClick={handleTap}
+      aria-label={label}
+      className="flex items-center gap-2 rounded-full bg-neutral-900 px-4 py-2 text-sm font-semibold text-white shadow-lg ring-1 ring-white/10 transition active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 dark:bg-neutral-800 motion-reduce:transition-none motion-reduce:active:scale-100"
+    >
+      <Trophy aria-hidden className="size-4 text-amber-300" />
+      <span aria-hidden>{headline}</span>
+      {totalKarma > 0 && (
+        <span aria-hidden className="text-amber-300">
+          {t("amount", { amount: totalKarma })}
+        </span>
+      )}
+    </button>
+  )
+}

--- a/apps/web/components/profile/AchievementsCard.tsx
+++ b/apps/web/components/profile/AchievementsCard.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import Link from "next/link"
+import { useTranslations } from "next-intl"
+import { ChevronRight, Trophy } from "lucide-react"
+import { SectionCard } from "@/components/profile/SectionCard"
+
+/**
+ * The Profile "Achievements" entry card — a LabCard sibling linking to the
+ * badge grid. Deliberately a plain affordance: the recent-badges showcase
+ * shelf is the D14 satellite, not this card.
+ */
+export function AchievementsCard() {
+  const t = useTranslations("profile.achievements")
+  return (
+    <Link href="/achievements" className="block transition-opacity hover:opacity-90">
+      <SectionCard>
+        <div className="flex items-center gap-3">
+          <Trophy className="size-[18px] shrink-0 text-primary" aria-hidden />
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <span className="text-base font-semibold text-foreground">{t("title")}</span>
+            <span className="text-sm text-muted-foreground">{t("subtitle")}</span>
+          </div>
+          <ChevronRight className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+        </div>
+      </SectionCard>
+    </Link>
+  )
+}

--- a/apps/web/lib/activity/achievement-activity.tsx
+++ b/apps/web/lib/activity/achievement-activity.tsx
@@ -1,0 +1,31 @@
+import { toast } from "sonner"
+import { AchievementUnlockPill } from "@/components/activity/AchievementUnlockPill"
+import type { AchievementUnlockResult } from "@/lib/data/data-provider"
+import type { Achievement } from "@/lib/types"
+
+// Stable id → a new unlock batch replaces the current pill rather than stacking.
+const ACHIEVEMENT_ACTIVITY_ID = "achievement-activity"
+
+/**
+ * Fire a glanceable achievement-unlock pill. Several unlocks in one
+ * check_achievements() response collapse into ONE pill (D8): a single unlock
+ * shows its localized title, several show a count phrase. `catalog` carries
+ * the rows matching the returned slugs so the pill can localize titles
+ * (family i18n + admin overrides) without another fetch path.
+ */
+export function notifyAchievements(
+  results: AchievementUnlockResult[],
+  catalog: Achievement[],
+): void {
+  if (results.length === 0) return
+  toast.custom(
+    // Sonner's toast row is full-width on mobile, so center the content-width
+    // pill within it — `position="bottom-center"` only centers the container.
+    (id) => (
+      <div className="flex w-full justify-center">
+        <AchievementUnlockPill toastId={id} results={results} catalog={catalog} />
+      </div>
+    ),
+    { id: ACHIEVEMENT_ACTIVITY_ID, duration: 4000 },
+  )
+}

--- a/apps/web/lib/activity/fire-achievement-check.ts
+++ b/apps/web/lib/activity/fire-achievement-check.ts
@@ -1,0 +1,26 @@
+import { notifyAchievements } from "@/lib/activity/achievement-activity"
+import type { DataProvider } from "@/lib/data/data-provider"
+
+/**
+ * Fire-and-forget achievement evaluation after a count-changing mutation (D5).
+ * Call AFTER the mutation succeeded and the store snapshot is pushed — this
+ * never blocks and never throws: the mutation already landed, and a failed
+ * check self-heals by construction (the next call re-evaluates live counts).
+ *
+ * The catalog fetch runs only when something actually unlocked (rare), and
+ * joins the returned slugs to their rows so the pill can localize titles from
+ * family i18n + admin overrides inside React — no translator plumbing needed
+ * at the six call sites.
+ */
+export function fireAchievementCheck(provider: DataProvider): void {
+  void provider
+    .checkAchievements()
+    .then(async (results) => {
+      if (results.length === 0) return
+      const catalog = await provider.getAchievements()
+      notifyAchievements(results, catalog)
+    })
+    .catch((err) => {
+      console.warn("[achievements] check_achievements failed", err)
+    })
+}

--- a/apps/web/lib/data/data-provider.ts
+++ b/apps/web/lib/data/data-provider.ts
@@ -10,6 +10,8 @@ import type {
   WalletSnapshot,
   RippleSummary,
   ProfileEngagement,
+  Achievement,
+  AchievementUnlock,
 } from "@/lib/types"
 
 // ---------------------------------------------------------------------------
@@ -82,6 +84,14 @@ export type WalletHistoryPage = {
   nextCursor: string | null
 }
 
+// One newly granted badge from `check_achievements()`. `karmaGranted` is what
+// the ledger actually received at unlock time (0 for reward-less badges),
+// never the catalog's current value.
+export type AchievementUnlockResult = {
+  slug: string
+  karmaGranted: number
+}
+
 // ---------------------------------------------------------------------------
 // Drafts (M47) — a draft is a PARTIAL compose-pebble wire payload, stored as
 // jsonb in `pebble_drafts.payload`. Deliberately keyed like the wire and not
@@ -143,6 +153,15 @@ export interface DataProvider {
   // assiduity from the get_profile_engagement RPC.
   getRipple(): Promise<RippleSummary>
   getProfileEngagement(tz: string): Promise<ProfileEngagement>
+
+  // Achievements (on-demand, not part of the eager store): the full public
+  // catalog including inactive rows (clients decide what to render), the
+  // caller's unlock ledger, and the idempotent evaluation RPC — it inserts
+  // whatever the caller now qualifies for and returns only what it NEWLY
+  // granted (empty array = nothing new).
+  getAchievements(): Promise<Achievement[]>
+  getAchievementUnlocks(): Promise<AchievementUnlock[]>
+  checkAchievements(): Promise<AchievementUnlockResult[]>
 
   listPebbles(): Promise<Pebble[]>
   getPebble(id: string): Promise<Pebble | undefined>

--- a/apps/web/lib/data/supabase-provider.ts
+++ b/apps/web/lib/data/supabase-provider.ts
@@ -14,6 +14,7 @@ import {
   type WalletHistoryPage,
   type PebbleDraftPayload,
   type PebbleDraftRecord,
+  type AchievementUnlockResult,
 } from "@/lib/data/data-provider"
 import type {
   Pebble,
@@ -27,6 +28,8 @@ import type {
   WalletSnapshot,
   RippleSummary,
   ProfileEngagement,
+  Achievement,
+  AchievementUnlock,
 } from "@/lib/types"
 import { DEFAULT_GLYPH_ID } from "@/lib/config/glyphs"
 import { processPebbleImage } from "@/lib/utils/process-pebble-image"
@@ -309,6 +312,65 @@ export class SupabaseProvider implements DataProvider {
       daysPracticed: (row?.days_practiced as number) ?? 0,
       assiduity: (row?.assiduity as boolean[]) ?? [],
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Achievements (M48) — public catalog, owner-scoped unlock ledger, and the
+  // idempotent check_achievements() evaluation RPC.
+  // ---------------------------------------------------------------------------
+
+  async getAchievements(): Promise<Achievement[]> {
+    const { data, error } = await this.supabase
+      .from("achievements")
+      .select("*")
+      .order("sort_order", { ascending: true })
+    if (error) throw new Error(`getAchievements failed: ${error.message}`)
+    return (data ?? []).map((row) => {
+      const r = row as Record<string, unknown>
+      return {
+        id: r.id as string,
+        slug: r.slug as string,
+        // The `family` CHECK constraint on the catalog makes this cast sound.
+        family: r.family as Achievement["family"],
+        threshold: (r.threshold as number | null) ?? null,
+        emotionId: (r.emotion_id as string | null) ?? null,
+        domainId: (r.domain_id as string | null) ?? null,
+        sortOrder: r.sort_order as number,
+        glyphId: (r.glyph_id as string | null) ?? null,
+        karmaReward: (r.karma_reward as number) ?? 0,
+        isActive: Boolean(r.is_active),
+        titleEn: (r.title_en as string | null) ?? null,
+        titleFr: (r.title_fr as string | null) ?? null,
+        descriptionEn: (r.description_en as string | null) ?? null,
+        descriptionFr: (r.description_fr as string | null) ?? null,
+      }
+    })
+  }
+
+  async getAchievementUnlocks(): Promise<AchievementUnlock[]> {
+    const { data, error } = await this.supabase
+      .from("achievement_unlocks")
+      .select("achievement_id, unlocked_at")
+      .eq("user_id", this.userId)
+    if (error) throw new Error(`getAchievementUnlocks failed: ${error.message}`)
+    return (data ?? []).map((row) => {
+      const r = row as Record<string, unknown>
+      return {
+        achievementId: r.achievement_id as string,
+        unlockedAt: r.unlocked_at as string,
+      }
+    })
+  }
+
+  async checkAchievements(): Promise<AchievementUnlockResult[]> {
+    // The RPC `returns table(...)`, so PostgREST yields an array of rows —
+    // empty when nothing newly unlocked.
+    const { data, error } = await this.supabase.rpc("check_achievements")
+    if (error) throw new Error(`check_achievements failed: ${error.message}`)
+    return ((data ?? []) as Record<string, unknown>[]).map((row) => ({
+      slug: row.slug as string,
+      karmaGranted: (row.karma_granted as number) ?? 0,
+    }))
   }
 
   // ---------------------------------------------------------------------------

--- a/apps/web/lib/data/useAchievements.ts
+++ b/apps/web/lib/data/useAchievements.ts
@@ -1,0 +1,63 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useDataProvider } from "@/lib/data/provider-context"
+import type { Achievement } from "@/lib/types"
+
+// Achievements are fetched on demand (not part of the eager global store load).
+// Opening the screen FIRST fires check_achievements() — the screen-open call IS
+// the retroactive grant (D5): a veteran's first visit unlocks their whole
+// history in one call — and only THEN reads catalog + unlocks, so fresh grants
+// are already in the ledger the grid renders from.
+export function useAchievements() {
+  const { provider } = useDataProvider()
+  const [achievements, setAchievements] = useState<Achievement[]>([])
+  // Unlocked achievement id → unlocked_at timestamp.
+  const [unlockedAt, setUnlockedAt] = useState<Map<string, string>>(new Map())
+  // Start in the loading state only when a provider is available to load from;
+  // without one (unauthenticated) there is nothing to fetch.
+  const [loading, setLoading] = useState(() => provider !== null)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    if (!provider) return
+    let cancelled = false
+
+    // The `await Promise.resolve()` defers state updates past the synchronous
+    // render boundary (mirrors useLab.ts) to satisfy react-hooks/set-state-in-effect.
+    void (async () => {
+      await Promise.resolve()
+      if (cancelled) return
+      setLoading(true)
+      setError(null)
+      // Evaluation failures are non-fatal: the reads below still render the
+      // current state, and the next check self-heals by construction (D5).
+      try {
+        await provider.checkAchievements()
+      } catch (err) {
+        console.warn("[achievements] check_achievements failed", err)
+      }
+      if (cancelled) return
+      try {
+        const [catalog, unlocks] = await Promise.all([
+          provider.getAchievements(),
+          provider.getAchievementUnlocks(),
+        ])
+        if (cancelled) return
+        setAchievements(catalog)
+        setUnlockedAt(new Map(unlocks.map((u) => [u.achievementId, u.unlockedAt])))
+        setLoading(false)
+      } catch (err) {
+        if (cancelled) return
+        setError(err instanceof Error ? err : new Error("Failed to load achievements"))
+        setLoading(false)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [provider])
+
+  return { achievements, unlockedAt, loading, error }
+}

--- a/apps/web/lib/data/useCollections.ts
+++ b/apps/web/lib/data/useCollections.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useDataProvider } from "@/lib/data/provider-context"
+import { fireAchievementCheck } from "@/lib/activity/fire-achievement-check"
 import type { CreateCollectionInput, UpdateCollectionInput } from "@/lib/data/data-provider"
 import type { Collection } from "@/lib/types"
 
@@ -13,6 +14,7 @@ export function useCollections() {
     if (!provider) throw new Error("Not authenticated")
     const collection = await provider.createCollection(input)
     setStore(provider.getStore())
+    fireAchievementCheck(provider)
     return collection
   }
 

--- a/apps/web/lib/data/useMarks.ts
+++ b/apps/web/lib/data/useMarks.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useDataProvider } from "@/lib/data/provider-context"
+import { fireAchievementCheck } from "@/lib/activity/fire-achievement-check"
 import type { CreateMarkInput, UpdateMarkInput } from "@/lib/data/data-provider"
 import type { Mark } from "@/lib/types"
 
@@ -11,6 +12,7 @@ export function useMarks() {
     if (!provider) throw new Error("Not authenticated")
     const mark = await provider.createMark(input)
     setStore(provider.getStore())
+    fireAchievementCheck(provider)
     return mark
   }
 

--- a/apps/web/lib/data/usePebble.ts
+++ b/apps/web/lib/data/usePebble.ts
@@ -2,6 +2,7 @@
 
 import { useDataProvider } from "@/lib/data/provider-context"
 import { notifyKarma } from "@/lib/activity/karma-activity"
+import { fireAchievementCheck } from "@/lib/activity/fire-achievement-check"
 import type { UpdatePebbleInput } from "@/lib/data/data-provider"
 import type { Pebble, PebbleSnap } from "@/lib/types"
 
@@ -22,6 +23,7 @@ export function usePebble(id: string) {
     setStore(after)
     const delta = after.karma - before
     if (delta > 0) notifyKarma(delta, "pebble_enriched")
+    fireAchievementCheck(provider)
     return updated
   }
 

--- a/apps/web/lib/data/usePebbles.ts
+++ b/apps/web/lib/data/usePebbles.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { notifyKarma } from "@/lib/activity/karma-activity"
+import { fireAchievementCheck } from "@/lib/activity/fire-achievement-check"
 import { useDataProvider } from "@/lib/data/provider-context"
 import type { CreatePebbleInput, UpdatePebbleInput } from "@/lib/data/data-provider"
 import type { Pebble, PebbleSnap } from "@/lib/types"
@@ -16,6 +17,7 @@ export function usePebbles() {
     setStore(after)
     const delta = after.karma - before
     if (delta > 0) notifyKarma(delta, "pebble_created")
+    fireAchievementCheck(provider)
     return pebble
   }
 
@@ -30,6 +32,7 @@ export function usePebbles() {
     setStore(after)
     const delta = after.karma - before
     if (delta > 0) notifyKarma(delta, "pebble_enriched")
+    fireAchievementCheck(provider)
     return pebble
   }
 

--- a/apps/web/lib/data/useSouls.ts
+++ b/apps/web/lib/data/useSouls.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useDataProvider } from "@/lib/data/provider-context"
+import { fireAchievementCheck } from "@/lib/activity/fire-achievement-check"
 import type { CreateSoulInput, UpdateSoulInput } from "@/lib/data/data-provider"
 import type { Soul } from "@/lib/types"
 
@@ -11,6 +12,7 @@ export function useSouls() {
     if (!provider) throw new Error("Not authenticated")
     const soul = await provider.createSoul(input)
     setStore(provider.getStore())
+    fireAchievementCheck(provider)
     return soul
   }
 

--- a/apps/web/lib/i18n/index.ts
+++ b/apps/web/lib/i18n/index.ts
@@ -14,6 +14,7 @@ export {
   useEmotionCategoryName,
   useDomainLocalized,
 } from "./useReferenceCatalog"
+export { useAchievementCopy, type AchievementCopy } from "./useAchievementCopy"
 export {
   formatDate,
   formatNumber,

--- a/apps/web/lib/i18n/messages/en.json
+++ b/apps/web/lib/i18n/messages/en.json
@@ -47,6 +47,10 @@
     },
     "collectionsTitle": "Collections",
     "newCollection": "New collection",
+    "achievements": {
+      "title": "Achievements",
+      "subtitle": "Badges & milestones"
+    },
     "lab": {
       "title": "Lab",
       "subtitle": "News & community"
@@ -157,7 +161,63 @@
     "glyphUnlocked": "Glyph unlocked",
     "spent": "−{amount} karma",
     "srUnlocked": "Unlocked {name} — {amount} karma spent.",
-    "viewGlyph": "View glyph"
+    "viewGlyph": "View glyph",
+    "achievementsUnlocked": "{count, plural, one {Achievement unlocked} other {# achievements unlocked}}",
+    "srAchievementUnlocked": "Achievement unlocked: {title}.",
+    "srAchievementsUnlocked": "{count, plural, one {# achievement unlocked} other {# achievements unlocked}}.",
+    "srAchievementKarma": "Earned {amount} karma.",
+    "viewAchievements": "View achievements"
+  },
+  "achievements": {
+    "title": "Achievements",
+    "loading": "Loading…",
+    "error": "Couldn't load your achievements. Please try again.",
+    "locked": "Locked",
+    "unlockedOn": "Unlocked {date}",
+    "group": {
+      "pebble_count": "Pebbles",
+      "emotion_first": "Emotions",
+      "domain_first": "Domains",
+      "first_collection": "Collections",
+      "first_glyph": "Glyphs",
+      "first_soul": "Souls",
+      "glyph_count": "Carving",
+      "glyph_sales": "Market"
+    },
+    "family": {
+      "pebble_count": {
+        "title": "{threshold, plural, one {First pebble} other {# pebbles}}",
+        "description": "{threshold, plural, one {Drop your first pebble on the path.} other {Collect # pebbles along your path.}}"
+      },
+      "emotion_first": {
+        "title": "First {name}",
+        "description": "Record your first pebble carrying {name}."
+      },
+      "domain_first": {
+        "title": "First steps in {name}",
+        "description": "Record your first pebble in {name}."
+      },
+      "first_collection": {
+        "title": "First collection",
+        "description": "Create your first collection."
+      },
+      "first_glyph": {
+        "title": "First glyph",
+        "description": "Carve your first glyph."
+      },
+      "first_soul": {
+        "title": "First soul",
+        "description": "Add your first soul."
+      },
+      "glyph_count": {
+        "title": "{threshold} glyphs",
+        "description": "Carve {threshold} glyphs of your own."
+      },
+      "glyph_sales": {
+        "title": "{threshold, plural, one {First sale} other {# sales}}",
+        "description": "{threshold, plural, one {Sell your first glyph in the market.} other {Make # glyph sales in the market.}}"
+      }
+    }
   },
   "wallet": {
     "title": "Wallet",

--- a/apps/web/lib/i18n/messages/fr.json
+++ b/apps/web/lib/i18n/messages/fr.json
@@ -47,6 +47,10 @@
     },
     "collectionsTitle": "Collections",
     "newCollection": "Nouvelle collection",
+    "achievements": {
+      "title": "Succès",
+      "subtitle": "Tes badges et jalons"
+    },
     "lab": {
       "title": "Lab",
       "subtitle": "Actus & communauté"
@@ -157,7 +161,63 @@
     "glyphUnlocked": "Glyphe débloqué",
     "spent": "−{amount} karma",
     "srUnlocked": "{name} débloqué — {amount} karma dépensés.",
-    "viewGlyph": "Voir le glyphe"
+    "viewGlyph": "Voir le glyphe",
+    "achievementsUnlocked": "{count, plural, one {Succès débloqué} other {# succès débloqués}}",
+    "srAchievementUnlocked": "Succès débloqué : {title}.",
+    "srAchievementsUnlocked": "{count, plural, one {# succès débloqué} other {# succès débloqués}}.",
+    "srAchievementKarma": "Tu as gagné {amount} karma.",
+    "viewAchievements": "Voir tes succès"
+  },
+  "achievements": {
+    "title": "Succès",
+    "loading": "Chargement…",
+    "error": "Impossible de charger tes succès. Réessaie un peu plus tard.",
+    "locked": "À débloquer",
+    "unlockedOn": "Débloqué le {date}",
+    "group": {
+      "pebble_count": "Galets",
+      "emotion_first": "Émotions",
+      "domain_first": "Domaines",
+      "first_collection": "Collections",
+      "first_glyph": "Glyphes",
+      "first_soul": "Âmes",
+      "glyph_count": "Gravure",
+      "glyph_sales": "Marché"
+    },
+    "family": {
+      "pebble_count": {
+        "title": "{threshold, plural, one {Premier galet} other {# galets}}",
+        "description": "{threshold, plural, one {Dépose ton tout premier galet sur ton chemin.} other {Rassemble # galets sur ton chemin.}}"
+      },
+      "emotion_first": {
+        "title": "Première fois : {name}",
+        "description": "Capture ton premier galet teinté par l'émotion {name}."
+      },
+      "domain_first": {
+        "title": "Premiers pas : {name}",
+        "description": "Capture ton premier galet dans le domaine {name}."
+      },
+      "first_collection": {
+        "title": "Première collection",
+        "description": "Crée ta toute première collection."
+      },
+      "first_glyph": {
+        "title": "Premier glyphe",
+        "description": "Grave ton tout premier glyphe."
+      },
+      "first_soul": {
+        "title": "Première âme",
+        "description": "Ajoute ta toute première âme."
+      },
+      "glyph_count": {
+        "title": "{threshold} glyphes",
+        "description": "Grave {threshold} glyphes de ta main."
+      },
+      "glyph_sales": {
+        "title": "{threshold, plural, one {Première vente} other {# ventes}}",
+        "description": "{threshold, plural, one {Un pebbler adopte l'un de tes glyphes.} other {Tes glyphes trouvent preneur # fois.}}"
+      }
+    }
   },
   "wallet": {
     "title": "Porte-karma",

--- a/apps/web/lib/i18n/useAchievementCopy.ts
+++ b/apps/web/lib/i18n/useAchievementCopy.ts
@@ -1,0 +1,87 @@
+"use client"
+
+import { useCallback } from "react"
+import { useTranslations } from "next-intl"
+import { useLocale } from "./useLocale"
+import { EMOTIONS } from "@/lib/config/emotions"
+import { DOMAINS } from "@/lib/config/domains"
+import type { Achievement } from "@/lib/types"
+
+export type AchievementCopy = { title: string; description: string }
+
+/**
+ * Resolve a badge's localized title & description (D7). Seeded rows carry no
+ * database copy: both strings are composed from family-keyed i18n, with
+ * `{threshold}` and — for emotion_first / domain_first — the reference
+ * entity's localized display `{name}` interpolated. When a row carries admin
+ * copy overrides (title_en/title_fr pairs), the current locale's override
+ * wins; overrides are written in pairs by the admin RPC, so the cross-language
+ * fallback is belt-and-braces only.
+ */
+export function useAchievementCopy(): (achievement: Achievement) => AchievementCopy {
+  const { locale } = useLocale()
+  // Untyped access because family and reference slugs are runtime DB values,
+  // not part of the typed message tree (mirrors useReferenceCatalog).
+  const t = useTranslations() as unknown as {
+    (key: string, values?: Record<string, string | number>): string
+    has(key: string): boolean
+  }
+
+  return useCallback(
+    (achievement: Achievement): AchievementCopy => {
+      const override =
+        locale === "fr"
+          ? {
+              title: achievement.titleFr ?? achievement.titleEn,
+              description: achievement.descriptionFr ?? achievement.descriptionEn,
+            }
+          : {
+              title: achievement.titleEn ?? achievement.titleFr,
+              description: achievement.descriptionEn ?? achievement.descriptionFr,
+            }
+
+      const values = {
+        threshold: achievement.threshold ?? 0,
+        name: referenceName(achievement, t),
+      }
+      return {
+        title: override.title ?? t(`achievements.family.${achievement.family}.title`, values),
+        description:
+          override.description ??
+          t(`achievements.family.${achievement.family}.description`, values),
+      }
+    },
+    [locale, t],
+  )
+}
+
+/**
+ * The localized emotion/domain display name interpolated into the
+ * emotion_first / domain_first patterns — resolved from the static reference
+ * config by id, then localized by slug with the DB-name fallback contract of
+ * useReferenceCatalog. Rows the config doesn't know yet (a server-side
+ * addition before the client catches up) fall back to the achievement slug's
+ * qualifier so the badge still renders something meaningful.
+ */
+function referenceName(
+  achievement: Achievement,
+  t: { (key: string): string; has(key: string): boolean },
+): string {
+  if (achievement.family === "emotion_first") {
+    const emotion = EMOTIONS.find((e) => e.id === achievement.emotionId)
+    if (emotion) {
+      const key = `emotion.${emotion.slug}.name`
+      return t.has(key) ? t(key) : emotion.name
+    }
+    return achievement.slug.replace(/^emotion-first-/, "")
+  }
+  if (achievement.family === "domain_first") {
+    const domain = DOMAINS.find((d) => d.id === achievement.domainId)
+    if (domain) {
+      const key = `domain.${domain.slug}.name`
+      return t.has(key) ? t(key) : domain.name
+    }
+    return achievement.slug.replace(/^domain-first-/, "")
+  }
+  return ""
+}

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -104,6 +104,48 @@ export type ProfileEngagement = {
   assiduity: boolean[]
 }
 
+// ---------------------------------------------------------------------------
+// Achievements (M48) — public catalog + owner-scoped unlock ledger
+// ---------------------------------------------------------------------------
+
+export type AchievementFamily =
+  | "pebble_count"
+  | "emotion_first"
+  | "domain_first"
+  | "first_collection"
+  | "first_glyph"
+  | "first_soul"
+  | "glyph_count"
+  | "glyph_sales"
+
+// One row of the public `achievements` catalog. Copy is composed client-side
+// from family-keyed i18n; the nullable EN/FR pairs are admin overrides that
+// win when present (D7). `isActive: false` retires a badge: it stops
+// evaluating and the grid hides it while locked, but earned unlocks keep
+// rendering.
+export type Achievement = {
+  id: string
+  slug: string
+  family: AchievementFamily
+  threshold: number | null
+  emotionId: string | null // emotion_first only
+  domainId: string | null // domain_first only
+  sortOrder: number
+  glyphId: string | null // system-owned visual; null → family fallback icon
+  karmaReward: number
+  isActive: boolean
+  titleEn: string | null
+  titleFr: string | null
+  descriptionEn: string | null
+  descriptionFr: string | null
+}
+
+// One row of the caller's `achievement_unlocks` ledger (permanent by design).
+export type AchievementUnlock = {
+  achievementId: string
+  unlockedAt: string
+}
+
 export type MarkStroke = {
   d: string
   width: number

--- a/docs/arkaik/bundle.json
+++ b/docs/arkaik/bundle.json
@@ -9,7 +9,7 @@
       "view_card_variant": "large"
     },
     "created_at": "2026-04-01T00:00:00.000Z",
-    "updated_at": "2026-07-30T01:15:00.000Z"
+    "updated_at": "2026-07-30T12:00:00.000Z"
   },
   "nodes": [
     {
@@ -471,7 +471,7 @@
       "species": "view",
       "title": "Achievements",
       "description": "Gallery of unlocked and upcoming achievements.",
-      "status": "idea",
+      "status": "development",
       "platforms": [
         "web",
         "ios",
@@ -945,7 +945,7 @@
       "species": "flow",
       "title": "Gamification Hub",
       "description": "Access bounce tempo, collection rise, and achievements.",
-      "status": "idea",
+      "status": "development",
       "platforms": [
         "web",
         "ios",
@@ -1127,7 +1127,7 @@
       "species": "data-model",
       "title": "Achievement",
       "description": "Unlockable reward earned through collecting and engagement.",
-      "status": "idea",
+      "status": "development",
       "platforms": [
         "web",
         "ios",
@@ -1413,7 +1413,20 @@
       "species": "api-endpoint",
       "title": "GET /achievements",
       "description": "Retrieve unlocked and available achievements.",
-      "status": "idea",
+      "status": "development",
+      "platforms": [
+        "web",
+        "ios",
+        "android"
+      ]
+    },
+    {
+      "id": "API-check-achievements",
+      "project_id": "pebbles",
+      "species": "api-endpoint",
+      "title": "POST /achievements/check",
+      "description": "Evaluate the caller's live stats against the active catalog, insert new unlocks with their karma grants, and return what was newly granted (check_achievements RPC).",
+      "status": "development",
       "platforms": [
         "web",
         "ios",
@@ -2865,6 +2878,13 @@
       "edge_type": "calls"
     },
     {
+      "id": "e-V-achievements-API-check-achievements",
+      "project_id": "pebbles",
+      "source_id": "V-achievements",
+      "target_id": "API-check-achievements",
+      "edge_type": "calls"
+    },
+    {
       "id": "e-V-weekly-cairn-API-get-weekly-cairn",
       "project_id": "pebbles",
       "source_id": "V-weekly-cairn",
@@ -3212,6 +3232,13 @@
       "project_id": "pebbles",
       "source_id": "API-get-bounce",
       "target_id": "DM-bounce",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-check-achievements-DM-achievement",
+      "project_id": "pebbles",
+      "source_id": "API-check-achievements",
+      "target_id": "DM-achievement",
       "edge_type": "queries"
     },
     {

--- a/docs/arkaik/journal.jsonl
+++ b/docs/arkaik/journal.jsonl
@@ -213,3 +213,10 @@
 {"id": "01KYR0A1QK5MNPQRSTVWXYZ235", "ts": "2026-07-30T00:30:00.000Z", "actor": "claude-code", "type": "node.updated", "node_id": "V-quick-pebble-editor", "fields": ["description"]}
 {"id": "01KYR1B2QJKMNPQRSTVWXYZ236", "ts": "2026-07-30T01:15:00.000Z", "actor": "claude-code", "type": "node.updated", "node_id": "V-pebble-drafts", "fields": ["description"]}
 {"id": "01KYR1B2QK5MNPQRSTVWXYZ237", "ts": "2026-07-30T01:15:00.000Z", "actor": "claude-code", "type": "node.updated", "node_id": "V-quick-pebble-editor", "fields": ["description"]}
+{"id": "01KYS2C3QJKMNPQRSTVWXYZ240", "ts": "2026-07-30T12:00:00.000Z", "actor": "claude-code", "type": "node.status_changed", "node_id": "V-achievements", "from": "idea", "to": "development"}
+{"id": "01KYS2C3QKKMNPQRSTVWXYZ241", "ts": "2026-07-30T12:00:00.000Z", "actor": "claude-code", "type": "node.status_changed", "node_id": "DM-achievement", "from": "idea", "to": "development"}
+{"id": "01KYS2C3QMKMNPQRSTVWXYZ242", "ts": "2026-07-30T12:00:00.000Z", "actor": "claude-code", "type": "node.status_changed", "node_id": "API-get-achievements", "from": "idea", "to": "development"}
+{"id": "01KYS2C3QNKMNPQRSTVWXYZ243", "ts": "2026-07-30T12:00:00.000Z", "actor": "claude-code", "type": "node.status_changed", "node_id": "F-gamification", "from": "idea", "to": "development"}
+{"id": "01KYS2C3QPKMNPQRSTVWXYZ244", "ts": "2026-07-30T12:00:00.000Z", "actor": "claude-code", "type": "node.created", "node_id": "API-check-achievements", "species": "api-endpoint", "title": "POST /achievements/check"}
+{"id": "01KYS2C3QQKMNPQRSTVWXYZ245", "ts": "2026-07-30T12:00:00.000Z", "actor": "claude-code", "type": "edge.added", "edge_id": "e-V-achievements-API-check-achievements", "source_id": "V-achievements", "target_id": "API-check-achievements", "edge_type": "calls"}
+{"id": "01KYS2C3QRKMNPQRSTVWXYZ246", "ts": "2026-07-30T12:00:00.000Z", "actor": "claude-code", "type": "edge.added", "edge_id": "e-API-check-achievements-DM-achievement", "source_id": "API-check-achievements", "target_id": "DM-achievement", "edge_type": "queries"}


### PR DESCRIPTION
Resolves #665

Web reference implementation of **M48 · Achievements**. Design: `docs/superpowers/specs/2026-07-29-achievements-design.md` (D5, D7, D8). Depends on #664 (merged).

## Key files

| File | What |
|---|---|
| `apps/web/lib/data/useAchievements.ts` + provider methods | on-demand catalog + unlocks read; `checkAchievements()` RPC; screen-open call fires first (the retroactive grant), never blocks the read |
| `apps/web/lib/activity/fire-achievement-check.ts` | shared fire-and-forget helper; six mutation sites are one-liners (`addPebble`, both `updatePebble`s, `addMark`, `addSoul`, `addCollection`) |
| `apps/web/lib/activity/achievement-activity.tsx` + `components/activity/AchievementUnlockPill.tsx` | Sonner pill sibling of `notifyKarma`; several unlocks collapse into one pill; tap opens `/achievements` |
| `apps/web/app/achievements/page.tsx` + `components/achievements/` | grid grouped by family in `sort_order`, locked greyed with non-color-only cues, inactive+locked hidden, no progress bars |
| `apps/web/lib/i18n/useAchievementCopy.ts` + `en.json`/`fr.json` | family-keyed copy with `{threshold}`/`{name}` interpolation; DB `title_*`/`description_*` overrides win by locale (D7); FR is a "Tu" adaptation |
| `apps/web/components/profile/AchievementsCard.tsx` | profile entry point (the showcase shelf is #669, not here) |
| `docs/arkaik/bundle.json` + `journal.jsonl` | flipped the four gamification nodes idea→development, added `API-check-achievements` + edges; validator passes |

## Implementation notes

- **Toast title resolution**: the pill resolves localized titles itself (same `useAchievementCopy` as the grid, DB overrides included), so the six fire sites need zero i18n plumbing; the helper fetches the public catalog only when a check actually returns new unlocks.
- **Unknown-family tolerance**: badge icon lookup falls back to a default and group headings fall back to the raw slug, so a server-side family added ahead of a web deploy degrades instead of crashing.
- **Arkaik hosted plane**: `$ARKAIK_TOKEN` is not available in this environment, so the hosted graph could not be mirrored — the local bundle/journal dual-write is included per current practice (see #644–#646); the hosted flips need a maintainer touch (or the ref-policy promotion on this PR).
- **Flagged, not changed** (needs approval, pre-existing string): FR `activity.srEarned` still uses "Vous" while the new copy direction is "Tu" — a karma pill and an achievement pill firing together read inconsistently to a French screen-reader user. One-line follow-up if you approve.

## Verification

`npm run lint --workspace=apps/web` clean; `npx turbo run build --filter=@pbbls/web --force` green with the `/achievements` route emitted (root `npm run build` fails only on `@pbbls/ios`'s `xcodegen`, absent on this Linux runner — pre-existing, untouched by this diff); `node .claude/skills/arkaik/scripts/validate-bundle.js` → VALID; both i18n files parse. Adversarial review pass covered RPC/type mapping against the regenerated `database.ts`, unmount safety, toast collapse, and a11y (aria-live loading, `role="alert"` error, spoken-sentence pill labels).

## Lab Note (EN/FR)

```yaml
species: feature
platform: webapp
status: in_progress
published: false
en:
  title: Badges for your journey
  summary: Your pebbles, souls, collections and glyphs now earn you achievements. Open your profile to browse every badge you have unlocked and see what is still ahead.
fr:
  title: Des badges pour ton chemin
  summary: Tes galets, tes âmes, tes collections et tes glyphes te font maintenant gagner des badges. Ouvre ton profil pour admirer ceux que tu as débloqués et repérer ceux qui t'attendent.
suggested:
  molecule: pbbls
  type: feature
  tags: [changelog]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkoQL1qxm4oYATiZYb3KZF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkoQL1qxm4oYATiZYb3KZF)_