### PR TITLE
quality(ui): remove the collections shortcut tile from the profile row

### DIFF
--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/ProfileScreen.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/ProfileScreen.kt
@@ -195,7 +195,6 @@ fun ProfileScreen(
                         glyphStrokes = glyphStrokes,
                     )
                     ProfileShortcutsRow(
-                        onOpenCollections = onOpenCollections,
                         onOpenSouls = onOpenSouls,
                         onOpenGlyphs = onOpenGlyphs,
                         onOpenConnections = onOpenConnections,

--- a/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/components/ProfileShortcutsRow.kt
+++ b/apps/android/app/src/main/kotlin/app/pbbls/android/features/profile/components/ProfileShortcutsRow.kt
@@ -16,14 +16,14 @@ import app.pbbls.android.theme.SurfaceTile
 
 /**
  * The Profile shortcut tiles — ports iOS `ProfileShortcutsRow.swift`
- * (Collections · Souls · Glyphs, in that order). Handlers are optional and a
- * tile renders only when its handler is wired (D11 — no dead chrome); all
- * three are live as of M43 (the Glyphs tile reversed the last omission).
+ * (Souls · Glyphs · Connections, in that order). Collections are reached from
+ * their own section card below, so they get no shortcut tile. Handlers are
+ * optional and a tile renders only when its handler is wired (D11 — no dead
+ * chrome).
  */
 @Composable
 fun ProfileShortcutsRow(
     modifier: Modifier = Modifier,
-    onOpenCollections: (() -> Unit)? = null,
     onOpenSouls: (() -> Unit)? = null,
     onOpenGlyphs: (() -> Unit)? = null,
     onOpenConnections: (() -> Unit)? = null,
@@ -32,13 +32,6 @@ fun ProfileShortcutsRow(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(PebblesTheme.spacing.sm),
     ) {
-        if (onOpenCollections != null) {
-            ShortcutTile(
-                iconRes = R.drawable.ic_stack,
-                label = stringResource(R.string.profile_collections_header),
-                onClick = onOpenCollections,
-            )
-        }
         if (onOpenSouls != null) {
             ShortcutTile(
                 iconRes = R.drawable.ic_person_pair,

--- a/apps/ios/Pebbles/Features/Profile/Components/ProfileShortcutsRow.swift
+++ b/apps/ios/Pebbles/Features/Profile/Components/ProfileShortcutsRow.swift
@@ -1,11 +1,10 @@
 import SwiftUI
 
+/// Souls / Glyphs / Circle. Collections are reached from their own section
+/// card below, so they get no shortcut tile here.
 struct ProfileShortcutsRow: View {
     var body: some View {
         HStack(spacing: Spacing.sm) {
-            ProfileShortcutTile(title: "Collections", systemImage: "square.stack.3d.up") {
-                CollectionsListView()
-            }
             ProfileShortcutTile(title: "Souls", systemImage: "person.2") {
                 SoulsListView()
             }

--- a/apps/web/components/profile/ShortcutsRow.tsx
+++ b/apps/web/components/profile/ShortcutsRow.tsx
@@ -1,19 +1,18 @@
 "use client"
 
 import { useTranslations } from "next-intl"
-import { FolderOpen, Users, Fingerprint, UserRoundPlus } from "lucide-react"
+import { Users, Fingerprint, UserRoundPlus } from "lucide-react"
 import { ShortcutTile } from "@/components/profile/ShortcutTile"
 
 /**
- * The Profile shortcuts (Collections / Souls / Glyphs / Connections) — web
- * port of the iOS `ProfileShortcutsRow`. Labels reuse the shared `nav.*`
- * translations.
+ * The Profile shortcuts (Souls / Glyphs / Connections) — web port of the iOS
+ * `ProfileShortcutsRow`. Labels reuse the shared `nav.*` translations.
+ * Collections have their own section card, so they get no shortcut tile.
  */
 export function ShortcutsRow() {
   const t = useTranslations("nav")
   return (
     <div className="flex gap-2.5">
-      <ShortcutTile href="/collections" icon={FolderOpen} label={t("collections")} />
       <ShortcutTile href="/souls" icon={Users} label={t("souls")} />
       <ShortcutTile href="/glyphs" icon={Fingerprint} label={t("glyphs")} />
       <ShortcutTile href="/connections" icon={UserRoundPlus} label={t("connections")} />


### PR DESCRIPTION
Resolves #718

The Profile screen already carries a dedicated Collections section card on every client surface, so the Collections shortcut tile above it was duplicate chrome. Removing it puts the shortcuts row back to three tiles.

## Key files

| Surface | File | Row now |
|---|---|---|
| Web | `apps/web/components/profile/ShortcutsRow.tsx` | Souls · Glyphs · Connections |
| iOS | `apps/ios/Pebbles/Features/Profile/Components/ProfileShortcutsRow.swift` | Souls · Glyphs · Circle |
| Android | `apps/android/.../features/profile/components/ProfileShortcutsRow.kt` | Souls · Glyphs · Connections |
| Android | `apps/android/.../features/profile/ProfileScreen.kt` | call site updated |

## Implementation notes

- Web also drops the now-unused `FolderOpen` lucide import.
- Android drops the now-unused `onOpenCollections` parameter from `ProfileShortcutsRow`; `ProfileScreen` still passes the same handler to `ProfileCollectionsCard(onOpenList = …)`, so nothing about navigation changes.
- The collections list stays reachable on all three surfaces from the section card header (`/collections` on web, `CollectionsListView` on iOS, `ROUTE_COLLECTIONS` on Android).
- No Arkaik update — no screen, route, data model or endpoint changed, only a shortcut into an existing one.

## Verification

- `npm run lint --workspace=apps/web` — clean.
- `npm run build --workspace=@pbbls/ios` — **BUILD SUCCEEDED**; SwiftLint clean on the touched file, repo-wide count unchanged from baseline (333 / 66 serious, all pre-existing).
- Android ktlint/build deferred to `android.yml` (no local SDK).

No Lab Note: `quality` species, no user-visible Arkaik view node touched.
