### PR TITLE
feat(ios): add public profile section in settings

### DIFF
--- a/apps/ios/Pebbles/Features/Profile/ProfileView.swift
+++ b/apps/ios/Pebbles/Features/Profile/ProfileView.swift
@@ -5,11 +5,15 @@ private struct ProfileRow: Decodable {
     var displayName: String?
     let createdAt: Date
     var glyphId: UUID?
+    var handle: String?
+    var publicProfile: Bool
 
     enum CodingKeys: String, CodingKey {
-        case displayName = "display_name"
-        case createdAt   = "created_at"
-        case glyphId     = "glyph_id"
+        case displayName   = "display_name"
+        case createdAt     = "created_at"
+        case glyphId       = "glyph_id"
+        case handle        = "handle"
+        case publicProfile = "public_profile"
     }
 }
 
@@ -74,11 +78,15 @@ struct ProfileView: View {
                 initialDisplayName: profile?.displayName ?? "",
                 initialGlyphId: profile?.glyphId,
                 initialGlyphStrokes: glyphStrokes,
+                initialHandle: profile?.handle,
+                initialPublicProfile: profile?.publicProfile ?? false,
                 email: supabase.session?.user.email,
-                onSaved: { newName, newGlyph in
+                onSaved: { newName, newGlyph, newHandle, isPublic in
                     if var current = profile {
                         current.displayName = newName
                         current.glyphId = newGlyph?.id ?? current.glyphId
+                        current.handle = newHandle
+                        current.publicProfile = isPublic
                         profile = current
                     }
                     if let strokes = newGlyph?.strokes {
@@ -94,7 +102,7 @@ struct ProfileView: View {
         do {
             let row: ProfileRow = try await supabase.client
                 .from("profiles")
-                .select("display_name, created_at, glyph_id")
+                .select("display_name, created_at, glyph_id, handle, public_profile")
                 .single().execute().value
             self.profile = row
             self.hasLoadedProfile = true

--- a/apps/ios/Pebbles/Features/Profile/Sheets/SettingsSheet.swift
+++ b/apps/ios/Pebbles/Features/Profile/Sheets/SettingsSheet.swift
@@ -10,8 +10,10 @@ struct SettingsSheet: View {
     let initialDisplayName: String
     let initialGlyphId: UUID?
     let initialGlyphStrokes: [GlyphStroke]?
+    let initialHandle: String?
+    let initialPublicProfile: Bool
     let email: String?
-    let onSaved: (_ displayName: String, _ glyph: Glyph?) -> Void
+    let onSaved: (_ displayName: String, _ glyph: Glyph?, _ handle: String?, _ isPublic: Bool) -> Void
 
     @Environment(SupabaseService.self) private var supabase
     @Environment(\.dismiss) private var dismiss
@@ -20,6 +22,9 @@ struct SettingsSheet: View {
     @State private var pickedGlyph: Glyph?
     @State private var currentPassword: String = ""
     @State private var newPassword: String = ""
+    @State private var handle: String
+    @State private var isPublicProfile: Bool
+    @State private var handleError: String?
     @State private var isSaving = false
     @State private var saveError: String?
     @State private var presentedLegalDoc: LegalDoc?
@@ -29,7 +34,7 @@ struct SettingsSheet: View {
     @State private var deleteError: String?
     @FocusState private var focusedField: Field?
 
-    private enum Field: Hashable { case displayName, newPassword }
+    private enum Field: Hashable { case displayName, newPassword, handle }
 
     private let logger = Logger(subsystem: "app.pbbls.ios", category: "settings-sheet")
 
@@ -37,26 +42,53 @@ struct SettingsSheet: View {
         initialDisplayName: String,
         initialGlyphId: UUID?,
         initialGlyphStrokes: [GlyphStroke]?,
+        initialHandle: String? = nil,
+        initialPublicProfile: Bool = false,
         email: String?,
-        onSaved: @escaping (_ displayName: String, _ glyph: Glyph?) -> Void
+        onSaved: @escaping (_ displayName: String, _ glyph: Glyph?, _ handle: String?, _ isPublic: Bool) -> Void
     ) {
         self.initialDisplayName = initialDisplayName
         self.initialGlyphId = initialGlyphId
         self.initialGlyphStrokes = initialGlyphStrokes
+        self.initialHandle = initialHandle
+        self.initialPublicProfile = initialPublicProfile
         self.email = email
         self.onSaved = onSaved
         self._displayName = State(initialValue: initialDisplayName)
+        self._handle = State(initialValue: initialHandle ?? "")
+        self._isPublicProfile = State(initialValue: initialPublicProfile)
     }
 
     private var trimmedDisplayName: String {
         displayName.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Handles are stored normalized (see the DB CHECK), so every comparison
+    /// and write uses the lowercased, trimmed form.
+    private var normalizedHandle: String {
+        handle.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private var handleChanged: Bool {
+        normalizedHandle != (initialHandle ?? "")
+    }
+
+    private var publicProfileChanged: Bool {
+        isPublicProfile != initialPublicProfile
+    }
+
     private var isDirty: Bool {
         let nameChanged = trimmedDisplayName != initialDisplayName && !trimmedDisplayName.isEmpty
         let glyphChanged = pickedGlyph != nil && pickedGlyph?.id != initialGlyphId
         let passwordSet = !newPassword.isEmpty
-        return nameChanged || glyphChanged || passwordSet
+        return nameChanged || glyphChanged || passwordSet || handleChanged || publicProfileChanged
+    }
+
+    /// The share row reflects what is actually live on the server, not staged
+    /// edits — a link to an unsaved handle would 404.
+    private var shareURL: URL? {
+        guard initialPublicProfile, let saved = initialHandle, !saved.isEmpty else { return nil }
+        return URL(string: "https://www.pbbls.app/u/\(saved)")
     }
 
     private var currentStrokes: [GlyphStroke]? {
@@ -68,6 +100,7 @@ struct SettingsSheet: View {
             List {
                 headerSection
                 informationsSection
+                publicProfileSection
                 if isSSO {
                     providersSection
                 } else {
@@ -241,6 +274,73 @@ struct SettingsSheet: View {
         }
     }
 
+    /// Public profile (M50): claim a handle, opt in, then share the link.
+    /// The toggle stays disabled until a handle is live on the server — the DB
+    /// CHECK rejects `public_profile = true` with no handle.
+    private var publicProfileSection: some View {
+        Section {
+            HStack {
+                Text("Handle")
+                    .foregroundStyle(Color.system.secondary)
+                Spacer()
+                Text(verbatim: "@")
+                    .foregroundStyle(Color.system.secondary)
+                TextField("your_handle", text: $handle)
+                    .multilineTextAlignment(.trailing)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                    .focused($focusedField, equals: .handle)
+                    .submitLabel(.done)
+                    .onSubmit { focusedField = nil }
+                    .onChange(of: handle) { _, newValue in
+                        handleError = nil
+                        // Emptying the field means "release my handle", which the
+                        // server pairs with dropping the public flag. Mirror it so
+                        // a save can never carry "public, no handle".
+                        if newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            isPublicProfile = false
+                        }
+                    }
+            }
+            .pebblesListRow(position: .top)
+
+            Toggle(isOn: $isPublicProfile) {
+                Text("Make my profile public")
+                    .foregroundStyle(
+                        initialHandle == nil ? Color.system.secondary : Color.system.foreground
+                    )
+            }
+            .tint(Color.accent.primary)
+            .disabled(initialHandle == nil)
+            .pebblesListRow(position: shareURL == nil ? .bottom : .middle)
+
+            if let shareURL {
+                ShareLink(item: shareURL) {
+                    HStack {
+                        Label("Share my profile", systemImage: "square.and.arrow.up")
+                        Spacer()
+                        Text(verbatim: shareURL.absoluteString)
+                            .font(.footnote)
+                            .foregroundStyle(Color.system.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                }
+                .pebblesListRow(position: .bottom)
+            }
+        } header: {
+            Text("Public profile").pebblesSectionHeader()
+        } footer: {
+            if let handleError {
+                Text(handleError).foregroundStyle(.red)
+            } else if initialHandle == nil {
+                Text("Claim a handle first to go public.")
+            } else {
+                Text("3 to 30 characters: lowercase letters, numbers, underscores. Leave empty to release your handle.")
+            }
+        }
+    }
+
     private var passwordSection: some View {
         Section {
             SecureField("New password", text: $newPassword)
@@ -315,10 +415,29 @@ struct SettingsSheet: View {
         }
     }
 
+    /// Maps a `set_handle` rejection to its user-facing reason. The RPC raises
+    /// stable codes (`invalid_handle` / `handle_taken` / `handle_reserved`);
+    /// anything else — `not_found`, a timeout, a dropped connection — is not a
+    /// verdict on the handle, so it falls through to the generic save error.
+    private func handleErrorMessage(for error: Error) -> String? {
+        let description = "\(error)"
+        if description.contains("handle_taken") {
+            return String(localized: "That handle is already taken.")
+        }
+        if description.contains("handle_reserved") {
+            return String(localized: "That handle is reserved.")
+        }
+        if description.contains("invalid_handle") {
+            return String(localized: "That handle isn't valid. Use 3 to 30 lowercase letters, numbers or underscores, starting and ending with a letter or number.")
+        }
+        return nil
+    }
+
     private func save() async {
         guard isDirty, !isSaving else { return }
         isSaving = true
         saveError = nil
+        handleError = nil
 
         let nameToSend: String? = {
             let trimmed = trimmedDisplayName
@@ -329,6 +448,28 @@ struct SettingsSheet: View {
             return picked.id.uuidString
         }()
         let passwordToSend: String? = newPassword.isEmpty ? nil : newPassword
+
+        // Handle first: claiming and going public in one save needs the handle
+        // stored before the public_profile write can pass the DB CHECK.
+        var savedHandle = initialHandle
+        if handleChanged {
+            do {
+                let claimed = normalizedHandle.isEmpty ? nil : normalizedHandle
+                try await supabase.client
+                    .rpc("set_handle", params: SetHandleParams(p_handle: claimed))
+                    .execute()
+                savedHandle = claimed
+            } catch {
+                logger.error("set_handle failed: \(error.localizedDescription, privacy: .private)")
+                if let message = handleErrorMessage(for: error) {
+                    handleError = message
+                } else {
+                    saveError = String(localized: "Couldn't save your changes. Please try again.")
+                }
+                isSaving = false
+                return
+            }
+        }
 
         do {
             if nameToSend != nil || glyphIdToSend != nil {
@@ -341,20 +482,42 @@ struct SettingsSheet: View {
                     .execute()
             }
 
+            // Single-column toggle: the sanctioned direct-update case (root
+            // AGENTS.md). Releasing the handle already cleared the flag
+            // server-side, so only write it while a handle exists.
+            if publicProfileChanged, savedHandle != nil, let userId = supabase.session?.user.id {
+                try await supabase.client
+                    .from("profiles")
+                    .update(["public_profile": isPublicProfile])
+                    .eq("user_id", value: userId)
+                    .execute()
+            }
+
             if let passwordToSend {
                 _ = try await supabase.client.auth.update(
                     user: UserAttributes(password: passwordToSend)
                 )
             }
 
-            onSaved(nameToSend ?? initialDisplayName, pickedGlyph)
+            onSaved(
+                nameToSend ?? initialDisplayName,
+                pickedGlyph,
+                savedHandle,
+                savedHandle == nil ? false : isPublicProfile
+            )
             dismiss()
         } catch {
             logger.error("settings save failed: \(error.localizedDescription, privacy: .private)")
-            saveError = "Couldn't save your changes. Please try again."
+            saveError = String(localized: "Couldn't save your changes. Please try again.")
             isSaving = false
         }
     }
+}
+
+/// Wire shape for `set_handle`. A null handle releases it (and drops the
+/// public flag) server-side.
+private struct SetHandleParams: Encodable {
+    let p_handle: String?
 }
 
 /// Wire shape for `update_profile` RPC. Null fields tell Postgres "don't change".
@@ -368,8 +531,10 @@ private struct UpdateProfileParams: Encodable {
         initialDisplayName: "Alexis",
         initialGlyphId: nil,
         initialGlyphStrokes: nil,
+        initialHandle: "alexis",
+        initialPublicProfile: true,
         email: "hello@bohns.design",
-        onSaved: { _, _ in }
+        onSaved: { _, _, _, _ in }
     )
     .environment(SupabaseService())
 }

--- a/apps/ios/Pebbles/Resources/Localizable.xcstrings
+++ b/apps/ios/Pebbles/Resources/Localizable.xcstrings
@@ -1,6 +1,176 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "3 to 30 characters: lowercase letters, numbers, underscores. Leave empty to release your handle." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3 to 30 characters: lowercase letters, numbers, underscores. Leave empty to release your handle."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3 \u00e0 30 caract\u00e8res : minuscules, chiffres, tirets bas. Laissez vide pour lib\u00e9rer votre pseudo."
+          }
+        }
+      }
+    },
+    "Claim a handle first to go public." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Claim a handle first to go public."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisissez d'abord un pseudo pour passer en public."
+          }
+        }
+      }
+    },
+    "Handle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Handle"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pseudo"
+          }
+        }
+      }
+    },
+    "Make my profile public" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make my profile public"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rendre mon profil public"
+          }
+        }
+      }
+    },
+    "Public profile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Public profile"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profil public"
+          }
+        }
+      }
+    },
+    "Share my profile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share my profile"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Partager mon profil"
+          }
+        }
+      }
+    },
+    "That handle is already taken." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That handle is already taken."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce pseudo est d\u00e9j\u00e0 pris."
+          }
+        }
+      }
+    },
+    "That handle is reserved." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That handle is reserved."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce pseudo est r\u00e9serv\u00e9."
+          }
+        }
+      }
+    },
+    "That handle isn't valid. Use 3 to 30 lowercase letters, numbers or underscores, starting and ending with a letter or number." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "That handle isn't valid. Use 3 to 30 lowercase letters, numbers or underscores, starting and ending with a letter or number."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce pseudo n'est pas valide. Utilisez 3 \u00e0 30 minuscules, chiffres ou tirets bas, en commen\u00e7ant et terminant par une lettre ou un chiffre."
+          }
+        }
+      }
+    },
+    "your_handle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "your_handle"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "votre_pseudo"
+          }
+        }
+      }
+    },
     "" : {
 
     },


### PR DESCRIPTION
Resolves #656

iOS surface of **M50 · Public profiles** (design: `docs/superpowers/specs/2026-07-29-public-profiles-design.md`, D6). Mirrors the web reference merged in #677; backend in #675.

## Changes
- **`Features/Profile/Sheets/SettingsSheet.swift`** — new "Public profile" `Section` between Informations and Providers/Password, built from the existing `.pebblesListRow(position:)` / `.pebblesSectionHeader()` chrome:
  - Handle `TextField` (`.textInputAutocapitalization(.never)`, autocorrection off) with an `@` prefix. Clearing it forces the public toggle off, so a save can never carry a contradictory "public, no handle".
  - Public `Toggle`, disabled until a handle is live on the server — the DB CHECK rejects `public_profile = true` with no handle.
  - `ShareLink` row for `https://www.pbbls.app/u/{handle}`, shown only when the *saved* state is public (a link to a staged, unsaved handle would 404). **First `ShareLink` in the app.**
  - Footer doubles as the inline error slot for the three stable `set_handle` codes; anything else (`not_found`, timeout, dropped connection) is not a verdict on the handle and falls through to the generic save error, logged via `os.Logger`.
  - `save()` writes the handle **first** so claiming and going public in one save satisfies the CHECK; the toggle is a direct single-column update (the sanctioned direct-write case per root `AGENTS.md`), mirroring the existing `patchDisplayNameIfDefault` pattern in `SupabaseService`.
- **`Features/Profile/ProfileView.swift`** — `ProfileRow` and its `select` gain `handle` + `public_profile`; the sheet receives them as initial values and the `onSaved` callback carries the new state back so the view doesn't need a refetch.
- **`Resources/Localizable.xcstrings`** — 10 new keys, each with `en` + `fr` (`vous`-form, matching the sheet's existing register).

## Notes
- **Not compiled.** There is no Swift toolchain or Xcode in this environment and no iOS CI workflow, so this PR carries no build proof — worth a local `⌘B` before merging. What I could verify mechanically: the string catalog parses as JSON, all 330 entries have both `en` and `fr`, and no entry is in a `new`/`stale` state; every new API call was checked against an existing call site in the repo (`Color.accent.primary`, `.tint(...)`, `String(localized: "literal")` at :413, the `.from("profiles").update(...).eq("user_id", ...)` shape, and the `Encodable` params-struct convention next to `UpdateProfileParams`). `ShareLink` is iOS 16+ against a 17.0 deployment target.
- The catalog edit is a 170-line insertion that preserves Xcode's exact formatting (`"key" : {`, escaped non-ASCII, no trailing newline) — a JSON round-trip would have rewritten all 7k lines and made the diff unreviewable.
- No new files, so `project.yml` needs no change and no `xcodegen` run.
- Viewing *other* users' profiles in-app stays out of scope (deferred to M49 with connections, design D7) — this PR is claim, opt in, share.

## Lab Note (EN/FR)

```yaml
species: feature
platform: ios
status: in_progress
published: false
en:
  title: Claim your handle and share your profile
  summary: Pick a handle in Settings, flip one switch, and your profile gets a page you can share from anywhere on your phone. Private until you decide otherwise.
fr:
  title: Réserve ton pseudo et partage ton profil
  summary: Choisis un pseudo dans les réglages, active l'interrupteur, et ton profil obtient une page que tu peux partager depuis ton téléphone. Privé jusqu'à ce que tu en décides autrement.
suggested:
  molecule: pbbls
  type: feature
  tags: [profile, sharing, changelog]
```

## Checklist
- [x] Branch name follows `type/issueNumber-description` (`feat/656-ios-public-profile-settings`)
- [x] PR title uses conventional commits
- [x] Labels applied (`feat`, `ui`)
- [x] Milestone assigned (M50 · Public profiles)
- [ ] `npm run build` — **not run**: the iOS workspace build needs `xcodegen`/`xcodebuild` (macOS only), unavailable here
- [x] `npm run lint` — n/a for `apps/ios` (no lint script; SwiftLint is not wired)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaPrQJcWwzWDvr7Ji9uLNP)_