### PR TITLE
fix(ui): isolate per-feed errors so one failure stops blanking the web Lab

### DIFF
--- a/apps/web/lib/data/settled-feed.test.ts
+++ b/apps/web/lib/data/settled-feed.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { allFailedError, settledOr } from "./settled-feed"
+
+const fulfilled = <T>(value: T): PromiseSettledResult<T> => ({ status: "fulfilled", value })
+const rejected = (reason: unknown): PromiseSettledResult<never> => ({ status: "rejected", reason })
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("settledOr", () => {
+  it("returns the value when the feed settled", () => {
+    expect(settledOr(fulfilled([1, 2, 3]), [], "test")).toEqual([1, 2, 3])
+  })
+
+  it("returns the fallback when the feed rejected", () => {
+    expect(settledOr(rejected(new Error("boom")), [], "test")).toEqual([])
+  })
+
+  it("logs the rejection with its scope rather than swallowing it silently", () => {
+    const reason = new Error("boom")
+    settledOr(rejected(reason), [], "useLabFeed:changelog")
+    expect(console.error).toHaveBeenCalledWith("[useLabFeed:changelog] failed to load", reason)
+  })
+
+  it("never throws — a failing feed must not take its callers down", () => {
+    expect(() => settledOr(rejected("a bare string"), new Set<string>(), "test")).not.toThrow()
+  })
+})
+
+describe("allFailedError", () => {
+  const boom = new Error("boom")
+
+  it("is null when every content feed succeeded", () => {
+    expect(allFailedError([fulfilled([]), fulfilled([]), fulfilled([]), fulfilled([])], "fallback")).toBeNull()
+  })
+
+  // The whole point of #700: three sections loading is not a page-level error.
+  it("is null when even one content feed succeeded", () => {
+    expect(allFailedError([rejected(boom), rejected(boom), rejected(boom), fulfilled([])], "fallback")).toBeNull()
+  })
+
+  it("returns an error only when every content feed failed", () => {
+    expect(allFailedError([rejected(boom), rejected(boom)], "fallback")).toBe(boom)
+  })
+
+  it("wraps a non-Error rejection in an Error carrying the fallback message", () => {
+    const result = allFailedError([rejected("just a string")], "Failed to load Lab")
+    expect(result).toBeInstanceOf(Error)
+    expect(result?.message).toBe("Failed to load Lab")
+  })
+
+  it("surfaces the first rejection, so the logged cause matches what the user hit", () => {
+    const first = new Error("first")
+    expect(allFailedError([rejected(first), rejected(new Error("second"))], "fallback")).toBe(first)
+  })
+
+  it("is null for an empty list — no content feeds means nothing failed", () => {
+    expect(allFailedError([], "fallback")).toBeNull()
+  })
+})

--- a/apps/web/lib/data/settled-feed.ts
+++ b/apps/web/lib/data/settled-feed.ts
@@ -1,0 +1,45 @@
+/**
+ * Helpers for feeds that settle independently.
+ *
+ * The Lab loads five things at once. Four are content (announcements,
+ * changelog, initiatives, backlog); the fifth, the reactions lookup, is
+ * enrichment. Under a single `Promise.all` + `try/catch`, any one rejection set
+ * the page's error state and `LabFeed` rendered nothing but `feedError` —
+ * including the sections that had loaded fine. #439 is a worked example: one
+ * missing column blanked the entire web Lab.
+ *
+ * iOS got per-feed isolation in #420 and Android inherited it in #596; this is
+ * the same contract for web. A fullscreen error is reserved for the case where
+ * every content feed failed, and the reactions lookup never counts toward it.
+ *
+ * Deliberately dependency-free so it is unit-testable: the hook it serves
+ * imports React and the Supabase client, and the node-environment Vitest setup
+ * resolves neither.
+ */
+
+/**
+ * A feed's value when it settled, or `fallback` when it rejected. Failures are
+ * logged and swallowed — the web analog of iOS `LabView.logFetchFailure`, where
+ * a failing feed is an isolated, recorded event rather than a page-level one.
+ */
+export function settledOr<T>(result: PromiseSettledResult<T>, fallback: T, scope: string): T {
+  if (result.status === "fulfilled") return result.value
+  console.error(`[${scope}] failed to load`, result.reason)
+  return fallback
+}
+
+/**
+ * The error to surface when EVERY content feed failed, and `null` when even one
+ * succeeded — a page showing three of its four sections is still a page.
+ *
+ * Only content results belong here. Passing the reactions lookup in would let a
+ * lost upvote state blank content that loaded perfectly well, which is the bug
+ * this module exists to prevent.
+ */
+export function allFailedError(results: PromiseSettledResult<unknown>[], message: string): Error | null {
+  if (results.length === 0) return null
+  if (!results.every((result) => result.status === "rejected")) return null
+  const first = results[0]
+  const reason = first.status === "rejected" ? first.reason : undefined
+  return reason instanceof Error ? reason : new Error(message)
+}

--- a/apps/web/lib/data/useLab.ts
+++ b/apps/web/lib/data/useLab.ts
@@ -16,6 +16,7 @@ import {
 } from "@/lib/data/logs-api"
 import type { Log } from "@/lib/types"
 import { LAB_CONFIG } from "@/lib/config/lab"
+import { allFailedError, settledOr } from "@/lib/data/settled-feed"
 
 // Lazy module-level singleton — `createClient()` reads env vars and must
 // not run during SSR/static prerender (where they're absent). Mirrors the
@@ -72,7 +73,10 @@ export function useLabFeed() {
       setLoading(true)
       setError(null)
       try {
-        const [ann, chg, init, back, reactions] = await Promise.all([
+        // allSettled, not all: each feed lands on its own so one failing
+        // section never blanks the four that loaded (#700, mirroring iOS #420
+        // and Android #596).
+        const [ann, chg, init, back, reactions] = await Promise.allSettled([
           fetchAnnouncements(supabase),
           fetchChangelog(supabase, { limit: LAB_CONFIG.feedLimit }),
           fetchInitiatives(supabase),
@@ -80,11 +84,16 @@ export function useLabFeed() {
           fetchMyReactions(supabase, userId),
         ])
         if (cancelled || activeUserIdRef.current !== userId) return
-        setAnnouncements(ann)
-        setChangelog(chg)
-        setInitiatives(init)
-        setBacklog(back)
-        setReactedIds(reactions)
+        setAnnouncements(settledOr(ann, [], "useLabFeed:announcements"))
+        setChangelog(settledOr(chg, [], "useLabFeed:changelog"))
+        setInitiatives(settledOr(init, [], "useLabFeed:initiatives"))
+        setBacklog(settledOr(back, [], "useLabFeed:backlog"))
+        // Enrichment, not content: losing the upvote state costs the filled-in
+        // hearts, never the feeds themselves.
+        setReactedIds(settledOr(reactions, new Set<string>(), "useLabFeed:reactions"))
+        // `LabFeed` renders the error state INSTEAD of the sections, so this
+        // is reserved for the case where there is genuinely nothing to show.
+        setError(allFailedError([ann, chg, init, back], "Failed to load Lab"))
         setLoading(false)
       } catch (err) {
         if (cancelled) return
@@ -159,13 +168,19 @@ export function useLogList(mode: LogListMode) {
       setLoading(true)
       setError(null)
       try {
-        const [list, reactions] = await Promise.all([
+        // Same isolation as the feed: the list is the content, the reactions
+        // lookup is enrichment. A failing reactions query used to take the
+        // whole list down with it even though the list had loaded.
+        const [list, reactions] = await Promise.allSettled([
           fetchLogs(supabase),
           fetchMyReactions(supabase, userId),
         ])
         if (cancelled) return
-        setLogs(list)
-        setReactedIds(reactions)
+        setLogs(settledOr(list, [], `useLogList:${mode}`))
+        setReactedIds(settledOr(reactions, new Set<string>(), `useLogList:${mode}:reactions`))
+        // Here the list IS the page, so its failure is genuinely fatal — the
+        // single-content-feed case of the same rule.
+        setError(allFailedError([list], "Failed to load list"))
         setLoading(false)
       } catch (err) {
         if (cancelled) return


### PR DESCRIPTION
Resolves #700

`useLabFeed` ran five fetches through one `Promise.all`, behind one `try/catch`, into one `error` state. `LabFeed` renders the error state *instead of* the sections, so any single rejection blanked the entire Lab — including the four sections that had loaded fine. #439 is a worked example: one missing column took the whole page down. `useLogList` had the same shape, where a failing reactions lookup blanked a list that had already loaded.

iOS got per-feed isolation in #420 and Android inherited it in #596. Web never did. This is the mirror image of #699.

## What changed

- **`Promise.allSettled`** in both hooks. Each feed lands on its own; a section that failed renders empty rather than taking its neighbours down.
- **The fullscreen error is reserved for "every content feed failed."** Three sections out of four is still a page.
- **The reactions lookup is enrichment, not content**, and never counts toward that verdict — losing the filled-in upvote state must not blank content that loaded. In `useLogList` the list *is* the page, so its failure stays fatal: the single-content-feed case of the same rule.
- **Every swallowed failure is logged with its feed name** (`[useLabFeed:changelog] failed to load`), the web analog of iOS `LabView.logFetchFailure`. Isolated, not silent.

## Key files

| File | Note |
|---|---|
| `apps/web/lib/data/settled-feed.ts` | New: `settledOr` + `allFailedError` |
| `apps/web/lib/data/settled-feed.test.ts` | 11 cases |
| `apps/web/lib/data/useLab.ts` | Both hooks converted |

## Why a separate module

The two decisions worth testing — what a failed feed falls back to, and which failures are page-level — are pure. `useLab.ts` imports React and the Supabase client, and the node-environment Vitest setup (`vitest.config.ts`, no jsdom, no path aliases) resolves neither, so testing them in place is not possible without changing that config. Extracting them keeps the assertions real and follows the existing precedent of `lib/data/karma.ts` + `karma.test.ts`. No behaviour was moved out of the hook beyond these two helpers.

## Verification

- `npm run test --workspace=apps/web` — **42 passed**
- `npm run lint --workspace=apps/web` — clean
- `npm run build --workspace=apps/web` — green

The case that matters most is asserted directly: three feeds rejected and one fulfilled yields **no** page-level error.

## Lab Note (EN/FR)

```yaml
species: feature
platform: webapp
status: in_progress
published: false
en:
  title: "The Lab no longer goes blank over one hiccup"
  summary: "If one section of the Lab fails to load, you now get every other section as usual instead of an empty page. Announcements, changelog, what is in progress and the backlog each stand on their own."
fr:
  title: "Le Lab ne se vide plus pour un rien"
  summary: "Si une section du Lab ne charge pas, tu vois maintenant toutes les autres comme d'habitude, au lieu d'une page vide. Les annonces, le registre, ce qui est en cours et la réserve tiennent chacun debout tout seuls."
suggested:
  molecule: pbbls
  type: fix
  tags: [changelog]
```
