### PR TITLE
feat(ui): add achievements grid, unlock capsule and profile entry on ios

### DIFF
--- a/apps/ios/Pebbles/Features/Glyph/Views/GlyphCarveSheet.swift
+++ b/apps/ios/Pebbles/Features/Glyph/Views/GlyphCarveSheet.swift
@@ -11,6 +11,7 @@ struct GlyphCarveSheet: View {
     let onSaved: (Glyph) -> Void
 
     @Environment(SupabaseService.self) private var supabase
+    @Environment(AchievementsService.self) private var achievements
     @Environment(\.dismiss) private var dismiss
 
     @State private var strokes: [GlyphStroke] = []
@@ -138,6 +139,7 @@ struct GlyphCarveSheet: View {
         saveError = nil
         do {
             let glyph = try await service.create(strokes: strokes, name: name)
+            achievements.fireCheck()
             onSaved(glyph)
             dismiss()
         } catch {

--- a/apps/ios/Pebbles/Features/Karma/AchievementNotificationService.swift
+++ b/apps/ios/Pebbles/Features/Karma/AchievementNotificationService.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// One achievement unlock moment. Several unlocks in a single
+/// `check_achievements()` response collapse into one content value (web
+/// parity): `title` carries the localized badge title when exactly one badge
+/// unlocked, else the capsule shows a count phrase. `karmaTotal` is the sum
+/// the server actually emitted.
+struct AchievementUnlockedContent: Equatable, Sendable {
+    let count: Int
+    let title: String?
+    let karmaTotal: Int
+}
+
+/// Explicit-fire entry point for the achievement unlock capsule. Sibling of
+/// `KarmaNotificationService` — same presentation contract (a bottom-center
+/// pastille in the shared overlay window), its own slot so an achievement
+/// moment and a karma flash fired by the same mutation coexist instead of one
+/// replacing the other (the overlay stacks them; see `KarmaOverlayRoot`).
+/// Delight only — never authoritative over what is unlocked.
+@Observable
+@MainActor
+final class AchievementNotificationService {
+    /// Content currently shown (nil = hidden). Observed by the overlay window.
+    private(set) var activeCapsule: AchievementUnlockedContent?
+
+    /// Counts feedback fires so tests can assert the guard without CoreHaptics.
+    private(set) var hapticTrigger: Int = 0
+
+    private let haptics: HapticsService
+    private var capsuleDismissTask: Task<Void, Never>?
+
+    /// Slightly longer than the karma flash: a badge title takes a beat more
+    /// to read than "+N".
+    let capsuleDuration: Duration = .milliseconds(3200)
+
+    init(haptics: HapticsService = HapticsService()) {
+        self.haptics = haptics
+    }
+
+    func notifyUnlocked(count: Int, title: String?, karmaTotal: Int) {
+        guard count > 0 else { return }
+
+        // Reuses the karma-earned haptic: same reward register, and a second
+        // bespoke waveform for a moment that often fires alongside the karma
+        // flash would double-buzz. One shared pattern keeps the pair coherent.
+        hapticTrigger &+= 1
+        haptics.playKarmaEarned()
+
+        presentCapsule(AchievementUnlockedContent(count: count, title: title, karmaTotal: karmaTotal))
+    }
+
+    private func presentCapsule(_ content: AchievementUnlockedContent) {
+        activeCapsule = content
+        capsuleDismissTask?.cancel()
+        capsuleDismissTask = Task { [weak self, capsuleDuration] in
+            try? await Task.sleep(for: capsuleDuration)
+            guard !Task.isCancelled else { return }
+            self?.activeCapsule = nil
+        }
+    }
+
+    /// Called when the user taps the pastille.
+    func dismissCapsule() {
+        capsuleDismissTask?.cancel()
+        activeCapsule = nil
+    }
+}

--- a/apps/ios/Pebbles/Features/Karma/KarmaEarnedCapsule.swift
+++ b/apps/ios/Pebbles/Features/Karma/KarmaEarnedCapsule.swift
@@ -84,24 +84,121 @@ private extension View {
     }
 }
 
-/// SwiftUI root hosted inside the overlay window: renders the active pastille
+/// Achievement-unlocked pastille, visual sibling of `KarmaEarnedCapsule`:
+/// same glass, trophy instead of sparkle, the badge title (or a count phrase
+/// for several unlocks) and the karma actually granted when > 0.
+struct AchievementUnlockedCapsule: View {
+    let content: AchievementUnlockedContent
+    var duration: Duration = .milliseconds(3200)
+    let onTap: () -> Void
+
+    @State private var ringProgress: CGFloat = 1
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "trophy")
+                .foregroundStyle(Color.accent.primary)
+            Text(headline)
+                .font(.ysabeauSemibold(16))
+                .foregroundStyle(Color.system.foreground)
+                .lineLimit(1)
+            if content.karmaTotal > 0 {
+                Text("+\(content.karmaTotal) karma")
+                    .font(.ysabeauSemibold(16))
+                    .foregroundStyle(Color.accent.primary)
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 11)
+        .karmaPastilleGlass()
+        .overlay { countdownRing }
+        .contentShape(Capsule())
+        .onTapGesture(perform: onTap)
+        .onAppear(perform: startCountdown)
+        .onChange(of: content) { startCountdown() }
+        .accessibilityElement()
+        .accessibilityLabel(accessibilityText)
+        .accessibilityAddTraits(.isStaticText)
+    }
+
+    private var headline: String {
+        if content.count == 1, let title = content.title {
+            return title
+        }
+        return String(format: NSLocalizedString(
+            "achievement.capsule.countPhrase",
+            value: "%lld achievements unlocked", comment: ""
+        ), content.count)
+    }
+
+    private var accessibilityText: String {
+        var parts: [String] = []
+        if content.count == 1, let title = content.title {
+            parts.append(String(format: NSLocalizedString(
+                "achievement.capsule.a11y.single",
+                value: "Achievement unlocked: %@", comment: ""
+            ), title))
+        } else {
+            parts.append(headline)
+        }
+        if content.karmaTotal > 0 {
+            parts.append(String(format: NSLocalizedString(
+                "achievement.capsule.a11y.karma",
+                value: "Earned %lld karma", comment: ""
+            ), content.karmaTotal))
+        }
+        return parts.joined(separator: ", ")
+    }
+
+    private var countdownRing: some View {
+        Capsule()
+            .trim(from: 0, to: ringProgress)
+            .stroke(Color.accent.primary, style: StrokeStyle(lineWidth: 2.5, lineCap: .round))
+            .padding(1.25)
+            .allowsHitTesting(false)
+    }
+
+    private func startCountdown() {
+        ringProgress = 1
+        withAnimation(.linear(duration: durationSeconds)) { ringProgress = 0 }
+    }
+
+    private var durationSeconds: Double {
+        let parts = duration.components
+        return Double(parts.seconds) + Double(parts.attoseconds) / 1_000_000_000_000_000_000
+    }
+}
+
+/// SwiftUI root hosted inside the overlay window: renders the active pastilles
 /// pinned to the bottom-center, animating in/out. `Color.clear` fills the space
-/// so the window has a hit-testable (but pass-through) root.
+/// so the window has a hit-testable (but pass-through) root. The achievement
+/// capsule stacks above the karma one so a mutation that fires both shows both
+/// (web parity: two toasts with distinct ids), each on its own lifetime.
 struct KarmaOverlayRoot: View {
     @Environment(KarmaNotificationService.self) private var karma
+    @Environment(AchievementNotificationService.self) private var achievements
 
     var body: some View {
         ZStack(alignment: .bottom) {
             Color.clear
-            if let earned = karma.activeCapsule {
-                KarmaEarnedCapsule(content: earned, duration: karma.capsuleDuration) {
-                    karma.dismissCapsule()
+            VStack(spacing: Spacing.sm) {
+                if let unlocked = achievements.activeCapsule {
+                    AchievementUnlockedCapsule(content: unlocked, duration: achievements.capsuleDuration) {
+                        achievements.dismissCapsule()
+                    }
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
                 }
-                .padding(.bottom, 44)
-                .transition(.move(edge: .bottom).combined(with: .opacity))
+                if let earned = karma.activeCapsule {
+                    KarmaEarnedCapsule(content: earned, duration: karma.capsuleDuration) {
+                        karma.dismissCapsule()
+                    }
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
             }
+            .padding(.bottom, 44)
         }
         .animation(.spring(response: 0.42, dampingFraction: 0.72), value: karma.activeCapsule)
+        .animation(.spring(response: 0.42, dampingFraction: 0.72), value: achievements.activeCapsule)
     }
 }
 
@@ -149,13 +246,14 @@ final class KarmaPassthroughWindow: UIWindow {
     .padding(40)
 }
 
-/// Owns the overlay window for the karma pastille. Created once from the active
-/// window scene and bound to the shared `KarmaNotificationService`.
+/// Owns the overlay window for the karma + achievement pastilles. Created once
+/// from the active window scene and bound to both shared notification services.
 @MainActor
 final class KarmaOverlayWindowController {
     private var window: KarmaPassthroughWindow?
 
-    func attachIfNeeded(service: KarmaNotificationService) {
+    func attachIfNeeded(service: KarmaNotificationService,
+                        achievements: AchievementNotificationService) {
         guard window == nil else { return }
         let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
         guard let scene = scenes.first(where: { $0.activationState == .foregroundActive })
@@ -164,7 +262,11 @@ final class KarmaOverlayWindowController {
         let window = KarmaPassthroughWindow(windowScene: scene)
         window.windowLevel = .alert + 1  // above presented sheets
         window.backgroundColor = .clear
-        let host = UIHostingController(rootView: KarmaOverlayRoot().environment(service))
+        let host = UIHostingController(
+            rootView: KarmaOverlayRoot()
+                .environment(service)
+                .environment(achievements)
+        )
         host.view.backgroundColor = .clear
         window.rootViewController = host
         window.isHidden = false

--- a/apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/CreatePebbleSheet.swift
@@ -12,6 +12,7 @@ struct CreatePebbleSheet: View {
     @Environment(SupabaseService.self) var supabase
     @Environment(ReferenceDataService.self) var refs
     @Environment(KarmaNotificationService.self) private var karma
+    @Environment(AchievementsService.self) private var achievements
     @Environment(PebbleDraftsService.self) var draftsService
     @Environment(ComposerSnapshotStore.self) var snapshots
     @Environment(\.scenePhase) private var scenePhase
@@ -188,12 +189,15 @@ struct CreatePebbleSheet: View {
                     decoder: decoder
                 )
             karma.notifyEarned(amount: response.karmaDelta ?? 0, reason: .pebbleCreated)
+            achievements.fireCheck()
             await consumeDraftAfterPublish()
             onCreated(response.pebbleId)
             dismiss()
         } catch let functionsError as FunctionsError {
             if let pebbleId = softSuccessPebbleId(from: functionsError) {
                 logger.warning("compose-pebble returned 5xx but pebble_id found — advancing to detail sheet")
+                // Soft success still inserted the pebble, so counts changed.
+                achievements.fireCheck()
                 await consumeDraftAfterPublish()
                 onCreated(pebbleId)
                 dismiss()

--- a/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
+++ b/apps/ios/Pebbles/Features/Path/EditPebbleSheet.swift
@@ -19,6 +19,7 @@ struct EditPebbleSheet: View {
     @Environment(EmotionPaletteService.self) private var palettes
     @Environment(ReferenceDataService.self) private var refs
     @Environment(KarmaNotificationService.self) private var karma
+    @Environment(AchievementsService.self) private var achievements
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.dismiss) private var dismiss
 
@@ -228,6 +229,9 @@ struct EditPebbleSheet: View {
                 )
             self.renderSvg = response.renderSvg ?? self.renderSvg
             karma.notifyEarned(amount: response.karmaDelta ?? 0, reason: .pebbleEnriched)
+            // An edit can change the pebble's emotion, newly qualifying an
+            // emotion_first badge.
+            achievements.fireCheck()
             onSaved()
             dismiss()
         } catch let functionsError as FunctionsError {
@@ -237,6 +241,7 @@ struct EditPebbleSheet: View {
             if case .httpError(let status, let data) = functionsError, status >= 500 {
                 let bodyString = String(data: data, encoding: .utf8) ?? "<non-utf8 body>"
                 logger.warning("compose-pebble-update returned \(status, privacy: .public) — advancing on soft-success. body=\(bodyString, privacy: .private)")
+                achievements.fireCheck()
                 onSaved()
                 dismiss()
             } else {

--- a/apps/ios/Pebbles/Features/Profile/AchievementsView.swift
+++ b/apps/ios/Pebbles/Features/Profile/AchievementsView.swift
@@ -1,0 +1,179 @@
+import SwiftUI
+import os
+
+/// Achievements grid (M48, D8): badges grouped by family in catalog
+/// `sort_order`, locked ones greyed alongside the unlocked. Opening the screen
+/// fires `check_achievements()` first — that call *is* the retroactive grant
+/// for existing users — then reads catalog + unlocks, so history appears
+/// unlocked on first visit with no celebration chain (the capsule is for the
+/// mutation path only, D13 territory).
+struct AchievementsView: View {
+    @Environment(AchievementsService.self) private var achievements
+    @Environment(EmotionPaletteService.self) private var palettes
+    @Environment(ReferenceDataService.self) private var refs
+
+    @State private var catalog: [AchievementRecord] = []
+    @State private var unlockedAt: [UUID: Date] = [:]
+    @State private var isLoading = true
+    @State private var loadError: String?
+
+    private let logger = Logger(subsystem: "app.pbbls.ios", category: "profile.achievements")
+
+    private let columns = [GridItem(.adaptive(minimum: 148), spacing: Spacing.lg)]
+
+    var body: some View {
+        content
+            .pebblesToolbarTitle("Achievements")
+            .task { await load() }
+            .pebblesScreen()
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isLoading {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let loadError {
+            ContentUnavailableView(
+                "Couldn't load achievements",
+                systemImage: "exclamationmark.triangle",
+                description: Text(loadError)
+            )
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: Spacing.xl) {
+                    ForEach(familyGroups, id: \.family) { group in
+                        VStack(alignment: .leading, spacing: Spacing.md) {
+                            Text(AchievementRecord.localizedGroupName(family: group.family))
+                                .pebblesFont(.headline)
+                                .foregroundStyle(Color.system.foreground)
+                            LazyVGrid(columns: columns, spacing: Spacing.lg) {
+                                ForEach(group.records) { record in
+                                    AchievementBadgeCell(
+                                        record: record,
+                                        unlockedAt: unlockedAt[record.id],
+                                        emotionName: emotionName(for: record),
+                                        domainName: domainName(for: record)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(Spacing.lg)
+            }
+        }
+    }
+
+    /// Families in first-appearance order (the catalog is already sorted by
+    /// `sort_order`, which the migration blocks per family). Inactive badges
+    /// only show once earned — retiring one hides it from the ladder without
+    /// revoking anyone's unlock.
+    private var familyGroups: [(family: String, records: [AchievementRecord])] {
+        let visible = catalog.filter { $0.isActive || unlockedAt[$0.id] != nil }
+        var order: [String] = []
+        var byFamily: [String: [AchievementRecord]] = [:]
+        for record in visible {
+            if byFamily[record.family] == nil { order.append(record.family) }
+            byFamily[record.family, default: []].append(record)
+        }
+        return order.map { (family: $0, records: byFamily[$0] ?? []) }
+    }
+
+    private func emotionName(for record: AchievementRecord) -> String? {
+        guard let emotionId = record.emotionId else { return nil }
+        return palettes.byEmotionId[emotionId]?.localizedName
+    }
+
+    private func domainName(for record: AchievementRecord) -> String? {
+        guard let domainId = record.domainId else { return nil }
+        return refs.domains.first(where: { $0.id == domainId })?.localizedName
+    }
+
+    private func load() async {
+        isLoading = true
+        loadError = nil
+        // The retroactive grant precedes the read so a veteran's history is
+        // already unlocked by the time the grid renders; its errors are
+        // deliberately non-fatal (the next call self-heals).
+        await achievements.checkIgnoringFailure()
+        do {
+            async let catalogRows = achievements.loadCatalog()
+            async let unlockRows = achievements.loadUnlocks()
+            let loadedCatalog = try await catalogRows
+            let loadedUnlocks = try await unlockRows
+            self.catalog = loadedCatalog
+            self.unlockedAt = Dictionary(
+                loadedUnlocks.map { ($0.achievementId, $0.unlockedAt) },
+                uniquingKeysWith: { first, _ in first }
+            )
+        } catch {
+            logger.error("achievements fetch failed: \(error.localizedDescription, privacy: .private)")
+            self.loadError = "Something went wrong. Please try again."
+        }
+        self.isLoading = false
+    }
+}
+
+/// One badge tile. Locked state reads through more than colour: muted styling
+/// plus a lock mark and an explicit caption, mirroring the web grid.
+struct AchievementBadgeCell: View {
+    let record: AchievementRecord
+    let unlockedAt: Date?
+    let emotionName: String?
+    let domainName: String?
+
+    private var isUnlocked: Bool { unlockedAt != nil }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            HStack {
+                Image(systemName: record.familySymbol)
+                    .pebblesIcon(.large)
+                    .foregroundStyle(isUnlocked ? Color.accent.primary : Color.system.muted)
+                Spacer()
+                if !isUnlocked {
+                    Image(systemName: "lock")
+                        .pebblesIcon(.medium)
+                        .foregroundStyle(Color.system.muted)
+                }
+            }
+            Text(record.localizedTitle(emotionName: emotionName, domainName: domainName))
+                .pebblesFont(.headline)
+                .foregroundStyle(isUnlocked ? Color.system.foreground : Color.system.secondary)
+                .multilineTextAlignment(.leading)
+            if let description = record.localizedDescription(emotionName: emotionName, domainName: domainName) {
+                Text(description)
+                    .pebblesFont(.subhead)
+                    .foregroundStyle(Color.system.secondary)
+                    .multilineTextAlignment(.leading)
+            }
+            if let unlockedAt {
+                HStack(spacing: 4) {
+                    Text("Unlocked")
+                    Text(unlockedAt, format: .dateTime.day().month().year())
+                }
+                .pebblesFont(.subhead)
+                .foregroundStyle(Color.accent.primary)
+            } else {
+                Text("Locked")
+                    .pebblesFont(.subhead)
+                    .foregroundStyle(Color.system.muted)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .profileCard()
+        .opacity(isUnlocked ? 1 : 0.72)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+#Preview {
+    let supabase = SupabaseService()
+    return NavigationStack {
+        AchievementsView()
+            .environment(AchievementsService(client: supabase.client))
+            .environment(EmotionPaletteService(client: supabase.client))
+            .environment(ReferenceDataService(client: supabase.client))
+    }
+}

--- a/apps/ios/Pebbles/Features/Profile/Components/ProfileAchievementsCard.swift
+++ b/apps/ios/Pebbles/Features/Profile/Components/ProfileAchievementsCard.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct ProfileAchievementsCard: View {
+    var body: some View {
+        NavigationLink {
+            AchievementsView()
+        } label: {
+            HStack(spacing: Spacing.lg) {
+                Image(systemName: "trophy")
+                    .pebblesIcon(.large)
+                    .foregroundStyle(Color.accent.primary)
+                VStack(alignment: .leading) {
+                    Text("Achievements")
+                        .pebblesFont(.headline)
+                        .foregroundStyle(Color.system.foreground)
+                    Text("Badges along your path")
+                        .pebblesFont(.subhead)
+                        .foregroundStyle(Color.system.secondary)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .pebblesIcon(.medium)
+                    .foregroundStyle(Color.system.muted)
+            }
+            .contentShape(Rectangle())
+            .profileCard()
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ProfileAchievementsCard().padding()
+    }
+}

--- a/apps/ios/Pebbles/Features/Profile/Models/Achievement+Localized.swift
+++ b/apps/ios/Pebbles/Features/Profile/Models/Achievement+Localized.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// Display copy for a badge (D7): the admin's `title_*`/`description_*`
+/// overrides win by the active locale, else the family-keyed catalog strings
+/// with the threshold or the localized emotion/domain name interpolated.
+/// Runtime-built keys use `NSLocalizedString(key:value:)` for the same reason
+/// as `Emotion.localizedName` — `String(localized:)` needs a StaticString.
+extension AchievementRecord {
+
+    /// Mirrors the web resolver: `fr` picks the French override first, any
+    /// other locale the English one; either falls back to its sibling before
+    /// dropping to the family strings, so a half-filled row still shows copy.
+    private var isFrench: Bool {
+        Locale.current.language.languageCode?.identifier == "fr"
+    }
+
+    private var overrideTitle: String? {
+        isFrench ? (titleFr ?? titleEn) : (titleEn ?? titleFr)
+    }
+
+    private var overrideDescription: String? {
+        isFrench ? (descriptionFr ?? descriptionEn) : (descriptionEn ?? descriptionFr)
+    }
+
+    /// `emotionName`/`domainName` are the already-localized reference names
+    /// (`localizedName`, never `.name`), supplied by the caller because copy
+    /// resolution has no business reaching into the service graph.
+    func localizedTitle(emotionName: String?, domainName: String?) -> String {
+        if let overrideTitle { return overrideTitle }
+        switch family {
+        case "pebble_count":
+            if threshold == 1 { return catalogString("achievement.family.pebble_count.title.one", fallback: "First pebble") }
+            return String(format: catalogString("achievement.family.pebble_count.title.other", fallback: "%lld pebbles"), threshold ?? 0)
+        case "emotion_first":
+            return String(format: catalogString("achievement.family.emotion_first.title", fallback: "First %@"), emotionName ?? slug)
+        case "domain_first":
+            return String(format: catalogString("achievement.family.domain_first.title", fallback: "First steps in %@"), domainName ?? slug)
+        case "first_collection":
+            return catalogString("achievement.family.first_collection.title", fallback: "First collection")
+        case "first_glyph":
+            return catalogString("achievement.family.first_glyph.title", fallback: "First glyph")
+        case "first_soul":
+            return catalogString("achievement.family.first_soul.title", fallback: "First soul")
+        case "glyph_count":
+            return String(format: catalogString("achievement.family.glyph_count.title", fallback: "%lld glyphs"), threshold ?? 0)
+        case "glyph_sales":
+            if threshold == 1 { return catalogString("achievement.family.glyph_sales.title.one", fallback: "First sale") }
+            return String(format: catalogString("achievement.family.glyph_sales.title.other", fallback: "%lld sales"), threshold ?? 0)
+        default:
+            // A family added server-side before iOS catches up: degrade to the
+            // slug rather than crash or show a bare key path (web parity).
+            return slug
+        }
+    }
+
+    func localizedDescription(emotionName: String?, domainName: String?) -> String? {
+        if let overrideDescription { return overrideDescription }
+        switch family {
+        case "pebble_count":
+            if threshold == 1 { return catalogString("achievement.family.pebble_count.description.one", fallback: "Drop your first pebble on the path.") }
+            return String(format: catalogString("achievement.family.pebble_count.description.other", fallback: "Collect %lld pebbles along your path."), threshold ?? 0)
+        case "emotion_first":
+            return String(format: catalogString("achievement.family.emotion_first.description", fallback: "Record your first pebble carrying %@."), emotionName ?? slug)
+        case "domain_first":
+            return String(format: catalogString("achievement.family.domain_first.description", fallback: "Record your first pebble in %@."), domainName ?? slug)
+        case "first_collection":
+            return catalogString("achievement.family.first_collection.description", fallback: "Create your first collection.")
+        case "first_glyph":
+            return catalogString("achievement.family.first_glyph.description", fallback: "Carve your first glyph.")
+        case "first_soul":
+            return catalogString("achievement.family.first_soul.description", fallback: "Add your first soul.")
+        case "glyph_count":
+            return String(format: catalogString("achievement.family.glyph_count.description", fallback: "Carve %lld glyphs of your own."), threshold ?? 0)
+        case "glyph_sales":
+            if threshold == 1 { return catalogString("achievement.family.glyph_sales.description.one", fallback: "Sell your first glyph in the market.") }
+            return String(format: catalogString("achievement.family.glyph_sales.description.other", fallback: "Make %lld glyph sales in the market."), threshold ?? 0)
+        default:
+            return nil
+        }
+    }
+
+    /// Group heading for the family section; unknown families show their raw
+    /// value instead of a key path.
+    static func localizedGroupName(family: String) -> String {
+        NSLocalizedString("achievement.group.\(family)", value: family, comment: "")
+    }
+
+    /// SF Symbol per family; unknown families get the trophy.
+    var familySymbol: String {
+        switch family {
+        case "pebble_count":     "circle.grid.3x3"
+        case "emotion_first":    "heart"
+        case "domain_first":     "safari"
+        case "first_collection": "square.stack.3d.up"
+        case "first_glyph":      "scribble"
+        case "first_soul":       "person.2"
+        case "glyph_count":      "pencil.and.outline"
+        case "glyph_sales":      "storefront"
+        default:                 "trophy"
+        }
+    }
+
+    private func catalogString(_ key: String, fallback: String) -> String {
+        NSLocalizedString(key, value: fallback, comment: "")
+    }
+}

--- a/apps/ios/Pebbles/Features/Profile/ProfileView.swift
+++ b/apps/ios/Pebbles/Features/Profile/ProfileView.swift
@@ -44,6 +44,8 @@ struct ProfileView: View {
                     karma: stats.karma
                 )
 
+                ProfileAchievementsCard()
+
                 ProfileCollectionsCard()
 
                 ProfileLabCard()

--- a/apps/ios/Pebbles/Features/Profile/Sheets/CreateCollectionSheet.swift
+++ b/apps/ios/Pebbles/Features/Profile/Sheets/CreateCollectionSheet.swift
@@ -7,6 +7,7 @@ struct CreateCollectionSheet: View {
     let onCreated: () -> Void
 
     @Environment(SupabaseService.self) private var supabase
+    @Environment(AchievementsService.self) private var achievements
     @Environment(\.dismiss) private var dismiss
 
     @State private var name: String = ""
@@ -92,6 +93,7 @@ struct CreateCollectionSheet: View {
                 .from("collections")
                 .insert(payload)
                 .execute()
+            achievements.fireCheck()
             onCreated()
             dismiss()
         } catch {

--- a/apps/ios/Pebbles/Features/Profile/Sheets/CreateSoulSheet.swift
+++ b/apps/ios/Pebbles/Features/Profile/Sheets/CreateSoulSheet.swift
@@ -9,6 +9,7 @@ struct CreateSoulSheet: View {
     let onCreated: (SoulWithGlyph) -> Void
 
     @Environment(SupabaseService.self) private var supabase
+    @Environment(AchievementsService.self) private var achievements
     @Environment(\.dismiss) private var dismiss
 
     @State private var draft = SoulDraft()
@@ -126,6 +127,7 @@ struct CreateSoulSheet: View {
                 .single()
                 .execute()
                 .value
+            achievements.fireCheck()
             onCreated(inserted)
             dismiss()
         } catch {

--- a/apps/ios/Pebbles/PebblesApp.swift
+++ b/apps/ios/Pebbles/PebblesApp.swift
@@ -9,18 +9,27 @@ struct PebblesApp: App {
     @State private var stats: PathStatsService
     @State private var snapURLs: SnapURLCache
     @State private var karma: KarmaNotificationService
+    @State private var achievementNotify: AchievementNotificationService
+    @State private var achievements: AchievementsService
     @State private var drafts: PebbleDraftsService
     @State private var snapshots: ComposerSnapshotStore
     @State private var karmaOverlay = KarmaOverlayWindowController()
 
     init() {
         let supabase = SupabaseService()
+        let palettes = EmotionPaletteService(client: supabase.client)
+        let refs = ReferenceDataService(client: supabase.client)
+        let achievementNotify = AchievementNotificationService()
+        let achievements = AchievementsService(client: supabase.client)
+        achievements.bind(palettes: palettes, refs: refs, notify: achievementNotify)
         self._supabase = State(initialValue: supabase)
-        self._palettes = State(initialValue: EmotionPaletteService(client: supabase.client))
-        self._refs     = State(initialValue: ReferenceDataService(client: supabase.client))
+        self._palettes = State(initialValue: palettes)
+        self._refs     = State(initialValue: refs)
         self._stats    = State(initialValue: PathStatsService(supabase: supabase))
         self._snapURLs = State(initialValue: SnapURLCache(client: supabase.client))
         self._karma    = State(initialValue: KarmaNotificationService())
+        self._achievementNotify = State(initialValue: achievementNotify)
+        self._achievements = State(initialValue: achievements)
         self._drafts   = State(initialValue: PebbleDraftsService(client: supabase.client))
         self._snapshots = State(initialValue: ComposerSnapshotStore())
         Self.configureSegmentedControlAppearance()
@@ -36,9 +45,11 @@ struct PebblesApp: App {
                 .environment(stats)
                 .environment(snapURLs)
                 .environment(karma)
+                .environment(achievementNotify)
+                .environment(achievements)
                 .environment(drafts)
                 .environment(snapshots)
-                .onAppear { karmaOverlay.attachIfNeeded(service: karma) }
+                .onAppear { karmaOverlay.attachIfNeeded(service: karma, achievements: achievementNotify) }
         }
     }
 

--- a/apps/ios/Pebbles/Resources/Localizable.xcstrings
+++ b/apps/ios/Pebbles/Resources/Localizable.xcstrings
@@ -33,7 +33,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aucun brouillon. Tout ce que tu commences \u00e0 garder appara\u00eet ici."
+            "value" : "Aucun brouillon. Tout ce que tu commences à garder apparaît ici."
           }
         }
       }
@@ -67,7 +67,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "On reprend o\u00f9 tu t'\u00e9tais arr\u00eat\u00e9 ?"
+            "value" : "On reprend où tu t'étais arrêté ?"
           }
         }
       }
@@ -118,7 +118,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Repartir de z\u00e9ro"
+            "value" : "Repartir de zéro"
           }
         }
       }
@@ -135,7 +135,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "R\u00e9essayer"
+            "value" : "Réessayer"
           }
         }
       }
@@ -152,7 +152,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "On a gard\u00e9 ce que tu \u00e9crivais ici. Remets ta photo quand tu veux."
+            "value" : "On a gardé ce que tu écrivais ici. Remets ta photo quand tu veux."
           }
         }
       }
@@ -5362,6 +5362,618 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Votre nom"
+          }
+        }
+      }
+    },
+    "Achievements" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Achievements"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Succès"
+          }
+        }
+      }
+    },
+    "Badges along your path" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Badges along your path"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tes badges le long du chemin"
+          }
+        }
+      }
+    },
+    "Couldn't load achievements" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load achievements"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de charger tes succès"
+          }
+        }
+      }
+    },
+    "Locked" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Locked"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "À débloquer"
+          }
+        }
+      }
+    },
+    "Unlocked" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unlocked"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Débloqué le"
+          }
+        }
+      }
+    },
+    "achievement.capsule.countPhrase" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld achievements unlocked"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld succès débloqués"
+          }
+        }
+      }
+    },
+    "achievement.capsule.a11y.single" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Achievement unlocked: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Succès débloqué : %@"
+          }
+        }
+      }
+    },
+    "achievement.capsule.a11y.karma" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Earned %lld karma"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu as gagné %lld karma"
+          }
+        }
+      }
+    },
+    "achievement.group.pebble_count" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pebbles"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Galets"
+          }
+        }
+      }
+    },
+    "achievement.group.emotion_first" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emotions"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Émotions"
+          }
+        }
+      }
+    },
+    "achievement.group.domain_first" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Domains"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Domaines"
+          }
+        }
+      }
+    },
+    "achievement.group.first_collection" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Collections"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Collections"
+          }
+        }
+      }
+    },
+    "achievement.group.first_glyph" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Glyphs"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Glyphes"
+          }
+        }
+      }
+    },
+    "achievement.group.first_soul" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Souls"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Âmes"
+          }
+        }
+      }
+    },
+    "achievement.group.glyph_count" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carving"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gravure"
+          }
+        }
+      }
+    },
+    "achievement.group.glyph_sales" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Market"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marché"
+          }
+        }
+      }
+    },
+    "achievement.family.pebble_count.title.one" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First pebble"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Premier galet"
+          }
+        }
+      }
+    },
+    "achievement.family.pebble_count.title.other" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld pebbles"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld galets"
+          }
+        }
+      }
+    },
+    "achievement.family.pebble_count.description.one" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drop your first pebble on the path."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dépose ton tout premier galet sur ton chemin."
+          }
+        }
+      }
+    },
+    "achievement.family.pebble_count.description.other" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Collect %lld pebbles along your path."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rassemble %lld galets sur ton chemin."
+          }
+        }
+      }
+    },
+    "achievement.family.emotion_first.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Première fois : %@"
+          }
+        }
+      }
+    },
+    "achievement.family.emotion_first.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Record your first pebble carrying %@."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capture ton premier galet teinté par l'émotion %@."
+          }
+        }
+      }
+    },
+    "achievement.family.domain_first.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First steps in %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Premiers pas : %@"
+          }
+        }
+      }
+    },
+    "achievement.family.domain_first.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Record your first pebble in %@."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capture ton premier galet dans le domaine %@."
+          }
+        }
+      }
+    },
+    "achievement.family.first_collection.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First collection"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Première collection"
+          }
+        }
+      }
+    },
+    "achievement.family.first_collection.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create your first collection."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crée ta toute première collection."
+          }
+        }
+      }
+    },
+    "achievement.family.first_glyph.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First glyph"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Premier glyphe"
+          }
+        }
+      }
+    },
+    "achievement.family.first_glyph.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carve your first glyph."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grave ton tout premier glyphe."
+          }
+        }
+      }
+    },
+    "achievement.family.first_soul.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First soul"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Première âme"
+          }
+        }
+      }
+    },
+    "achievement.family.first_soul.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add your first soul."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajoute ta toute première âme."
+          }
+        }
+      }
+    },
+    "achievement.family.glyph_count.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld glyphs"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld glyphes"
+          }
+        }
+      }
+    },
+    "achievement.family.glyph_count.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carve %lld glyphs of your own."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grave %lld glyphes de ta main."
+          }
+        }
+      }
+    },
+    "achievement.family.glyph_sales.title.one" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First sale"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Première vente"
+          }
+        }
+      }
+    },
+    "achievement.family.glyph_sales.title.other" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld sales"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld ventes"
+          }
+        }
+      }
+    },
+    "achievement.family.glyph_sales.description.one" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sell your first glyph in the market."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un pebbler adopte l'un de tes glyphes."
+          }
+        }
+      }
+    },
+    "achievement.family.glyph_sales.description.other" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make %lld glyph sales in the market."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tes glyphes trouvent preneur %lld fois."
           }
         }
       }

--- a/apps/ios/Pebbles/Services/AchievementsService.swift
+++ b/apps/ios/Pebbles/Services/AchievementsService.swift
@@ -1,0 +1,222 @@
+import Foundation
+import Observation
+import Supabase
+import os
+
+/// One `achievements` catalog row. The catalog is public-read reference data
+/// (M48); copy columns are nullable admin overrides — `Achievement+Localized`
+/// resolves display copy from them or from the family-keyed catalog strings.
+struct AchievementRecord: Identifiable, Decodable, Equatable {
+    let id: UUID
+    let slug: String
+    let family: String
+    let threshold: Int?
+    let emotionId: UUID?
+    let domainId: UUID?
+    let sortOrder: Int
+    let glyphId: UUID?
+    let karmaReward: Int
+    let isActive: Bool
+    let titleEn: String?
+    let titleFr: String?
+    let descriptionEn: String?
+    let descriptionFr: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case slug
+        case family
+        case threshold
+        case emotionId = "emotion_id"
+        case domainId = "domain_id"
+        case sortOrder = "sort_order"
+        case glyphId = "glyph_id"
+        case karmaReward = "karma_reward"
+        case isActive = "is_active"
+        case titleEn = "title_en"
+        case titleFr = "title_fr"
+        case descriptionEn = "description_en"
+        case descriptionFr = "description_fr"
+    }
+}
+
+/// One of the caller's `achievement_unlocks` rows (owner-scoped by RLS).
+///
+/// `unlocked_at` is decoded from its **string** form through `ISO8601Flexible`
+/// rather than left to the ambient decoder's date strategy (#651): Postgres
+/// returns microsecond precision and a fixed-precision decoder fails the whole
+/// row, which would silently empty the achievements grid.
+struct AchievementUnlockRecord: Decodable, Equatable {
+    let achievementId: UUID
+    let unlockedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case achievementId = "achievement_id"
+        case unlockedAt = "unlocked_at"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        achievementId = try container.decode(UUID.self, forKey: .achievementId)
+        let raw = try container.decode(String.self, forKey: .unlockedAt)
+        guard let parsed = ISO8601Flexible.parse(raw) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .unlockedAt, in: container,
+                debugDescription: "unparseable unlocked_at: \(raw)"
+            )
+        }
+        unlockedAt = parsed
+    }
+
+    /// Memberwise init, for tests and previews.
+    init(achievementId: UUID, unlockedAt: Date) {
+        self.achievementId = achievementId
+        self.unlockedAt = unlockedAt
+    }
+}
+
+/// One newly unlocked badge as `check_achievements()` reports it: the karma is
+/// what the server actually emitted at unlock time, not the catalog's current
+/// value — the capsule can never show a number the ledger doesn't hold.
+struct AchievementCheckResult: Decodable, Equatable {
+    let slug: String
+    let karmaGranted: Int
+
+    enum CodingKeys: String, CodingKey {
+        case slug
+        case karmaGranted = "karma_granted"
+    }
+}
+
+/// Achievements data access + the fire-and-forget evaluation call (M48).
+///
+/// `check_achievements()` is the design's single evaluation path: idempotent,
+/// client-called after count-changing mutations and on screen open — the
+/// screen-open call is the retroactive grant, so a failed fire here self-heals
+/// on the next call and must never block or fail the mutation that triggered it.
+///
+/// Production wiring lives in `PebblesApp`; `bind(...)` connects the services
+/// the unlock moment needs (they are all constructed there together).
+@Observable
+@MainActor
+final class AchievementsService {
+
+    private let client: SupabaseClient
+    private let logger = Logger(subsystem: "app.pbbls.ios", category: "achievements")
+
+    private weak var palettes: EmotionPaletteService?
+    private weak var refs: ReferenceDataService?
+    private weak var notify: AchievementNotificationService?
+
+    init(client: SupabaseClient) {
+        self.client = client
+    }
+
+    /// Connects the collaborators the unlock capsule needs. Called once from
+    /// `PebblesApp.init`; weak because the app owns all of them for its lifetime.
+    func bind(palettes: EmotionPaletteService,
+              refs: ReferenceDataService,
+              notify: AchievementNotificationService) {
+        self.palettes = palettes
+        self.refs = refs
+        self.notify = notify
+    }
+
+    /// Full catalog, inactive rows included — the view filters (an inactive
+    /// badge stays visible when already unlocked, hidden while locked).
+    func loadCatalog() async throws -> [AchievementRecord] {
+        let rows: [AchievementRecord] = try await client
+            .from("achievements")
+            .select("id, slug, family, threshold, emotion_id, domain_id, sort_order, glyph_id, karma_reward, is_active, title_en, title_fr, description_en, description_fr")
+            .order("sort_order", ascending: true)
+            .execute()
+            .value
+        return rows
+    }
+
+    /// The caller's unlocks; RLS scopes to `auth.uid()`.
+    func loadUnlocks() async throws -> [AchievementUnlockRecord] {
+        let rows: [AchievementUnlockRecord] = try await client
+            .from("achievement_unlocks")
+            .select("achievement_id, unlocked_at")
+            .execute()
+            .value
+        return rows
+    }
+
+    /// Runs the evaluation. SETOF-returning RPC, so PostgREST yields an array
+    /// (empty = nothing newly unlocked).
+    func check() async throws -> [AchievementCheckResult] {
+        let rows: [AchievementCheckResult] = try await client
+            .rpc("check_achievements")
+            .execute()
+            .value
+        return rows
+    }
+
+    /// Screen-open variant: the retroactive grant must never surface as an
+    /// error — the grid renders whatever `loadUnlocks()` then returns.
+    func checkIgnoringFailure() async {
+        do {
+            _ = try await check()
+        } catch {
+            logger.warning("achievement check on screen open failed: \(error.localizedDescription, privacy: .private)")
+        }
+    }
+
+    /// Mutation-path variant: fire-and-forget from a success handler. Never
+    /// throws, never blocks the caller; new unlocks collapse into one capsule
+    /// (mirrors web's `fireAchievementCheck`). Karma notifies stay untouched —
+    /// the capsule carries its own "+N karma" line.
+    func fireCheck() {
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let results = try await self.check()
+                guard !results.isEmpty else { return }
+                self.presentUnlockMoment(for: results)
+            } catch {
+                self.logger.warning("achievement check failed (self-heals on next call): \(error.localizedDescription, privacy: .private)")
+            }
+        }
+    }
+
+    private func presentUnlockMoment(for results: [AchievementCheckResult]) {
+        guard let notify else {
+            logger.error("achievement notify service not bound; dropping unlock moment")
+            return
+        }
+        Task { [weak self] in
+            guard let self else { return }
+            let karmaTotal = results.reduce(0) { $0 + $1.karmaGranted }
+            var title: String?
+            if results.count == 1, let slug = results.first?.slug {
+                // One extra catalog read per actual unlock (rare) buys the
+                // localized badge title without threading i18n through six
+                // call sites — same trade the web pill makes.
+                do {
+                    let catalog = try await self.loadCatalog()
+                    if let record = catalog.first(where: { $0.slug == slug }) {
+                        title = record.localizedTitle(
+                            emotionName: self.emotionName(for: record),
+                            domainName: self.domainName(for: record)
+                        )
+                    }
+                } catch {
+                    self.logger.warning("catalog fetch for unlock capsule failed: \(error.localizedDescription, privacy: .private)")
+                }
+            }
+            notify.notifyUnlocked(count: results.count, title: title, karmaTotal: karmaTotal)
+        }
+    }
+
+    private func emotionName(for record: AchievementRecord) -> String? {
+        guard let emotionId = record.emotionId else { return nil }
+        return palettes?.byEmotionId[emotionId]?.localizedName
+    }
+
+    private func domainName(for record: AchievementRecord) -> String? {
+        guard let domainId = record.domainId else { return nil }
+        return refs?.domains.first(where: { $0.id == domainId })?.localizedName
+    }
+}

--- a/apps/ios/PebblesTests/AchievementsDecodingTests.swift
+++ b/apps/ios/PebblesTests/AchievementsDecodingTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Testing
+@testable import Pebbles
+
+/// Decoding contracts for the achievements rows (M48). Fixtures are foreign
+/// payloads in the shapes PostgREST actually emits — including the timestamp
+/// precision variants that motivated `ISO8601Flexible` (#651) — never
+/// round-trips of this surface's own encoder.
+@Suite("Achievements decoding")
+struct AchievementsDecodingTests {
+
+    @Test("catalog row decodes with nulls and overrides")
+    func catalogRow() throws {
+        let json = """
+        [{
+          "id": "044be862-0a82-1cc4-5f47-02552c91eb6e",
+          "slug": "pebble-count-10",
+          "family": "pebble_count",
+          "threshold": 10,
+          "emotion_id": null,
+          "domain_id": null,
+          "sort_order": 110,
+          "glyph_id": null,
+          "karma_reward": 0,
+          "is_active": true,
+          "title_en": null,
+          "title_fr": null,
+          "description_en": null,
+          "description_fr": null
+        },
+        {
+          "id": "1f0e2d3c-4b5a-4978-8695-a4b3c2d1e0f9",
+          "slug": "emotion-first-joyful",
+          "family": "emotion_first",
+          "threshold": null,
+          "emotion_id": "2a1b3c4d-5e6f-4a8b-9c0d-1e2f3a4b5c6d",
+          "domain_id": null,
+          "sort_order": 200,
+          "glyph_id": null,
+          "karma_reward": 5,
+          "is_active": true,
+          "title_en": "Custom title",
+          "title_fr": "Titre perso",
+          "description_en": null,
+          "description_fr": null
+        }]
+        """.data(using: .utf8)!
+
+        let rows = try JSONDecoder().decode([AchievementRecord].self, from: json)
+        #expect(rows.count == 2)
+        #expect(rows[0].slug == "pebble-count-10")
+        #expect(rows[0].threshold == 10)
+        #expect(rows[0].emotionId == nil)
+        #expect(rows[0].titleEn == nil)
+        #expect(rows[1].karmaReward == 5)
+        #expect(rows[1].titleFr == "Titre perso")
+        #expect(rows[1].emotionId != nil)
+    }
+
+    @Test("unlock row decodes Postgres microsecond timestamps", arguments: [
+        "2026-07-30T09:15:42.123456+00:00",  // PostgREST microseconds
+        "2026-07-30T09:15:42.123Z",          // web milliseconds
+        "2026-07-30T09:15:42Z",              // whole seconds
+    ])
+    func unlockRowTimestampPrecisions(raw: String) throws {
+        let json = """
+        [{"achievement_id": "044be862-0a82-1cc4-5f47-02552c91eb6e", "unlocked_at": "\(raw)"}]
+        """.data(using: .utf8)!
+
+        let rows = try JSONDecoder().decode([AchievementUnlockRecord].self, from: json)
+        #expect(rows.count == 1)
+        let seconds = rows[0].unlockedAt.timeIntervalSince1970
+        // All three variants land within the same second.
+        #expect(abs(seconds - 1785402942) < 1)
+    }
+
+    @Test("check result decodes slug and granted karma")
+    func checkResult() throws {
+        let json = """
+        [{"slug": "first-soul", "karma_granted": 7}, {"slug": "pebble-count-1", "karma_granted": 0}]
+        """.data(using: .utf8)!
+
+        let rows = try JSONDecoder().decode([AchievementCheckResult].self, from: json)
+        #expect(rows.count == 2)
+        #expect(rows[0].slug == "first-soul")
+        #expect(rows[0].karmaGranted == 7)
+        #expect(rows[1].karmaGranted == 0)
+    }
+
+    @Test("unknown family degrades to slug title and trophy symbol")
+    func unknownFamilyTolerance() throws {
+        let json = """
+        [{
+          "id": "3c2b1a0d-9e8f-4765-8493-a2b1c0d9e8f7",
+          "slug": "mystery-badge",
+          "family": "brand_new_family",
+          "threshold": null,
+          "emotion_id": null,
+          "domain_id": null,
+          "sort_order": 900,
+          "glyph_id": null,
+          "karma_reward": 0,
+          "is_active": true,
+          "title_en": null,
+          "title_fr": null,
+          "description_en": null,
+          "description_fr": null
+        }]
+        """.data(using: .utf8)!
+
+        let rows = try JSONDecoder().decode([AchievementRecord].self, from: json)
+        let record = try #require(rows.first)
+        #expect(record.localizedTitle(emotionName: nil, domainName: nil) == "mystery-badge")
+        #expect(record.localizedDescription(emotionName: nil, domainName: nil) == nil)
+        #expect(record.familySymbol == "trophy")
+    }
+}


### PR DESCRIPTION
Resolves #666

iOS port of **M48 · Achievements** (#665/#676 is the reference implementation). Design: `docs/superpowers/specs/2026-07-29-achievements-design.md` (D5, D7, D8). Depends on #664 (merged).

## Key files

| File | What |
|---|---|
| `Services/AchievementsService.swift` | catalog/unlocks reads + `check_achievements` RPC (SETOF → array decode); `fireCheck()` fire-and-forget helper; `unlocked_at` decoded via `ISO8601Flexible` per the #651 rule |
| `Features/Karma/AchievementNotificationService.swift` + `KarmaEarnedCapsule.swift` | unlock pastille as a sibling of the karma flash — its own overlay slot, stacked above the karma capsule so a mutation firing both shows both (web parity: two toasts, distinct ids); several unlocks collapse into one capsule with "+N karma" when granted |
| `Features/Profile/AchievementsView.swift` | grid grouped by family in `sort_order`; screen-open fires the check first (the retroactive grant, non-fatal) then reads; locked = muted + lock + caption (not color-only); inactive+locked hidden; no progress bars |
| `Features/Profile/Models/Achievement+Localized.swift` | D7 copy: DB `title_*`/`description_*` overrides win by locale, else family-keyed catalog strings with threshold/emotion/domain interpolation (`localizedName`, never `.name`); unknown family degrades to slug + trophy |
| `Features/Profile/Components/ProfileAchievementsCard.swift` | profile entry (LabCard pattern); the showcase shelf is #670, not here |
| Fire sites | `CreatePebbleSheet` (incl. soft-success), `EditPebbleSheet` (incl. soft-success — an edit can change the emotion), `GlyphCarveSheet`, `CreateSoulSheet`, `CreateCollectionSheet` |
| `Resources/Localizable.xcstrings` | 36 new keys, EN+FR ("Tu", elision-safe copy matching the web's French) |
| `PebblesTests/AchievementsDecodingTests.swift` | foreign-payload decoding tests per the #651 rule: all three timestamp precisions, null/override catalog rows, unknown-family tolerance |

## Notes

- **No Swift toolchain on this runner** (`xcodegen` absent on Linux), so this was not compiled here. Every API call mirrors an existing in-repo usage verbatim (drafts service, PathStats RPC decode, karma capsule/overlay, profile cards, souls grid); new files land inside `project.yml`'s directory globs, so `xcodegen generate` picks them up. The decoding tests cover the row contracts.
- Encoding side-effect in `Localizable.xcstrings`: five M47-era entries stored as `\uXXXX` escapes were normalized to literal UTF-8 (the format the rest of the file and Xcode use); no values changed.

## Lab Note (EN/FR)

```yaml
species: feature
platform: ios
status: in_progress
published: false
en:
  title: Badges arrive on iPhone
  summary: Your pebbles, souls, collections and glyphs now earn you achievements on iOS too. Find your badges from your profile, and watch a little trophy pop up when you unlock one.
fr:
  title: Les badges arrivent sur iPhone
  summary: Tes galets, tes âmes, tes collections et tes glyphes te font aussi gagner des badges sur iOS. Retrouve-les depuis ton profil, et guette le petit trophée qui surgit quand tu en débloques un.
suggested:
  molecule: pbbls
  type: feature
  tags: [changelog]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkoQL1qxm4oYATiZYb3KZF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkoQL1qxm4oYATiZYb3KZF)_