### PR TITLE
feat(facility): add the achievements library manager to the back-office

### DIFF
--- a/apps/admin/app/(authed)/achievements/[id]/_components/AchievementEditor.tsx
+++ b/apps/admin/app/(authed)/achievements/[id]/_components/AchievementEditor.tsx
@@ -1,0 +1,373 @@
+"use client"
+
+import { useMemo, useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { Badge } from "@/components/ui/badge"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { GlyphPreview } from "@/components/pebblestore/GlyphPreview"
+import {
+  GLYPH_CANVAS_VIEWBOX,
+  IDENTITY_ADJUST,
+  type Adjust,
+  type GlyphStroke,
+} from "@/lib/pebblestore/types"
+import { svgToStrokes } from "@/lib/pebblestore/svg-to-strokes"
+import { bakeAdjust } from "@/lib/pebblestore/transform-path"
+import { familyLabel, type AdminAchievement } from "@/lib/achievements/types"
+import { deleteAchievement, setAchievementGlyph, updateAchievement } from "../../actions"
+
+/**
+ * Badge editor. What it can change is deliberately narrow: copy, karma, order,
+ * retirement and the visual. Family, threshold and the emotion/domain binding
+ * define what the badge *means* — editing them under users who already unlocked
+ * it would rewrite history, so the RPC refuses and they render read-only here.
+ */
+export function AchievementEditor({ achievement }: { achievement: AdminAchievement }) {
+  const router = useRouter()
+
+  const [titleEn, setTitleEn] = useState(achievement.title_en ?? "")
+  const [titleFr, setTitleFr] = useState(achievement.title_fr ?? "")
+  const [descriptionEn, setDescriptionEn] = useState(achievement.description_en ?? "")
+  const [descriptionFr, setDescriptionFr] = useState(achievement.description_fr ?? "")
+  const [karma, setKarma] = useState(String(achievement.karma_reward))
+  const [sortOrder, setSortOrder] = useState(String(achievement.sort_order))
+  const [isActive, setIsActive] = useState(achievement.is_active)
+
+  // Glyph editing: null strokes = keep the current glyph (no new SVG staged).
+  const [strokes, setStrokes] = useState<GlyphStroke[] | null>(null)
+  const [viewBox, setViewBox] = useState(achievement.view_box ?? GLYPH_CANVAS_VIEWBOX)
+  const [skipped, setSkipped] = useState<string[]>([])
+  const [parseError, setParseError] = useState<string | null>(null)
+  const [adjust, setAdjust] = useState<Adjust>(IDENTITY_ADJUST)
+
+  const [formError, setFormError] = useState<string | null>(null)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [pending, startTransition] = useTransition()
+
+  const hasNewGlyph = strokes !== null && strokes.length > 0
+
+  const previewStrokes = useMemo(() => {
+    if (hasNewGlyph) return bakeAdjust(strokes as GlyphStroke[], viewBox, adjust)
+    return achievement.strokes ?? []
+  }, [hasNewGlyph, strokes, viewBox, adjust, achievement.strokes])
+
+  const previewViewBox = hasNewGlyph ? viewBox : achievement.view_box ?? GLYPH_CANVAS_VIEWBOX
+
+  const karmaValue = Number(karma)
+  const karmaValid =
+    karma.trim() !== "" && Number.isInteger(karmaValue) && karmaValue >= 0 && karmaValue <= 32767
+  const sortValue = Number(sortOrder)
+  const sortValid = sortOrder.trim() !== "" && Number.isInteger(sortValue)
+
+  const canSave =
+    titleEn.trim().length > 0 && titleFr.trim().length > 0 && karmaValid && sortValid && !pending
+
+  const onFile = async (file: File | undefined) => {
+    if (!file) return
+    setParseError(null)
+    try {
+      const text = await file.text()
+      const r = svgToStrokes(text)
+      if (r.strokes.length === 0) {
+        setParseError("No supported strokes found in this SVG (see the supported subset).")
+        setStrokes(null)
+        setSkipped(r.skipped)
+        return
+      }
+      setStrokes(r.strokes)
+      setViewBox(r.viewBox)
+      setSkipped(r.skipped)
+      setAdjust(IDENTITY_ADJUST)
+    } catch (e) {
+      setParseError(e instanceof Error ? e.message : String(e))
+      setStrokes(null)
+    }
+  }
+
+  const onSave = () => {
+    setFormError(null)
+    startTransition(async () => {
+      const res = await updateAchievement({
+        id: achievement.id,
+        titleEn: titleEn.trim(),
+        titleFr: titleFr.trim(),
+        descriptionEn: descriptionEn.trim(),
+        descriptionFr: descriptionFr.trim(),
+        karmaReward: karmaValue,
+        sortOrder: sortValue,
+        isActive,
+      })
+      if (res?.error) {
+        setFormError(res.error)
+        return
+      }
+      if (hasNewGlyph) {
+        const baked = bakeAdjust(strokes as GlyphStroke[], viewBox, adjust)
+        const glyphRes = await setAchievementGlyph({
+          id: achievement.id,
+          strokes: baked,
+          viewBox,
+        })
+        if (glyphRes?.error) {
+          setFormError(glyphRes.error)
+          return
+        }
+        setStrokes(null)
+      }
+      toast.success("Achievement saved")
+    })
+  }
+
+  const onDelete = () => {
+    startTransition(async () => {
+      const res = await deleteAchievement(achievement.id)
+      if (res?.error) {
+        setConfirmDelete(false)
+        setFormError(res.error)
+        return
+      }
+      router.push("/achievements")
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-lg font-semibold">{achievement.title_en ?? achievement.slug}</h1>
+          <p className="text-xs text-muted-foreground">{achievement.slug}</p>
+        </div>
+        {achievement.is_active ? null : <Badge variant="outline">Retired</Badge>}
+      </div>
+
+      <GlyphPreview
+        strokes={previewStrokes}
+        viewBox={previewViewBox}
+        className="mx-auto aspect-square w-40 rounded-md border bg-card text-foreground"
+      />
+
+      <dl className="grid gap-2 rounded-lg border p-4 text-sm sm:grid-cols-2">
+        <div>
+          <dt className="text-muted-foreground">Family</dt>
+          <dd>{familyLabel(achievement.family)}</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Threshold</dt>
+          <dd>{achievement.threshold ?? "—"}</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Bound to</dt>
+          <dd>{achievement.emotion_slug ?? achievement.domain_slug ?? "—"}</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Unlocked by</dt>
+          <dd>
+            {achievement.unlock_count} {achievement.unlock_count === 1 ? "user" : "users"}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="title-en">Title (EN)</Label>
+          <Input id="title-en" value={titleEn} onChange={(e) => setTitleEn(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="title-fr">Title (FR)</Label>
+          <Input id="title-fr" value={titleFr} onChange={(e) => setTitleFr(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="desc-en">Description (EN)</Label>
+          <Input
+            id="desc-en"
+            value={descriptionEn}
+            onChange={(e) => setDescriptionEn(e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="desc-fr">Description (FR)</Label>
+          <Input
+            id="desc-fr"
+            value={descriptionFr}
+            onChange={(e) => setDescriptionFr(e.target.value)}
+          />
+        </div>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Titles here override the apps&rsquo; built-in copy for this badge, so both
+        languages are required. Leave descriptions empty to fall back to the
+        app&rsquo;s own wording.
+      </p>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="karma">Karma reward</Label>
+          <Input
+            id="karma"
+            type="number"
+            min={0}
+            max={32767}
+            value={karma}
+            onChange={(e) => setKarma(e.target.value)}
+          />
+          {karmaValid ? null : (
+            <p className="text-xs text-destructive">A whole number from 0 to 32767.</p>
+          )}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="sort-order">Sort order</Label>
+          <Input
+            id="sort-order"
+            type="number"
+            value={sortOrder}
+            onChange={(e) => setSortOrder(e.target.value)}
+          />
+          {sortValid ? null : <p className="text-xs text-destructive">A whole number.</p>}
+        </div>
+      </div>
+
+      <label className="flex items-center gap-3 text-sm">
+        <Switch checked={isActive} onCheckedChange={setIsActive} />
+        <span>
+          Active
+          <span className="block text-xs text-muted-foreground">
+            Retiring a badge stops new unlocks and its karma. Users who already earned
+            it keep it.
+          </span>
+        </span>
+      </label>
+
+      <div className="space-y-2">
+        <Label htmlFor="svg-file">Replace badge glyph (SVG)</Label>
+        <Input
+          id="svg-file"
+          type="file"
+          accept=".svg,image/svg+xml"
+          onChange={(e) => onFile(e.target.files?.[0])}
+        />
+        {parseError ? <p className="text-sm text-destructive">{parseError}</p> : null}
+        {skipped.length > 0 ? (
+          <p className="text-xs text-muted-foreground">
+            Skipped (unsupported): {skipped.join(", ")}. Glyphs are stroke-only — filled
+            shapes import as outlines.
+          </p>
+        ) : null}
+      </div>
+
+      {hasNewGlyph ? (
+        <fieldset className="space-y-3 rounded-lg border p-4">
+          <legend className="px-1 text-sm font-medium">Adjust</legend>
+          <div className="space-y-1">
+            <Label htmlFor="adjust-scale">Scale: {adjust.scale.toFixed(2)}</Label>
+            <input
+              id="adjust-scale"
+              type="range"
+              min={0.3}
+              max={1.5}
+              step={0.05}
+              value={adjust.scale}
+              onChange={(e) => setAdjust((a) => ({ ...a, scale: Number(e.target.value) }))}
+              className="w-full"
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label htmlFor="adjust-x">Offset X: {adjust.offsetX}</Label>
+              <input
+                id="adjust-x"
+                type="range"
+                min={-50}
+                max={50}
+                step={1}
+                value={adjust.offsetX}
+                onChange={(e) => setAdjust((a) => ({ ...a, offsetX: Number(e.target.value) }))}
+                className="w-full"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="adjust-y">Offset Y: {adjust.offsetY}</Label>
+              <input
+                id="adjust-y"
+                type="range"
+                min={-50}
+                max={50}
+                step={1}
+                value={adjust.offsetY}
+                onChange={(e) => setAdjust((a) => ({ ...a, offsetY: Number(e.target.value) }))}
+                className="w-full"
+              />
+            </div>
+          </div>
+          <div className="flex gap-6">
+            <label className="flex items-center gap-2 text-sm">
+              <Switch
+                checked={adjust.flipH}
+                onCheckedChange={(v) => setAdjust((a) => ({ ...a, flipH: v }))}
+              />
+              Flip H
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <Switch
+                checked={adjust.flipV}
+                onCheckedChange={(v) => setAdjust((a) => ({ ...a, flipV: v }))}
+              />
+              Flip V
+            </label>
+          </div>
+        </fieldset>
+      ) : null}
+
+      {formError ? <p className="text-sm text-destructive">{formError}</p> : null}
+
+      <div className="flex items-center justify-between gap-4">
+        <Button disabled={!canSave} onClick={onSave}>
+          {pending ? "Saving…" : "Save"}
+        </Button>
+        {achievement.unlock_count === 0 ? (
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={pending}
+            onClick={() => setConfirmDelete(true)}
+          >
+            Delete
+          </Button>
+        ) : null}
+      </div>
+
+      <Dialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete this achievement?</DialogTitle>
+            <DialogDescription>
+              &ldquo;{achievement.title_en ?? achievement.slug}&rdquo; will be removed from
+              the catalog. Nobody has unlocked it, so nothing is taken away from a user —
+              but this cannot be undone. To take a badge out of circulation without
+              deleting it, switch it to inactive instead.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setConfirmDelete(false)}>
+              Cancel
+            </Button>
+            <Button type="button" variant="destructive" disabled={pending} onClick={onDelete}>
+              {pending ? "Deleting…" : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/apps/admin/app/(authed)/achievements/[id]/page.tsx
+++ b/apps/admin/app/(authed)/achievements/[id]/page.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { ChevronLeft } from "lucide-react"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+import type { AdminAchievement } from "@/lib/achievements/types"
+import { AchievementEditor } from "./_components/AchievementEditor"
+
+export default async function AchievementEditorPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const supabase = await createServerSupabaseClient()
+  const { data, error } = await supabase.rpc("admin_list_achievements")
+
+  if (error) {
+    console.error("[achievements/[id]] admin_list_achievements failed:", error.message)
+  }
+  const achievement = ((data ?? []) as AdminAchievement[]).find((a) => a.id === id)
+  if (!achievement) notFound()
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <Link
+        href="/achievements"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ChevronLeft className="size-4" aria-hidden />
+        All achievements
+      </Link>
+      <AchievementEditor achievement={achievement} />
+    </div>
+  )
+}

--- a/apps/admin/app/(authed)/achievements/actions.ts
+++ b/apps/admin/app/(authed)/achievements/actions.ts
@@ -1,0 +1,111 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { achievementErrorMessage } from "@/lib/achievements/types"
+import type { GlyphStroke } from "@/lib/pebblestore/types"
+
+export type ActionResult = { error: string } | undefined
+export type CreateResult = { error: string } | { id: string }
+
+const LIST_PATH = "/achievements"
+
+export async function createAchievement(input: {
+  slug: string
+  family: string
+  threshold: number | null
+  emotionId: string | null
+  domainId: string | null
+  titleEn: string
+  titleFr: string
+  descriptionEn: string
+  descriptionFr: string
+  karmaReward: number
+  sortOrder: number
+}): Promise<CreateResult> {
+  const supabase = await createServerSupabaseClient()
+  // The per-family arguments default to null in SQL, so an omitted key is how a
+  // family that has no threshold (or no reference row) says so.
+  const { data, error } = await supabase.rpc("admin_create_achievement", {
+    p_slug: input.slug,
+    p_family: input.family,
+    p_title_en: input.titleEn,
+    p_title_fr: input.titleFr,
+    p_karma_reward: input.karmaReward,
+    p_sort_order: input.sortOrder,
+    p_threshold: input.threshold ?? undefined,
+    p_emotion_id: input.emotionId ?? undefined,
+    p_domain_id: input.domainId ?? undefined,
+    p_description_en: input.descriptionEn,
+    p_description_fr: input.descriptionFr,
+  })
+  if (error) {
+    console.error("[achievements] createAchievement failed:", error.message)
+    return { error: achievementErrorMessage(error.message) }
+  }
+  revalidatePath(LIST_PATH)
+  return { id: data as unknown as string }
+}
+
+export async function updateAchievement(input: {
+  id: string
+  titleEn: string
+  titleFr: string
+  descriptionEn: string
+  descriptionFr: string
+  karmaReward: number
+  sortOrder: number
+  isActive: boolean
+}): Promise<ActionResult> {
+  const supabase = await createServerSupabaseClient()
+  const { error } = await supabase.rpc("admin_update_achievement", {
+    p_achievement_id: input.id,
+    p_title_en: input.titleEn,
+    p_title_fr: input.titleFr,
+    p_karma_reward: input.karmaReward,
+    p_description_en: input.descriptionEn,
+    p_description_fr: input.descriptionFr,
+    p_sort_order: input.sortOrder,
+    p_is_active: input.isActive,
+  })
+  if (error) {
+    console.error("[achievements] updateAchievement failed:", error.message)
+    return { error: achievementErrorMessage(error.message) }
+  }
+  revalidatePath(LIST_PATH)
+  revalidatePath(`${LIST_PATH}/${input.id}`)
+  return undefined
+}
+
+export async function setAchievementGlyph(input: {
+  id: string
+  strokes: GlyphStroke[]
+  viewBox: string
+}): Promise<ActionResult> {
+  const supabase = await createServerSupabaseClient()
+  const { error } = await supabase.rpc("admin_set_achievement_glyph", {
+    p_achievement_id: input.id,
+    p_strokes: input.strokes as unknown as never, // jsonb
+    p_view_box: input.viewBox,
+  })
+  if (error) {
+    console.error("[achievements] setAchievementGlyph failed:", error.message)
+    return { error: achievementErrorMessage(error.message) }
+  }
+  revalidatePath(LIST_PATH)
+  revalidatePath(`${LIST_PATH}/${input.id}`)
+  return undefined
+}
+
+export async function deleteAchievement(id: string): Promise<ActionResult> {
+  const supabase = await createServerSupabaseClient()
+  const { error } = await supabase.rpc("admin_delete_achievement", {
+    p_achievement_id: id,
+  })
+  if (error) {
+    console.error("[achievements] deleteAchievement failed:", error.message)
+    return { error: achievementErrorMessage(error.message) }
+  }
+  revalidatePath(LIST_PATH)
+  return undefined
+}

--- a/apps/admin/app/(authed)/achievements/new/_components/NewAchievementForm.tsx
+++ b/apps/admin/app/(authed)/achievements/new/_components/NewAchievementForm.tsx
@@ -1,0 +1,308 @@
+"use client"
+
+import { useMemo, useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  ACHIEVEMENT_FAMILIES,
+  COUNTING_FAMILIES,
+  REFERENCE_FAMILIES,
+  familyLabel,
+  type AchievementFamily,
+} from "@/lib/achievements/types"
+import { createAchievement } from "../../actions"
+
+type ReferenceRow = { id: string; slug: string; name: string }
+type ExistingRow = {
+  slug: string
+  family: string
+  threshold: number | null
+  sortOrder: number
+}
+
+/**
+ * Adds a new tier to an existing family. The family list is fixed: it mirrors
+ * the column's CHECK, which is exactly what `check_achievements()` knows how to
+ * evaluate — a new *kind* of rule needs a migration, not a form.
+ *
+ * The form mirrors the RPC's validation so the common mistakes are caught before
+ * a round-trip, but the RPC stays the authority.
+ */
+export function NewAchievementForm({
+  existing,
+  emotions,
+  domains,
+}: {
+  existing: ExistingRow[]
+  emotions: ReferenceRow[]
+  domains: ReferenceRow[]
+}) {
+  const router = useRouter()
+
+  const [family, setFamily] = useState<AchievementFamily>("pebble_count")
+  const [slug, setSlug] = useState("")
+  const [threshold, setThreshold] = useState("")
+  const [referenceId, setReferenceId] = useState<string | null>(null)
+  const [titleEn, setTitleEn] = useState("")
+  const [titleFr, setTitleFr] = useState("")
+  const [descriptionEn, setDescriptionEn] = useState("")
+  const [descriptionFr, setDescriptionFr] = useState("")
+  const [karma, setKarma] = useState("0")
+  const [sortOrder, setSortOrder] = useState("")
+  const [formError, setFormError] = useState<string | null>(null)
+  const [pending, startTransition] = useTransition()
+
+  const needsThreshold = COUNTING_FAMILIES.includes(family)
+  const needsReference = REFERENCE_FAMILIES.includes(family)
+  const references = family === "emotion_first" ? emotions : domains
+
+  // Existing tiers of the chosen family, so the ladder being extended is visible
+  // and the next sort_order can be suggested rather than guessed.
+  const siblings = useMemo(
+    () =>
+      existing
+        .filter((a) => a.family === family)
+        .sort((a, b) => a.sortOrder - b.sortOrder),
+    [existing, family],
+  )
+  const suggestedSort = siblings.length > 0 ? siblings[siblings.length - 1].sortOrder + 10 : 900
+
+  const trimmedSlug = slug.trim()
+  const slugValid = /^[a-z0-9]+(-[a-z0-9]+)*$/.test(trimmedSlug)
+  const slugTaken = existing.some((a) => a.slug === trimmedSlug)
+  const thresholdValue = Number(threshold)
+  const thresholdValid = needsThreshold
+    ? threshold.trim() !== "" && Number.isInteger(thresholdValue) && thresholdValue > 0
+    : true
+  const karmaValue = Number(karma)
+  const karmaValid =
+    karma.trim() !== "" && Number.isInteger(karmaValue) && karmaValue >= 0 && karmaValue <= 32767
+  const sortValue = sortOrder.trim() === "" ? suggestedSort : Number(sortOrder)
+  const sortValid = Number.isInteger(sortValue)
+
+  const canSave =
+    slugValid &&
+    !slugTaken &&
+    thresholdValid &&
+    karmaValid &&
+    sortValid &&
+    (!needsReference || referenceId !== null) &&
+    titleEn.trim().length > 0 &&
+    titleFr.trim().length > 0 &&
+    !pending
+
+  // Base UI hands back `null` when a select is cleared; the family always has a
+  // value here, so a null is simply ignored.
+  const onFamilyChange = (next: AchievementFamily | null) => {
+    if (next === null) return
+    setFamily(next)
+    setReferenceId(null)
+    setThreshold("")
+  }
+
+  const onCreate = () => {
+    setFormError(null)
+    startTransition(async () => {
+      const res = await createAchievement({
+        slug: trimmedSlug,
+        family,
+        threshold: needsThreshold ? thresholdValue : null,
+        emotionId: family === "emotion_first" ? referenceId : null,
+        domainId: family === "domain_first" ? referenceId : null,
+        titleEn: titleEn.trim(),
+        titleFr: titleFr.trim(),
+        descriptionEn: descriptionEn.trim(),
+        descriptionFr: descriptionFr.trim(),
+        karmaReward: karmaValue,
+        sortOrder: sortValue,
+      })
+      if ("error" in res) {
+        setFormError(res.error)
+        return
+      }
+      toast.success("Achievement created")
+      router.push(`/achievements/${res.id}`)
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-lg font-semibold">New achievement</h1>
+        <p className="text-sm text-muted-foreground">
+          Adds a tier to one of the eight families the apps already evaluate. A new
+          kind of rule needs a migration.
+        </p>
+      </header>
+
+      <div className="space-y-2">
+        <Label htmlFor="family">Family</Label>
+        <Select name="family" value={family} onValueChange={onFamilyChange}>
+          <SelectTrigger id="family">
+            <SelectValue placeholder="Select a family" />
+          </SelectTrigger>
+          <SelectContent>
+            {ACHIEVEMENT_FAMILIES.map((f) => (
+              <SelectItem key={f} value={f}>
+                {familyLabel(f)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {siblings.length > 0 ? (
+          <p className="text-xs text-muted-foreground">
+            Existing:{" "}
+            {siblings
+              .map((s) => (s.threshold !== null ? String(s.threshold) : s.slug))
+              .join(" · ")}
+          </p>
+        ) : null}
+      </div>
+
+      {needsReference ? (
+        <div className="space-y-2">
+          <Label htmlFor="reference">
+            {family === "emotion_first" ? "Emotion" : "Domain"}
+          </Label>
+          <Select
+            name="reference"
+            value={referenceId}
+            onValueChange={(v) => setReferenceId(v as string | null)}
+          >
+            <SelectTrigger id="reference">
+              <SelectValue placeholder="Select one" />
+            </SelectTrigger>
+            <SelectContent>
+              {references.map((r) => (
+                <SelectItem key={r.id} value={r.id}>
+                  {r.name} ({r.slug})
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Most of these already have a badge — the catalog generates one per emotion
+            and per domain automatically.
+          </p>
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="slug">Slug</Label>
+          <Input
+            id="slug"
+            value={slug}
+            onChange={(e) => setSlug(e.target.value)}
+            placeholder="pebble-count-2000"
+          />
+          {trimmedSlug !== "" && !slugValid ? (
+            <p className="text-xs text-destructive">
+              Lowercase words joined by hyphens.
+            </p>
+          ) : null}
+          {slugTaken ? (
+            <p className="text-xs text-destructive">That slug is already taken.</p>
+          ) : null}
+        </div>
+        {needsThreshold ? (
+          <div className="space-y-2">
+            <Label htmlFor="threshold">Threshold</Label>
+            <Input
+              id="threshold"
+              type="number"
+              min={1}
+              value={threshold}
+              onChange={(e) => setThreshold(e.target.value)}
+            />
+            {threshold.trim() !== "" && !thresholdValid ? (
+              <p className="text-xs text-destructive">A whole number above zero.</p>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="title-en">Title (EN)</Label>
+          <Input id="title-en" value={titleEn} onChange={(e) => setTitleEn(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="title-fr">Title (FR)</Label>
+          <Input id="title-fr" value={titleFr} onChange={(e) => setTitleFr(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="desc-en">Description (EN)</Label>
+          <Input
+            id="desc-en"
+            value={descriptionEn}
+            onChange={(e) => setDescriptionEn(e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="desc-fr">Description (FR)</Label>
+          <Input
+            id="desc-fr"
+            value={descriptionFr}
+            onChange={(e) => setDescriptionFr(e.target.value)}
+          />
+        </div>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Both languages are required: the apps have no built-in copy for a badge
+        created here, so this is the only wording users will see.
+      </p>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="karma">Karma reward</Label>
+          <Input
+            id="karma"
+            type="number"
+            min={0}
+            max={32767}
+            value={karma}
+            onChange={(e) => setKarma(e.target.value)}
+          />
+          {karmaValid ? null : (
+            <p className="text-xs text-destructive">A whole number from 0 to 32767.</p>
+          )}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="sort-order">Sort order</Label>
+          <Input
+            id="sort-order"
+            type="number"
+            value={sortOrder}
+            onChange={(e) => setSortOrder(e.target.value)}
+            placeholder={String(suggestedSort)}
+          />
+          <p className="text-xs text-muted-foreground">
+            Leave empty to use {suggestedSort}.
+          </p>
+        </div>
+      </div>
+
+      {formError ? <p className="text-sm text-destructive">{formError}</p> : null}
+
+      <div className="flex items-center gap-3">
+        <Button disabled={!canSave} onClick={onCreate}>
+          {pending ? "Creating…" : "Create"}
+        </Button>
+        <p className="text-xs text-muted-foreground">
+          The badge visual is set after creating, on its editor page.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/admin/app/(authed)/achievements/new/page.tsx
+++ b/apps/admin/app/(authed)/achievements/new/page.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link"
+import { ChevronLeft } from "lucide-react"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+import type { AdminAchievement } from "@/lib/achievements/types"
+import type { AdminDomain } from "@/lib/domains/types"
+import type { AdminEmotion } from "@/lib/emotions/types"
+import { NewAchievementForm } from "./_components/NewAchievementForm"
+
+export default async function NewAchievementPage() {
+  const supabase = await createServerSupabaseClient()
+  const [catalog, emotions, domains] = await Promise.all([
+    supabase.rpc("admin_list_achievements"),
+    supabase.rpc("admin_list_emotions"),
+    supabase.rpc("admin_list_domains"),
+  ])
+
+  for (const [label, res] of [
+    ["admin_list_achievements", catalog],
+    ["admin_list_emotions", emotions],
+    ["admin_list_domains", domains],
+  ] as const) {
+    if (res.error) console.error(`[achievements/new] ${label} failed:`, res.error.message)
+  }
+
+  const rows = (catalog.data ?? []) as AdminAchievement[]
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <Link
+        href="/achievements"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ChevronLeft className="size-4" aria-hidden />
+        All achievements
+      </Link>
+      <NewAchievementForm
+        existing={rows.map((a) => ({
+          slug: a.slug,
+          family: a.family,
+          threshold: a.threshold,
+          sortOrder: a.sort_order,
+        }))}
+        emotions={((emotions.data ?? []) as AdminEmotion[]).map((e) => ({
+          id: e.id,
+          slug: e.slug,
+          name: e.name,
+        }))}
+        domains={((domains.data ?? []) as AdminDomain[]).map((d) => ({
+          id: d.id,
+          slug: d.slug,
+          name: d.name,
+        }))}
+      />
+    </div>
+  )
+}

--- a/apps/admin/app/(authed)/achievements/page.tsx
+++ b/apps/admin/app/(authed)/achievements/page.tsx
@@ -1,0 +1,140 @@
+import Link from "next/link"
+import { Plus } from "lucide-react"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { GlyphPreview } from "@/components/pebblestore/GlyphPreview"
+import {
+  ACHIEVEMENT_FAMILIES,
+  familyLabel,
+  type AdminAchievement,
+} from "@/lib/achievements/types"
+
+/**
+ * The achievements library. Rows are grouped by family in catalog `sort_order`
+ * — the same order the apps render — so the ladder reads here the way users
+ * see it. Inactive (retired) badges stay listed: the admin has to see what it
+ * took out of circulation.
+ */
+export default async function AchievementsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ family?: string }>
+}) {
+  const { family } = await searchParams
+  const supabase = await createServerSupabaseClient()
+  const { data, error } = await supabase.rpc("admin_list_achievements")
+
+  if (error) {
+    console.error("[achievements] admin_list_achievements failed:", error.message)
+  }
+  const all: AdminAchievement[] = (data ?? []) as AdminAchievement[]
+  const rows = family ? all.filter((a) => a.family === family) : all
+
+  // Families in catalog order, keeping only the ones that have rows.
+  const families = ACHIEVEMENT_FAMILIES.filter((f) => rows.some((a) => a.family === f))
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">Achievements</h1>
+          <p className="text-sm text-muted-foreground">
+            Edit a badge&rsquo;s copy, karma, order and visual, or add a new tier to an
+            existing family. Karma edits apply to future unlocks only — nobody is
+            paid again or clawed back.
+          </p>
+        </div>
+        <Button size="sm" render={<Link href="/achievements/new" />}>
+          <Plus aria-hidden />
+          New tier
+        </Button>
+      </header>
+
+      <nav className="flex flex-wrap gap-2">
+        <Button
+          size="sm"
+          variant={family ? "outline" : "default"}
+          render={<Link href="/achievements" />}
+        >
+          All ({all.length})
+        </Button>
+        {ACHIEVEMENT_FAMILIES.map((f) => {
+          const count = all.filter((a) => a.family === f).length
+          if (count === 0) return null
+          return (
+            <Button
+              key={f}
+              size="sm"
+              variant={family === f ? "default" : "outline"}
+              render={<Link href={`?family=${f}`} />}
+            >
+              {familyLabel(f)} ({count})
+            </Button>
+          )
+        })}
+      </nav>
+
+      {error ? (
+        <p className="text-sm text-destructive">
+          Could not load achievements. Check the server console.
+        </p>
+      ) : (
+        <div className="space-y-8">
+          {families.map((f) => (
+            <div key={f} className="space-y-3">
+              <h2 className="text-sm font-semibold text-muted-foreground">
+                {familyLabel(f)}
+              </h2>
+              <ul className="grid gap-3 sm:grid-cols-2">
+                {rows
+                  .filter((a) => a.family === f)
+                  .map((a) => (
+                    <li key={a.id}>
+                      <Link
+                        href={`/achievements/${a.id}`}
+                        className="flex items-center gap-4 rounded-lg border p-4 transition-colors hover:bg-muted/50"
+                      >
+                        <span className="grid size-14 shrink-0 place-items-center rounded-md border bg-card text-foreground">
+                          {a.strokes && a.strokes.length > 0 && a.view_box ? (
+                            <GlyphPreview
+                              strokes={a.strokes}
+                              viewBox={a.view_box}
+                              className="size-10"
+                            />
+                          ) : (
+                            <span className="text-xs text-muted-foreground">—</span>
+                          )}
+                        </span>
+                        <span className="min-w-0 flex-1">
+                          <span className="flex items-center gap-2">
+                            <span className="truncate font-medium">
+                              {a.title_en ?? a.slug}
+                            </span>
+                            {a.is_active ? null : (
+                              <Badge variant="outline">Retired</Badge>
+                            )}
+                          </span>
+                          <span className="block truncate text-sm text-muted-foreground">
+                            {a.threshold !== null ? `Threshold ${a.threshold} · ` : ""}
+                            {a.karma_reward > 0
+                              ? `${a.karma_reward} karma`
+                              : "No karma"}
+                            {" · "}
+                            {a.unlock_count} unlocked
+                          </span>
+                          <span className="block text-xs text-muted-foreground/70">
+                            {a.slug}
+                          </span>
+                        </span>
+                      </Link>
+                    </li>
+                  ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/apps/admin/components/layout/Sidebar.tsx
+++ b/apps/admin/components/layout/Sidebar.tsx
@@ -2,7 +2,16 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { BarChart3, Megaphone, Palette, Shapes, Smile, Sparkles, Store } from "lucide-react"
+import {
+  BarChart3,
+  Megaphone,
+  Palette,
+  Shapes,
+  Smile,
+  Sparkles,
+  Store,
+  Trophy,
+} from "lucide-react"
 import {
   Sidebar,
   SidebarContent,
@@ -32,6 +41,7 @@ const REFERENCE_ITEMS = [
   { href: "/domains", label: "Domains", icon: Shapes },
   { href: "/emotions/palettes", label: "Palettes", icon: Palette },
   { href: "/emotions/emojis", label: "Emojis", icon: Smile },
+  { href: "/achievements", label: "Achievements", icon: Trophy },
 ] as const
 
 export function AppSidebar() {

--- a/apps/admin/lib/achievements/types.ts
+++ b/apps/admin/lib/achievements/types.ts
@@ -1,0 +1,99 @@
+// apps/admin/lib/achievements/types.ts
+import type { GlyphStroke } from "@/lib/pebblestore/types"
+
+/** A row from the admin_list_achievements RPC. */
+export type AdminAchievement = {
+  id: string
+  slug: string
+  family: string
+  threshold: number | null
+  emotion_id: string | null
+  emotion_slug: string | null
+  domain_id: string | null
+  domain_slug: string | null
+  sort_order: number
+  glyph_id: string | null
+  strokes: GlyphStroke[] | null
+  view_box: string | null
+  karma_reward: number
+  is_active: boolean
+  title_en: string | null
+  title_fr: string | null
+  description_en: string | null
+  description_fr: string | null
+  unlock_count: number
+}
+
+/**
+ * The eight families `check_achievements()` can evaluate. The list is a mirror
+ * of the column's CHECK constraint — a ninth family needs a migration and a new
+ * `case` arm in that function, so the admin can only add tiers within these.
+ */
+export const ACHIEVEMENT_FAMILIES = [
+  "pebble_count",
+  "emotion_first",
+  "domain_first",
+  "first_collection",
+  "first_glyph",
+  "first_soul",
+  "glyph_count",
+  "glyph_sales",
+] as const
+
+export type AchievementFamily = (typeof ACHIEVEMENT_FAMILIES)[number]
+
+export const FAMILY_LABELS: Record<AchievementFamily, string> = {
+  pebble_count: "Pebble count",
+  emotion_first: "First of an emotion",
+  domain_first: "First of a domain",
+  first_collection: "First collection",
+  first_glyph: "First glyph",
+  first_soul: "First soul",
+  glyph_count: "Glyphs carved",
+  glyph_sales: "Glyph sales",
+}
+
+/** Families counting up to a threshold; the rest are one-shot. */
+export const COUNTING_FAMILIES: readonly AchievementFamily[] = [
+  "pebble_count",
+  "glyph_count",
+  "glyph_sales",
+]
+
+/** Families whose badge is bound to one reference row. */
+export const REFERENCE_FAMILIES: readonly AchievementFamily[] = [
+  "emotion_first",
+  "domain_first",
+]
+
+export function familyLabel(family: string): string {
+  return FAMILY_LABELS[family as AchievementFamily] ?? family
+}
+
+/** Map the SQL error contract to English admin copy. */
+export function achievementErrorMessage(code: string): string {
+  switch (code) {
+    case "not_admin":
+      return "You are not authorized to perform this action."
+    case "not_found":
+      return "That achievement no longer exists."
+    case "bad_slug":
+      return "Slugs are lowercase words joined by hyphens, e.g. pebble-count-2000."
+    case "duplicate_slug":
+      return "An achievement with that slug already exists."
+    case "missing_copy":
+      return "Both the English and French titles are required."
+    case "bad_karma":
+      return "Karma must be between 0 and 32767."
+    case "bad_threshold":
+      return "Counting families need a positive threshold; one-shot families must not have one."
+    case "missing_reference":
+      return "Pick the emotion or domain this badge belongs to."
+    case "has_unlocks":
+      return "Users have already unlocked this badge. Retire it instead of deleting it."
+    case "empty_glyph":
+      return "This glyph has no usable strokes to save."
+    default:
+      return "Something went wrong. Check the server console for details."
+  }
+}

--- a/packages/supabase/supabase/migrations/20260730150000_admin_achievement_management.sql
+++ b/packages/supabase/supabase/migrations/20260730150000_admin_achievement_management.sql
@@ -1,0 +1,299 @@
+-- =============================================================================
+-- Admin achievement management (#668, M48) — the library manager's RPCs (D12)
+-- =============================================================================
+-- The back-office manages the CATALOG, not the rule engine: new tiers of
+-- existing families, copy, visual, karma, retirement. A new *kind* of rule
+-- stays a migration plus a new `case` arm in check_achievements(), because the
+-- family CHECK is exactly the boundary of what that function can evaluate.
+--
+-- Design: docs/superpowers/specs/2026-07-29-achievements-design.md (D12).
+-- Style: the domain/emotion admin RPCs (20260703000000, 20260717120000) —
+-- is_admin-gated `security definer`, `authenticated`-only grants, the guard
+-- doing the gating rather than the grant.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. admin_list_achievements — rows for the editor
+-- ---------------------------------------------------------------------------
+-- Returns the FULL catalog including inactive rows (the client grid filters;
+-- the admin must see what it retired), the joined glyph geometry, and a
+-- per-badge unlock count so curation is informed by what users actually reach.
+create or replace function public.admin_list_achievements()
+returns table (
+  id uuid,
+  slug text,
+  family text,
+  threshold integer,
+  emotion_id uuid,
+  emotion_slug text,
+  domain_id uuid,
+  domain_slug text,
+  sort_order integer,
+  glyph_id uuid,
+  strokes jsonb,
+  view_box text,
+  karma_reward integer,
+  is_active boolean,
+  title_en text,
+  title_fr text,
+  description_en text,
+  description_fr text,
+  unlock_count bigint
+)
+language plpgsql stable security definer set search_path = public as $$
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'not_admin' using errcode = '42501';
+  end if;
+  return query
+    select a.id, a.slug, a.family, a.threshold,
+           a.emotion_id, e.slug, a.domain_id, d.slug,
+           a.sort_order, a.glyph_id, g.strokes, g.view_box,
+           a.karma_reward, a.is_active,
+           a.title_en, a.title_fr, a.description_en, a.description_fr,
+           (select count(*) from public.achievement_unlocks u
+             where u.achievement_id = a.id)
+    from public.achievements a
+    left join public.emotions e on e.id = a.emotion_id
+    left join public.domains  d on d.id = a.domain_id
+    left join public.glyphs   g on g.id = a.glyph_id
+    order by a.sort_order, a.slug;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 2. admin_create_achievement — a new tier of an EXISTING family
+-- ---------------------------------------------------------------------------
+-- Family-bound by construction: the column's CHECK rejects anything
+-- check_achievements() cannot evaluate, so the admin can add a
+-- `pebble-count-2000` or a new sales rung but not invent a rule.
+--
+-- Bilingual copy is mandatory here (D7): a runtime-created row is one no
+-- client has shipped strings for, so it must carry its own EN and FR.
+-- Threshold rules mirror the seed: the counting families need one, the
+-- one-shot families must not have one, and emotion_first/domain_first must
+-- reference their row (which is what the generated seed does).
+-- Signature order is deliberate: what every family needs comes first, and the
+-- per-family/optional arguments carry `default null` so a caller omits what does
+-- not apply (and the generated TypeScript types mark them optional rather than
+-- demanding an explicit null). PostgREST always calls by name, so order is a
+-- typing concern only.
+create or replace function public.admin_create_achievement(
+  p_slug text,
+  p_family text,
+  p_title_en text,
+  p_title_fr text,
+  p_karma_reward integer,
+  p_sort_order integer,
+  p_threshold integer default null,
+  p_emotion_id uuid default null,
+  p_domain_id uuid default null,
+  p_description_en text default null,
+  p_description_fr text default null
+)
+returns uuid
+language plpgsql security definer set search_path = public as $$
+declare
+  v_slug text := btrim(coalesce(p_slug, ''));
+  v_id   uuid;
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'not_admin' using errcode = '42501';
+  end if;
+
+  -- Slug shape matches the seeded convention (kebab, lowercase) so the
+  -- catalog stays greppable and deterministic ids stay the seed's business.
+  if v_slug !~ '^[a-z0-9]+(-[a-z0-9]+)*$' then
+    raise exception 'bad_slug';
+  end if;
+  if btrim(coalesce(p_title_en, '')) = '' or btrim(coalesce(p_title_fr, '')) = '' then
+    raise exception 'missing_copy';
+  end if;
+  if p_karma_reward is null or p_karma_reward < 0 or p_karma_reward > 32767 then
+    raise exception 'bad_karma';
+  end if;
+
+  -- Threshold/reference coherence per family. The counting families are
+  -- meaningless without a positive threshold; the one-shot families are
+  -- meaningless with one.
+  if p_family in ('pebble_count', 'glyph_count', 'glyph_sales') then
+    if p_threshold is null or p_threshold <= 0 then
+      raise exception 'bad_threshold';
+    end if;
+  elsif p_family in ('first_collection', 'first_glyph', 'first_soul') then
+    if p_threshold is not null then
+      raise exception 'bad_threshold';
+    end if;
+  elsif p_family = 'emotion_first' then
+    if p_emotion_id is null then raise exception 'missing_reference'; end if;
+  elsif p_family = 'domain_first' then
+    if p_domain_id is null then raise exception 'missing_reference'; end if;
+  end if;
+  -- Anything else fails on the column CHECK below, which is the authority.
+
+  insert into public.achievements (
+    slug, family, threshold, emotion_id, domain_id, sort_order,
+    karma_reward, title_en, title_fr, description_en, description_fr
+  ) values (
+    v_slug, p_family, p_threshold,
+    case when p_family = 'emotion_first' then p_emotion_id end,
+    case when p_family = 'domain_first'  then p_domain_id  end,
+    coalesce(p_sort_order, 900),
+    p_karma_reward,
+    btrim(p_title_en), btrim(p_title_fr),
+    nullif(btrim(coalesce(p_description_en, '')), ''),
+    nullif(btrim(coalesce(p_description_fr, '')), '')
+  )
+  returning id into v_id;
+
+  return v_id;
+exception
+  when unique_violation then
+    raise exception 'duplicate_slug';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3. admin_update_achievement — copy, karma, order, retirement
+-- ---------------------------------------------------------------------------
+-- Deliberately CANNOT change family/threshold/emotion_id/domain_id: those
+-- define what the badge means, and editing them under users who already
+-- unlocked it would rewrite history. Retire and re-create instead.
+--
+-- A karma edit applies to FUTURE unlocks only (D9) — check_achievements()
+-- reads karma_reward at unlock time and never re-emits, so nothing here
+-- retro-pays or claws back.
+create or replace function public.admin_update_achievement(
+  p_achievement_id uuid,
+  p_title_en text,
+  p_title_fr text,
+  p_karma_reward integer,
+  p_description_en text default null,
+  p_description_fr text default null,
+  p_sort_order integer default null,
+  p_is_active boolean default null
+)
+returns void
+language plpgsql security definer set search_path = public as $$
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'not_admin' using errcode = '42501';
+  end if;
+  if btrim(coalesce(p_title_en, '')) = '' or btrim(coalesce(p_title_fr, '')) = '' then
+    raise exception 'missing_copy';
+  end if;
+  if p_karma_reward is null or p_karma_reward < 0 or p_karma_reward > 32767 then
+    raise exception 'bad_karma';
+  end if;
+
+  update public.achievements
+     set title_en       = btrim(p_title_en),
+         title_fr       = btrim(p_title_fr),
+         description_en = nullif(btrim(coalesce(p_description_en, '')), ''),
+         description_fr = nullif(btrim(coalesce(p_description_fr, '')), ''),
+         karma_reward   = p_karma_reward,
+         sort_order     = coalesce(p_sort_order, sort_order),
+         is_active      = coalesce(p_is_active, is_active)
+   where id = p_achievement_id;
+
+  if not found then
+    raise exception 'not_found';
+  end if;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 4. admin_set_achievement_glyph — set/replace the badge visual in place
+-- ---------------------------------------------------------------------------
+-- The admin_set_domain_glyph pattern (20260703000000): the badge visual is a
+-- SYSTEM-OWNED glyph (user_id null), replaced in place on the same id so every
+-- consumer and cache reflects the change, and so purge_account never matches
+-- it (it only deletes by owner).
+--
+-- One deliberate divergence from that precedent: it inserts `shape_id`, a
+-- column dropped in 20260701114205, so its first-glyph path raises
+-- `column "shape_id" does not exist` at runtime. Reported separately rather
+-- than patched here; this function omits the column.
+create or replace function public.admin_set_achievement_glyph(
+  p_achievement_id uuid,
+  p_strokes jsonb,
+  p_view_box text
+)
+returns uuid
+language plpgsql security definer set search_path = public as $$
+declare
+  v_glyph_id uuid;
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'not_admin' using errcode = '42501';
+  end if;
+  if p_strokes is null or jsonb_array_length(p_strokes) = 0 then
+    raise exception 'empty_glyph';
+  end if;
+
+  select glyph_id into v_glyph_id
+  from public.achievements where id = p_achievement_id;
+  if not found then
+    raise exception 'not_found';
+  end if;
+
+  if v_glyph_id is null then
+    insert into public.glyphs (user_id, name, strokes, view_box)
+    values (null, null, p_strokes, p_view_box)
+    returning id into v_glyph_id;
+
+    update public.achievements set glyph_id = v_glyph_id where id = p_achievement_id;
+  else
+    update public.glyphs
+       set strokes = p_strokes,
+           view_box = p_view_box,
+           updated_at = now()
+     where id = v_glyph_id;
+  end if;
+
+  return v_glyph_id;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 5. admin_delete_achievement — correction path only
+-- ---------------------------------------------------------------------------
+-- Retirement is `is_active = false` (D12): unlocks FK the row and badges are
+-- permanent (D3), so a badge someone earned can never be deleted. Deleting is
+-- reserved for fixing a row created by mistake, and only while nobody holds it.
+create or replace function public.admin_delete_achievement(p_achievement_id uuid)
+returns void
+language plpgsql security definer set search_path = public as $$
+declare
+  v_unlocks bigint;
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'not_admin' using errcode = '42501';
+  end if;
+
+  select count(*) into v_unlocks
+  from public.achievement_unlocks where achievement_id = p_achievement_id;
+  if v_unlocks > 0 then
+    raise exception 'has_unlocks';
+  end if;
+
+  delete from public.achievements where id = p_achievement_id;
+  if not found then
+    raise exception 'not_found';
+  end if;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 6. Grants: authenticated only; the is_admin guard does the gating.
+-- ---------------------------------------------------------------------------
+revoke all on function public.admin_list_achievements()                          from public, anon;
+revoke all on function public.admin_create_achievement(text, text, text, text, integer, integer, integer, uuid, uuid, text, text) from public, anon;
+revoke all on function public.admin_update_achievement(uuid, text, text, integer, text, text, integer, boolean) from public, anon;
+revoke all on function public.admin_set_achievement_glyph(uuid, jsonb, text)      from public, anon;
+revoke all on function public.admin_delete_achievement(uuid)                     from public, anon;
+grant execute on function public.admin_list_achievements()                          to authenticated;
+grant execute on function public.admin_create_achievement(text, text, text, text, integer, integer, integer, uuid, uuid, text, text) to authenticated;
+grant execute on function public.admin_update_achievement(uuid, text, text, integer, text, text, integer, boolean) to authenticated;
+grant execute on function public.admin_set_achievement_glyph(uuid, jsonb, text)      to authenticated;
+grant execute on function public.admin_delete_achievement(uuid)                     to authenticated;

--- a/packages/supabase/types/database.ts
+++ b/packages/supabase/types/database.ts
@@ -1842,8 +1842,52 @@ export type Database = {
         Args: { p_glyph_id: string; p_user_id: string }
         Returns: Json
       }
+      admin_create_achievement: {
+        Args: {
+          p_description_en?: string
+          p_description_fr?: string
+          p_domain_id?: string
+          p_emotion_id?: string
+          p_family: string
+          p_karma_reward: number
+          p_slug: string
+          p_sort_order: number
+          p_threshold?: number
+          p_title_en: string
+          p_title_fr: string
+        }
+        Returns: string
+      }
+      admin_delete_achievement: {
+        Args: { p_achievement_id: string }
+        Returns: undefined
+      }
       admin_delete_glyph: { Args: { p_glyph_id: string }; Returns: undefined }
       admin_find_user: { Args: { p_email: string }; Returns: Json }
+      admin_list_achievements: {
+        Args: never
+        Returns: {
+          description_en: string
+          description_fr: string
+          domain_id: string
+          domain_slug: string
+          emotion_id: string
+          emotion_slug: string
+          family: string
+          glyph_id: string
+          id: string
+          is_active: boolean
+          karma_reward: number
+          slug: string
+          sort_order: number
+          strokes: Json
+          threshold: number
+          title_en: string
+          title_fr: string
+          unlock_count: number
+          view_box: string
+        }[]
+      }
       admin_list_domains: {
         Args: never
         Returns: {
@@ -1887,9 +1931,26 @@ export type Database = {
         Args: { p_status?: string }
         Returns: Json
       }
+      admin_set_achievement_glyph: {
+        Args: { p_achievement_id: string; p_strokes: Json; p_view_box: string }
+        Returns: string
+      }
       admin_set_domain_glyph: {
         Args: { p_domain_id: string; p_strokes: Json; p_view_box: string }
         Returns: string
+      }
+      admin_update_achievement: {
+        Args: {
+          p_achievement_id: string
+          p_description_en?: string
+          p_description_fr?: string
+          p_is_active?: boolean
+          p_karma_reward: number
+          p_sort_order?: number
+          p_title_en: string
+          p_title_fr: string
+        }
+        Returns: undefined
       }
       admin_update_domain: {
         Args: { p_domain_id: string; p_label: string; p_name: string }


### PR DESCRIPTION
Resolves #668

First satellite of **M48 · Achievements**. Design: `docs/superpowers/specs/2026-07-29-achievements-design.md` (D12). Depends on #664 (merged).

The back-office manages the **catalog**, not the rule engine: new tiers of existing families, copy, karma, visual, retirement. A new *kind* of rule still needs a migration and a new `case` arm in `check_achievements()` — the family CHECK is exactly the boundary of what that function can evaluate, and the UI says so.

## Key files

| File | What |
|---|---|
| `…/20260730150000_admin_achievement_management.sql` | five `is_admin`-gated `security definer` RPCs: `admin_list_achievements` (full catalog incl. retired, joined glyph, per-badge unlock count), `admin_create_achievement` (family-bound, bilingual copy mandatory, per-family threshold/reference coherence), `admin_update_achievement` (copy/karma/order/active only), `admin_set_achievement_glyph` (replace-in-place, system-owned), `admin_delete_achievement` (refuses when unlocks exist) |
| `apps/admin/app/(authed)/achievements/` | list grouped by family with a family filter, detail editor, and a "new tier" form |
| `apps/admin/lib/achievements/types.ts` | row type, family constants mirroring the CHECK, and the SQL→English error mapper |
| `components/layout/Sidebar.tsx` | Achievements entry under Reference |

## Design notes

- **Update deliberately cannot change family, threshold, or the emotion/domain binding.** Those define what a badge *means*; editing them under users who already unlocked it would rewrite history. They render read-only in the editor, and the RPC has no parameters for them. Retire and re-create instead.
- **Retirement over deletion**: `is_active = false` stops future unlocks and their karma while existing unlocks keep rendering. Delete is a correction path only — the RPC raises `has_unlocks`, and the button is hidden once anyone holds the badge.
- **Karma edits apply to future unlocks only** (D9) — `check_achievements()` reads `karma_reward` at unlock time, so nothing retro-pays or claws back. Probed explicitly.
- **Signature ordering**: required arguments first, per-family/optional ones with `default null`, so the generated TypeScript types mark them optional instead of demanding explicit nulls. PostgREST calls by name, so this is a typing concern only.

## Verification

Full migration history replays clean on a local Postgres 17, then a nine-probe acceptance suite passes: non-admin refused on all five RPCs; the catalog is unwritable even to an admin session except through the RPCs; retired rows stay listed; every create validation (slug shape, duplicate, missing FR copy, karma range, threshold/family coherence, unknown family); a created tier is immediately evaluable by `check_achievements()`; update leaves family/threshold untouched and a karma edit emits zero ledger rows; the glyph is system-owned and replaced on the same id; `purge_account` leaves badge glyphs alone; delete refuses an unlocked badge. `types/database.ts` regenerated (additive only), `npm run lint --workspace=apps/admin` clean, admin + web builds green.

## Found in passing, not fixed

`admin_set_domain_glyph` (`20260703000000`) still inserts `glyphs.shape_id`, a column dropped in `20260701114205`, so **setting a domain's first glyph raises `column "shape_id" does not exist`** at runtime. The replace-in-place path is unaffected, which is why it has gone unnoticed — every domain already has a glyph. Not touched here (out of scope, and it wants its own fix); the achievements equivalent omits the column and is commented to say why. Happy to open a `fix` issue.

No Lab Note — admin-only surface, no user-facing change (`no-lab-note` applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkoQL1qxm4oYATiZYb3KZF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkoQL1qxm4oYATiZYb3KZF)_