### PR TITLE
fix(auth): enforce the '+' email ban on web

### DIFF
--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useAuth } from "@/lib/data/auth-context"
 import { isSafeRelativePath } from "@/lib/utils/safe-relative-path"
+import { hasDisallowedEmailChar, normalizeEmailInput } from "@/lib/utils/email-input"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 
@@ -27,6 +28,7 @@ export default function LoginPage() {
       ? tErrors("callbackFailed")
       : null
   })
+  const [emailError, setEmailError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
   // Optional validated post-auth destination (M49, D12) — e.g. back to a
   // pending /invite/<token> page. Non-relative values are dropped.
@@ -45,18 +47,32 @@ export default function LoginPage() {
 
   if (isLoading || isAuthenticated) return null
 
+  // Strip '+' as it is typed, and explain why — the strip is the only
+  // normalization a user would otherwise experience as a keystroke silently
+  // going missing. Lowercasing stays silent on purpose. Mirrors iOS
+  // `AuthView.onChange(of: email)` and Android `AuthLogic.normalizeEmailInput`.
+  const handleEmailChange = (raw: string) => {
+    setEmailError(hasDisallowedEmailChar(raw) ? tErrors("emailPlusNotAllowed") : null)
+    setEmail(normalizeEmailInput(raw))
+  }
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     setError(null)
 
-    if (!email.trim() || !password) {
+    // Normalize again at the boundary rather than trusting the field: a
+    // password manager or autofill can set the value without firing React's
+    // change handler, which is exactly the path the input-time strip misses.
+    const submittedEmail = normalizeEmailInput(email.trim())
+
+    if (!submittedEmail || !password) {
       setError(tErrors("fillFields"))
       return
     }
 
     setSubmitting(true)
     try {
-      await login({ email: email.trim(), password })
+      await login({ email: submittedEmail, password })
     } catch (err) {
       const message =
         err instanceof Error ? err.message : tErrors("generic")
@@ -109,10 +125,16 @@ export default function LoginPage() {
             autoComplete="email"
             autoCapitalize="none"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            aria-invalid={error ? true : undefined}
+            onChange={(e) => handleEmailChange(e.target.value)}
+            aria-invalid={error || emailError ? true : undefined}
+            aria-describedby={emailError ? "login-email-error" : undefined}
             disabled={submitting}
           />
+          {emailError && (
+            <p id="login-email-error" role="alert" className="text-sm text-destructive">
+              {emailError}
+            </p>
+          )}
         </div>
 
         <div className="flex flex-col gap-1.5 text-left">

--- a/apps/web/app/register/page.tsx
+++ b/apps/web/app/register/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { useAuth } from "@/lib/data/auth-context"
 import { isSafeRelativePath } from "@/lib/utils/safe-relative-path"
+import { hasDisallowedEmailChar, normalizeEmailInput } from "@/lib/utils/email-input"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
@@ -24,6 +25,7 @@ export default function RegisterPage() {
   const [termsAccepted, setTermsAccepted] = useState(false)
   const [privacyAccepted, setPrivacyAccepted] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [emailError, setEmailError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
   // Optional validated post-auth destination for the OAuth round-trip (M49,
   // D12). The client-side redirect below deliberately stays /onboarding — the
@@ -43,11 +45,27 @@ export default function RegisterPage() {
 
   if (isLoading || isAuthenticated) return null
 
+  // Strip '+' as it is typed, and explain why — the strip is the only
+  // normalization a user would otherwise experience as a keystroke silently
+  // going missing. Lowercasing stays silent on purpose. Mirrors iOS
+  // `AuthView.onChange(of: email)` and Android `AuthLogic.normalizeEmailInput`.
+  const handleEmailChange = (raw: string) => {
+    setEmailError(hasDisallowedEmailChar(raw) ? tErrors("emailPlusNotAllowed") : null)
+    setEmail(normalizeEmailInput(raw))
+  }
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     setError(null)
 
-    if (!email.trim() || !password || !confirmPassword) {
+    // Normalize again at the boundary rather than trusting the field: a
+    // password manager or autofill can set the value without firing React's
+    // change handler, which is exactly the path the input-time strip misses.
+    // On sign-up this is the one that matters — it decides what address the
+    // account is actually created with.
+    const submittedEmail = normalizeEmailInput(email.trim())
+
+    if (!submittedEmail || !password || !confirmPassword) {
       setError(tErrors("fillFields"))
       return
     }
@@ -65,7 +83,7 @@ export default function RegisterPage() {
     setSubmitting(true)
     try {
       await register({
-        email: email.trim(),
+        email: submittedEmail,
         password,
         terms_accepted: termsAccepted,
         privacy_accepted: privacyAccepted,
@@ -122,10 +140,16 @@ export default function RegisterPage() {
             autoComplete="email"
             autoCapitalize="none"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            aria-invalid={error ? true : undefined}
+            onChange={(e) => handleEmailChange(e.target.value)}
+            aria-invalid={error || emailError ? true : undefined}
+            aria-describedby={emailError ? "register-email-error" : undefined}
             disabled={submitting}
           />
+          {emailError && (
+            <p id="register-email-error" role="alert" className="text-sm text-destructive">
+              {emailError}
+            </p>
+          )}
         </div>
 
         <div className="flex flex-col gap-1.5 text-left">

--- a/apps/web/lib/i18n/messages/en.json
+++ b/apps/web/lib/i18n/messages/en.json
@@ -407,7 +407,8 @@
       "passwordsMismatch": "Passwords do not match.",
       "mustAcceptLegal": "You must accept the Terms of Service and Privacy Policy.",
       "generic": "Something went wrong.",
-      "callbackFailed": "Sign-in failed. Please try again."
+      "callbackFailed": "Sign-in failed. Please try again.",
+      "emailPlusNotAllowed": "The '+' character is not allowed in email addresses."
     },
     "login": {
       "title": "Log in",

--- a/apps/web/lib/i18n/messages/fr.json
+++ b/apps/web/lib/i18n/messages/fr.json
@@ -407,7 +407,8 @@
       "passwordsMismatch": "Les mots de passe ne correspondent pas.",
       "mustAcceptLegal": "Vous devez accepter les Conditions Générales d'Utilisation et la Politique de Confidentialité.",
       "generic": "Une erreur est survenue.",
-      "callbackFailed": "La connexion a échoué. Veuillez réessayer."
+      "callbackFailed": "La connexion a échoué. Veuillez réessayer.",
+      "emailPlusNotAllowed": "Le caractère « + » n’est pas autorisé dans les adresses e-mail."
     },
     "login": {
       "title": "Me connecter",

--- a/apps/web/lib/utils/email-input.test.ts
+++ b/apps/web/lib/utils/email-input.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import { hasDisallowedEmailChar, normalizeEmailInput } from "./email-input"
+
+// Parity note: these cases mirror the iOS `AuthViewLogicTests` /
+// Android `AuthLogicTest` expectations for the same helpers. The three surfaces
+// must agree on what a valid address is — that agreement, not the strip itself,
+// is the point of the rule (`docs/decisions/log.md`, 2026-05-26).
+describe("normalizeEmailInput", () => {
+  // The character is removed; the tag after it is NOT. "alex+spam@gmail.com"
+  // becomes "alexspam@gmail.com", not "alex@gmail.com" — which is what defeats
+  // aliasing, since the result no longer routes to the original mailbox. iOS
+  // (`removeAll { $0 == "+" }`) and Android (`filter { it != '+' }`) do exactly
+  // this, and web matching them character-for-character is the whole point.
+  it("strips the banned '+' anywhere in the address, keeping the rest", () => {
+    expect(normalizeEmailInput("alex+spam@gmail.com")).toBe("alexspam@gmail.com")
+    expect(normalizeEmailInput("+leading@gmail.com")).toBe("leading@gmail.com")
+    expect(normalizeEmailInput("trailing@gmail.com+")).toBe("trailing@gmail.com")
+  })
+
+  it("strips every occurrence, not just the first", () => {
+    expect(normalizeEmailInput("a+b+c@gmail.com")).toBe("abc@gmail.com")
+  })
+
+  it("lowercases, matching iOS and Android", () => {
+    expect(normalizeEmailInput("Alex.Bohns@Gmail.COM")).toBe("alex.bohns@gmail.com")
+  })
+
+  it("leaves a clean address untouched", () => {
+    expect(normalizeEmailInput("alex@gmail.com")).toBe("alex@gmail.com")
+  })
+
+  it("handles the empty string", () => {
+    expect(normalizeEmailInput("")).toBe("")
+  })
+
+  it("is idempotent — re-normalizing a normalized value is a no-op", () => {
+    const once = normalizeEmailInput("Alex+Spam@Gmail.com")
+    expect(normalizeEmailInput(once)).toBe(once)
+  })
+})
+
+describe("hasDisallowedEmailChar", () => {
+  it("detects the banned character before it is stripped", () => {
+    expect(hasDisallowedEmailChar("alex+spam@gmail.com")).toBe(true)
+  })
+
+  it("is false for a clean address", () => {
+    expect(hasDisallowedEmailChar("alex@gmail.com")).toBe(false)
+  })
+
+  it("is false once the value has been normalized — why callers must check first", () => {
+    expect(hasDisallowedEmailChar(normalizeEmailInput("alex+spam@gmail.com"))).toBe(false)
+  })
+})

--- a/apps/web/lib/utils/email-input.ts
+++ b/apps/web/lib/utils/email-input.ts
@@ -1,0 +1,32 @@
+/**
+ * Email input normalization for the auth surfaces.
+ *
+ * Product policy bans `+` in email input on every client (anti Gmail-alias
+ * abuse), recorded in `docs/decisions/log.md` (2026-05-26) and scoped there to
+ * `ios, webapp`. iOS (`AuthView.normalizeEmailInput`) and Android
+ * (`AuthLogic.normalizeEmailInput`) already enforce it; web did not, which made
+ * the policy bypassable on the surface most exposed to alias abuse and left the
+ * three clients disagreeing about what a valid address even is.
+ */
+
+/** The one character the policy bans. */
+export const DISALLOWED_EMAIL_CHAR = "+"
+
+/**
+ * Lowercases and strips `+` from raw email input. Real-time scrubbing keeps the
+ * visible field, the submitted value, and the server's view of the address in
+ * sync — the same contract as the iOS and Android helpers this mirrors.
+ */
+export function normalizeEmailInput(raw: string): string {
+  return raw.toLowerCase().replaceAll(DISALLOWED_EMAIL_CHAR, "")
+}
+
+/**
+ * Whether raw input carries the banned character. Callers must check this
+ * BEFORE normalizing: after the strip there is nothing left to detect, and the
+ * inline explanation is the only way a user learns why their keystroke
+ * vanished. Lowercasing is silent on purpose; this is not.
+ */
+export function hasDisallowedEmailChar(raw: string): boolean {
+  return raw.includes(DISALLOWED_EMAIL_CHAR)
+}


### PR DESCRIPTION
Resolves #698

The policy banning `+` in email input (anti Gmail-alias abuse) is recorded in `docs/decisions/log.md` (2026-05-26), scoped there to `ios, webapp`, and implemented on iOS and Android — but never on web. It was bypassable on the surface most exposed to alias abuse in the first place, and the three clients disagreed about what a valid address even is, so the same address was accepted on one and refused on another.

## What changed

- **`lib/utils/email-input.ts`** — `normalizeEmailInput` + `hasDisallowedEmailChar`, character-for-character the iOS `removeAll { $0 == "+" }` / Android `filter { it != '+' }` behaviour. The `+` goes and the text after it stays (`alex+spam@gmail.com` → `alexspam@gmail.com`), which is what stops the alias routing back to the original mailbox.
- **Both auth pages** strip on input and show an inline explanation. Stripping is the one normalization a user would otherwise experience as a keystroke silently vanishing; lowercasing stays silent on purpose, exactly as on iOS.
- **Submit re-normalizes** rather than trusting the field. A password manager or autofill can set the value without firing React's change handler, which is precisely the path an input-time strip misses — and on `/register` it decides what address the account is created with.
- **The inline message reuses the strings already localized in the iOS xcstrings**, so all three surfaces say the same sentence in both EN and FR.

`type="email"` appears in exactly two places in `apps/web`, both covered here — so this is the whole web surface, not a sample of it.

## Key files

| File | Note |
|---|---|
| `apps/web/lib/utils/email-input.ts` | New pure helpers |
| `apps/web/lib/utils/email-input.test.ts` | 9 cases, incl. the parity semantics |
| `apps/web/app/login/page.tsx`, `apps/web/app/register/page.tsx` | Strip on input, inline error, normalize at submit |
| `apps/web/lib/i18n/messages/{en,fr}.json` | `auth.errors.emailPlusNotAllowed` |

## Verification

- `npm run test --workspace=apps/web` — **41 passed**
- `npm run lint --workspace=apps/web` — clean
- `npm run build --workspace=apps/web` — green

One note worth recording: my first draft of the test asserted `alex+spam@gmail.com` → `alex@gmail.com`, i.e. Gmail-alias-tag removal. The test failed and it was the expectation that was wrong, not the code — iOS and Android strip the character, not the tag. Had I written the implementation to match my assumption instead, web would have "enforced the policy" while still disagreeing with the other two surfaces, which is the exact failure mode this issue is about.

## Accessibility

The inline error is `role="alert"` and wired to the input via `aria-describedby`, and `aria-invalid` now reflects the email error as well as the form error.

## Lab Note (EN/FR)

```yaml
species: feature
platform: webapp
status: in_progress
published: false
en:
  title: "Signing up on the web now plays by the same rules"
  summary: "The web sign-in and sign-up forms now handle your email exactly like the iPhone and Android apps do, so one address works the same everywhere instead of being accepted in one place and refused in another."
fr:
  title: "L'inscription sur le web suit enfin les mêmes règles"
  summary: "Les formulaires de connexion et d'inscription du web traitent maintenant ton adresse e-mail exactement comme les apps iPhone et Android. Une même adresse marche donc partout, au lieu de passer ici et d'être refusée là."
suggested:
  molecule: pbbls
  type: fix
  tags: [changelog]
```
