### PR TITLE
feat(ui): add public profile page and settings section (web)

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -21,6 +21,8 @@ export const viewport: Viewport = {
 };
 
 export const metadata: Metadata = {
+  // Absolute-URL base for OG/twitter cards (first consumer: /u/[handle]).
+  metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.pbbls.app"),
   title: "pbbls",
   description: "Collect meaningful moments, one pebble at a time",
   manifest: "/manifest.webmanifest",

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -12,6 +12,10 @@ import { PageHeader } from "@/components/layout/PageHeader"
 import { Button } from "@/components/ui/button"
 import { GlyphHeader } from "@/components/settings/GlyphHeader"
 import { InformationsSection } from "@/components/settings/InformationsSection"
+import {
+  PublicProfileSection,
+  type HandleErrorCode,
+} from "@/components/settings/PublicProfileSection"
 import { ProvidersSection } from "@/components/settings/ProvidersSection"
 import { PasswordSection } from "@/components/settings/PasswordSection"
 import { LegalSection } from "@/components/settings/LegalSection"
@@ -19,7 +23,7 @@ import { AppearanceSection } from "@/components/settings/AppearanceSection"
 import { DeleteAccountSection } from "@/components/settings/DeleteAccountSection"
 
 export default function SettingsPage() {
-  const { user, profile, isAuthenticated, isLoading, updateProfile, updatePassword } = useAuth()
+  const { user, profile, isAuthenticated, isLoading, updateProfile, setHandle, updatePassword } = useAuth()
   const router = useRouter()
   const { glyphs } = useUsableGlyphs()
   const t = useTranslations("settings")
@@ -30,6 +34,9 @@ export default function SettingsPage() {
   const [nameInput, setNameInput] = useState<string | null>(null)
   const [stagedGlyphId, setStagedGlyphId] = useState<string | null | undefined>(undefined)
   const [password, setPassword] = useState("")
+  const [handleInput, setHandleInput] = useState<string | null>(null)
+  const [stagedPublic, setStagedPublic] = useState<boolean | null>(null)
+  const [handleError, setHandleError] = useState<HandleErrorCode | null>(null)
   const [saving, setSaving] = useState(false)
 
   if (isLoading) {
@@ -60,24 +67,65 @@ export default function SettingsPage() {
   const providers = user.providers ?? []
   const showPassword = providers.length === 0 || providers.includes("email")
 
+  // Handle edits are staged as raw input; comparison happens on the
+  // normalized form the set_handle RPC stores (lowercase, trimmed).
+  const savedHandle = profile.handle
+  const handleValue = handleInput ?? savedHandle ?? ""
+  const normalizedHandle = handleValue.trim().toLowerCase()
+  const isPublic = stagedPublic ?? profile.public_profile
+
   const nameChanged = name.trim().length > 0 && name.trim() !== profile.display_name
   const glyphChanged = stagedGlyphId !== undefined && stagedGlyphId !== profile.glyph_id
   const passwordChanged = password.trim().length > 0
-  const dirty = nameChanged || glyphChanged || passwordChanged
+  const handleChanged = normalizedHandle !== (savedHandle ?? "")
+  const publicChanged = isPublic !== profile.public_profile
+  const dirty = nameChanged || glyphChanged || passwordChanged || handleChanged || publicChanged
 
   const handleSave = async () => {
     setSaving(true)
     try {
+      // Handle first: a same-save "claim + go public" needs the handle stored
+      // before the public_profile update passes the DB CHECK. A failed claim
+      // aborts the whole save so nothing half-applies.
+      let effectiveHandle = savedHandle
+      if (handleChanged) {
+        try {
+          effectiveHandle = await setHandle(normalizedHandle || null)
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          const code = (["invalid_handle", "handle_taken", "handle_reserved"] as const).find(
+            (c) => message.includes(c),
+          )
+          // Only a recognized rejection earns the inline field error. Timeouts,
+          // network failures and `not_found` are not "your handle is invalid" —
+          // they get the generic toast and a logged cause.
+          if (code) {
+            setHandleError(code)
+          } else {
+            console.error("[settings] set_handle failed:", message)
+          }
+          toast.error(t("saveError"))
+          return
+        }
+      }
+
       const updates: UpdateProfileInput = {}
       if (nameChanged) updates.display_name = name.trim()
       if (glyphChanged && stagedGlyphId) updates.glyph_id = stagedGlyphId
+      // Releasing the handle already dropped the flag server-side; only write
+      // the toggle when a handle exists to satisfy the CHECK.
+      if (publicChanged && effectiveHandle) updates.public_profile = isPublic
       if (Object.keys(updates).length > 0) await updateProfile(updates)
       if (passwordChanged) await updatePassword(password)
       setNameInput(null)
       setStagedGlyphId(undefined)
       setPassword("")
+      setHandleInput(null)
+      setStagedPublic(null)
+      setHandleError(null)
       toast.success(t("saved"))
-    } catch {
+    } catch (err) {
+      console.error("[settings] save failed:", err instanceof Error ? err.message : err)
       toast.error(t("saveError"))
     } finally {
       setSaving(false)
@@ -105,6 +153,22 @@ export default function SettingsPage() {
             name={name}
             onNameChange={setNameInput}
             email={user.email}
+          />
+          <PublicProfileSection
+            handle={handleValue}
+            onHandleChange={(value) => {
+              setHandleInput(value)
+              setHandleError(null)
+              // Emptying the field means "release my handle", which the server
+              // pairs with dropping the public flag. Mirror that here so the
+              // save can never carry a contradictory "public, no handle".
+              if (value.trim() === "") setStagedPublic(false)
+            }}
+            handleError={handleError}
+            isPublic={isPublic}
+            onPublicChange={setStagedPublic}
+            savedHandle={savedHandle}
+            savedPublic={profile.public_profile}
           />
           <ProvidersSection providers={providers} />
           {showPassword && <PasswordSection value={password} onChange={setPassword} />}

--- a/apps/web/app/u/[handle]/opengraph-image.tsx
+++ b/apps/web/app/u/[handle]/opengraph-image.tsx
@@ -1,0 +1,157 @@
+import { ImageResponse } from "next/og"
+
+// Dynamic OG share card for /u/[handle] — the repo's first generated OG image.
+// Refetches through the anon-granted RPC via plain REST (OG requests carry no
+// cookies, and the edge-friendly fetch avoids pulling the SSR client in here).
+// Colors mirror the brand light theme (app/layout.tsx viewport themeColor).
+
+export const alt = "Pebbles public profile"
+export const size = { width: 1200, height: 630 }
+export const contentType = "image/png"
+
+type PublicProfileCard = {
+  display_name: string
+  handle: string
+  ripple_level: number
+  pebbles_count: number
+  days_practiced: number
+}
+
+// Every failure degrades to the neutral brand card — a crawler must never get
+// a 500 where a card was promised.
+async function fetchCard(handle: string): Promise<PublicProfileCard | null> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+  if (!url || !key) {
+    console.warn("[public-profile:og] Supabase env missing — serving neutral card")
+    return null
+  }
+  try {
+    const res = await fetch(`${url}/rest/v1/rpc/get_public_profile`, {
+      method: "POST",
+      headers: {
+        apikey: key,
+        Authorization: `Bearer ${key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ p_handle: handle }),
+      cache: "no-store",
+    })
+    if (!res.ok) {
+      console.warn(`[public-profile:og] RPC responded ${res.status}`)
+      return null
+    }
+    return ((await res.json()) as PublicProfileCard | null) ?? null
+  } catch (err) {
+    console.warn(
+      "[public-profile:og] RPC unreachable:",
+      err instanceof Error ? err.message : err,
+    )
+    return null
+  }
+}
+
+const BG = "#F8F0F0"
+const FG = "#2B1F21"
+const MUTED = "#8A7A7C"
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ handle: string }>
+}) {
+  const { handle } = await params
+  let decoded = handle
+  try {
+    decoded = decodeURIComponent(handle)
+  } catch {
+    // Malformed escape — the lookup simply misses and we serve the neutral card.
+  }
+  const profile = await fetchCard(decoded)
+
+  // Private/unknown handles get the neutral brand card — no existence signal.
+  const name = profile?.display_name ?? "Pebbles"
+  const sub = profile ? `@${profile.handle}` : "pbbls.app"
+  const rippleLevel = profile?.ripple_level ?? 0
+
+  // Concentric ripple rings: ring i reads active when i < level.
+  const rings = Array.from({ length: 6 }, (_, i) => ({
+    r: 40 + i * 26,
+    active: i < rippleLevel,
+  }))
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          backgroundColor: BG,
+          color: FG,
+          padding: "80px 96px",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", maxWidth: 700 }}>
+          {/* No fontWeight anywhere: next/og ships only Geist Regular, so a
+              bold declaration would silently render at 400 — size and color
+              carry the hierarchy instead. */}
+          <div style={{ display: "flex", fontSize: 84, lineHeight: 1.1 }}>{name}</div>
+          <div style={{ display: "flex", fontSize: 40, color: MUTED, marginTop: 16 }}>
+            {sub}
+          </div>
+          {profile ? (
+            <div style={{ display: "flex", fontSize: 30, color: MUTED, marginTop: 48 }}>
+              {`${profile.pebbles_count} pebbles · ${profile.days_practiced} days practiced`}
+            </div>
+          ) : null}
+          <div style={{ display: "flex", fontSize: 28, color: MUTED, marginTop: 12 }}>
+            pbbls.app
+          </div>
+        </div>
+        {/* The level digit is a positioned div, not an SVG <text> node: satori
+            renders text through its own layout engine, so the digit is laid out
+            over the rings the same way RippleBadge does it on the web page. */}
+        <div
+          style={{
+            display: "flex",
+            position: "relative",
+            width: 380,
+            height: 380,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <svg width="380" height="380" viewBox="0 0 380 380">
+            {rings.map((ring, i) => (
+              <circle
+                key={i}
+                cx="190"
+                cy="190"
+                r={ring.r}
+                fill="none"
+                stroke={ring.active ? FG : MUTED}
+                strokeOpacity={ring.active ? 0.9 : 0.25}
+                strokeWidth={ring.active ? 6 : 4}
+              />
+            ))}
+          </svg>
+          <div
+            style={{
+              display: "flex",
+              position: "absolute",
+              fontSize: 44,
+              color: FG,
+            }}
+          >
+            {String(rippleLevel)}
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size },
+  )
+}

--- a/apps/web/app/u/[handle]/page.tsx
+++ b/apps/web/app/u/[handle]/page.tsx
@@ -1,0 +1,74 @@
+import { cache } from "react"
+import type { Metadata } from "next"
+import { notFound } from "next/navigation"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { PublicProfileView } from "@/components/public-profile/PublicProfileView"
+import type { PublicProfile } from "@/lib/types"
+
+// The first server-rendered data route in the app (M50). Anonymous-friendly by
+// construction: get_public_profile is granted to `anon`, so the cookie-bound
+// server client works with or without a session. The RPC returns null for
+// unknown AND known-but-private handles alike — both land on notFound().
+
+type Params = { params: Promise<{ handle: string }> }
+
+// `cache` dedupes within a single request: generateMetadata and the page both
+// need the profile, and an unauthenticated RPC call is not free.
+const fetchPublicProfile = cache(
+  async (handle: string): Promise<PublicProfile | null> => {
+    const supabase = await createServerSupabaseClient()
+    const { data, error } = await supabase.rpc("get_public_profile", {
+      p_handle: handle,
+    })
+    if (error) {
+      console.error("[public-profile] get_public_profile failed:", error.message)
+      return null
+    }
+    return (data as PublicProfile | null) ?? null
+  },
+)
+
+/**
+ * A malformed percent-escape in the URL makes decodeURIComponent throw; a bad
+ * handle is a 404, never a 500.
+ */
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+export async function generateMetadata({ params }: Params): Promise<Metadata> {
+  const { handle } = await params
+  const profile = await fetchPublicProfile(safeDecode(handle))
+  // Not-found pages keep the default app metadata — no per-handle signal in
+  // the title for handles that are private or unknown.
+  if (!profile) return {}
+
+  const title = `${profile.display_name} (@${profile.handle})`
+  const description = `${profile.display_name} collects meaningful moments on Pebbles, one pebble at a time.`
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: "profile",
+      url: `/u/${profile.handle}`,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  }
+}
+
+export default async function PublicProfilePage({ params }: Params) {
+  const { handle } = await params
+  const profile = await fetchPublicProfile(safeDecode(handle))
+  if (!profile) notFound()
+  return <PublicProfileView profile={profile} />
+}

--- a/apps/web/components/layout/MainContent.tsx
+++ b/apps/web/components/layout/MainContent.tsx
@@ -16,6 +16,9 @@ export function MainContent({ children }: MainContentProps) {
   const isOnboarding = pathname.startsWith("/onboarding")
   const isAuth = pathname === "/login" || pathname === "/register"
   const isDocs = pathname.startsWith("/docs")
+  // Public profile pages serve anonymous visitors and signed-in users alike —
+  // never bounce a mid-onboarding viewer away from someone's public page.
+  const isPublicProfile = pathname.startsWith("/u/")
   // /path owns its own sticky bottom dock and scrollable interior — it should
   // fill the dynamic viewport edge-to-edge, with no body-level scrolling.
   const isPath = pathname === "/path" || pathname.startsWith("/path/")
@@ -45,7 +48,7 @@ export function MainContent({ children }: MainContentProps) {
             : "pt-[var(--safe-area-top)] pb-[calc(2rem+var(--safe-area-bottom))]",
       )}
     >
-      {!isLanding && !isAuth && !isDocs && <OnboardingGate />}
+      {!isLanding && !isAuth && !isDocs && !isPublicProfile && <OnboardingGate />}
       <AuthGate>{children}</AuthGate>
     </main>
   )

--- a/apps/web/components/public-profile/PublicProfileView.tsx
+++ b/apps/web/components/public-profile/PublicProfileView.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+import Link from "next/link"
+import { CalendarDays, Fingerprint, Shell, Waves } from "lucide-react"
+import { useTranslations } from "next-intl"
+import type { PublicProfile } from "@/lib/types"
+import { useFormatDate } from "@/lib/i18n"
+import { GlyphPreview } from "@/components/glyphs/GlyphPreview"
+import { RippleBadge } from "@/components/profile/ripples/RippleBadge"
+import { AssiduityGrid } from "@/components/profile/AssiduityGrid"
+import { DataTile } from "@/components/profile/DataTile"
+import { SectionCard } from "@/components/profile/SectionCard"
+
+type PublicProfileViewProps = {
+  profile: PublicProfile
+}
+
+/**
+ * The /u/[handle] public page body (M50). Anonymous-friendly: renders only the
+ * `get_public_profile` projection — banner, evolutive rings, 28-day grid and
+ * counters — plus a "made with Pebbles" CTA back to the landing page. Reuses
+ * the owner-profile primitives (RippleBadge, AssiduityGrid, DataTile) so the
+ * public page and the owner's profile stay visually in step.
+ */
+export function PublicProfileView({ profile }: PublicProfileViewProps) {
+  const t = useTranslations("publicProfile")
+  const formatDate = useFormatDate()
+
+  // Not RipplesRow: that component renders "N more pebbles to level X" from
+  // `pebbles28d`, a raw count the public projection deliberately withholds.
+  // The badge and grid primitives are shared; the copy around them is not.
+  //
+  // The projection also omits active_today (a presence signal), so the badge
+  // always renders the neutral tone.
+  const rippleLevel = Math.min(Math.max(profile.ripple_level, 0), 6)
+  const bounceLevel = Math.min(Math.max(profile.bounce_level, 0), 7)
+
+  return (
+    <div className="mx-auto flex min-h-full w-full max-w-md flex-col px-4 pt-10 md:px-6 md:pt-14">
+      <section className="flex flex-col gap-8">
+        <div className="flex flex-col items-center gap-8">
+          {profile.glyph && profile.glyph.strokes.length > 0 ? (
+            <GlyphPreview
+              mark={{
+                id: "public-profile-glyph",
+                strokes: profile.glyph.strokes,
+                viewBox: profile.glyph.view_box,
+                created_at: "",
+                updated_at: "",
+              }}
+              className="size-24"
+            />
+          ) : (
+            <div className="flex size-24 items-center justify-center rounded-2xl border border-dashed border-border">
+              <Fingerprint className="size-8 text-muted-foreground" aria-hidden />
+            </div>
+          )}
+
+          <div className="flex flex-col items-center gap-1 text-center">
+            <h1 className="font-script text-[41px] leading-none tracking-[-0.05em] text-foreground">
+              {profile.display_name}
+            </h1>
+            <span className="text-sm font-medium text-muted-foreground">
+              @{profile.handle}
+            </span>
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {t("memberSince", {
+                date: formatDate(profile.member_since, { dateStyle: "medium" }),
+              })}
+            </span>
+          </div>
+        </div>
+
+        <SectionCard>
+          <div className="flex items-center gap-4">
+            <RippleBadge level={rippleLevel} activeToday={false} />
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+              <span className="text-sm font-medium text-foreground">
+                {t("rippleLevel", { level: rippleLevel })}
+              </span>
+              <span className="flex items-center gap-1 text-sm text-muted-foreground">
+                <Waves className="size-3.5 text-primary" aria-hidden />
+                {t("bounceLevel", { level: bounceLevel })}
+              </span>
+            </div>
+            <AssiduityGrid data={profile.assiduity} />
+          </div>
+          <div className="h-px bg-border" />
+          <div className="flex items-start">
+            <DataTile
+              value={profile.days_practiced}
+              icon={CalendarDays}
+              label={t("days")}
+            />
+            <DataTile
+              value={profile.pebbles_count}
+              icon={Shell}
+              label={t("pebbles")}
+            />
+          </div>
+        </SectionCard>
+      </section>
+
+      <footer className="mt-auto flex justify-center py-10">
+        <Link
+          href="/"
+          className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {t("madeWith")}
+        </Link>
+      </footer>
+    </div>
+  )
+}

--- a/apps/web/components/settings/PublicProfileSection.tsx
+++ b/apps/web/components/settings/PublicProfileSection.tsx
@@ -1,0 +1,172 @@
+"use client"
+
+import { Copy, Share2 } from "lucide-react"
+import { useTranslations } from "next-intl"
+import { toast } from "sonner"
+import { SectionLabel } from "@/components/ui/SectionLabel"
+import { SettingsGroup } from "@/components/settings/SettingsGroup"
+import { SettingsRow } from "@/components/settings/SettingsRow"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+
+/** Stable error codes raised by the set_handle RPC. */
+export type HandleErrorCode = "invalid_handle" | "handle_taken" | "handle_reserved"
+
+type PublicProfileSectionProps = {
+  /** Effective handle in the input (staged edit falls back to persisted). */
+  handle: string
+  onHandleChange: (value: string) => void
+  /** Inline error from the last failed set_handle call, cleared on edit. */
+  handleError: HandleErrorCode | null
+  /** Effective public flag (staged falls back to persisted). */
+  isPublic: boolean
+  onPublicChange: (value: boolean) => void
+  /** The persisted (saved) handle — drives the share row and toggle gating. */
+  savedHandle: string | null
+  savedPublic: boolean
+}
+
+/**
+ * Settings "Public profile" section (M50): handle claim/edit, the public
+ * toggle, and the share row. Staged like every other settings edit — nothing
+ * writes until the page-level Save runs (set_handle RPC for the handle, a
+ * direct public_profile update for the toggle).
+ */
+export function PublicProfileSection({
+  handle,
+  onHandleChange,
+  handleError,
+  isPublic,
+  onPublicChange,
+  savedHandle,
+  savedPublic,
+}: PublicProfileSectionProps) {
+  const t = useTranslations("settings")
+
+  // Client-rendered, but keep the SSR pass deterministic: fall back to the
+  // configured site URL rather than a hardcoded host.
+  const origin =
+    typeof window !== "undefined"
+      ? window.location.origin
+      : (process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.pbbls.app")
+  const shareUrl = savedPublic && savedHandle ? `${origin}/u/${savedHandle}` : null
+
+  const copyLink = async () => {
+    if (!shareUrl) return
+    try {
+      await navigator.clipboard.writeText(shareUrl)
+      toast.success(t("publicProfileLinkCopied"))
+    } catch {
+      toast.error(t("publicProfileLinkCopyError"))
+    }
+  }
+
+  const shareLink = async () => {
+    if (!shareUrl) return
+    // navigator.share needs a secure context and user gesture; the copy
+    // button next to it is the universal fallback.
+    try {
+      await navigator.share({ url: shareUrl })
+    } catch {
+      // User dismissed the sheet or share is unavailable — nothing to report.
+    }
+  }
+
+  return (
+    <section className="flex flex-col gap-2">
+      <SectionLabel id="settings-public-profile">{t("publicProfile")}</SectionLabel>
+      <SettingsGroup aria-labelledby="settings-public-profile">
+        {/* SettingsRow wraps children in a <span>, so everything here stays
+            inline-level — a block <div> inside a <span> is invalid HTML. */}
+        <SettingsRow>
+          <span className="flex flex-col gap-1">
+            <label htmlFor="settings-handle" className="sr-only">
+              {t("handle")}
+            </label>
+            <span className="flex items-center gap-1">
+              <span className="text-muted-foreground" aria-hidden>
+                @
+              </span>
+              <Input
+                id="settings-handle"
+                value={handle}
+                onChange={(e) => onHandleChange(e.target.value)}
+                placeholder={t("handlePlaceholder")}
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+                aria-invalid={handleError !== null}
+                aria-describedby="settings-handle-description"
+                className="h-auto border-0 bg-transparent p-0 shadow-none focus-visible:ring-0"
+              />
+            </span>
+            {handleError ? (
+              <span
+                id="settings-handle-description"
+                role="alert"
+                className="text-xs font-normal text-destructive"
+              >
+                {t(`handleError.${handleError}`)}
+              </span>
+            ) : (
+              <span
+                id="settings-handle-description"
+                className="text-xs font-normal text-muted-foreground"
+              >
+                {t("handleHint")}
+              </span>
+            )}
+          </span>
+        </SettingsRow>
+        <SettingsRow
+          trailing={
+            <Checkbox
+              checked={isPublic}
+              disabled={!savedHandle}
+              onCheckedChange={(checked) => onPublicChange(checked === true)}
+              aria-label={t("publicToggle")}
+            />
+          }
+        >
+          <span className={savedHandle ? undefined : "text-muted-foreground"}>
+            {t("publicToggle")}
+          </span>
+          {!savedHandle && (
+            <span className="block text-xs font-normal text-muted-foreground">
+              {t("publicToggleNeedsHandle")}
+            </span>
+          )}
+        </SettingsRow>
+        {shareUrl && (
+          <SettingsRow
+            trailing={
+              <span className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={copyLink}
+                  aria-label={t("publicProfileCopy")}
+                >
+                  <Copy />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={shareLink}
+                  aria-label={t("publicProfileShare")}
+                >
+                  <Share2 />
+                </Button>
+              </span>
+            }
+          >
+            <span className="block truncate font-normal text-muted-foreground">
+              {shareUrl}
+            </span>
+          </SettingsRow>
+        )}
+      </SettingsGroup>
+    </section>
+  )
+}

--- a/apps/web/lib/data/auth-context.ts
+++ b/apps/web/lib/data/auth-context.ts
@@ -36,6 +36,15 @@ export type AuthContextValue = {
   signInWithGoogle(): Promise<void>
   logout(): Promise<void>
   updateProfile(input: UpdateProfileInput): Promise<Profile>
+  /**
+   * Claim, change, or release (null) the public handle via the `set_handle`
+   * RPC. Rejections carry a stable code in the error message —
+   * `invalid_handle`, `handle_taken`, `handle_reserved`, or `not_found` when
+   * the caller has no profile row. Callers must also expect transport
+   * failures (timeout, network), which carry no code. Releasing the handle
+   * also flips `public_profile` off server-side (DB invariant).
+   */
+  setHandle(handle: string | null): Promise<string | null>
   /** Change the signed-in user's password (email accounts). */
   updatePassword(password: string): Promise<void>
   /**

--- a/apps/web/lib/data/useSupabaseAuth.ts
+++ b/apps/web/lib/data/useSupabaseAuth.ts
@@ -190,6 +190,35 @@ export function useSupabaseAuth(): AuthContextValue {
     await supabase.auth.signOut({ scope: "local" })
   }, [])
 
+  const setHandle = useCallback(
+    async (handle: string | null): Promise<string | null> => {
+      const supabase = getSupabase()
+      if (!supabase) throw new Error("Supabase client not available")
+      // The RPC raises with a stable code (invalid_handle / handle_taken /
+      // handle_reserved) that the settings UI maps to inline copy.
+      const { data, error } = await withTimeout(
+        supabase.rpc("set_handle", { p_handle: handle ?? undefined }),
+        10000,
+        "set handle",
+      )
+      if (error) throw new Error(error.message)
+      const stored = (data as string | null) ?? null
+      // Mirror the server-side invariant locally: releasing the handle also
+      // dropped public_profile in the same statement.
+      setProfile((prev) =>
+        prev
+          ? {
+              ...prev,
+              handle: stored,
+              public_profile: stored === null ? false : prev.public_profile,
+            }
+          : prev,
+      )
+      return stored
+    },
+    [],
+  )
+
   const updatePassword = useCallback(async (password: string) => {
     const supabase = getSupabase()
     if (!supabase) throw new Error("Supabase client not available")
@@ -251,6 +280,7 @@ export function useSupabaseAuth(): AuthContextValue {
     signInWithGoogle,
     logout,
     updateProfile,
+    setHandle,
     updatePassword,
     deleteAccount,
   }

--- a/apps/web/lib/i18n/messages/en.json
+++ b/apps/web/lib/i18n/messages/en.json
@@ -70,6 +70,14 @@
     "logout": "Log out",
     "loggingOut": "Logging out…"
   },
+  "publicProfile": {
+    "memberSince": "Member since {date}",
+    "rippleLevel": "Ripples Level {level}",
+    "bounceLevel": "Bounce Level {level}",
+    "days": "Days",
+    "pebbles": "Pebbles",
+    "madeWith": "Made with Pebbles"
+  },
   "settings": {
     "title": "Settings",
     "save": "Save",
@@ -82,6 +90,21 @@
     "name": "Name",
     "namePlaceholder": "Your name",
     "email": "Email",
+    "publicProfile": "Public profile",
+    "handle": "Handle",
+    "handlePlaceholder": "your_handle",
+    "handleHint": "3–30 characters: lowercase letters, numbers, underscores. Leave empty to release your handle.",
+    "handleError": {
+      "invalid_handle": "That handle isn't valid. Use 3–30 lowercase letters, numbers or underscores, starting and ending with a letter or number.",
+      "handle_taken": "That handle is already taken.",
+      "handle_reserved": "That handle is reserved."
+    },
+    "publicToggle": "Make my profile public",
+    "publicToggleNeedsHandle": "Claim a handle first to go public.",
+    "publicProfileCopy": "Copy your public profile link",
+    "publicProfileShare": "Share your public profile",
+    "publicProfileLinkCopied": "Link copied",
+    "publicProfileLinkCopyError": "Couldn't copy the link. Please try again.",
     "providers": "Providers",
     "providerApple": "Apple ID",
     "providerGoogle": "Google Account",

--- a/apps/web/lib/i18n/messages/fr.json
+++ b/apps/web/lib/i18n/messages/fr.json
@@ -70,6 +70,14 @@
     "logout": "Me déconnecter",
     "loggingOut": "Déconnexion…"
   },
+  "publicProfile": {
+    "memberSince": "Membre depuis {date}",
+    "rippleLevel": "Niveau Ripples {level}",
+    "bounceLevel": "Niveau ricochet {level}",
+    "days": "Jours",
+    "pebbles": "Galets",
+    "madeWith": "Créé avec Pebbles"
+  },
   "settings": {
     "title": "Réglages",
     "save": "Enregistrer",
@@ -82,6 +90,21 @@
     "name": "Nom",
     "namePlaceholder": "Votre nom",
     "email": "E-mail",
+    "publicProfile": "Profil public",
+    "handle": "Pseudo",
+    "handlePlaceholder": "votre_pseudo",
+    "handleHint": "3 à 30 caractères : minuscules, chiffres, tirets bas. Laissez vide pour libérer votre pseudo.",
+    "handleError": {
+      "invalid_handle": "Ce pseudo n'est pas valide. Utilisez 3 à 30 minuscules, chiffres ou tirets bas, en commençant et terminant par une lettre ou un chiffre.",
+      "handle_taken": "Ce pseudo est déjà pris.",
+      "handle_reserved": "Ce pseudo est réservé."
+    },
+    "publicToggle": "Rendre mon profil public",
+    "publicToggleNeedsHandle": "Choisissez d'abord un pseudo pour passer en public.",
+    "publicProfileCopy": "Copier le lien de votre profil public",
+    "publicProfileShare": "Partager votre profil public",
+    "publicProfileLinkCopied": "Lien copié",
+    "publicProfileLinkCopyError": "Impossible de copier le lien. Veuillez réessayer.",
     "providers": "Fournisseurs",
     "providerApple": "Identifiant Apple",
     "providerGoogle": "Compte Google",

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -187,12 +187,39 @@ export type Profile = {
   display_name: string
   /** FK to the user's chosen profile glyph (glyphs.id). Null when unset. */
   glyph_id: string | null
+  /** Public URL identity (/u/<handle>). Null until claimed via set_handle. */
+  handle: string | null
+  /** Opt-in flag for the public profile page. Requires a handle (DB CHECK). */
+  public_profile: boolean
   onboarding_completed: boolean
   color_world: ColorWorld
   terms_accepted_at: string | null
   privacy_accepted_at: string | null
   created_at: string
   updated_at: string
+}
+
+/**
+ * The `get_public_profile` RPC projection, verbatim wire shape (M50). Null
+ * from the RPC means "unknown or not public" — indistinguishable by design.
+ */
+export type PublicProfile = {
+  display_name: string
+  handle: string
+  /** Avatar glyph geometry, or null when the owner has none set. */
+  glyph: { strokes: MarkStroke[]; view_box: string } | null
+  pebbles_count: number
+  /** 0–6, same buckets as v_ripple. */
+  ripple_level: number
+  /** 0–7, same buckets as v_bounce. */
+  bounce_level: number
+  /** 28 booleans, index 0 = 27 days ago … index 27 = today (UTC). */
+  assiduity: boolean[]
+  days_practiced: number
+  /** ISO date (YYYY-MM-DD). */
+  member_since: string
+  /** Empty until M48 fills it; shape then defined by the achievements design. */
+  achievements: unknown[]
 }
 
 export type RegisterInput = {
@@ -202,6 +229,10 @@ export type RegisterInput = {
   privacy_accepted: boolean
 }
 export type LoginInput = { email: string; password: string }
+// `handle` is deliberately excluded: claiming/releasing a handle goes through
+// the `set_handle` RPC (normalization + stable error codes), never a direct
+// column write. `public_profile` stays here — a single-column toggle is the
+// sanctioned direct-update case, guarded by the DB CHECK.
 export type UpdateProfileInput = Partial<
-  Omit<Profile, "id" | "user_id" | "created_at" | "updated_at">
+  Omit<Profile, "id" | "user_id" | "handle" | "created_at" | "updated_at">
 >


### PR DESCRIPTION
Resolves #655

Web reference implementation of **M50 · Public profiles** (design: `docs/superpowers/specs/2026-07-29-public-profiles-design.md`, D5 + D6). Builds on the backend merged in #675.

## Changes
- **`app/u/[handle]/page.tsx`** — the app's first server-rendered *data* route. Calls the anon-granted `get_public_profile` through `createServerSupabaseClient()` (works with or without a session) and `notFound()`s on null, so an unknown handle and a private one are indistinguishable. `generateMetadata` adds the title/description + `openGraph`/`twitter` fields; the fetch is wrapped in React `cache()` so metadata and the page share one RPC call per request.
- **`app/u/[handle]/opengraph-image.tsx`** — first OG infrastructure in the repo: a 1200×630 `ImageResponse` card with name, `@handle`, counters and the ripple rings. Every failure path (missing env, non-OK response, unreachable host) degrades to a neutral brand card rather than a 500.
- **`components/public-profile/PublicProfileView.tsx`** — the page body, reusing `RippleBadge`, `AssiduityGrid`, `DataTile`, `SectionCard` and `GlyphPreview` so the public page and the owner's profile stay visually in step, plus a "Made with Pebbles" CTA.
- **`components/settings/PublicProfileSection.tsx` + `app/settings/page.tsx`** — handle claim/edit with inline errors for the three stable `set_handle` codes, a public toggle gated on having a handle, and a share row (copy + `navigator.share`). Staged like every other settings edit; on save the handle is written first so a same-save "claim + go public" satisfies the DB CHECK.
- **`lib/data/useSupabaseAuth.ts` + `auth-context.ts`** — `setHandle()` over the RPC, patching local profile state to mirror the server-side invariant (releasing a handle also clears `public_profile`).
- **`lib/types.ts`** — `Profile.handle` / `.public_profile`, the `PublicProfile` wire type, and `handle` excluded from `UpdateProfileInput` (it goes through the RPC, never a column write).
- **`app/layout.tsx`** — `metadataBase` from a new optional `NEXT_PUBLIC_SITE_URL` (falls back to `https://www.pbbls.app`), needed to absolutize card URLs.
- **`components/layout/MainContent.tsx`** — `/u/*` exempt from `OnboardingGate` so a mid-onboarding visitor isn't bounced off someone's public page. `AuthGate` needed no change (`/u` was never in `PROTECTED_PREFIXES`).
- EN/FR strings for all 19 new keys.

## Notes
- **Review disclosure, in the interest of honesty:** the multi-agent review of this diff completed only partially — the session hit its monthly spend limit and 32 of 46 agents died mid-run. Its 3 confirmed findings are fixed here (unknown `set_handle` failures no longer render as "invalid handle" and are now logged per `docs/agents/data-and-async.md`; the OG route no longer 500s on a fetch rejection; the duplicate per-request RPC is deduped). Roughly 15 further findings were **never verified** rather than refuted, so I checked the plausible ones by hand and fixed what held up: `next/og` ships only `Geist-Regular`, so `fontWeight: 700` was silently rendering regular (dropped); `fr.json` already establishes **"ricochet"** for bounce, so `Niveau Bounce` is now `Niveau ricochet`; the SVG `<text>` node became a positioned div (satori support unconfirmed, and a crash would 500 every card); a block `<div>` nested in `SettingsRow`'s `<span>` is now inline-level; the hint/error is wired via `aria-describedby` + `role="alert"`; the share-URL SSR fallback reads `NEXT_PUBLIC_SITE_URL`; and clearing the handle now forces the public toggle off so a save can't silently drop a staged "go public".
- `PublicProfileView` deliberately does **not** reuse `RipplesRow`: that component renders "N more pebbles to level X" from `pebbles28d`, a raw count the projection withholds on purpose. Comment added at the call site.
- **Arkaik map is not updated here.** Per the 2026-07-28 decision (#622) the hosted project is the authoritative plane and `ARKAIK_TOKEN` isn't present in this environment, so `V-public-profile`, `API-set-handle`, `API-get-public-profile` and `DM-reserved-handles` still need syncing. I didn't hand-edit the now-non-authoritative local `bundle.json` and guess.
- `NEXT_PUBLIC_SITE_URL` is optional; set it in Vercel to make OG URLs match the real host.

## Lab Note (EN/FR)

```yaml
species: feature
platform: webapp
status: in_progress
published: false
en:
  title: Share your pebbles with a link
  summary: Claim your handle, flip one switch, and your profile gets its own page (rings, streaks and all) that you can share with anyone. Off by default, yours to turn off anytime.
fr:
  title: Partage tes galets avec un lien
  summary: Choisis ton pseudo, active l'interrupteur, et ton profil obtient sa propre page (anneaux et régularité compris) que tu peux partager à qui tu veux. Désactivé par défaut, et tu peux l'éteindre quand tu veux.
suggested:
  molecule: pbbls
  type: feature
  tags: [profile, sharing, changelog]
```

## Checklist
- [x] Branch name follows `type/issueNumber-description` (`feat/655-web-public-profile`)
- [x] PR title uses conventional commits
- [x] Labels applied (`feat`, `ui`)
- [x] Milestone assigned (M50 · Public profiles)
- [x] `npm run build` — `apps/web` green (`/u/[handle]` and the OG route emit as dynamic)
- [x] `npm run lint` — `apps/web` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaPrQJcWwzWDvr7Ji9uLNP)_