### PR TITLE
feat(android): add public profile section in settings

### DIFF
--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/ProfileScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/ProfileScreen.kt
@@ -243,12 +243,20 @@ fun ProfileScreen(
                         ?.map { it.provider },
                 ),
             onDismiss = { isPresentingSettings = false },
-            onSaved = { newName, newGlyph ->
-                profile = profile?.copy(displayName = newName, glyphId = newGlyph?.id ?: profile?.glyphId)
+            onSaved = { newName, newGlyph, newHandle, isPublic ->
+                profile =
+                    profile?.copy(
+                        displayName = newName,
+                        glyphId = newGlyph?.id ?: profile?.glyphId,
+                        handle = newHandle,
+                        publicProfile = isPublic,
+                    )
                 newGlyph?.strokes?.let { glyphStrokes = it }
                 isPresentingSettings = false
             },
             modifier = Modifier.fillMaxSize(),
+            initialHandle = profile?.handle,
+            initialPublicProfile = profile?.publicProfile ?: false,
         )
     }
 }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/SettingsScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/SettingsScreen.kt
@@ -1,5 +1,7 @@
 package app.pbbls.android.features.profile
 
+import android.content.Context
+import android.content.Intent
 import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
@@ -20,6 +22,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -78,8 +82,10 @@ fun SettingsScreen(
     email: String?,
     providers: List<String>,
     onDismiss: () -> Unit,
-    onSaved: (displayName: String, glyph: Glyph?) -> Unit,
+    onSaved: (displayName: String, glyph: Glyph?, handle: String?, isPublic: Boolean) -> Unit,
     modifier: Modifier = Modifier,
+    initialHandle: String? = null,
+    initialPublicProfile: Boolean = false,
 ) {
     val profileService = LocalProfileService.current
     val supabase = LocalSupabaseService.current
@@ -90,6 +96,9 @@ fun SettingsScreen(
     var displayName by remember { mutableStateOf(initialDisplayName) }
     var pickedGlyph by remember { mutableStateOf<Glyph?>(null) }
     var newPassword by remember { mutableStateOf("") }
+    var handle by remember { mutableStateOf(initialHandle ?: "") }
+    var isPublicProfile by remember { mutableStateOf(initialPublicProfile) }
+    var handleErrorRes by remember { mutableStateOf<Int?>(null) }
     var isSaving by remember { mutableStateOf(false) }
     var showSaveError by remember { mutableStateOf(false) }
     var isPresentingGlyphPicker by remember { mutableStateOf(false) }
@@ -97,6 +106,9 @@ fun SettingsScreen(
     var isDeleting by remember { mutableStateOf(false) }
     var showDeleteError by remember { mutableStateOf(false) }
 
+    // Handles are stored normalized (DB CHECK), so comparisons and writes use
+    // the lowercased, trimmed form.
+    val normalizedHandle = handle.trim().lowercase()
     val isDirty =
         settingsIsDirty(
             initialName = initialDisplayName,
@@ -104,8 +116,19 @@ fun SettingsScreen(
             initialGlyphId = initialGlyphId,
             pickedGlyphId = pickedGlyph?.id,
             newPassword = newPassword,
+            initialHandle = initialHandle,
+            handle = handle,
+            initialPublicProfile = initialPublicProfile,
+            isPublicProfile = isPublicProfile,
         )
     val currentStrokes = pickedGlyph?.strokes ?: initialGlyphStrokes
+
+    // The share row reflects what is live on the server, not staged edits — a
+    // link to an unsaved handle would 404.
+    val shareUrl =
+        initialHandle
+            ?.takeIf { initialPublicProfile && it.isNotEmpty() }
+            ?.let { "https://www.pbbls.app/u/$it" }
 
     BackHandler(enabled = !isSaving && !isDeleting) { onDismiss() }
 
@@ -114,17 +137,46 @@ fun SettingsScreen(
         scope.launch {
             isSaving = true
             showSaveError = false
+            handleErrorRes = null
             val trimmed = displayName.trim()
             val nameToSend = trimmed.takeIf { it != initialDisplayName && it.isNotEmpty() }
             val glyphToSend = pickedGlyph?.takeIf { it.id != initialGlyphId }
             val passwordToSend = newPassword.takeIf { it.isNotEmpty() }
+
+            // Handle first: claiming and going public in one save needs the
+            // handle stored before the public_profile write passes the CHECK.
+            var savedHandle = initialHandle
+            if (normalizedHandle != (initialHandle ?: "")) {
+                val claimed = normalizedHandle.takeIf { it.isNotEmpty() }
+                try {
+                    profileService.setHandle(claimed)
+                    savedHandle = claimed
+                } catch (e: Exception) {
+                    Log.e(TAG, "set_handle failed", e)
+                    val code = handleErrorStringRes(e)
+                    if (code != null) handleErrorRes = code else showSaveError = true
+                    isSaving = false
+                    return@launch
+                }
+            }
+
             try {
                 profileService.saveSettings(
                     displayName = nameToSend,
                     glyphId = glyphToSend?.id,
                     password = passwordToSend,
                 )
-                onSaved(nameToSend ?: initialDisplayName, pickedGlyph)
+                // Releasing the handle already cleared the flag server-side, so
+                // only write the toggle while a handle exists.
+                if (isPublicProfile != initialPublicProfile && savedHandle != null) {
+                    profileService.setPublicProfile(isPublicProfile)
+                }
+                onSaved(
+                    nameToSend ?: initialDisplayName,
+                    pickedGlyph,
+                    savedHandle,
+                    if (savedHandle == null) false else isPublicProfile,
+                )
             } catch (e: Exception) {
                 Log.e(TAG, "settings save failed", e)
                 showSaveError = true
@@ -264,6 +316,129 @@ fun SettingsScreen(
                         },
                     ),
             )
+
+            // Public profile (M50): claim a handle, opt in, then share the link.
+            Column(verticalArrangement = Arrangement.spacedBy(PebblesTheme.spacing.sm)) {
+                val publicProfileRows: List<@Composable () -> Unit> =
+                    buildList {
+                        add {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                PebblesText(
+                                    text = stringResource(R.string.settings_handle_label),
+                                    style = PebblesTypography.body,
+                                    color = system.secondary,
+                                )
+                                Spacer(Modifier.weight(1f))
+                                PebblesText(
+                                    text = "@",
+                                    style = PebblesTypography.body,
+                                    color = system.secondary,
+                                )
+                                BasicTextField(
+                                    value = handle,
+                                    onValueChange = {
+                                        handle = it
+                                        handleErrorRes = null
+                                        // Emptying the field means "release my handle",
+                                        // which the server pairs with dropping the public
+                                        // flag. Mirror it so a save can never carry
+                                        // "public, no handle".
+                                        if (it.trim().isEmpty()) isPublicProfile = false
+                                    },
+                                    singleLine = true,
+                                    textStyle =
+                                        PebblesTypography.body.copy(
+                                            color = system.foreground,
+                                            textAlign = TextAlign.End,
+                                        ),
+                                    cursorBrush = SolidColor(PebblesTheme.colors.accent.primary),
+                                    keyboardOptions =
+                                        KeyboardOptions(
+                                            capitalization = KeyboardCapitalization.None,
+                                            autoCorrectEnabled = false,
+                                        ),
+                                    decorationBox = { inner ->
+                                        if (handle.isEmpty()) {
+                                            PebblesText(
+                                                text = stringResource(R.string.settings_handle_placeholder),
+                                                style = PebblesTypography.body,
+                                                color = system.muted,
+                                            )
+                                        }
+                                        inner()
+                                    },
+                                    modifier = Modifier.weight(2f),
+                                )
+                            }
+                        }
+                        add {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .clickable(enabled = initialHandle != null) {
+                                            isPublicProfile = !isPublicProfile
+                                        },
+                            ) {
+                                PebblesText(
+                                    text = stringResource(R.string.settings_public_profile_toggle),
+                                    style = PebblesTypography.body,
+                                    color = if (initialHandle != null) system.foreground else system.muted,
+                                )
+                                Spacer(Modifier.weight(1f))
+                                Switch(
+                                    checked = isPublicProfile,
+                                    onCheckedChange = { isPublicProfile = it },
+                                    enabled = initialHandle != null,
+                                    colors =
+                                        SwitchDefaults.colors(
+                                            checkedTrackColor = PebblesTheme.colors.accent.primary,
+                                        ),
+                                )
+                            }
+                        }
+                        if (shareUrl != null) {
+                            add {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .clickable { sharePublicProfile(context, shareUrl) },
+                                ) {
+                                    PebblesText(
+                                        text = stringResource(R.string.settings_public_profile_share),
+                                        style = PebblesTypography.body,
+                                        color = system.foreground,
+                                    )
+                                    Spacer(Modifier.weight(1f))
+                                    Icon(
+                                        painter = painterResource(R.drawable.ic_chevron_right),
+                                        contentDescription = null,
+                                        tint = system.secondary,
+                                        modifier = Modifier.size(16.dp),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                PebblesListSection(
+                    header = stringResource(R.string.settings_public_profile_header),
+                    rows = publicProfileRows,
+                )
+                PebblesText(
+                    text =
+                        handleErrorRes?.let { stringResource(it) }
+                            ?: if (initialHandle == null) {
+                                stringResource(R.string.settings_public_profile_needs_handle)
+                            } else {
+                                stringResource(R.string.settings_handle_footer)
+                            },
+                    style = PebblesTypography.subhead,
+                    color = if (handleErrorRes != null) PebblesDestructive else system.secondary,
+                )
+            }
 
             if (providers.isNotEmpty()) {
                 PebblesListSection(
@@ -443,7 +618,8 @@ fun SettingsScreen(
 
 /**
  * Pure dirty-check — mirrors `SettingsSheet.isDirty`: a trimmed, non-empty
- * name change, a different picked glyph, or a non-empty new password.
+ * name change, a different picked glyph, a non-empty new password, a changed
+ * handle (compared normalized, as the DB stores it), or a flipped public flag.
  */
 internal fun settingsIsDirty(
     initialName: String,
@@ -451,9 +627,47 @@ internal fun settingsIsDirty(
     initialGlyphId: String?,
     pickedGlyphId: String?,
     newPassword: String,
+    initialHandle: String? = null,
+    handle: String = initialHandle ?: "",
+    initialPublicProfile: Boolean = false,
+    isPublicProfile: Boolean = initialPublicProfile,
 ): Boolean {
     val trimmed = name.trim()
     val nameChanged = trimmed != initialName && trimmed.isNotEmpty()
     val glyphChanged = pickedGlyphId != null && pickedGlyphId != initialGlyphId
-    return nameChanged || glyphChanged || newPassword.isNotEmpty()
+    val handleChanged = handle.trim().lowercase() != (initialHandle ?: "")
+    val publicChanged = isPublicProfile != initialPublicProfile
+    return nameChanged || glyphChanged || newPassword.isNotEmpty() || handleChanged || publicChanged
+}
+
+/**
+ * Maps a `set_handle` rejection to its inline string resource. The RPC raises
+ * stable codes; anything else (`not_found`, a dropped connection) is not a
+ * verdict on the handle, so it returns null and the caller falls back to the
+ * generic save error.
+ */
+internal fun handleErrorStringRes(error: Throwable): Int? {
+    val description = error.message ?: error.toString()
+    return when {
+        description.contains("handle_taken") -> R.string.settings_handle_error_taken
+        description.contains("handle_reserved") -> R.string.settings_handle_error_reserved
+        description.contains("invalid_handle") -> R.string.settings_handle_error_invalid
+        else -> null
+    }
+}
+
+/**
+ * Android's share affordance for the public profile — the app's first
+ * `ACTION_SEND` chooser (iOS uses `ShareLink`).
+ */
+private fun sharePublicProfile(
+    context: Context,
+    url: String,
+) {
+    val intent =
+        Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, url)
+        }
+    context.startActivity(Intent.createChooser(intent, null))
 }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/services/ProfileService.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/services/ProfileService.kt
@@ -12,6 +12,7 @@ import io.github.jan.supabase.postgrest.query.Columns
 import io.github.jan.supabase.postgrest.query.Order
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import java.time.OffsetDateTime
@@ -30,7 +31,7 @@ class ProfileService(
     suspend fun loadProfile(): ProfileRow =
         supabase.client
             .from("profiles")
-            .select(Columns.raw("display_name, created_at, glyph_id"))
+            .select(Columns.raw("display_name, created_at, glyph_id, handle, public_profile"))
             .decodeSingle()
 
     /** Stroke data for the profile glyph — mirrors `ProfileView.loadGlyphStrokes`. */
@@ -81,6 +82,36 @@ class ProfileService(
         }
     }
 
+    /**
+     * Claims, changes, or releases (null) the public handle — mirrors
+     * `SettingsSheet.save()`'s `set_handle` call. The RPC normalizes and
+     * validates, raising the stable codes `invalid_handle` / `handle_taken` /
+     * `handle_reserved`; a null handle releases it and drops `public_profile`
+     * in the same statement. Throws on failure; the screen maps the code.
+     */
+    suspend fun setHandle(handle: String?) {
+        supabase.client.postgrest.rpc(
+            "set_handle",
+            buildJsonObject {
+                if (handle == null) put("p_handle", JsonNull) else put("p_handle", handle)
+            },
+        )
+    }
+
+    /**
+     * Flips the public-profile opt-in. A single-column owner-scoped write is
+     * the sanctioned direct-client case (root `AGENTS.md`) — no RPC. The DB
+     * CHECK rejects `true` without a handle, so callers claim first.
+     */
+    suspend fun setPublicProfile(isPublic: Boolean) {
+        val userId = supabase.session?.user?.id ?: error("not authenticated")
+        supabase.client
+            .from("profiles")
+            .update(buildJsonObject { put("public_profile", isPublic) }) {
+                filter { eq("user_id", userId) }
+            }
+    }
+
     @Serializable
     private data class GlyphStrokesRow(
         val strokes: List<GlyphStroke>,
@@ -97,6 +128,9 @@ data class ProfileRow(
     val createdAt: OffsetDateTime,
     @SerialName("glyph_id")
     val glyphId: String? = null,
+    val handle: String? = null,
+    @SerialName("public_profile")
+    val publicProfile: Boolean = false,
 )
 
 /** CompositionLocal for [ProfileService] — see [LocalSupabaseService] (D4). */

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -86,6 +86,16 @@
     <string name="settings_password_header">Mot de passe</string>
     <string name="settings_password_placeholder">Nouveau mot de passe</string>
     <string name="settings_password_footer">Laissez vide pour conserver votre mot de passe actuel.</string>
+    <string name="settings_public_profile_header">Profil public</string>
+    <string name="settings_handle_label">Pseudo</string>
+    <string name="settings_handle_placeholder">votre_pseudo</string>
+    <string name="settings_handle_footer">3 à 30 caractères : minuscules, chiffres, tirets bas. Laissez vide pour libérer votre pseudo.</string>
+    <string name="settings_public_profile_toggle">Rendre mon profil public</string>
+    <string name="settings_public_profile_needs_handle">Choisissez d\'abord un pseudo pour passer en public.</string>
+    <string name="settings_public_profile_share">Partager mon profil</string>
+    <string name="settings_handle_error_invalid">Ce pseudo n\'est pas valide. Utilisez 3 à 30 minuscules, chiffres ou tirets bas, en commençant et terminant par une lettre ou un chiffre.</string>
+    <string name="settings_handle_error_taken">Ce pseudo est déjà pris.</string>
+    <string name="settings_handle_error_reserved">Ce pseudo est réservé.</string>
     <string name="settings_providers_header">Fournisseurs</string>
     <string name="settings_legal_header">Mentions légales</string>
     <string name="settings_save_error">Impossible d\'enregistrer vos modifications. Veuillez réessayer.</string>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -93,6 +93,16 @@
     <string name="settings_password_header">Password</string>
     <string name="settings_password_placeholder">New password</string>
     <string name="settings_password_footer">Leave blank to keep your current password.</string>
+    <string name="settings_public_profile_header">Public profile</string>
+    <string name="settings_handle_label">Handle</string>
+    <string name="settings_handle_placeholder">your_handle</string>
+    <string name="settings_handle_footer">3 to 30 characters: lowercase letters, numbers, underscores. Leave empty to release your handle.</string>
+    <string name="settings_public_profile_toggle">Make my profile public</string>
+    <string name="settings_public_profile_needs_handle">Claim a handle first to go public.</string>
+    <string name="settings_public_profile_share">Share my profile</string>
+    <string name="settings_handle_error_invalid">That handle isn\'t valid. Use 3 to 30 lowercase letters, numbers or underscores, starting and ending with a letter or number.</string>
+    <string name="settings_handle_error_taken">That handle is already taken.</string>
+    <string name="settings_handle_error_reserved">That handle is reserved.</string>
     <string name="settings_providers_header">Providers</string>
     <string name="settings_legal_header">Legal</string>
     <string name="settings_save_error">Couldn\'t save your changes. Please try again.</string>

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/profile/SettingsLogicTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/profile/SettingsLogicTest.kt
@@ -1,7 +1,9 @@
 package app.pbbls.android.features.profile
 
+import app.pbbls.android.R
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -38,6 +40,73 @@ class SettingsLogicTest {
     @Test
     fun `a non-empty password is dirty`() {
         assertTrue(settingsIsDirty("Alexis", "Alexis", "g1", null, "hunter2"))
+    }
+
+    /** Claiming, releasing, and case-only edits, with the other fields pristine. */
+    private fun handleDirty(
+        initialHandle: String?,
+        handle: String,
+    ): Boolean = settingsIsDirty("A", "A", null, null, "", initialHandle, handle)
+
+    @Test
+    fun `a changed handle is dirty, compared normalized like the DB stores it`() {
+        assertTrue(handleDirty(initialHandle = null, handle = "sam"))
+        // Same handle in a different case is not a change — the RPC would store
+        // the identical normalized value.
+        assertFalse(handleDirty(initialHandle = "sam", handle = "  SAM  "))
+        // Clearing the field is the release path, which is a change.
+        assertTrue(handleDirty(initialHandle = "sam", handle = ""))
+        // No handle before, still none: not dirty.
+        assertFalse(handleDirty(initialHandle = null, handle = "   "))
+    }
+
+    @Test
+    fun `a flipped public-profile toggle is dirty`() {
+        assertTrue(
+            settingsIsDirty(
+                initialName = "A",
+                name = "A",
+                initialGlyphId = null,
+                pickedGlyphId = null,
+                newPassword = "",
+                initialHandle = "sam",
+                handle = "sam",
+                initialPublicProfile = false,
+                isPublicProfile = true,
+            ),
+        )
+        assertFalse(
+            settingsIsDirty(
+                initialName = "A",
+                name = "A",
+                initialGlyphId = null,
+                pickedGlyphId = null,
+                newPassword = "",
+                initialHandle = "sam",
+                handle = "sam",
+                initialPublicProfile = true,
+                isPublicProfile = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `set_handle codes map to inline errors, everything else falls through`() {
+        assertEquals(
+            R.string.settings_handle_error_taken,
+            handleErrorStringRes(RuntimeException("...handle_taken...")),
+        )
+        assertEquals(
+            R.string.settings_handle_error_reserved,
+            handleErrorStringRes(RuntimeException("...handle_reserved...")),
+        )
+        assertEquals(
+            R.string.settings_handle_error_invalid,
+            handleErrorStringRes(RuntimeException("...invalid_handle...")),
+        )
+        // not_found, timeouts and transport failures are not handle verdicts.
+        assertNull(handleErrorStringRes(RuntimeException("not_found")))
+        assertNull(handleErrorStringRes(RuntimeException("timeout")))
     }
 
     @Test


### PR DESCRIPTION
Resolves #657

Android surface of **M50 · Public profiles** (design: `docs/superpowers/specs/2026-07-29-public-profiles-design.md`, D6). Mirrors iOS (#678) and the web reference (#677); backend in #675. Last slice of the milestone.

## Changes
- **`features/profile/SettingsScreen.kt`** — new "Public profile" `PebblesListSection` before Providers/Password:
  - Handle `BasicTextField` with an `@` prefix, `KeyboardCapitalization.None` + `autoCorrectEnabled = false`. Clearing it forces the toggle off so a save can never carry a contradictory "public, no handle".
  - Material 3 `Switch` tinted with `accent.primary`, disabled until a handle is live on the server (the DB CHECK rejects `true` without one). The whole row is clickable, matching the section's other rows.
  - Share row shown only when the *saved* state is public — a link to a staged, unsaved handle would 404. Fires an `Intent.ACTION_SEND` chooser: the app's **first** share intent.
  - The section footer doubles as the inline error slot; `save()` writes the handle first (so claim + go public in one save satisfies the CHECK), then name/glyph/password, then the toggle.
- **`services/ProfileService.kt`** — `setHandle(handle: String?)` over the RPC (explicit `JsonNull` for the release path, mirroring iOS) and `setPublicProfile(isPublic:)` as a single-column owner-scoped update (the sanctioned direct-write case per root `AGENTS.md`, following the `patchDisplayNameIfDefault` shape). `ProfileRow` + its `select` gain `handle` and `public_profile`.
- **`features/profile/ProfileScreen.kt`** — passes the new initial values and carries the saved state back through `onSaved`.
- **`res/values/strings.xml` + `values-fr/strings.xml`** — 10 new keys each (`LocalizationParityTest` enforces the key-set parity).
- **`SettingsLogicTest.kt`** — `settingsIsDirty` gained defaulted params (existing 5-arg calls still compile) plus new cases: handle changes compared *normalized* (a case-only edit is not dirty, clearing is), the toggle flip, and `handleErrorStringRes` mapping only the three stable codes while `not_found`/timeouts fall through to the generic error.

## Notes
- **This is the one slice with real CI**, so `android.yml` (ktlint + unit tests + `assembleDebug`) is the actual gate — I can't run it here (no Android SDK in this environment; `scripts/gradle-if-sdk.sh` no-ops by design). I pre-empted the likely failures by checking each new API against an in-repo precedent rather than memory: `autoCorrectEnabled` (not the older `autoCorrect`) per `AuthScreen.kt:156`, `buildList` with an explicit `List<@Composable () -> Unit>` type per `GlyphPickerSheet.kt:211`, the `.update(buildJsonObject { … }) { filter { … } }` shape per `SupabaseService.kt:233`, no line over ktlint's 140 limit, and one-argument-per-line wrapping in the new multi-line calls. I'll drive CI to green if anything still trips.
- One deliberate rename: the error mapper is `handleErrorStringRes`, not `handleErrorRes`, because the composable already holds `var handleErrorRes` — same-name resolution would have been legal but genuinely confusing to read.
- Viewing *other* users' profiles in-app stays out of scope (deferred to M49 with connections, design D7).

## Lab Note (EN/FR)

```yaml
species: feature
platform: android
status: in_progress
published: false
en:
  title: Claim your handle and share your profile
  summary: Pick a handle in Settings, flip one switch, and your profile gets a page you can share with anyone. Private until you decide otherwise.
fr:
  title: Réserve ton pseudo et partage ton profil
  summary: Choisis un pseudo dans les réglages, active l'interrupteur, et ton profil obtient une page que tu peux partager à qui tu veux. Privé jusqu'à ce que tu en décides autrement.
suggested:
  molecule: pbbls
  type: feature
  tags: [profile, sharing, changelog]
```

## Checklist
- [x] Branch name follows `type/issueNumber-description` (`feat/657-android-public-profile-settings`)
- [x] PR title uses conventional commits
- [x] Labels applied (`feat`, `ui`)
- [x] Milestone assigned (M50 · Public profiles)
- [ ] `npm run build` / `npm run lint` — **delegated to `android.yml`**: no Android SDK in this environment, so the local task no-ops by design (D13). CI is the authoritative gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaPrQJcWwzWDvr7Ji9uLNP)_