### PR TITLE
docs: quote Lab Note titles and summaries, so a colon can't break the note

### DIFF
--- a/.claude/skills/lab-note/SKILL.md
+++ b/.claude/skills/lab-note/SKILL.md
@@ -59,6 +59,21 @@ between two clauses, use a period and start a new sentence. This applies to
 - Wrong: `The whole detail view — background, title, tiles — now tints.`
 - Right: `The whole detail view (background, title, tiles) now tints.`
 
+## Always quote titles and summaries
+
+Wrap every `title` and `summary` in double quotes, in both languages, as every
+example below does. A colon is the natural way to write a sentence ("Heads up:
+it moved", "ton compte : ceux que...") and it is exactly what an unquoted YAML
+value cannot hold: the parser reads `key: value` and the whole note fails to
+parse, which fails the post-on-merge job. Quoting costs nothing and takes the
+failure mode off the table, apostrophes included.
+
+- Wrong: `summary: Heads up: the widget moved.`
+- Right: `summary: "Heads up: the widget moved."`
+
+Slug-ish values (`species`, `platform`, `status`, `molecule`, `type`, `tags`)
+need no quotes.
+
 ## When to use
 
 Only for **user-facing** PRs. Gate (same as the PR checklist):
@@ -81,11 +96,11 @@ status: in_progress       # backlog | planned | in_progress | shipped
 release-date: 2026-07-17T20:00:00   # optional; maps to released_at
 published: false          # boolean
 en:
-  title: Swap glyphs with the community
-  summary: Your Glyphs page now has Mine, Owned, and Commu tabs. Find a community glyph you love and swap it for karma.
+  title: "Swap glyphs with the community"
+  summary: "Your Glyphs page now has Mine, Owned, and Commu tabs. Find a community glyph you love and swap it for karma."
 fr:
-  title: Échange des glyphes avec la communauté
-  summary: Ta page Glyphes propose désormais les onglets Miens, Acquis et Commu. Trouve un glyphe qui te plaît pour l'échanger contre du karma.
+  title: "Échange des glyphes avec la communauté"
+  summary: "Ta page Glyphes propose désormais les onglets Miens, Acquis et Commu. Trouve un glyphe qui te plaît pour l'échanger contre du karma."
 suggested:                  # optional; for the Ariko vault only
   molecule: pbbls
   atom: glyphs              # only when confidently known
@@ -143,11 +158,11 @@ platform: webapp
 status: in_progress
 published: false
 en:
-  title: Your path, now on a timeline
-  summary: See every pebble you've placed in order, and jump back to any moment in your journey.
+  title: "Your path, now on a timeline"
+  summary: "See every pebble you've placed in order, and jump back to any moment in your journey."
 fr:
-  title: Ton chemin, maintenant en frise
-  summary: Retrouve chaque galet que tu as posé dans l'ordre, et reviens à n'importe quel moment de ton parcours.
+  title: "Ton chemin, maintenant en frise"
+  summary: "Retrouve chaque galet que tu as posé dans l'ordre, et reviens à n'importe quel moment de ton parcours."
 ```
 
 ```yaml
@@ -157,11 +172,11 @@ platform: android
 status: in_progress
 published: false
 en:
-  title: Widgets land on Android
-  summary: Drop a Pebbles widget on your home screen to see today's prompt without opening the app.
+  title: "Widgets land on Android"
+  summary: "Drop a Pebbles widget on your home screen to see today's prompt without opening the app."
 fr:
-  title: Les widgets débarquent sur Android
-  summary: Ajoute un widget Pebbles sur ton écran d'accueil pour voir la question du jour sans ouvrir l'app.
+  title: "Les widgets débarquent sur Android"
+  summary: "Ajoute un widget Pebbles sur ton écran d'accueil pour voir la question du jour sans ouvrir l'app."
 ```
 
 ## Where it goes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,8 @@ Resolves #
   the allowed values, and the friendly casual tone (French uses "Tu"). PR-time defaults:
   status: in_progress, published: false, and omit release-date (the maintainer sets those
   at release). Both languages are mandatory; no em dashes in either.
+  Keep the quotes around every title and summary: a colon in a sentence breaks an
+  unquoted YAML value, and that is the most common malformed note.
 -->
 
 ```yaml
@@ -32,11 +34,11 @@ platform: ios             # all | webapp | ios | android | project | infra
 status: in_progress       # backlog | planned | in_progress | shipped
 published: false
 en:
-  title:
-  summary:
+  title: ""
+  summary: ""
 fr:
-  title:
-  summary:
+  title: ""
+  summary: ""
 suggested:                # optional; read only by the Ariko vault
   molecule: pbbls
   type: feature           # feature | improvement | fix | announcement

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ Cadence: promote during the periodic monorepo-audit grooming pass at **milestone
 
 **The gate.** The PR has the `feat` label, **or** it touches a user-visible Arkaik view node (`docs/arkaik/bundle.json`) → write a note. Chore, refactor, infra, or docs-only → **no note**: delete the section from the PR body (if the advisory `lab-note-reminder` still comments, add the **`no-lab-note`** label to silence it).
 
-**The contract.** One `## Lab Note (EN/FR)` section holding exactly one ` ```yaml ` fence. Both languages are mandatory (`en.title`, `en.summary`, `fr.title`, `fr.summary`) — French is a real adaptation using the informal "Tu", never a literal translation. **No em dashes** in either language; use parentheses or a new sentence. PR-time defaults: `status: in_progress`, `published: false`, omit `release-date` (the maintainer's release-time switches).
+**The contract.** One `## Lab Note (EN/FR)` section holding exactly one ` ```yaml ` fence. Both languages are mandatory (`en.title`, `en.summary`, `fr.title`, `fr.summary`) — French is a real adaptation using the informal "Tu", never a literal translation. **No em dashes** in either language; use parentheses or a new sentence. **Always double-quote every title and summary**, as the skeleton below does: a colon is the natural way to write a sentence ("Heads up: it moved", "ton compte : ceux que...") and it is exactly what an unquoted YAML value cannot hold, so the parser reads `key: value` and the whole note fails. Quoting removes the failure mode outright, apostrophes included; slug-ish values need no quotes. PR-time defaults: `status: in_progress`, `published: false`, omit `release-date` (the maintainer's release-time switches).
 
 ```yaml
 species: feature          # announcement | feature — a user-facing fix is a `feature`
@@ -104,11 +104,11 @@ platform: ios             # all | webapp | ios | android | project | infra
 status: in_progress       # backlog | planned | in_progress | shipped
 published: false
 en:
-  title: Short, benefit-first title
-  summary: One or two sentences, user-facing.
+  title: "Short, benefit-first title"
+  summary: "One or two sentences, user-facing."
 fr:
-  title: Titre court, orienté bénéfice
-  summary: Une ou deux phrases, adaptées, pas traduites littéralement.
+  title: "Titre court, orienté bénéfice"
+  summary: "Une ou deux phrases, adaptées, pas traduites littéralement."
 suggested:                # optional; read only by the Ariko vault
   molecule: pbbls         # THIS repo's molecule slug
   type: feature           # feature | improvement | fix | announcement


### PR DESCRIPTION
Every Lab Note skeleton and example in this repo showed values unquoted:

```yaml
en:
  title: Short, benefit-first title
  summary: One or two sentences, user-facing.
```

Follow that and write a normal sentence with a colon in it — "Heads up: it
moved", or the French spaced form "ton compte : ceux que..." — and the YAML no
longer parses: the parser reads `key: value` inside the plain scalar and gives
up on the whole block, failing the post-on-merge job.

Not hypothetical: it just happened on alexisbohns/arkaik#298, authored from the
sibling version of this skeleton. The advisory reminder caught it and commented
within ten seconds, which is the system working; the guidance is what put the
colon there unquoted.

## What changed

`CLAUDE.md`, the PR template, and all four examples in the repo-local
`lab-note` skill now quote every title and summary, with the rule stated next
to each: always double-quote titles and summaries; slug-ish values (`species`,
`platform`, `status`, `molecule`, `type`, `tags`) need no quotes. Quoting takes
the failure mode off the table entirely, apostrophes included.

The *values* are unchanged, so the release-time paste into the Lab admin
behaves exactly as before — YAML strips the quotes on parse. Verified: every
YAML block in the changed files loads, and the `en.title`/`en.summary` values
come back as the same strings.

The repo-local skill keeps precedence over `lab-note@ariko` by design; this
keeps the two consistent on the quoting rule.

## Rollout

Sibling half of alexisbohns/ariko#21, which fixes the shared skill and README
plus a parse error that now names the cause ("the summary contains a colon, so
it must be wrapped in quotes") instead of js-yaml's "bad indentation of a
mapping entry". Matching PRs in arkaik (#299) and femfolk (#15).

No Lab Note — authoring guidance, nothing a user would notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)