### PR TITLE
feat(ui): add the achievements rewarding moment and profile shelf on ios

### DIFF
--- a/apps/ios/Pebbles/Features/Karma/AchievementMomentView.swift
+++ b/apps/ios/Pebbles/Features/Karma/AchievementMomentView.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+/// The unlock moment (D13): one card per newly unlocked badge, chained in
+/// catalog order and advanced by tapping. Hosted by the karma overlay window,
+/// so it floats above whatever sheet fired it.
+///
+/// Dismissal is never blocking — tapping the scrim skips the rest of the queue.
+struct AchievementMomentView: View {
+    @Environment(AchievementNotificationService.self) private var achievements
+
+    var body: some View {
+        ZStack {
+            // The scrim is a real subview, so the passthrough window lets it
+            // capture touches for as long as the moment is up.
+            Color.black.opacity(0.55)
+                .ignoresSafeArea()
+                .contentShape(Rectangle())
+                .onTapGesture { achievements.dismiss() }
+                .accessibilityHidden(true)
+
+            if let card = achievements.currentCard {
+                cardBody(card)
+                    .padding(.horizontal, Spacing.xl)
+                    .transition(.scale(scale: 0.92).combined(with: .opacity))
+                    .id(card.id)
+            }
+        }
+        .animation(.spring(response: 0.34, dampingFraction: 0.78), value: achievements.index)
+    }
+
+    @ViewBuilder
+    private func cardBody(_ card: AchievementMomentCard) -> some View {
+        VStack(spacing: Spacing.lg) {
+            Image(systemName: "trophy")
+                .font(.system(size: 44))
+                .foregroundStyle(Color.accent.primary)
+                .padding(Spacing.lg)
+                .background(Circle().fill(Color.accent.primary.opacity(0.12)))
+
+            VStack(spacing: Spacing.xs) {
+                Text("Achievement unlocked")
+                    .pebblesFont(.subhead)
+                    .foregroundStyle(Color.system.secondary)
+                Text(card.title)
+                    .pebblesFont(.headlineEmphasized)
+                    .foregroundStyle(Color.system.foreground)
+                    .multilineTextAlignment(.center)
+                if let description = card.description {
+                    Text(description)
+                        .pebblesFont(.subhead)
+                        .foregroundStyle(Color.system.secondary)
+                        .multilineTextAlignment(.center)
+                }
+            }
+
+            if card.karmaGranted > 0 {
+                Text("+\(card.karmaGranted) karma")
+                    .pebblesFont(.headline)
+                    .foregroundStyle(Color.accent.primary)
+            }
+
+            if achievements.cards.count > 1 {
+                Text("\(achievements.index + 1) of \(achievements.cards.count)")
+                    .pebblesFont(.subhead)
+                    .foregroundStyle(Color.system.muted)
+            }
+
+            Button {
+                achievements.advance()
+            } label: {
+                Text(achievements.isShowingLastCard ? "Nice" : "Next")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(Color.accent.primary)
+        }
+        .padding(Spacing.xl)
+        .frame(maxWidth: 340)
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(Color.system.background)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(accessibilityLabel(card))
+    }
+
+    private func accessibilityLabel(_ card: AchievementMomentCard) -> String {
+        var parts = [String(localized: "Achievement unlocked"), card.title]
+        if card.karmaGranted > 0 {
+            parts.append(String(format: NSLocalizedString(
+                "achievement.moment.a11y.karma",
+                value: "Earned %lld karma", comment: ""
+            ), card.karmaGranted))
+        }
+        return parts.joined(separator: ", ")
+    }
+}
+
+#Preview("One badge") {
+    let service = AchievementNotificationService()
+    service.present(cards: [
+        AchievementMomentCard(
+            id: "first-soul", title: "First soul",
+            description: "Add your first soul.", karmaGranted: 5
+        )
+    ])
+    return AchievementMomentView().environment(service)
+}

--- a/apps/ios/Pebbles/Features/Karma/AchievementNotificationService.swift
+++ b/apps/ios/Pebbles/Features/Karma/AchievementNotificationService.swift
@@ -1,67 +1,81 @@
 import Foundation
 
-/// One achievement unlock moment. Several unlocks in a single
-/// `check_achievements()` response collapse into one content value (web
-/// parity): `title` carries the localized badge title when exactly one badge
-/// unlocked, else the capsule shows a count phrase. `karmaTotal` is the sum
-/// the server actually emitted.
-struct AchievementUnlockedContent: Equatable, Sendable {
-    let count: Int
-    let title: String?
-    let karmaTotal: Int
+/// One card of an unlock moment: a badge that just unlocked, with the karma it
+/// actually paid (as reported by `check_achievements()`, never the catalog's
+/// current value).
+struct AchievementMomentCard: Equatable, Sendable, Identifiable {
+    /// The badge slug — stable, and the fallback headline if copy is missing.
+    let id: String
+    let title: String
+    let description: String?
+    let karmaGranted: Int
 }
 
-/// Explicit-fire entry point for the achievement unlock capsule. Sibling of
-/// `KarmaNotificationService` — same presentation contract (a bottom-center
-/// pastille in the shared overlay window), its own slot so an achievement
-/// moment and a karma flash fired by the same mutation coexist instead of one
-/// replacing the other (the overlay stacks them; see `KarmaOverlayRoot`).
-/// Delight only — never authoritative over what is unlocked.
+/// Explicit-fire entry point for the achievement unlock moment (D13).
+///
+/// Sibling of `KarmaNotificationService`, but a different shape of celebration:
+/// where karma flashes a pastille that times out, an unlock opens a chained
+/// card per badge that the user taps through. Both are hosted by the same
+/// overlay window, which floats above presented sheets — the composer dismisses
+/// itself on the very success that fires this, so presenting from the view tree
+/// would race that dismissal.
+///
+/// Only the mutation path celebrates: the screen-open call in `AchievementsView`
+/// is the retroactive grant and can return a veteran's whole history at once,
+/// so it renders in the grid instead of chaining twenty cards.
 @Observable
 @MainActor
 final class AchievementNotificationService {
-    /// Content currently shown (nil = hidden). Observed by the overlay window.
-    private(set) var activeCapsule: AchievementUnlockedContent?
+    /// The queue being celebrated (empty = nothing showing).
+    private(set) var cards: [AchievementMomentCard] = []
+    /// Index of the card on screen.
+    private(set) var index: Int = 0
 
     /// Counts feedback fires so tests can assert the guard without CoreHaptics.
     private(set) var hapticTrigger: Int = 0
 
     private let haptics: HapticsService
-    private var capsuleDismissTask: Task<Void, Never>?
-
-    /// Slightly longer than the karma flash: a badge title takes a beat more
-    /// to read than "+N".
-    let capsuleDuration: Duration = .milliseconds(3200)
 
     init(haptics: HapticsService = HapticsService()) {
         self.haptics = haptics
     }
 
-    func notifyUnlocked(count: Int, title: String?, karmaTotal: Int) {
-        guard count > 0 else { return }
+    /// The card on screen, or nil when the moment is idle.
+    var currentCard: AchievementMomentCard? {
+        guard index >= 0, index < cards.count else { return nil }
+        return cards[index]
+    }
+
+    var isShowingLastCard: Bool {
+        index + 1 >= cards.count
+    }
+
+    func present(cards: [AchievementMomentCard]) {
+        guard !cards.isEmpty else { return }
 
         // Reuses the karma-earned haptic: same reward register, and a second
         // bespoke waveform for a moment that often fires alongside the karma
-        // flash would double-buzz. One shared pattern keeps the pair coherent.
+        // flash would double-buzz.
         hapticTrigger &+= 1
         haptics.playKarmaEarned()
 
-        presentCapsule(AchievementUnlockedContent(count: count, title: title, karmaTotal: karmaTotal))
+        self.cards = cards
+        self.index = 0
     }
 
-    private func presentCapsule(_ content: AchievementUnlockedContent) {
-        activeCapsule = content
-        capsuleDismissTask?.cancel()
-        capsuleDismissTask = Task { [weak self, capsuleDuration] in
-            try? await Task.sleep(for: capsuleDuration)
-            guard !Task.isCancelled else { return }
-            self?.activeCapsule = nil
+    /// Advances to the next card, ending the moment after the last one.
+    func advance() {
+        if isShowingLastCard {
+            dismiss()
+        } else {
+            index += 1
         }
     }
 
-    /// Called when the user taps the pastille.
-    func dismissCapsule() {
-        capsuleDismissTask?.cancel()
-        activeCapsule = nil
+    /// Ends the moment immediately — tapping outside or swiping down skips the
+    /// rest of the queue. Dismissal is never blocking.
+    func dismiss() {
+        cards = []
+        index = 0
     }
 }

--- a/apps/ios/Pebbles/Features/Karma/KarmaEarnedCapsule.swift
+++ b/apps/ios/Pebbles/Features/Karma/KarmaEarnedCapsule.swift
@@ -84,91 +84,6 @@ private extension View {
     }
 }
 
-/// Achievement-unlocked pastille, visual sibling of `KarmaEarnedCapsule`:
-/// same glass, trophy instead of sparkle, the badge title (or a count phrase
-/// for several unlocks) and the karma actually granted when > 0.
-struct AchievementUnlockedCapsule: View {
-    let content: AchievementUnlockedContent
-    var duration: Duration = .milliseconds(3200)
-    let onTap: () -> Void
-
-    @State private var ringProgress: CGFloat = 1
-
-    var body: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "trophy")
-                .foregroundStyle(Color.accent.primary)
-            Text(headline)
-                .font(.ysabeauSemibold(16))
-                .foregroundStyle(Color.system.foreground)
-                .lineLimit(1)
-            if content.karmaTotal > 0 {
-                Text("+\(content.karmaTotal) karma")
-                    .font(.ysabeauSemibold(16))
-                    .foregroundStyle(Color.accent.primary)
-            }
-        }
-        .padding(.horizontal, 18)
-        .padding(.vertical, 11)
-        .karmaPastilleGlass()
-        .overlay { countdownRing }
-        .contentShape(Capsule())
-        .onTapGesture(perform: onTap)
-        .onAppear(perform: startCountdown)
-        .onChange(of: content) { startCountdown() }
-        .accessibilityElement()
-        .accessibilityLabel(accessibilityText)
-        .accessibilityAddTraits(.isStaticText)
-    }
-
-    private var headline: String {
-        if content.count == 1, let title = content.title {
-            return title
-        }
-        return String(format: NSLocalizedString(
-            "achievement.capsule.countPhrase",
-            value: "%lld achievements unlocked", comment: ""
-        ), content.count)
-    }
-
-    private var accessibilityText: String {
-        var parts: [String] = []
-        if content.count == 1, let title = content.title {
-            parts.append(String(format: NSLocalizedString(
-                "achievement.capsule.a11y.single",
-                value: "Achievement unlocked: %@", comment: ""
-            ), title))
-        } else {
-            parts.append(headline)
-        }
-        if content.karmaTotal > 0 {
-            parts.append(String(format: NSLocalizedString(
-                "achievement.capsule.a11y.karma",
-                value: "Earned %lld karma", comment: ""
-            ), content.karmaTotal))
-        }
-        return parts.joined(separator: ", ")
-    }
-
-    private var countdownRing: some View {
-        Capsule()
-            .trim(from: 0, to: ringProgress)
-            .stroke(Color.accent.primary, style: StrokeStyle(lineWidth: 2.5, lineCap: .round))
-            .padding(1.25)
-            .allowsHitTesting(false)
-    }
-
-    private func startCountdown() {
-        ringProgress = 1
-        withAnimation(.linear(duration: durationSeconds)) { ringProgress = 0 }
-    }
-
-    private var durationSeconds: Double {
-        let parts = duration.components
-        return Double(parts.seconds) + Double(parts.attoseconds) / 1_000_000_000_000_000_000
-    }
-}
-
 /// SwiftUI root hosted inside the overlay window: renders the active pastilles
 /// pinned to the bottom-center, animating in/out. `Color.clear` fills the space
 /// so the window has a hit-testable (but pass-through) root. The achievement
@@ -181,30 +96,33 @@ struct KarmaOverlayRoot: View {
     var body: some View {
         ZStack(alignment: .bottom) {
             Color.clear
-            VStack(spacing: Spacing.sm) {
-                if let unlocked = achievements.activeCapsule {
-                    AchievementUnlockedCapsule(content: unlocked, duration: achievements.capsuleDuration) {
-                        achievements.dismissCapsule()
-                    }
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            if let earned = karma.activeCapsule {
+                KarmaEarnedCapsule(content: earned, duration: karma.capsuleDuration) {
+                    karma.dismissCapsule()
                 }
-                if let earned = karma.activeCapsule {
-                    KarmaEarnedCapsule(content: earned, duration: karma.capsuleDuration) {
-                        karma.dismissCapsule()
-                    }
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-                }
+                .padding(.bottom, 44)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
             }
-            .padding(.bottom, 44)
+            // The unlock moment covers the screen, so it sits above the
+            // pastille rather than beside it: a mutation that earns karma AND
+            // unlocks a badge shows the flash behind the card, and the card's
+            // own "+N karma" line is the badge's, never the pebble's.
+            if achievements.currentCard != nil {
+                AchievementMomentView()
+                    .transition(.opacity)
+            }
         }
         .animation(.spring(response: 0.42, dampingFraction: 0.72), value: karma.activeCapsule)
-        .animation(.spring(response: 0.42, dampingFraction: 0.72), value: achievements.activeCapsule)
+        .animation(.easeInOut(duration: 0.2), value: achievements.currentCard)
     }
 }
 
 /// A window whose empty areas pass touches through to the app below; only the
-/// pastille itself is interactive. Lets the karma flash float above presented
-/// sheets (create/edit/detail) without blocking interaction with them.
+/// overlay's own content is interactive. Lets the karma flash and the unlock
+/// moment float above presented sheets (create/edit/detail) — the composer
+/// dismisses itself on the very success that fires them, so presenting from the
+/// view tree would race that dismissal. The moment's full-screen scrim is a
+/// real subview, so it correctly captures touches while it is up.
 final class KarmaPassthroughWindow: UIWindow {
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         guard let hit = super.hitTest(point, with: event) else { return nil }

--- a/apps/ios/Pebbles/Features/Profile/Components/ProfileAchievementsCard.swift
+++ b/apps/ios/Pebbles/Features/Profile/Components/ProfileAchievementsCard.swift
@@ -1,6 +1,28 @@
 import SwiftUI
+import os
 
+/// How many recent badges the shelf shows before "view all" takes over.
+private let shelfSize = 6
+
+/// The Profile achievements shelf (D14): the most recently unlocked badges, the
+/// total count, and a way into the full grid. It reads the same two queries the
+/// grid does — no new endpoint, no new RLS — and M50's public-profile projection
+/// reuses exactly this shape.
+///
+/// The shelf shows what you have EARNED; the grid shows the whole ladder. So
+/// locked badges never appear here, and a profile with nothing unlocked yet
+/// falls back to a plain invitation rather than an empty row.
 struct ProfileAchievementsCard: View {
+    @Environment(AchievementsService.self) private var achievements
+    @Environment(EmotionPaletteService.self) private var palettes
+    @Environment(ReferenceDataService.self) private var refs
+
+    @State private var recent: [AchievementRecord] = []
+    @State private var unlockedCount = 0
+    @State private var hasLoaded = false
+
+    private let logger = Logger(subsystem: "app.pbbls.ios", category: "profile.achievements-shelf")
+
     var body: some View {
         NavigationLink {
             AchievementsView()
@@ -9,13 +31,21 @@ struct ProfileAchievementsCard: View {
                 Image(systemName: "trophy")
                     .pebblesIcon(.large)
                     .foregroundStyle(Color.accent.primary)
-                VStack(alignment: .leading) {
+                VStack(alignment: .leading, spacing: Spacing.xs) {
                     Text("Achievements")
                         .pebblesFont(.headline)
                         .foregroundStyle(Color.system.foreground)
-                    Text("Badges along your path")
+                    Text(subtitle)
                         .pebblesFont(.subhead)
                         .foregroundStyle(Color.system.secondary)
+                    if !recent.isEmpty {
+                        HStack(spacing: Spacing.sm) {
+                            ForEach(recent) { record in
+                                badge(record)
+                            }
+                        }
+                        .padding(.top, Spacing.xs)
+                    }
                 }
                 Spacer()
                 Image(systemName: "chevron.right")
@@ -26,11 +56,78 @@ struct ProfileAchievementsCard: View {
             .profileCard()
         }
         .buttonStyle(.plain)
+        .task { await load() }
+    }
+
+    private var subtitle: String {
+        guard hasLoaded else { return String(localized: "Badges along your path") }
+        guard unlockedCount > 0 else { return String(localized: "Badges along your path") }
+        return String(format: NSLocalizedString(
+            "achievement.shelf.unlockedCount",
+            value: "%lld earned", comment: ""
+        ), unlockedCount)
+    }
+
+    @ViewBuilder
+    private func badge(_ record: AchievementRecord) -> some View {
+        Image(systemName: record.familySymbol)
+            .pebblesIcon(.medium)
+            .foregroundStyle(Color.accent.primary)
+            .frame(width: 32, height: 32)
+            .background(Circle().fill(Color.accent.primary.opacity(0.12)))
+            .accessibilityLabel(
+                record.localizedTitle(
+                    emotionName: emotionName(for: record),
+                    domainName: domainName(for: record)
+                )
+            )
+    }
+
+    /// Reads only — the shelf never fires an evaluation. The grid's screen-open
+    /// call is the retroactive grant; doing it here too would double the work on
+    /// every profile visit.
+    private func load() async {
+        guard !hasLoaded else { return }
+        do {
+            async let catalogRows = achievements.loadCatalog()
+            async let unlockRows = achievements.loadUnlocks()
+            let catalog = try await catalogRows
+            let unlocks = try await unlockRows
+
+            let byId = Dictionary(catalog.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+            let earned = unlocks
+                .sorted { $0.unlockedAt > $1.unlockedAt }
+                .compactMap { byId[$0.achievementId] }
+
+            unlockedCount = earned.count
+            recent = Array(earned.prefix(shelfSize))
+            hasLoaded = true
+        } catch {
+            // A failed shelf is not worth an error state on the profile: the
+            // card still navigates, and the grid surfaces real failures.
+            logger.error("achievements shelf fetch failed: \(error.localizedDescription, privacy: .private)")
+            hasLoaded = true
+        }
+    }
+
+    private func emotionName(for record: AchievementRecord) -> String? {
+        guard let emotionId = record.emotionId else { return nil }
+        return palettes.byEmotionId[emotionId]?.localizedName
+    }
+
+    private func domainName(for record: AchievementRecord) -> String? {
+        guard let domainId = record.domainId else { return nil }
+        return refs.domains.first(where: { $0.id == domainId })?.localizedName
     }
 }
 
 #Preview {
-    NavigationStack {
-        ProfileAchievementsCard().padding()
+    let supabase = SupabaseService()
+    return NavigationStack {
+        ProfileAchievementsCard()
+            .environment(AchievementsService(client: supabase.client))
+            .environment(EmotionPaletteService(client: supabase.client))
+            .environment(ReferenceDataService(client: supabase.client))
+            .padding()
     }
 }

--- a/apps/ios/Pebbles/Resources/Localizable.xcstrings
+++ b/apps/ios/Pebbles/Resources/Localizable.xcstrings
@@ -13,7 +13,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "3 \u00e0 30 caract\u00e8res : minuscules, chiffres, tirets bas. Laissez vide pour lib\u00e9rer votre pseudo."
+            "value" : "3 à 30 caractères : minuscules, chiffres, tirets bas. Laissez vide pour libérer votre pseudo."
           }
         }
       }
@@ -115,7 +115,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ce pseudo est d\u00e9j\u00e0 pris."
+            "value" : "Ce pseudo est déjà pris."
           }
         }
       }
@@ -132,7 +132,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ce pseudo est r\u00e9serv\u00e9."
+            "value" : "Ce pseudo est réservé."
           }
         }
       }
@@ -149,7 +149,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ce pseudo n'est pas valide. Utilisez 3 \u00e0 30 minuscules, chiffres ou tirets bas, en commen\u00e7ant et terminant par une lettre ou un chiffre."
+            "value" : "Ce pseudo n'est pas valide. Utilisez 3 à 30 minuscules, chiffres ou tirets bas, en commençant et terminant par une lettre ou un chiffre."
           }
         }
       }
@@ -6144,6 +6144,108 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tes glyphes trouvent preneur %lld fois."
+          }
+        }
+      }
+    },
+    "Achievement unlocked" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Achievement unlocked"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Succès débloqué"
+          }
+        }
+      }
+    },
+    "Next" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suivant"
+          }
+        }
+      }
+    },
+    "Nice" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nice"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Super"
+          }
+        }
+      }
+    },
+    "%lld of %lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld of %lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld sur %lld"
+          }
+        }
+      }
+    },
+    "achievement.moment.a11y.karma" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Earned %lld karma"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu as gagné %lld karma"
+          }
+        }
+      }
+    },
+    "achievement.shelf.unlockedCount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld earned"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld décrochés"
           }
         }
       }

--- a/apps/ios/Pebbles/Services/AchievementsService.swift
+++ b/apps/ios/Pebbles/Services/AchievementsService.swift
@@ -181,6 +181,10 @@ final class AchievementsService {
         }
     }
 
+    /// Builds one card per newly unlocked badge and hands the queue to the
+    /// moment (D13). One extra catalog read per actual unlock (rare) buys the
+    /// localized copy without threading i18n through five call sites — the same
+    /// trade the web moment makes.
     private func presentUnlockMoment(for results: [AchievementCheckResult]) {
         guard let notify else {
             logger.error("achievement notify service not bound; dropping unlock moment")
@@ -188,25 +192,45 @@ final class AchievementsService {
         }
         Task { [weak self] in
             guard let self else { return }
-            let karmaTotal = results.reduce(0) { $0 + $1.karmaGranted }
-            var title: String?
-            if results.count == 1, let slug = results.first?.slug {
-                // One extra catalog read per actual unlock (rare) buys the
-                // localized badge title without threading i18n through six
-                // call sites — same trade the web pill makes.
-                do {
-                    let catalog = try await self.loadCatalog()
-                    if let record = catalog.first(where: { $0.slug == slug }) {
-                        title = record.localizedTitle(
-                            emotionName: self.emotionName(for: record),
-                            domainName: self.domainName(for: record)
+            var catalog: [AchievementRecord] = []
+            do {
+                catalog = try await self.loadCatalog()
+            } catch {
+                self.logger.warning("catalog fetch for the unlock moment failed: \(error.localizedDescription, privacy: .private)")
+            }
+            let bySlug = Dictionary(catalog.map { ($0.slug, $0) }, uniquingKeysWith: { first, _ in first })
+
+            let cards = results
+                .map { result -> (card: AchievementMomentCard, sortOrder: Int) in
+                    guard let record = bySlug[result.slug] else {
+                        // A check racing a catalog change: still celebrate,
+                        // headlined by the slug, and sort last.
+                        return (
+                            AchievementMomentCard(
+                                id: result.slug, title: result.slug,
+                                description: nil, karmaGranted: result.karmaGranted
+                            ),
+                            Int.max
                         )
                     }
-                } catch {
-                    self.logger.warning("catalog fetch for unlock capsule failed: \(error.localizedDescription, privacy: .private)")
+                    let emotionName = self.emotionName(for: record)
+                    let domainName = self.domainName(for: record)
+                    return (
+                        AchievementMomentCard(
+                            id: record.slug,
+                            title: record.localizedTitle(emotionName: emotionName, domainName: domainName),
+                            description: record.localizedDescription(emotionName: emotionName, domainName: domainName),
+                            karmaGranted: result.karmaGranted
+                        ),
+                        record.sortOrder
+                    )
                 }
-            }
-            notify.notifyUnlocked(count: results.count, title: title, karmaTotal: karmaTotal)
+                // Chain in the order the ladder reads, so a multi-tier unlock
+                // walks up rather than arriving shuffled.
+                .sorted { $0.sortOrder < $1.sortOrder }
+                .map(\.card)
+
+            notify.present(cards: cards)
         }
     }
 

--- a/apps/ios/PebblesTests/AchievementMomentTests.swift
+++ b/apps/ios/PebblesTests/AchievementMomentTests.swift
@@ -1,0 +1,78 @@
+import Testing
+@testable import Pebbles
+
+/// The unlock moment's queue (D13): an empty response never presents, cards
+/// advance one at a time, the last card ends the moment, and dismissing skips
+/// the rest of the queue.
+@MainActor
+@Suite("AchievementNotificationService")
+struct AchievementMomentTests {
+
+    private func card(_ id: String, karma: Int = 0) -> AchievementMomentCard {
+        AchievementMomentCard(id: id, title: id, description: nil, karmaGranted: karma)
+    }
+
+    @Test("an empty result set never presents")
+    func emptyNeverPresents() {
+        let service = AchievementNotificationService()
+        service.present(cards: [])
+        #expect(service.currentCard == nil)
+        #expect(service.hapticTrigger == 0)
+    }
+
+    @Test("a single unlock shows one card and ends on advance")
+    func singleCard() {
+        let service = AchievementNotificationService()
+        service.present(cards: [card("first-soul", karma: 5)])
+
+        #expect(service.currentCard?.id == "first-soul")
+        #expect(service.currentCard?.karmaGranted == 5)
+        #expect(service.isShowingLastCard)
+        #expect(service.hapticTrigger == 1)
+
+        service.advance()
+        #expect(service.currentCard == nil)
+    }
+
+    @Test("several unlocks chain in the order they were given")
+    func chainedCards() {
+        let service = AchievementNotificationService()
+        service.present(cards: [card("pebble-count-1"), card("pebble-count-10"), card("first-glyph")])
+
+        #expect(service.currentCard?.id == "pebble-count-1")
+        #expect(!service.isShowingLastCard)
+
+        service.advance()
+        #expect(service.currentCard?.id == "pebble-count-10")
+
+        service.advance()
+        #expect(service.currentCard?.id == "first-glyph")
+        #expect(service.isShowingLastCard)
+
+        service.advance()
+        #expect(service.currentCard == nil)
+    }
+
+    @Test("dismissing skips the rest of the queue")
+    func dismissSkipsQueue() {
+        let service = AchievementNotificationService()
+        service.present(cards: [card("a"), card("b"), card("c")])
+
+        service.dismiss()
+        #expect(service.currentCard == nil)
+        #expect(service.cards.isEmpty)
+    }
+
+    @Test("a fresh moment replaces the previous queue")
+    func freshMomentReplaces() {
+        let service = AchievementNotificationService()
+        service.present(cards: [card("a"), card("b")])
+        service.advance()
+        #expect(service.currentCard?.id == "b")
+
+        service.present(cards: [card("c")])
+        #expect(service.currentCard?.id == "c")
+        #expect(service.cards.count == 1)
+        #expect(service.isShowingLastCard)
+    }
+}


### PR DESCRIPTION
Resolves #670

iOS port of the M48 satellite (#669/#684 is the reference). Design: `docs/superpowers/specs/2026-07-29-achievements-design.md` (D13, D14). Depends on #666 (merged).

## Key files

| File | What |
|---|---|
| `Features/Karma/AchievementNotificationService.swift` | was a single timed pastille, now the moment's queue: `present(cards:)` / `advance()` / `dismiss()`, one card per unlocked badge |
| `Features/Karma/AchievementMomentView.swift` | the celebration — trophy, title, description, the badge's own "+N karma", progress when several, tap-through, scrim dismiss |
| `Features/Karma/KarmaEarnedCapsule.swift` | overlay root now hosts the karma pastille *and* the moment; the achievement pastille struct is gone |
| `Services/AchievementsService.swift` | builds a card per result, resolving localized copy from the catalog and chaining in `sort_order` |
| `Features/Profile/Components/ProfileAchievementsCard.swift` | the plain row becomes the shelf: recent 6 earned badges + total count |
| `Resources/Localizable.xcstrings` | 6 new keys, EN+FR |
| `PebblesTests/AchievementMomentTests.swift` | queue behavior: empty never presents, chaining, last-card end, dismiss-skips, fresh-moment-replaces |

## Design notes

- **The moment lives in the existing overlay window, not a `.fullScreenCover`.** The composer dismisses itself on the very success that fires the unlock, so presenting from the view tree would race that dismissal — the same reason the karma pastille already lives there. The scrim is a real subview, so the passthrough window correctly lets it capture touches while it is up.
- **Only the mutation path celebrates.** `fireCheck()` presents; the screen-open `checkIgnoringFailure()` in the grid stays silent, because it is the retroactive grant and can return a veteran's whole history at once.
- **Karma is never announced twice**: each badge's karma is inside its own card, and the karma pastille keeps firing independently for the pebble's own karma (the card sits above it).
- **The shelf reads only** — it never fires an evaluation, since the grid's screen-open call is already the retroactive grant and doing it on every profile visit would double the work. A failed shelf fetch degrades to the plain invitation rather than an error state.
- Unknown slugs (a check racing a catalog change) still celebrate, headlined by the slug, sorted last.

## Notes

No Swift toolchain on this runner (`xcodegen`/`xcodebuild` are macOS-only), so this was not compiled here. Every API mirrors an existing in-repo usage; new files land inside `project.yml`'s directory globs. The `Localizable.xcstrings` edit is additive (6 keys, both languages).

## Lab Note (EN/FR)

```yaml
species: feature
platform: ios
status: in_progress
published: false
en:
  title: Your badges, celebrated
  summary: Unlocking an achievement now gets its own little moment, with the karma it earned you. Your profile keeps a shelf of the badges you have collected so far.
fr:
  title: Tes badges, comme il se doit
  summary: Débloquer un succès a maintenant droit à son petit moment, avec le karma qu'il t'a rapporté. Ton profil garde une étagère des badges que tu as déjà décrochés.
suggested:
  molecule: pbbls
  type: feature
  tags: [changelog]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkoQL1qxm4oYATiZYb3KZF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkoQL1qxm4oYATiZYb3KZF)_