### PR TITLE
fix(ios): isolate the wobble render caches so the glyph ink test stops taking the runner down

### DIFF
--- a/apps/ios/Pebbles/Features/Path/Render/Wobble/WobbleOutlineBuilder.swift
+++ b/apps/ios/Pebbles/Features/Path/Render/Wobble/WobbleOutlineBuilder.swift
@@ -3,7 +3,9 @@ import Foundation
 
 /// The wobbled render of one artwork piece: the leaky filled ink, plus the
 /// displaced centerline the appear animation's reveal mask strokes along.
-final class WobbleArt {
+/// `@unchecked Sendable`: both stored properties are immutable `CGPath` copies
+/// that nothing mutates after `init`. CGPath simply predates `Sendable`.
+final class WobbleArt: @unchecked Sendable {
     let ink: CGPath
     let centerline: CGPath
 

--- a/apps/ios/Pebbles/Features/Path/Render/Wobble/WobbleRenderer.swift
+++ b/apps/ios/Pebbles/Features/Path/Render/Wobble/WobbleRenderer.swift
@@ -1,11 +1,14 @@
 import CoreGraphics
 import Foundation
-import SwiftUI
 import os
 
 /// Per-layer wobbled artwork for a composed pebble SVG, index-aligned with
 /// `PebbleSVGModel.layers`.
-final class WobblePebbleArt {
+///
+/// `@unchecked Sendable`: every stored property is a `let`, and the `CGPath`s
+/// they transitively hold are immutable copies (`CGMutablePath.copy()`) that
+/// nothing mutates after `init`. CGPath simply predates `Sendable`.
+final class WobblePebbleArt: @unchecked Sendable {
     let layers: [WobbleArt]
 
     init(layers: [WobbleArt]) {
@@ -14,7 +17,8 @@ final class WobblePebbleArt {
 }
 
 /// Wobbled backdrop silhouette, in its asset's viewBox space.
-final class WobbleBackdropArt {
+/// `@unchecked Sendable` for the same reason as `WobblePebbleArt`.
+final class WobbleBackdropArt: @unchecked Sendable {
     let path: CGPath
     let viewBox: CGRect
     /// `large-lowlight.svg` carves a hole with `fill-rule="evenodd"`; the
@@ -39,6 +43,29 @@ enum WobbleRenderer {
     /// One noise field for the whole app: the static look is seed 3 (§1).
     private static let noise = SVGTurbulence(seed: WobbleParams.seed)
 
+    /// Guards every memoize below. `NSCache` is individually thread-safe, but
+    /// look-up → build → store is not: the wobble entry points are called from
+    /// SwiftUI `View` bodies *and* from `Canvas` renderer closures, which run
+    /// off the main actor and concurrently with each other. Without this,
+    /// two threads race to build and publish competing art for one key
+    /// (issue #650). Held across the build so the memoize is single-flight —
+    /// the cost is paid once per artwork by design, never per frame.
+    private static let cacheLock = NSLock()
+
+    /// Look-up-or-build under `cacheLock`.
+    private static func memoized<Value: AnyObject>(
+        _ cache: NSCache<NSString, Value>,
+        key: NSString,
+        build: () -> Value?
+    ) -> Value? {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        if let cached = cache.object(forKey: key) { return cached }
+        guard let built = build() else { return nil }
+        cache.setObject(built, forKey: key)
+        return built
+    }
+
     // Keys are content strings: collision-proof, and a few KB per key is
     // negligible next to the cached paths. NSCache additionally evicts
     // under memory pressure.
@@ -57,9 +84,14 @@ enum WobbleRenderer {
     // MARK: - Pebble render (layer:shape / layer:fossil / layer:glyph)
 
     static func pebbleArt(svg: String, model: PebbleSVGModel) -> WobblePebbleArt {
-        if let cached = pebbleCache.object(forKey: svg as NSString) {
-            return cached
+        let art = memoized(pebbleCache, key: svg as NSString) {
+            buildPebbleArt(model: model)
         }
+        // `build` never returns nil here; the fallback keeps the API non-optional.
+        return art ?? buildPebbleArt(model: model)
+    }
+
+    private static func buildPebbleArt(model: PebbleSVGModel) -> WobblePebbleArt {
         let canvasParams = WobbleParams.scaled(for: model.viewBox.size)
         let layers = model.layers.map { layer -> WobbleArt in
             let params: WobbleParams
@@ -82,29 +114,25 @@ enum WobbleRenderer {
             let polylines = WobblePathFlattener.flatten(layer.combinedPath, step: params.flattenStep)
             return WobbleOutlineBuilder.art(for: polylines, halfWidth: halfWidth, params: params, noise: noise)
         }
-        let art = WobblePebbleArt(layers: layers)
-        pebbleCache.setObject(art, forKey: svg as NSString)
-        return art
+        return WobblePebbleArt(layers: layers)
     }
 
     // MARK: - Backdrop silhouettes (bundled assets)
 
     static func backdropArt(size: ValenceSizeGroup, polarity: ValencePolarity) -> WobbleBackdropArt? {
         let name = "\(size.rawValue)-\(polarity.rawValue)"
-        if let cached = backdropCache.object(forKey: name as NSString) {
-            return cached
+        return memoized(backdropCache, key: name as NSString) {
+            guard let url = Bundle.main.url(forResource: name, withExtension: "svg"),
+                  let raw = try? String(contentsOf: url, encoding: .utf8) else {
+                logger.error("wobble backdrop: missing outline asset \(name, privacy: .public).svg")
+                return nil
+            }
+            guard let art = backdropArt(fromAsset: raw) else {
+                logger.error("wobble backdrop: could not parse outline asset \(name, privacy: .public).svg")
+                return nil
+            }
+            return art
         }
-        guard let url = Bundle.main.url(forResource: name, withExtension: "svg"),
-              let raw = try? String(contentsOf: url, encoding: .utf8) else {
-            logger.error("wobble backdrop: missing outline asset \(name, privacy: .public).svg")
-            return nil
-        }
-        guard let art = backdropArt(fromAsset: raw) else {
-            logger.error("wobble backdrop: could not parse outline asset \(name, privacy: .public).svg")
-            return nil
-        }
-        backdropCache.setObject(art, forKey: name as NSString)
-        return art
     }
 
     /// Parses one outline asset — a single filled `<path>`, the verified shape
@@ -149,17 +177,19 @@ enum WobbleRenderer {
     // swiftlint:disable:next identifier_name
     static func glyphInk(d: String, width: Double) -> CGPath? {
         let key = "\(width)|\(d)" as NSString
-        if let cached = glyphCache.object(forKey: key) {
-            return cached.ink
-        }
-        let path = SVGPath.path(from: d).cgPath
-        guard !path.isEmpty else { return nil }
-        let params = WobbleParams.canonical
-        let polylines = WobblePathFlattener.flatten(path, step: params.flattenStep)
-        guard !polylines.isEmpty else { return nil }
-        let art = WobbleOutlineBuilder.art(for: polylines, halfWidth: width / 2, params: params, noise: noise)
-        glyphCache.setObject(art, forKey: key)
-        return art.ink
+        return memoized(glyphCache, key: key) {
+            // `SVGPathParser` rather than `SVGPath` (SwiftUI `Path`): this runs
+            // inside `Canvas` renderer closures, off the main actor, and the
+            // wobble renderer must stay pure CoreGraphics there. It also parses
+            // a superset of the same grammar, so no glyph regresses.
+            guard let path = SVGPathParser.parse(d), !path.isEmpty else { return nil }
+            let params = WobbleParams.canonical
+            let polylines = WobblePathFlattener.flatten(path, step: params.flattenStep)
+            guard !polylines.isEmpty else { return nil }
+            return WobbleOutlineBuilder.art(
+                for: polylines, halfWidth: width / 2, params: params, noise: noise
+            )
+        }?.ink
     }
 
     // MARK: - Minimal asset scanning

--- a/apps/ios/Pebbles/Features/Path/Render/Wobble/WobbleShapes.swift
+++ b/apps/ios/Pebbles/Features/Path/Render/Wobble/WobbleShapes.swift
@@ -4,7 +4,10 @@ import SwiftUI
 /// un-wobbled layer: layer transform → viewBox-fit scale → centering offset.
 /// The fit math intentionally mirrors `LayerShape.path(in:)` instead of
 /// reusing it, so deleting the wobble module touches nothing else.
-struct WobbledPathShape: Shape {
+/// `@unchecked Sendable`: `path` is an immutable `CGPath` copy handed over by
+/// `WobbleRenderer` and never mutated. `Shape` requires `Sendable`, and CGPath
+/// predates it (issue #650).
+struct WobbledPathShape: Shape, @unchecked Sendable {
     let path: CGPath
     let layerTransform: CGAffineTransform
     let viewBox: CGRect
@@ -27,7 +30,9 @@ struct WobbledPathShape: Shape {
 }
 
 /// Aspect-fits a wobbled backdrop silhouette into the proposed rect.
-struct WobbledBackdropShape: Shape {
+/// `@unchecked Sendable` for the same reason as `WobbledPathShape`:
+/// `WobbleBackdropArt` is an immutable, already-`Sendable` box around a CGPath.
+struct WobbledBackdropShape: Shape, @unchecked Sendable {
     let art: WobbleBackdropArt
 
     func path(in rect: CGRect) -> Path {

--- a/apps/ios/PebblesTests/Wobble/WobbleRendererTests.swift
+++ b/apps/ios/PebblesTests/Wobble/WobbleRendererTests.swift
@@ -93,4 +93,27 @@ struct WobbleRendererTests {
         // Unparseable input falls back to nil (caller strokes plainly).
         #expect(WobbleRenderer.glyphInk(d: "not a path", width: 6) == nil)
     }
+
+    @Test("concurrent glyph ink requests return one canonical object")
+    func glyphInkConcurrency() async {
+        // Regression for #650: the glyph entry point is called from `Canvas`
+        // renderer closures, which run off the main actor and concurrently.
+        // A racing look-up → build → store used to hand different callers
+        // different art for one key (and took the test runner down with it).
+        // swiftlint:disable:next identifier_name
+        let d = "M10,10 Q40,90 90,90 L180,20"
+        let identities = await withTaskGroup(of: ObjectIdentifier?.self) { group in
+            for _ in 0..<32 {
+                group.addTask {
+                    WobbleRenderer.glyphInk(d: d, width: 7).map { ObjectIdentifier($0) }
+                }
+            }
+            var seen: Set<ObjectIdentifier> = []
+            for await identity in group {
+                if let identity { seen.insert(identity) }
+            }
+            return seen
+        }
+        #expect(identities.count == 1)
+    }
 }


### PR DESCRIPTION
WobbleRenderer memoized through three NSCaches with an unguarded
look-up -> build -> store. NSCache is individually thread-safe, that
sequence is not, and the glyph entry point is called from `Canvas`
renderer closures that run off the main actor and concurrently with
each other -- so two callers could build and publish competing art for
one key.

- serialize all three memoizes behind a single lock, held across the
  build, so each key resolves to one canonical object
- parse glyph `d` with SVGPathParser (pure CoreGraphics, a superset of
  the same grammar) instead of SwiftUI's SVGPath, keeping SwiftUI out
  of a renderer that runs off the main actor
- mark the immutable art boxes and the two wobble Shapes Sendable,
  clearing the CGPath / WobbleBackdropArt warnings that are errors in
  the Swift 6 language mode
- add a concurrency regression test over glyphInk

Resolves #650

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016poqrKSyxbYs4G3uRR5NWa