### PR TITLE
feat(ui): add achievements grid, unlock capsule and profile entry on android

### DIFF
--- a/apps/android/app/src/main/kotlin/app/pbbls/android/MainActivity.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/MainActivity.kt
@@ -8,8 +8,10 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.CompositionLocalProvider
 import app.pbbls.android.features.glyph.services.LocalGlyphMarketService
 import app.pbbls.android.features.glyph.services.LocalGlyphService
+import app.pbbls.android.features.karma.LocalAchievementNotificationService
 import app.pbbls.android.features.karma.LocalKarmaNotificationService
 import app.pbbls.android.features.lab.services.LocalLogsService
+import app.pbbls.android.services.LocalAchievementsService
 import app.pbbls.android.services.LocalCollectionsService
 import app.pbbls.android.services.LocalComposerSnapshotStore
 import app.pbbls.android.services.LocalEmotionPaletteService
@@ -62,6 +64,8 @@ class MainActivity : ComponentActivity() {
                     LocalGlyphMarketService provides app.glyphMarket,
                     LocalLogsService provides app.logsService,
                     LocalKarmaNotificationService provides app.karma,
+                    LocalAchievementNotificationService provides app.achievementNotify,
+                    LocalAchievementsService provides app.achievements,
                 ) {
                     RootScreen()
                 }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/PebblesApp.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/PebblesApp.kt
@@ -5,8 +5,8 @@ import app.pbbls.android.features.glyph.services.GlyphMarketService
 import app.pbbls.android.features.glyph.services.GlyphService
 import app.pbbls.android.features.karma.AchievementNotificationService
 import app.pbbls.android.features.karma.KarmaNotificationService
-import app.pbbls.android.services.AchievementsService
 import app.pbbls.android.features.lab.services.LogsService
+import app.pbbls.android.services.AchievementsService
 import app.pbbls.android.services.CollectionsService
 import app.pbbls.android.services.ComposerSnapshotStore
 import app.pbbls.android.services.EmotionPaletteService

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/PebblesApp.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/PebblesApp.kt
@@ -3,7 +3,9 @@ package app.pbbls.android
 import android.app.Application
 import app.pbbls.android.features.glyph.services.GlyphMarketService
 import app.pbbls.android.features.glyph.services.GlyphService
+import app.pbbls.android.features.karma.AchievementNotificationService
 import app.pbbls.android.features.karma.KarmaNotificationService
+import app.pbbls.android.services.AchievementsService
 import app.pbbls.android.features.lab.services.LogsService
 import app.pbbls.android.services.CollectionsService
 import app.pbbls.android.services.ComposerSnapshotStore
@@ -88,6 +90,12 @@ class PebblesApp :
     lateinit var karma: KarmaNotificationService
         private set
 
+    lateinit var achievementNotify: AchievementNotificationService
+        private set
+
+    lateinit var achievements: AchievementsService
+        private set
+
     override fun onCreate() {
         super.onCreate()
         Rive.init(this)
@@ -108,6 +116,8 @@ class PebblesApp :
         glyphMarket = GlyphMarketService(supabase)
         logsService = LogsService(supabase)
         karma = KarmaNotificationService()
+        achievementNotify = AchievementNotificationService()
+        achievements = AchievementsService(supabase, achievementNotify)
     }
 
     /**

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/RootScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/RootScreen.kt
@@ -21,12 +21,14 @@ import app.pbbls.android.features.auth.AuthMode
 import app.pbbls.android.features.auth.AuthScreen
 import app.pbbls.android.features.glyph.store.GlyphsListScreen
 import app.pbbls.android.features.karma.KarmaOverlayHost
+import app.pbbls.android.features.karma.LocalAchievementNotificationService
 import app.pbbls.android.features.karma.LocalKarmaNotificationService
 import app.pbbls.android.features.lab.LabScreen
 import app.pbbls.android.features.onboarding.OnboardingGate
 import app.pbbls.android.features.onboarding.OnboardingScreen
 import app.pbbls.android.features.onboarding.OnboardingSteps
 import app.pbbls.android.features.path.PathScreen
+import app.pbbls.android.features.profile.AchievementsScreen
 import app.pbbls.android.features.profile.CollectionDetailScreen
 import app.pbbls.android.features.profile.CollectionsListScreen
 import app.pbbls.android.features.profile.ProfileScreen
@@ -53,6 +55,7 @@ private const val ROUTE_COLLECTIONS = "collections"
 private const val ROUTE_COLLECTION_DETAIL = "collections/{collectionId}"
 private const val ROUTE_GLYPHS = "glyphs"
 private const val ROUTE_LAB = "lab"
+private const val ROUTE_ACHIEVEMENTS = "achievements"
 
 /**
  * Top-level auth gate — the `RootView` analog (D5). The gate is conditional
@@ -72,6 +75,7 @@ fun RootScreen() {
     val palettes = LocalEmotionPaletteService.current
     val referenceData = LocalReferenceDataService.current
     val karma = LocalKarmaNotificationService.current
+    val achievementNotify = LocalAchievementNotificationService.current
     val snapUrls = LocalSnapURLCache.current
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -140,9 +144,14 @@ fun RootScreen() {
                     },
                 )
             }
-            // Karma flash floats above the authed surfaces (create/detail live
-            // inside PathScreen, so they're below it) — drawn last for z-order (D9).
-            KarmaOverlayHost(service = karma, modifier = Modifier.fillMaxSize())
+            // Karma + achievement flashes float above the authed surfaces
+            // (create/detail live inside PathScreen, so they're below) —
+            // drawn last for z-order (D9).
+            KarmaOverlayHost(
+                service = karma,
+                achievements = achievementNotify,
+                modifier = Modifier.fillMaxSize(),
+            )
         } else {
             WelcomeAuthNavHost(
                 contentRevealed = welcomeContentRevealed,
@@ -184,6 +193,7 @@ private fun AuthedNavHost(onSignOut: () -> Unit) {
                 },
                 onOpenGlyphs = { navController.navigate(ROUTE_GLYPHS) },
                 onOpenLab = { navController.navigate(ROUTE_LAB) },
+                onOpenAchievements = { navController.navigate(ROUTE_ACHIEVEMENTS) },
             )
         }
         composable(ROUTE_GLYPHS) {
@@ -191,6 +201,9 @@ private fun AuthedNavHost(onSignOut: () -> Unit) {
         }
         composable(ROUTE_LAB) {
             LabScreen(onBack = { navController.popBackStack() })
+        }
+        composable(ROUTE_ACHIEVEMENTS) {
+            AchievementsScreen(onBack = { navController.popBackStack() })
         }
         composable(ROUTE_SOULS) {
             SoulsListScreen(

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/glyph/carve/GlyphCarveScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/glyph/carve/GlyphCarveScreen.kt
@@ -56,6 +56,7 @@ import app.pbbls.android.features.glyph.models.Glyph
 import app.pbbls.android.features.glyph.models.GlyphStroke
 import app.pbbls.android.features.glyph.services.LocalGlyphService
 import app.pbbls.android.features.path.render.GlyphImage
+import app.pbbls.android.services.LocalAchievementsService
 import app.pbbls.android.theme.PebblesDestructive
 import app.pbbls.android.theme.PebblesScreen
 import app.pbbls.android.theme.PebblesText
@@ -89,6 +90,7 @@ fun GlyphCarveScreen(
     modifier: Modifier = Modifier,
 ) {
     val glyphService = LocalGlyphService.current
+    val achievements = LocalAchievementsService.current
     val system = PebblesTheme.colors.system
     val scope = rememberCoroutineScope()
 
@@ -110,6 +112,7 @@ fun GlyphCarveScreen(
             showSaveError = false
             try {
                 val glyph = glyphService.create(strokes = strokes, name = name)
+                achievements.fireCheck()
                 onSaved(glyph)
             } catch (e: Exception) {
                 Log.e(TAG, "glyph save failed", e)

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/karma/AchievementNotificationService.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/karma/AchievementNotificationService.kt
@@ -1,0 +1,74 @@
+package app.pbbls.android.features.karma
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import app.pbbls.android.services.AchievementRecord
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * One achievement unlock moment. Several unlocks in a single
+ * `check_achievements()` response collapse into one content value (web
+ * parity): [single] carries the catalog row when exactly one badge unlocked —
+ * the capsule resolves its localized title — else a count phrase shows.
+ * [karmaTotal] is the sum the server actually emitted.
+ */
+data class AchievementUnlockedContent(
+    val count: Int,
+    val single: AchievementRecord?,
+    val karmaTotal: Int,
+)
+
+/**
+ * Explicit-fire entry point for the achievement unlock capsule. Sibling of
+ * [KarmaNotificationService] — same presentation contract, its own slot so an
+ * achievement moment and a karma flash fired by the same mutation coexist
+ * instead of one replacing the other (the overlay stacks them; see
+ * `KarmaOverlayHost`). Delight only — never authoritative over what is
+ * unlocked.
+ */
+class AchievementNotificationService(
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
+) {
+    /** Content shown in the pastille (null = hidden). Observed by the overlay. */
+    var activeCapsule: AchievementUnlockedContent? by mutableStateOf(null)
+        private set
+
+    private var dismissJob: Job? = null
+
+    fun notifyUnlocked(
+        count: Int,
+        single: AchievementRecord?,
+        karmaTotal: Int,
+    ) {
+        if (count <= 0) return
+        activeCapsule = AchievementUnlockedContent(count, single, karmaTotal)
+        dismissJob?.cancel()
+        dismissJob =
+            scope.launch {
+                delay(CAPSULE_DURATION_MS)
+                activeCapsule = null
+            }
+    }
+
+    fun dismiss() {
+        dismissJob?.cancel()
+        activeCapsule = null
+    }
+
+    companion object {
+        /** Slightly longer than the karma flash: a badge title takes a beat more to read. */
+        const val CAPSULE_DURATION_MS = 3_200L
+    }
+}
+
+val LocalAchievementNotificationService =
+    staticCompositionLocalOf<AchievementNotificationService> {
+        error("LocalAchievementNotificationService not provided — wrap the tree in MainActivity's CompositionLocalProvider")
+    }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/karma/AchievementUnlockedCapsule.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/karma/AchievementUnlockedCapsule.kt
@@ -1,0 +1,129 @@
+package app.pbbls.android.features.karma
+
+import android.view.HapticFeedbackConstants
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import app.pbbls.android.R
+import app.pbbls.android.features.shared.achievements.achievementTitle
+import app.pbbls.android.theme.PebblesText
+import app.pbbls.android.theme.PebblesTheme
+import app.pbbls.android.theme.PebblesTypography
+
+/**
+ * The achievement-unlocked pastille, visual sibling of [KarmaEarnedCapsule]:
+ * trophy instead of sparkle, the badge title (or a count phrase for several
+ * unlocks) and the karma actually granted when > 0. Localized title
+ * resolution happens here — `achievementTitle` is composable (it reads the
+ * reference-data locals), which is why the service hands over the catalog row
+ * rather than a string.
+ */
+@Composable
+fun AchievementUnlockedCapsule(
+    content: AchievementUnlockedContent,
+    onTap: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val system = PebblesTheme.colors.system
+    val accent = PebblesTheme.colors.accent
+    val view = LocalView.current
+    val ring = remember { Animatable(1f) }
+
+    val headline =
+        if (content.count == 1 && content.single != null) {
+            achievementTitle(content.single)
+        } else {
+            pluralStringResource(R.plurals.achievement_capsule_count, content.count, content.count)
+        }
+    val a11y =
+        buildString {
+            append(
+                if (content.count == 1 && content.single != null) {
+                    stringResource(R.string.achievement_capsule_a11y_single, headline)
+                } else {
+                    headline
+                },
+            )
+            if (content.karmaTotal > 0) {
+                append(", ")
+                append(stringResource(R.string.achievement_capsule_a11y_karma, content.karmaTotal))
+            }
+        }
+
+    LaunchedEffect(content) {
+        view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+    }
+    LaunchedEffect(content) {
+        ring.snapTo(1f)
+        ring.animateTo(
+            targetValue = 0f,
+            animationSpec =
+                tween(
+                    AchievementNotificationService.CAPSULE_DURATION_MS.toInt(),
+                    easing = LinearEasing,
+                ),
+        )
+    }
+
+    Surface(
+        shape = CircleShape,
+        color = system.background,
+        tonalElevation = 3.dp,
+        shadowElevation = 8.dp,
+        modifier =
+            modifier
+                .semantics { contentDescription = a11y }
+                .clickable(onClick = onTap)
+                .drawWithContent {
+                    drawContent()
+                    drawKarmaRing(ring.value, accent.primary)
+                },
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 18.dp, vertical = 11.dp),
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_trophy),
+                contentDescription = null,
+                tint = accent.primary,
+                modifier = Modifier.size(16.dp),
+            )
+            PebblesText(
+                text = headline,
+                style = PebblesTypography.buttonLabel,
+                color = system.foreground,
+                maxLines = 1,
+            )
+            if (content.karmaTotal > 0) {
+                PebblesText(
+                    text = stringResource(R.string.karma_flash_amount, content.karmaTotal),
+                    style = PebblesTypography.buttonLabel,
+                    color = accent.primary,
+                )
+            }
+        }
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/karma/KarmaEarnedCapsule.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/karma/KarmaEarnedCapsule.kt
@@ -12,6 +12,7 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -49,33 +50,57 @@ import app.pbbls.android.theme.PebblesTheme
 import app.pbbls.android.theme.PebblesTypography
 
 /**
- * Bottom-center overlay hosting the "+N karma" pastille — the iOS
- * `KarmaOverlayRoot` analog (D9). Drawn last in `RootScreen`'s authed branch so
- * it floats above the create/detail surfaces. Observes
- * [KarmaNotificationService.activeCapsule]; the service owns the auto-dismiss.
+ * Bottom-center overlay hosting the "+N karma" pastille and its M48 sibling,
+ * the achievement-unlocked pastille — the iOS `KarmaOverlayRoot` analog (D9).
+ * Drawn last in `RootScreen`'s authed branch so it floats above the
+ * create/detail surfaces. The achievement capsule stacks above the karma one
+ * so a mutation that fires both shows both (web parity: two toasts with
+ * distinct ids), each on its own lifetime; the services own the auto-dismiss.
  */
 @Composable
 fun KarmaOverlayHost(
     service: KarmaNotificationService,
+    achievements: AchievementNotificationService,
     modifier: Modifier = Modifier,
 ) {
     val content = service.activeCapsule
-    // Retain the last content during the exit animation so it doesn't blank out.
+    val unlocked = achievements.activeCapsule
+    // Retain the last contents during the exit animations so they don't blank out.
     var lastContent by remember { mutableStateOf(KarmaEarnedContent(0, KarmaReason.PEBBLE_CREATED)) }
     if (content != null) lastContent = content
+    var lastUnlocked by remember { mutableStateOf<AchievementUnlockedContent?>(null) }
+    if (unlocked != null) lastUnlocked = unlocked
 
     Box(modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter) {
-        AnimatedVisibility(
-            visible = content != null,
-            enter = fadeIn() + slideInVertically { it / 2 },
-            exit = fadeOut() + slideOutVertically { it / 2 },
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+            modifier = Modifier.padding(bottom = 44.dp),
         ) {
-            val shown = content ?: lastContent
-            KarmaEarnedCapsule(
-                content = shown,
-                onTap = { service.dismiss() },
-                modifier = Modifier.padding(bottom = 44.dp),
-            )
+            AnimatedVisibility(
+                visible = unlocked != null,
+                enter = fadeIn() + slideInVertically { it / 2 },
+                exit = fadeOut() + slideOutVertically { it / 2 },
+            ) {
+                val shown = unlocked ?: lastUnlocked
+                if (shown != null) {
+                    AchievementUnlockedCapsule(
+                        content = shown,
+                        onTap = { achievements.dismiss() },
+                    )
+                }
+            }
+            AnimatedVisibility(
+                visible = content != null,
+                enter = fadeIn() + slideInVertically { it / 2 },
+                exit = fadeOut() + slideOutVertically { it / 2 },
+            ) {
+                val shown = content ?: lastContent
+                KarmaEarnedCapsule(
+                    content = shown,
+                    onTap = { service.dismiss() },
+                )
+            }
         }
     }
 }
@@ -148,9 +173,10 @@ fun KarmaEarnedCapsule(
 /**
  * Draws the capsule-outline countdown stroke trimmed to [progress] (1 → 0)
  * via [PathMeasure]. A full-perimeter round-rect matching the pastille's pill
- * shape, drained clockwise from the top.
+ * shape, drained clockwise from the top. Internal so the achievement capsule
+ * (its M48 sibling) shares the exact same drain.
  */
-private fun DrawScope.drawKarmaRing(
+internal fun DrawScope.drawKarmaRing(
     progress: Float,
     color: Color,
 ) {

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/EditPebbleScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/EditPebbleScreen.kt
@@ -43,6 +43,7 @@ import app.pbbls.android.features.pebblemedia.ImagePipeline
 import app.pbbls.android.features.pebblemedia.SnapUploadCoordinator
 import app.pbbls.android.features.pebblemedia.models.FormSnap
 import app.pbbls.android.services.ComposeResult
+import app.pbbls.android.services.LocalAchievementsService
 import app.pbbls.android.services.LocalEmotionPaletteService
 import app.pbbls.android.services.LocalPebbleDetailService
 import app.pbbls.android.services.LocalPebbleWriteService
@@ -79,6 +80,7 @@ fun EditPebbleScreen(
     val referenceData = LocalReferenceDataService.current
     val palettes = LocalEmotionPaletteService.current
     val karma = LocalKarmaNotificationService.current
+    val achievements = LocalAchievementsService.current
     val supabase = LocalSupabaseService.current
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -194,9 +196,15 @@ fun EditPebbleScreen(
                 is ComposeResult.Success -> {
                     renderSvg = result.response.renderSvg ?: renderSvg
                     karma.notifyEarned(result.response.karmaDelta ?: 0, KarmaReason.PEBBLE_ENRICHED)
+                    // An edit can change the pebble's emotion, newly
+                    // qualifying an emotion_first badge.
+                    achievements.fireCheck()
                     onSaved()
                 }
-                is ComposeResult.SoftSuccess -> onSaved()
+                is ComposeResult.SoftSuccess -> {
+                    achievements.fireCheck()
+                    onSaved()
+                }
                 is ComposeResult.Failure -> {
                     saveErrorRes = result.messageRes
                     isSaving = false

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/create/CreatePebbleScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/create/CreatePebbleScreen.kt
@@ -43,6 +43,7 @@ import app.pbbls.android.features.pebblemedia.ImagePipeline
 import app.pbbls.android.features.pebblemedia.SnapUploadCoordinator
 import app.pbbls.android.services.ComposeResult
 import app.pbbls.android.services.ComposerAutosave
+import app.pbbls.android.services.LocalAchievementsService
 import app.pbbls.android.services.LocalComposerSnapshotStore
 import app.pbbls.android.services.LocalEmotionPaletteService
 import app.pbbls.android.services.LocalPebbleDraftsService
@@ -93,6 +94,7 @@ fun CreatePebbleScreen(
     val writeService = LocalPebbleWriteService.current
     val refs = LocalReferenceDataService.current
     val karma = LocalKarmaNotificationService.current
+    val achievements = LocalAchievementsService.current
     val palettes = LocalEmotionPaletteService.current
     val supabase = LocalSupabaseService.current
     val draftsService = LocalPebbleDraftsService.current
@@ -277,10 +279,13 @@ fun CreatePebbleScreen(
             when (val result = writeService.create(draft, snapPayload)) {
                 is ComposeResult.Success -> {
                     karma.notifyEarned(result.response.karmaDelta ?: 0, KarmaReason.PEBBLE_CREATED)
+                    achievements.fireCheck()
                     consumeDraftAfterPublish()
                     onCreated(result.response.pebbleId)
                 }
                 is ComposeResult.SoftSuccess -> {
+                    // Soft success still inserted the pebble, so counts changed.
+                    achievements.fireCheck()
                     consumeDraftAfterPublish()
                     onCreated(result.pebbleId)
                 }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/create/pickers/SoulPickerSheet.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/path/create/pickers/SoulPickerSheet.kt
@@ -27,6 +27,7 @@ import app.pbbls.android.components.PebblesTextInput
 import app.pbbls.android.features.profile.models.SoulWithGlyph
 import app.pbbls.android.features.shared.SoulItem
 import app.pbbls.android.features.shared.SoulItemCase
+import app.pbbls.android.services.LocalAchievementsService
 import app.pbbls.android.services.LocalReferenceDataService
 import app.pbbls.android.theme.PebblesText
 import app.pbbls.android.theme.PebblesTheme
@@ -51,6 +52,7 @@ fun SoulPickerSheet(
     onConfirm: (List<String>) -> Unit,
 ) {
     val refs = LocalReferenceDataService.current
+    val achievements = LocalAchievementsService.current
     val scope = rememberCoroutineScope()
     var selection by remember { mutableStateOf(currentSelection.toSet()) }
     var showCreate by remember { mutableStateOf(false) }
@@ -80,6 +82,7 @@ fun SoulPickerSheet(
                 scope.launch {
                     val created = refs.createSoul(name)
                     if (created != null) {
+                        achievements.fireCheck()
                         selection = selection + created.id
                         showCreate = false
                     }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/AchievementsScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/AchievementsScreen.kt
@@ -1,0 +1,271 @@
+package app.pbbls.android.features.profile
+
+import android.util.Log
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import app.pbbls.android.R
+import app.pbbls.android.features.shared.achievements.achievementDescription
+import app.pbbls.android.features.shared.achievements.achievementFamilyIcon
+import app.pbbls.android.features.shared.achievements.achievementGroupName
+import app.pbbls.android.features.shared.achievements.achievementTitle
+import app.pbbls.android.services.AchievementRecord
+import app.pbbls.android.services.LocalAchievementsService
+import app.pbbls.android.theme.PebblesIconToken
+import app.pbbls.android.theme.PebblesScreen
+import app.pbbls.android.theme.PebblesText
+import app.pbbls.android.theme.PebblesTheme
+import app.pbbls.android.theme.PebblesTopBar
+import app.pbbls.android.theme.PebblesTypography
+import app.pbbls.android.theme.profileCard
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+private const val TAG = "achievements-screen"
+
+/**
+ * Achievements grid (M48, D8) — ports web `/achievements` and iOS
+ * `AchievementsView`: badges grouped by family in catalog `sort_order`, locked
+ * ones greyed alongside the unlocked. Opening the screen fires
+ * `check_achievements()` first — that call *is* the retroactive grant — then
+ * reads catalog + unlocks, so history appears unlocked on first visit with no
+ * celebration chain (the capsule is for the mutation path only).
+ */
+@Composable
+fun AchievementsScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val achievements = LocalAchievementsService.current
+    val system = PebblesTheme.colors.system
+
+    var catalog by remember { mutableStateOf<List<AchievementRecord>>(emptyList()) }
+    var unlockedAt by remember { mutableStateOf<Map<String, OffsetDateTime>>(emptyMap()) }
+    var isLoading by remember { mutableStateOf(true) }
+    var loadFailed by remember { mutableStateOf(false) }
+    var loadKey by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(loadKey) {
+        isLoading = true
+        loadFailed = false
+        // The retroactive grant precedes the read so a veteran's history is
+        // already unlocked when the grid renders; its errors are non-fatal.
+        achievements.checkIgnoringFailure()
+        try {
+            catalog = achievements.loadCatalog()
+            unlockedAt = achievements.loadUnlocks().associate { it.achievementId to it.unlockedAt }
+        } catch (e: Exception) {
+            Log.e(TAG, "achievements fetch failed", e)
+            loadFailed = true
+        } finally {
+            isLoading = false
+        }
+    }
+
+    PebblesScreen(
+        modifier = modifier,
+        topBar = {
+            PebblesTopBar(
+                title = stringResource(R.string.achievements_title),
+                leading = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_arrow_back),
+                            contentDescription = stringResource(R.string.profile_back_a11y),
+                            tint = system.secondary,
+                            modifier = Modifier.size(24.dp),
+                        )
+                    }
+                },
+            )
+        },
+    ) {
+        when {
+            isLoading ->
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    CircularProgressIndicator(color = PebblesTheme.colors.accent.primary)
+                }
+
+            loadFailed ->
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    PebblesText(
+                        text = stringResource(R.string.achievements_load_error),
+                        style = PebblesTypography.body,
+                        color = system.secondary,
+                    )
+                    TextButton(onClick = { loadKey++ }) {
+                        PebblesText(
+                            text = stringResource(R.string.profile_retry),
+                            style = PebblesTypography.buttonLabel,
+                            color = PebblesTheme.colors.accent.primary,
+                        )
+                    }
+                }
+
+            else -> AchievementsContent(catalog = catalog, unlockedAt = unlockedAt)
+        }
+    }
+}
+
+/** Stateless grid layer, preview/screenshot-friendly. */
+@Composable
+fun AchievementsContent(
+    catalog: List<AchievementRecord>,
+    unlockedAt: Map<String, OffsetDateTime>,
+    modifier: Modifier = Modifier,
+) {
+    val groups = visibleFamilyGroups(catalog, unlockedAt.keys)
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(156.dp),
+        contentPadding = PaddingValues(PebblesTheme.spacing.lg),
+        horizontalArrangement = Arrangement.spacedBy(PebblesTheme.spacing.lg),
+        verticalArrangement = Arrangement.spacedBy(PebblesTheme.spacing.lg),
+        modifier = modifier.fillMaxSize(),
+    ) {
+        groups.forEach { group ->
+            item(key = "header-${group.family}", span = { GridItemSpan(maxLineSpan) }) {
+                PebblesText(
+                    text = achievementGroupName(group.family),
+                    style = PebblesTypography.headline,
+                    color = PebblesTheme.colors.system.foreground,
+                )
+            }
+            items(group.records, key = { it.id }) { record ->
+                AchievementBadgeCell(record = record, unlockedAt = unlockedAt[record.id])
+            }
+        }
+    }
+}
+
+/**
+ * One badge tile. Locked state reads through more than colour: muted styling
+ * plus a lock mark and an explicit caption, mirroring web and iOS.
+ */
+@Composable
+private fun AchievementBadgeCell(
+    record: AchievementRecord,
+    unlockedAt: OffsetDateTime?,
+) {
+    val system = PebblesTheme.colors.system
+    val accent = PebblesTheme.colors.accent
+    val isUnlocked = unlockedAt != null
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .profileCard()
+                .alpha(if (isUnlocked) 1f else 0.72f),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                painter = painterResource(achievementFamilyIcon(record.family)),
+                contentDescription = null,
+                tint = if (isUnlocked) accent.primary else system.muted,
+                modifier = Modifier.size(PebblesIconToken.LARGE.size),
+            )
+            Spacer(Modifier.weight(1f))
+            if (!isUnlocked) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_lock),
+                    contentDescription = null,
+                    tint = system.muted,
+                    modifier = Modifier.size(PebblesIconToken.MEDIUM.size),
+                )
+            }
+        }
+        PebblesText(
+            text = achievementTitle(record),
+            style = PebblesTypography.headline,
+            color = if (isUnlocked) system.foreground else system.secondary,
+        )
+        achievementDescription(record)?.let { description ->
+            PebblesText(
+                text = description,
+                style = PebblesTypography.subhead,
+                color = system.secondary,
+            )
+        }
+        if (unlockedAt != null) {
+            PebblesText(
+                text =
+                    stringResource(
+                        R.string.achievement_unlocked_on,
+                        unlockedAt.toLocalDate().format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)),
+                    ),
+                style = PebblesTypography.subhead,
+                color = accent.primary,
+            )
+        } else {
+            PebblesText(
+                text = stringResource(R.string.achievement_locked),
+                style = PebblesTypography.subhead,
+                color = system.muted,
+            )
+        }
+    }
+}
+
+/** One family section: records already in catalog `sort_order`. */
+internal data class AchievementFamilyGroup(
+    val family: String,
+    val records: List<AchievementRecord>,
+)
+
+/**
+ * Families in first-appearance order (the catalog is sorted by `sort_order`,
+ * which the migration blocks per family). Inactive badges only show once
+ * earned — retiring one hides it from the ladder without revoking anyone's
+ * unlock. Pure so the filter is JVM-testable.
+ */
+internal fun visibleFamilyGroups(
+    catalog: List<AchievementRecord>,
+    unlockedIds: Set<String>,
+): List<AchievementFamilyGroup> {
+    val visible = catalog.filter { it.isActive || it.id in unlockedIds }
+    val order = mutableListOf<String>()
+    val byFamily = mutableMapOf<String, MutableList<AchievementRecord>>()
+    for (record in visible) {
+        if (record.family !in byFamily) order.add(record.family)
+        byFamily.getOrPut(record.family) { mutableListOf() }.add(record)
+    }
+    return order.map { AchievementFamilyGroup(it, byFamily.getValue(it)) }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/AchievementsScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/AchievementsScreen.kt
@@ -8,9 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/CollectionFormScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/CollectionFormScreen.kt
@@ -36,6 +36,7 @@ import app.pbbls.android.R
 import app.pbbls.android.features.profile.components.labelRes
 import app.pbbls.android.features.profile.models.Collection
 import app.pbbls.android.features.profile.models.CollectionMode
+import app.pbbls.android.services.LocalAchievementsService
 import app.pbbls.android.services.LocalCollectionsService
 import app.pbbls.android.theme.PebblesDestructive
 import app.pbbls.android.theme.PebblesListSection
@@ -70,6 +71,7 @@ fun CollectionFormScreen(
     modifier: Modifier = Modifier,
 ) {
     val collectionsService = LocalCollectionsService.current
+    val achievements = LocalAchievementsService.current
     val system = PebblesTheme.colors.system
     val scope = rememberCoroutineScope()
 
@@ -97,6 +99,7 @@ fun CollectionFormScreen(
             try {
                 if (original == null) {
                     collectionsService.create(name = trimmed, mode = mode)
+                    achievements.fireCheck()
                 } else {
                     collectionsService.update(collectionId = original.id, name = trimmed, mode = mode)
                 }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/ProfileScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/ProfileScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import app.pbbls.android.R
 import app.pbbls.android.features.glyph.models.GlyphStroke
+import app.pbbls.android.features.profile.components.ProfileAchievementsCard
 import app.pbbls.android.features.profile.components.ProfileBanner
 import app.pbbls.android.features.profile.components.ProfileCollectionsCard
 import app.pbbls.android.features.profile.components.ProfileLabCard
@@ -70,6 +71,7 @@ fun ProfileScreen(
     onOpenCollection: (Collection) -> Unit,
     onOpenGlyphs: () -> Unit,
     onOpenLab: () -> Unit,
+    onOpenAchievements: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val profileService = LocalProfileService.current
@@ -203,6 +205,7 @@ fun ProfileScreen(
                         pebbles = stats.pebbles,
                         karma = stats.karma,
                     )
+                    ProfileAchievementsCard(onOpen = onOpenAchievements)
                     ProfileCollectionsCard(
                         collections = collections,
                         hasLoaded = collectionsLoaded,

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/SoulFormScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/SoulFormScreen.kt
@@ -40,6 +40,7 @@ import app.pbbls.android.features.glyph.views.GlyphView
 import app.pbbls.android.features.glyph.views.GlyphViewCase
 import app.pbbls.android.features.path.create.pickers.GlyphPickerSheet
 import app.pbbls.android.features.profile.models.SoulWithGlyph
+import app.pbbls.android.services.LocalAchievementsService
 import app.pbbls.android.services.LocalSoulsService
 import app.pbbls.android.theme.PebblesDestructive
 import app.pbbls.android.theme.PebblesListSection
@@ -74,6 +75,7 @@ fun SoulFormScreen(
     modifier: Modifier = Modifier,
 ) {
     val soulsService = LocalSoulsService.current
+    val achievements = LocalAchievementsService.current
     val system = PebblesTheme.colors.system
     val scope = rememberCoroutineScope()
 
@@ -121,6 +123,7 @@ fun SoulFormScreen(
             try {
                 if (original == null) {
                     soulsService.create(name = trimmed, glyphId = glyphId)
+                    achievements.fireCheck()
                 } else {
                     soulsService.update(soulId = original.id, name = trimmed, glyphId = glyphId)
                 }

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/components/ProfileAchievementsCard.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/components/ProfileAchievementsCard.kt
@@ -1,0 +1,76 @@
+package app.pbbls.android.features.profile.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import app.pbbls.android.R
+import app.pbbls.android.theme.PebblesIconToken
+import app.pbbls.android.theme.PebblesText
+import app.pbbls.android.theme.PebblesTheme
+import app.pbbls.android.theme.PebblesTypography
+import app.pbbls.android.theme.profileCard
+
+/**
+ * The Profile "Achievements" card (M48) — ports iOS `ProfileAchievementsCard`:
+ * trophy in accent, title + subtitle, muted chevron, `profileCard` chrome.
+ * Pushes the achievements grid; the showcase shelf is the D14 satellite, not
+ * this card.
+ */
+@Composable
+fun ProfileAchievementsCard(
+    onOpen: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val system = PebblesTheme.colors.system
+    val accent = PebblesTheme.colors.accent
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(PebblesTheme.spacing.lg),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(PebblesTheme.spacing.lg))
+                .clickable(onClick = onOpen)
+                .profileCard(),
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_trophy),
+            contentDescription = null,
+            tint = accent.primary,
+            modifier = Modifier.size(PebblesIconToken.LARGE.size),
+        )
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            PebblesText(
+                text = stringResource(R.string.achievements_title),
+                style = PebblesTypography.headline,
+                color = system.foreground,
+            )
+            PebblesText(
+                text = stringResource(R.string.achievements_card_subtitle),
+                style = PebblesTypography.subhead,
+                color = system.secondary,
+            )
+        }
+        Icon(
+            painter = painterResource(R.drawable.ic_chevron_right),
+            contentDescription = null,
+            tint = system.muted,
+            modifier = Modifier.size(PebblesIconToken.MEDIUM.size),
+        )
+    }
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/shared/achievements/AchievementCopy.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/shared/achievements/AchievementCopy.kt
@@ -1,0 +1,116 @@
+package app.pbbls.android.features.shared.achievements
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import app.pbbls.android.R
+import app.pbbls.android.services.AchievementRecord
+import app.pbbls.android.services.LocalEmotionPaletteService
+import app.pbbls.android.services.LocalReferenceDataService
+import app.pbbls.android.theme.ReferenceStrings
+import app.pbbls.android.theme.ReferenceType
+import java.util.Locale
+
+/**
+ * Display copy for a badge (design D7): the admin's `title_*`/`description_*`
+ * overrides win by the active locale, else the family-keyed string resources
+ * with the threshold or the localized emotion/domain name interpolated
+ * ([ReferenceStrings.referenceName], never the DB `name`). Unknown families
+ * degrade to the slug rather than crash — a family can ship server-side
+ * before this client catches up.
+ */
+
+/**
+ * Pure override pick, mirrored from web/iOS: `fr` prefers the French override,
+ * any other locale the English one; either falls back to its sibling before
+ * dropping to the family strings, so a half-filled row still shows copy.
+ */
+internal fun achievementOverride(
+    en: String?,
+    fr: String?,
+    isFrench: Boolean,
+): String? = if (isFrench) fr ?: en else en ?: fr
+
+private val isFrenchLocale: Boolean
+    get() = Locale.getDefault().language == "fr"
+
+@Composable
+fun achievementTitle(record: AchievementRecord): String {
+    achievementOverride(record.titleEn, record.titleFr, isFrenchLocale)?.let { return it }
+    val threshold = record.threshold ?: 0
+    return when (record.family) {
+        "pebble_count" -> pluralStringResource(R.plurals.achievement_family_pebble_count_title, threshold, threshold)
+        "emotion_first" -> stringResource(R.string.achievement_family_emotion_first_title, emotionName(record))
+        "domain_first" -> stringResource(R.string.achievement_family_domain_first_title, domainName(record))
+        "first_collection" -> stringResource(R.string.achievement_family_first_collection_title)
+        "first_glyph" -> stringResource(R.string.achievement_family_first_glyph_title)
+        "first_soul" -> stringResource(R.string.achievement_family_first_soul_title)
+        "glyph_count" -> stringResource(R.string.achievement_family_glyph_count_title, threshold)
+        "glyph_sales" -> pluralStringResource(R.plurals.achievement_family_glyph_sales_title, threshold, threshold)
+        else -> record.slug
+    }
+}
+
+@Composable
+fun achievementDescription(record: AchievementRecord): String? {
+    achievementOverride(record.descriptionEn, record.descriptionFr, isFrenchLocale)?.let { return it }
+    val threshold = record.threshold ?: 0
+    return when (record.family) {
+        "pebble_count" ->
+            pluralStringResource(R.plurals.achievement_family_pebble_count_description, threshold, threshold)
+        "emotion_first" -> stringResource(R.string.achievement_family_emotion_first_description, emotionName(record))
+        "domain_first" -> stringResource(R.string.achievement_family_domain_first_description, domainName(record))
+        "first_collection" -> stringResource(R.string.achievement_family_first_collection_description)
+        "first_glyph" -> stringResource(R.string.achievement_family_first_glyph_description)
+        "first_soul" -> stringResource(R.string.achievement_family_first_soul_description)
+        "glyph_count" -> stringResource(R.string.achievement_family_glyph_count_description, threshold)
+        "glyph_sales" ->
+            pluralStringResource(R.plurals.achievement_family_glyph_sales_description, threshold, threshold)
+        else -> null
+    }
+}
+
+/** Group heading for a family section; unknown families show their raw value. */
+@Composable
+fun achievementGroupName(family: String): String =
+    when (family) {
+        "pebble_count" -> stringResource(R.string.achievement_group_pebble_count)
+        "emotion_first" -> stringResource(R.string.achievement_group_emotion_first)
+        "domain_first" -> stringResource(R.string.achievement_group_domain_first)
+        "first_collection" -> stringResource(R.string.achievement_group_first_collection)
+        "first_glyph" -> stringResource(R.string.achievement_group_first_glyph)
+        "first_soul" -> stringResource(R.string.achievement_group_first_soul)
+        "glyph_count" -> stringResource(R.string.achievement_group_glyph_count)
+        "glyph_sales" -> stringResource(R.string.achievement_group_glyph_sales)
+        else -> family
+    }
+
+/** Icon per family from the existing asset set; unknown families get the trophy. */
+fun achievementFamilyIcon(family: String): Int =
+    when (family) {
+        "pebble_count" -> R.drawable.ic_fossil_shell
+        "emotion_first" -> R.drawable.ic_pebble_emotion
+        "domain_first" -> R.drawable.ic_pebble_domain
+        "first_collection" -> R.drawable.ic_stack
+        "first_glyph" -> R.drawable.ic_scribble
+        "first_soul" -> R.drawable.ic_person_pair
+        "glyph_count" -> R.drawable.ic_scribble
+        "glyph_sales" -> R.drawable.ic_sparkle
+        else -> R.drawable.ic_trophy
+    }
+
+@Composable
+private fun emotionName(record: AchievementRecord): String {
+    val palettes = LocalEmotionPaletteService.current
+    val emotion = record.emotionId?.let { palettes.byEmotionId[it] }
+    return emotion?.let { ReferenceStrings.referenceName(ReferenceType.EMOTION, it.slug, it.name) }
+        ?: record.slug
+}
+
+@Composable
+private fun domainName(record: AchievementRecord): String {
+    val refs = LocalReferenceDataService.current
+    val domain = record.domainId?.let { id -> refs.domains.firstOrNull { it.id == id } }
+    return domain?.let { ReferenceStrings.referenceName(ReferenceType.DOMAIN, it.slug, it.name) }
+        ?: record.slug
+}

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/shared/achievements/AchievementCopy.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/shared/achievements/AchievementCopy.kt
@@ -11,14 +11,12 @@ import app.pbbls.android.theme.ReferenceStrings
 import app.pbbls.android.theme.ReferenceType
 import java.util.Locale
 
-/**
- * Display copy for a badge (design D7): the admin's `title_*`/`description_*`
- * overrides win by the active locale, else the family-keyed string resources
- * with the threshold or the localized emotion/domain name interpolated
- * ([ReferenceStrings.referenceName], never the DB `name`). Unknown families
- * degrade to the slug rather than crash — a family can ship server-side
- * before this client catches up.
- */
+// Display copy for a badge (design D7): the admin's `title_*`/`description_*`
+// overrides win by the active locale, else the family-keyed string resources
+// with the threshold or the localized emotion/domain name interpolated
+// (`ReferenceStrings.referenceName`, never the DB `name`). Unknown families
+// degrade to the slug rather than crash — a family can ship server-side
+// before this client catches up.
 
 /**
  * Pure override pick, mirrored from web/iOS: `fr` prefers the French override,

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/services/AchievementsService.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/services/AchievementsService.kt
@@ -1,0 +1,176 @@
+package app.pbbls.android.services
+
+import android.util.Log
+import androidx.compose.runtime.staticCompositionLocalOf
+import app.pbbls.android.features.karma.AchievementNotificationService
+import app.pbbls.android.features.path.models.OffsetDateTimeSerializer
+import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.postgrest
+import io.github.jan.supabase.postgrest.query.Columns
+import io.github.jan.supabase.postgrest.query.Order
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.time.OffsetDateTime
+
+private const val TAG = "achievements"
+
+/**
+ * One `achievements` catalog row (M48). Public-read reference data; the copy
+ * columns are nullable admin overrides — display copy resolves through
+ * `AchievementCopy` from them or from the family-keyed string resources.
+ */
+@Serializable
+data class AchievementRecord(
+    val id: String,
+    val slug: String,
+    val family: String,
+    val threshold: Int? = null,
+    @SerialName("emotion_id")
+    val emotionId: String? = null,
+    @SerialName("domain_id")
+    val domainId: String? = null,
+    @SerialName("sort_order")
+    val sortOrder: Int,
+    @SerialName("glyph_id")
+    val glyphId: String? = null,
+    @SerialName("karma_reward")
+    val karmaReward: Int,
+    @SerialName("is_active")
+    val isActive: Boolean,
+    @SerialName("title_en")
+    val titleEn: String? = null,
+    @SerialName("title_fr")
+    val titleFr: String? = null,
+    @SerialName("description_en")
+    val descriptionEn: String? = null,
+    @SerialName("description_fr")
+    val descriptionFr: String? = null,
+)
+
+/**
+ * One of the caller's `achievement_unlocks` rows (owner-scoped by RLS).
+ * `unlocked_at` stays an [OffsetDateTime] through [OffsetDateTimeSerializer] —
+ * PostgREST emits `+00:00` offsets that `Instant.parse` rejects (#651).
+ */
+@Serializable
+data class AchievementUnlockRecord(
+    @SerialName("achievement_id")
+    val achievementId: String,
+    @SerialName("unlocked_at")
+    @Serializable(with = OffsetDateTimeSerializer::class)
+    val unlockedAt: OffsetDateTime,
+)
+
+/**
+ * One newly unlocked badge as `check_achievements()` reports it: the karma is
+ * what the server actually emitted at unlock time, never the catalog's
+ * current value.
+ */
+@Serializable
+data class AchievementCheckResult(
+    val slug: String,
+    @SerialName("karma_granted")
+    val karmaGranted: Int,
+)
+
+/**
+ * Achievements data access + the fire-and-forget evaluation call (M48).
+ *
+ * `check_achievements()` is the design's single evaluation path: idempotent,
+ * client-called after count-changing mutations and on screen open — the
+ * screen-open call is the retroactive grant, so a failed fire self-heals on
+ * the next call and must never block or fail the mutation that triggered it.
+ *
+ * The [scope] is constructor-injectable so `fireCheck`'s launch is
+ * unit-testable on a virtual clock, mirroring [AchievementNotificationService].
+ */
+class AchievementsService(
+    private val supabase: SupabaseService,
+    private val notify: AchievementNotificationService,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
+) {
+    /**
+     * Full catalog, inactive rows included — the screen filters (an inactive
+     * badge stays visible once unlocked, hidden while locked).
+     */
+    suspend fun loadCatalog(): List<AchievementRecord> =
+        supabase.client
+            .from(TABLE)
+            .select(Columns.raw(CATALOG_COLUMNS)) {
+                order("sort_order", Order.ASCENDING)
+            }.decodeList()
+
+    /** The caller's unlocks; RLS scopes to `auth.uid()`. */
+    suspend fun loadUnlocks(): List<AchievementUnlockRecord> =
+        supabase.client
+            .from("achievement_unlocks")
+            .select(Columns.raw("achievement_id, unlocked_at"))
+            .decodeList()
+
+    /**
+     * Runs the evaluation. SETOF-returning RPC, so PostgREST yields an array
+     * (empty = nothing newly unlocked).
+     */
+    suspend fun check(): List<AchievementCheckResult> =
+        supabase.client.postgrest
+            .rpc("check_achievements")
+            .decodeList()
+
+    /**
+     * Screen-open variant: the retroactive grant must never surface as an
+     * error — the grid renders whatever `loadUnlocks()` then returns.
+     */
+    suspend fun checkIgnoringFailure() {
+        try {
+            check()
+        } catch (e: Exception) {
+            Log.w(TAG, "achievement check on screen open failed (self-heals on next call)", e)
+        }
+    }
+
+    /**
+     * Mutation-path variant: fire-and-forget from a success handler. Never
+     * throws, never blocks the caller; new unlocks collapse into one capsule
+     * (web parity). Karma notifies stay untouched — the capsule carries its
+     * own "+N karma" line. A single unlock rides with its catalog row so the
+     * capsule can resolve the localized badge title; the one extra catalog
+     * read per actual unlock (rare) keeps i18n out of six call sites.
+     */
+    fun fireCheck() {
+        scope.launch {
+            try {
+                val results = check()
+                if (results.isEmpty()) return@launch
+                val karmaTotal = results.sumOf { it.karmaGranted }
+                val single =
+                    results.singleOrNull()?.let { result ->
+                        try {
+                            loadCatalog().firstOrNull { it.slug == result.slug }
+                        } catch (e: Exception) {
+                            Log.w(TAG, "catalog fetch for unlock capsule failed", e)
+                            null
+                        }
+                    }
+                notify.notifyUnlocked(count = results.size, single = single, karmaTotal = karmaTotal)
+            } catch (e: Exception) {
+                Log.w(TAG, "achievement check failed (self-heals on next call)", e)
+            }
+        }
+    }
+
+    private companion object {
+        const val TABLE = "achievements"
+        const val CATALOG_COLUMNS =
+            "id, slug, family, threshold, emotion_id, domain_id, sort_order, " +
+                "glyph_id, karma_reward, is_active, title_en, title_fr, description_en, description_fr"
+    }
+}
+
+val LocalAchievementsService =
+    staticCompositionLocalOf<AchievementsService> {
+        error("LocalAchievementsService not provided — wrap the tree in MainActivity's CompositionLocalProvider")
+    }

--- a/apps/android/app/src/main/res/drawable/ic_trophy.xml
+++ b/apps/android/app/src/main/res/drawable/ic_trophy.xml
@@ -1,0 +1,13 @@
+<!--
+  Achievement trophy. Standard Material path data; tinted at the call site by
+  Icon, so fillColor is a placeholder. Unlock capsule + badge fallback (M48).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M19,5h-2V3H7v2H5C3.9,5 3,5.9 3,7v1c0,2.55 1.92,4.63 4.39,4.94 0.63,1.5 1.98,2.63 3.61,2.96V19H7v2h10v-2h-4v-3.1c1.63,-0.33 2.98,-1.46 3.61,-2.96C19.08,12.63 21,10.55 21,8V7C21,5.9 20.1,5 19,5zM5,8V7h2v3.82C5.84,10.4 5,9.3 5,8zM19,8c0,1.3 -0.84,2.4 -2,2.82V7h2V8z" />
+</vector>

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -366,4 +366,52 @@
     <string name="drafts_saved_ago">Gardé il y a %1$s</string>
     <string name="drafts_empty">Aucun brouillon. Tout ce que tu commences à garder apparaît ici.</string>
     <string name="drafts_load_error">Impossible de charger tes brouillons. Réessaie.</string>
+    <!-- Achievements (M48) -->
+    <string name="achievements_title">Succès</string>
+    <string name="achievements_card_subtitle">Tes badges le long du chemin</string>
+    <string name="achievements_load_error">Impossible de charger tes succès. Réessaie.</string>
+    <string name="achievement_locked">À débloquer</string>
+    <string name="achievement_unlocked_on">Débloqué le %1$s</string>
+    <string name="achievement_group_pebble_count">Galets</string>
+    <string name="achievement_group_emotion_first">Émotions</string>
+    <string name="achievement_group_domain_first">Domaines</string>
+    <string name="achievement_group_first_collection">Collections</string>
+    <string name="achievement_group_first_glyph">Glyphes</string>
+    <string name="achievement_group_first_soul">Âmes</string>
+    <string name="achievement_group_glyph_count">Gravure</string>
+    <string name="achievement_group_glyph_sales">Marché</string>
+    <plurals name="achievement_family_pebble_count_title">
+        <item quantity="one">Premier galet</item>
+        <item quantity="other">%1$d galets</item>
+    </plurals>
+    <plurals name="achievement_family_pebble_count_description">
+        <item quantity="one">Dépose ton tout premier galet sur ton chemin.</item>
+        <item quantity="other">Rassemble %1$d galets sur ton chemin.</item>
+    </plurals>
+    <string name="achievement_family_emotion_first_title">Première fois : %1$s</string>
+    <string name="achievement_family_emotion_first_description">Capture ton premier galet teinté par l\'émotion %1$s.</string>
+    <string name="achievement_family_domain_first_title">Premiers pas : %1$s</string>
+    <string name="achievement_family_domain_first_description">Capture ton premier galet dans le domaine %1$s.</string>
+    <string name="achievement_family_first_collection_title">Première collection</string>
+    <string name="achievement_family_first_collection_description">Crée ta toute première collection.</string>
+    <string name="achievement_family_first_glyph_title">Premier glyphe</string>
+    <string name="achievement_family_first_glyph_description">Grave ton tout premier glyphe.</string>
+    <string name="achievement_family_first_soul_title">Première âme</string>
+    <string name="achievement_family_first_soul_description">Ajoute ta toute première âme.</string>
+    <string name="achievement_family_glyph_count_title">%1$d glyphes</string>
+    <string name="achievement_family_glyph_count_description">Grave %1$d glyphes de ta main.</string>
+    <plurals name="achievement_family_glyph_sales_title">
+        <item quantity="one">Première vente</item>
+        <item quantity="other">%1$d ventes</item>
+    </plurals>
+    <plurals name="achievement_family_glyph_sales_description">
+        <item quantity="one">Un pebbler adopte l\'un de tes glyphes.</item>
+        <item quantity="other">Tes glyphes trouvent preneur %1$d fois.</item>
+    </plurals>
+    <plurals name="achievement_capsule_count">
+        <item quantity="one">%1$d succès débloqué</item>
+        <item quantity="other">%1$d succès débloqués</item>
+    </plurals>
+    <string name="achievement_capsule_a11y_single">Succès débloqué : %1$s</string>
+    <string name="achievement_capsule_a11y_karma">Tu as gagné %1$d karma</string>
 </resources>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -379,4 +379,52 @@
     <string name="drafts_saved_ago">Saved %1$s ago</string>
     <string name="drafts_empty">No drafts yet. Anything you start keeping shows up here.</string>
     <string name="drafts_load_error">Couldn\'t load your drafts. Please try again.</string>
+    <!-- Achievements (M48) -->
+    <string name="achievements_title">Achievements</string>
+    <string name="achievements_card_subtitle">Badges along your path</string>
+    <string name="achievements_load_error">Couldn\'t load your achievements. Please try again.</string>
+    <string name="achievement_locked">Locked</string>
+    <string name="achievement_unlocked_on">Unlocked %1$s</string>
+    <string name="achievement_group_pebble_count">Pebbles</string>
+    <string name="achievement_group_emotion_first">Emotions</string>
+    <string name="achievement_group_domain_first">Domains</string>
+    <string name="achievement_group_first_collection">Collections</string>
+    <string name="achievement_group_first_glyph">Glyphs</string>
+    <string name="achievement_group_first_soul">Souls</string>
+    <string name="achievement_group_glyph_count">Carving</string>
+    <string name="achievement_group_glyph_sales">Market</string>
+    <plurals name="achievement_family_pebble_count_title">
+        <item quantity="one">First pebble</item>
+        <item quantity="other">%1$d pebbles</item>
+    </plurals>
+    <plurals name="achievement_family_pebble_count_description">
+        <item quantity="one">Drop your first pebble on the path.</item>
+        <item quantity="other">Collect %1$d pebbles along your path.</item>
+    </plurals>
+    <string name="achievement_family_emotion_first_title">First %1$s</string>
+    <string name="achievement_family_emotion_first_description">Record your first pebble carrying %1$s.</string>
+    <string name="achievement_family_domain_first_title">First steps in %1$s</string>
+    <string name="achievement_family_domain_first_description">Record your first pebble in %1$s.</string>
+    <string name="achievement_family_first_collection_title">First collection</string>
+    <string name="achievement_family_first_collection_description">Create your first collection.</string>
+    <string name="achievement_family_first_glyph_title">First glyph</string>
+    <string name="achievement_family_first_glyph_description">Carve your first glyph.</string>
+    <string name="achievement_family_first_soul_title">First soul</string>
+    <string name="achievement_family_first_soul_description">Add your first soul.</string>
+    <string name="achievement_family_glyph_count_title">%1$d glyphs</string>
+    <string name="achievement_family_glyph_count_description">Carve %1$d glyphs of your own.</string>
+    <plurals name="achievement_family_glyph_sales_title">
+        <item quantity="one">First sale</item>
+        <item quantity="other">%1$d sales</item>
+    </plurals>
+    <plurals name="achievement_family_glyph_sales_description">
+        <item quantity="one">Sell your first glyph in the market.</item>
+        <item quantity="other">Make %1$d glyph sales in the market.</item>
+    </plurals>
+    <plurals name="achievement_capsule_count">
+        <item quantity="one">%1$d achievement unlocked</item>
+        <item quantity="other">%1$d achievements unlocked</item>
+    </plurals>
+    <string name="achievement_capsule_a11y_single">Achievement unlocked: %1$s</string>
+    <string name="achievement_capsule_a11y_karma">You earned %1$d karma</string>
 </resources>

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/features/karma/AchievementNotificationServiceTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/features/karma/AchievementNotificationServiceTest.kt
@@ -1,0 +1,72 @@
+package app.pbbls.android.features.karma
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The achievement-unlock capsule entry point (M48): zero-count calls never
+ * surface, a shown capsule auto-dismisses after
+ * [AchievementNotificationService.CAPSULE_DURATION_MS], `dismiss` clears it
+ * immediately, and a fresh unlock replaces the current one and resets the
+ * timer — mirrors [KarmaNotificationServiceTest]'s virtual-clock approach.
+ */
+class AchievementNotificationServiceTest {
+    @Test
+    fun `a zero count never surfaces a capsule`() =
+        runTest {
+            val service = AchievementNotificationService(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+            service.notifyUnlocked(count = 0, single = null, karmaTotal = 0)
+            assertNull(service.activeCapsule)
+        }
+
+    @Test
+    fun `an unlock shows the capsule and auto-dismisses after the duration`() =
+        runTest {
+            val service = AchievementNotificationService(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+            service.notifyUnlocked(count = 2, single = null, karmaTotal = 5)
+            assertEquals(
+                AchievementUnlockedContent(count = 2, single = null, karmaTotal = 5),
+                service.activeCapsule,
+            )
+
+            advanceTimeBy(AchievementNotificationService.CAPSULE_DURATION_MS + 1)
+            runCurrent()
+            assertNull(service.activeCapsule)
+        }
+
+    @Test
+    fun `dismiss clears the capsule immediately`() =
+        runTest {
+            val service = AchievementNotificationService(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+            service.notifyUnlocked(count = 1, single = null, karmaTotal = 0)
+            service.dismiss()
+            assertNull(service.activeCapsule)
+        }
+
+    @Test
+    fun `a fresh unlock replaces the capsule and resets the timer`() =
+        runTest {
+            val service = AchievementNotificationService(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+            service.notifyUnlocked(count = 1, single = null, karmaTotal = 0)
+            advanceTimeBy(AchievementNotificationService.CAPSULE_DURATION_MS - 100)
+            service.notifyUnlocked(count = 3, single = null, karmaTotal = 7)
+
+            advanceTimeBy(200)
+            runCurrent()
+            assertEquals(3, service.activeCapsule?.count)
+
+            advanceTimeBy(AchievementNotificationService.CAPSULE_DURATION_MS)
+            runCurrent()
+            assertNull(service.activeCapsule)
+        }
+}

--- a/apps/android/app/src/test/kotlin/app/pbbls/android/services/AchievementsDecodingTest.kt
+++ b/apps/android/app/src/test/kotlin/app/pbbls/android/services/AchievementsDecodingTest.kt
@@ -1,0 +1,108 @@
+package app.pbbls.android.services
+
+import app.pbbls.android.features.profile.visibleFamilyGroups
+import app.pbbls.android.features.shared.achievements.achievementOverride
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Achievements row contracts (M48) — foreign payloads in the shapes PostgREST
+ * actually emits, mirroring iOS `AchievementsDecodingTests.swift`, including
+ * the timestamp precision variants that motivated the OffsetDateTime rule
+ * (#651): microseconds with `+00:00`, web milliseconds with `Z`, whole seconds.
+ */
+class AchievementsDecodingTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `catalog row decodes with nulls and overrides`() {
+        val rows =
+            json.decodeFromString<List<AchievementRecord>>(
+                """
+                [{ "id": "a1", "slug": "pebble-count-10", "family": "pebble_count",
+                   "threshold": 10, "emotion_id": null, "domain_id": null,
+                   "sort_order": 110, "glyph_id": null, "karma_reward": 0,
+                   "is_active": true, "title_en": null, "title_fr": null,
+                   "description_en": null, "description_fr": null },
+                 { "id": "a2", "slug": "emotion-first-joyful", "family": "emotion_first",
+                   "threshold": null, "emotion_id": "e1", "domain_id": null,
+                   "sort_order": 200, "glyph_id": null, "karma_reward": 5,
+                   "is_active": true, "title_en": "Custom title", "title_fr": "Titre perso",
+                   "description_en": null, "description_fr": null }]
+                """.trimIndent(),
+            )
+        assertEquals(2, rows.size)
+        assertEquals(10, rows[0].threshold)
+        assertNull(rows[0].emotionId)
+        assertEquals(5, rows[1].karmaReward)
+        assertEquals("Titre perso", rows[1].titleFr)
+    }
+
+    @Test
+    fun `unlock rows decode every timestamp precision`() {
+        for (raw in listOf(
+            "2026-07-30T09:15:42.123456+00:00",
+            "2026-07-30T09:15:42.123Z",
+            "2026-07-30T09:15:42Z",
+        )) {
+            val rows =
+                json.decodeFromString<List<AchievementUnlockRecord>>(
+                    """[{ "achievement_id": "a1", "unlocked_at": "$raw" }]""",
+                )
+            assertEquals("a1", rows[0].achievementId)
+            assertEquals(1_785_402_942L, rows[0].unlockedAt.toEpochSecond())
+        }
+    }
+
+    @Test
+    fun `check result decodes slug and granted karma`() {
+        val rows =
+            json.decodeFromString<List<AchievementCheckResult>>(
+                """[{ "slug": "first-soul", "karma_granted": 7 },
+                    { "slug": "pebble-count-1", "karma_granted": 0 }]""",
+            )
+        assertEquals("first-soul", rows[0].slug)
+        assertEquals(7, rows[0].karmaGranted)
+        assertEquals(0, rows[1].karmaGranted)
+    }
+
+    @Test
+    fun `override pick prefers the active locale and falls back to the sibling`() {
+        assertEquals("fr", achievementOverride(en = "en", fr = "fr", isFrench = true))
+        assertEquals("en", achievementOverride(en = "en", fr = "fr", isFrench = false))
+        assertEquals("en", achievementOverride(en = "en", fr = null, isFrench = true))
+        assertEquals("fr", achievementOverride(en = null, fr = "fr", isFrench = false))
+        assertNull(achievementOverride(en = null, fr = null, isFrench = true))
+    }
+
+    @Test
+    fun `inactive badges only show once unlocked, families keep catalog order`() {
+        fun record(
+            id: String,
+            family: String,
+            sort: Int,
+            active: Boolean = true,
+        ) = AchievementRecord(
+            id = id,
+            slug = id,
+            family = family,
+            sortOrder = sort,
+            karmaReward = 0,
+            isActive = active,
+        )
+        val catalog =
+            listOf(
+                record("p1", "pebble_count", 100),
+                record("p2", "pebble_count", 110, active = false),
+                record("s1", "first_soul", 400),
+                record("g1", "glyph_count", 500, active = false),
+            )
+        val groups = visibleFamilyGroups(catalog, unlockedIds = setOf("p2"))
+        assertEquals(listOf("pebble_count", "first_soul"), groups.map { it.family })
+        assertEquals(listOf("p1", "p2"), groups[0].records.map { it.id })
+        assertEquals(listOf("s1"), groups[1].records.map { it.id })
+    }
+}


### PR DESCRIPTION
Resolves #667

Android port of **M48 · Achievements**, symmetric to #665/#676 (web reference) and #666/#679 (iOS). Design: `docs/superpowers/specs/2026-07-29-achievements-design.md` (D5, D7, D8). Depends on #664 (merged).

## Key files

| File | What |
|---|---|
| `services/AchievementsService.kt` | catalog/unlocks reads + `check_achievements` RPC (`decodeList`); `fireCheck()` fire-and-forget on an injectable scope; `unlocked_at` via `OffsetDateTimeSerializer` per the #651 rule |
| `features/karma/AchievementNotificationService.kt` + `AchievementUnlockedCapsule.kt` + `KarmaOverlayHost` | unlock pastille as a sibling of the karma flash — the overlay now stacks both capsules (web parity: two toasts, distinct ids), each on its own lifetime; several unlocks collapse into one capsule with "+N karma" when granted |
| `features/profile/AchievementsScreen.kt` | grid grouped by family in `sort_order` (full-span headers); screen-open fires the check first (the retroactive grant, non-fatal) then reads; locked = muted + lock + caption; inactive+locked hidden (pure `visibleFamilyGroups`, JVM-tested); stateless `AchievementsContent` layer |
| `features/shared/achievements/AchievementCopy.kt` | D7 copy: DB overrides win by locale (pure `achievementOverride`, JVM-tested), else family plurals/strings with threshold or `ReferenceStrings.referenceName` interpolation — resolution stays composable-side because `referenceName` is `@Composable`, so the notify content carries the catalog row, not a string |
| `features/profile/components/ProfileAchievementsCard.kt` + route | profile entry (LabCard pattern) + `ROUTE_ACHIEVEMENTS`; the showcase shelf is #671, not here |
| Fire sites | `CreatePebbleScreen` (Success + SoftSuccess), `EditPebbleScreen` (Success + SoftSuccess — an edit can change the emotion), `GlyphCarveScreen` (covers both carve hosts), `SoulFormScreen` + `SoulPickerSheet` quick-create, `CollectionFormScreen` (create only) |
| `res/values/strings.xml` + `values-fr/` | full key set EN+FR ("Tu", elision-safe) — `LocalizationParityTest` gates parity |
| `res/drawable/ic_trophy.xml` | new Material trophy vector for the capsule + badge fallback |
| Tests | `AchievementsDecodingTest` (foreign payloads incl. all three timestamp precisions, override pick, family-group filter), `AchievementNotificationServiceTest` (virtual-clock auto-dismiss) |

## Notes

- Android is not buildable locally on this runner (no SDK; `gradle-if-sdk.sh` no-ops), so `android.yml` — ktlint, unit tests incl. localization parity, assembleDebug — is the gate, per the issue.
- No screenshot preview added for the new screen in this PR; can follow up with `AchievementsScreenshots.kt` if wanted (the stateless content layer is already in place for it).

## Lab Note (EN/FR)

```yaml
species: feature
platform: android
status: in_progress
published: false
en:
  title: Badges arrive on Android
  summary: Your pebbles, souls, collections and glyphs now earn you achievements on Android too. Find your badges from your profile, and watch a little trophy pop up when you unlock one.
fr:
  title: Les badges arrivent sur Android
  summary: Tes galets, tes âmes, tes collections et tes glyphes te font aussi gagner des badges sur Android. Retrouve-les depuis ton profil, et guette le petit trophée qui surgit quand tu en débloques un.
suggested:
  molecule: pbbls
  type: feature
  tags: [changelog]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkoQL1qxm4oYATiZYb3KZF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkoQL1qxm4oYATiZYb3KZF)_